### PR TITLE
Changed slider cursor

### DIFF
--- a/src/less/components/slider.less
+++ b/src/less/components/slider.less
@@ -51,7 +51,7 @@
   }
 
   .mui-slider-handle {
-    cursor: ew-resize;
+    cursor: pointer;
     position: absolute;
     top: 0;
     left: 0%;


### PR DESCRIPTION
The previous arrow bar as the cursor looked rather unintuitive. I changed the cursor from `ew-resize` to `pointer`.