### PR TITLE
#169 arguments.callee is deprecated in strict mode for ecma 5

### DIFF
--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -1,22 +1,30 @@
 module.exports = {
-
-  once: function (el, type, callback) {
-    var typeArray = type.split(' ');
-
-    for (var i = typeArray.length - 1; i >= 0; i--) {
-      el.addEventListener(typeArray[i], function(e) {
-        e.target.removeEventListener(e.type, arguments.callee);
-        return callback(e);
-      });
-    };
-  },
-
-  on: function(el, type, callback, capture) {
-    el.addEventListener(type, callback, capture || false);
-  },
-
-  off: function(el, type, callback, capture) {
-    el.removeEventListener(type, callback, capture || false);
-  }
-
-}
+    once: function(el, type, callback) {
+        var typeArray = type.split(' ');
+        var recursiveFunction = function(e){
+            e.target.removeEventListener(e.type, recursiveFunction);
+            return callback(e);
+        };
+        for(var i = typeArray.length - 1; i > 0; i--) {
+            on(el, typeArray[i], recursiveFunction);
+        }
+    },
+    // IE8+ Support
+    on: function(el, type, callback) {
+        if(el.addEventListener) {
+            el.addEventListener(type, callback);
+        } else {
+            el.attachEvent('on' + type, function() {
+                callback.call(el);
+            });
+        }
+    },
+    // IE8+ Support
+    off: function(el, type, callback) {
+        if(el.removeEventListener) {
+            el.removeEventListener(type, callback);
+        } else {
+            el.detachEvent('on' + type, callback);
+        }
+    }
+};


### PR DESCRIPTION
- Fix deprecated arguments.callee property in ECMA 5
- Add if statement to support IE8 for addEventListener