### PR TITLE
Link stylus version + draggable update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Material-UI is available as an [npm package](https://www.npmjs.org/package/mater
 npm install material-ui
 ```
 
-Use [browserify](http://browserify.org/) and [reactify](https://github.com/andreypopp/reactify) for dependency management and JSX transformation. The CSS framework is written in [Less](http://lesscss.org/), so you'll need to compile that as well. For [Sass](http://www.sass-lang.com) users, [material-ui-sass](https://github.com/gpbl/material-ui-sass) contains the .scss version of the Less framework.
+Use [browserify](http://browserify.org/) and [reactify](https://github.com/andreypopp/reactify) for dependency management and JSX transformation. The CSS framework is written in [Less](http://lesscss.org/), so you'll need to compile that as well. For [Sass](http://www.sass-lang.com) users, [material-ui-sass](https://github.com/gpbl/material-ui-sass) contains the .scss version of the Less framework. People working with [Stylus](http://learnboost.github.io/stylus/) can use [material-ui-stylus](https://github.com/Autarc/material-ui-stylus) to import
+the proper .styl version of the files.
 
 ### React-Tap-Event-Plugin
 Some components uses [react-tap-event-plugin](https://github.com/zilverline/react-tap-event-plugin) to

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "react": "^0.12.2",
-    "react-draggable2": "^0.4.1",
+    "react-draggable2": "^0.4.2",
     "react-tap-event-plugin": "^0.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Just added a link to a stylus version for the style sheets. Moreover I've pulled the updated draggable module, as it checks the context and allows to use the framework now for server rendering as well.