### PR TITLE
Addresses issue #193

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -32,10 +32,6 @@
     "watchify": "^2.2.1"
   },
   "dependencies": {
-    "highlight.js": "^8.4.0",
-    "react": "^0.12.2",
-    "react-draggable2": "^0.4.1",
-    "react-router": "^0.11.6",
-    "react-tap-event-plugin": "^0.1.3"
+    "highlight.js": "^8.4.0"
   }
 }


### PR DESCRIPTION
Removes dependencies in docs folder that install second instance of react in NPM install. This allows for local website build to respond again and removes 'cannot read firstChild of undefined' issue. Outside of that - does not seem to negatively affect website by removing dependencies.