### PR TITLE
Formatted code, added documentation, and grouped classes together for pages/switches

### DIFF
--- a/docs/src/app/components/pages/components/switches.jsx
+++ b/docs/src/app/components/pages/components/switches.jsx
@@ -3,99 +3,220 @@ var React = require('react'),
     Checkbox = mui.Checkbox,
     RadioButton = mui.RadioButton,
     Toggle = mui.Toggle,
-    CodeExample = require('../../code-example/code-example.jsx');
+    CodeExample = require('../../code-example/code-example.jsx'),
+    ComponentDoc = require('../../component-doc.jsx');;
 
 var SwitchesPage = React.createClass({
 
   render: function() {
+
+    var code = 
+      '//Checkboxes\n' +
+      '<Checkbox\n' +
+      '  name="checkboxName1"\n' +
+      '  value="checkboxValue1" />\n' +
+      '<Checkbox\n' +
+      '  name="checkboxName2"\n' +
+      '  value="checkboxValue2" />\n' +
+      '<Checkbox\n' +
+      '  name="checkboxName3"\n' +
+      '  value="checkboxValue3"\n' + 
+      '  checked={true} />\n\n' +
+      '//Radio Buttons\n' +
+      '<RadioButton\n' +
+      '  name="shipSpeed1"\n' +
+      '  value="light"\n' +
+      '  label="prepare for light speed" />\n' +
+      '<RadioButton\n' +
+      '  name="shipSpeed2"\n' +
+      '  value="not_light"\n' +
+      '  label="light speed too slow"\n' +
+      '  defaultChecked={true} />\n' +
+      '<RadioButton\n' +
+      '  name="shipSpeed3"\n' +
+      '  value="ludicrous"\n' +
+      '  label="go to ludicous speed" />\n\n' +
+      '//Toggle\n' +
+      '<Toggle />\n';
+
+    var desc = 'This component generates a switches element and all props except for the custom ' +
+        'props below will be passed down to the switch element.';
+
+    var componentInfo = [
+      {
+        name: 'Checkbox',
+        infoArray: [
+          {
+            name: 'name',
+            type: 'string',
+            header: 'required',
+            desc: 'This is the name of the checkbox.'
+          },
+          {
+            name: 'value',
+            type: 'string',
+            header: 'required',
+            desc: 'The value of our checkbox component.'
+          },
+          {
+            name: 'checked',
+            type: 'boolean',
+            header: 'default:false',
+            desc: 'The current state of our checkbox component.'
+          }
+        ]
+      },
+      {
+        name: 'Radio Button',
+        infoArray: [
+          {
+            name: 'name',
+            type: 'string',
+            header: 'required',
+            desc: 'The name of the radio button component.'
+          },
+          {
+            name: 'value',
+            type: 'string',
+            header: 'required',
+            desc: 'The value of our radio button component.'
+          },
+          {
+            name: 'label',
+            type: 'string',
+            header: 'optional',
+            desc: 'The text that is displayed next to the right of the radio button.'
+          },
+          {
+            name: 'defaultChecked',
+            type: 'boolean',
+            header: 'default:false',
+            desc: 'The default value of the radio button when the page finishes loading.'
+          }
+        ]
+      },
+      {
+        name: 'Toggle',
+        infoArray: [
+          {
+            name: 'onToggle',
+            type: 'event',
+            header: 'optional',
+            desc: 'The function that is called each time the user clicks the toggle button.'
+          },
+          {
+            name: 'toggled',
+            type: 'boolean',
+            header: 'default:false',
+            desc: 'The value of the toggle button. Is true when toggle has been turned on. ' + 
+              'False otherwise.'
+          }
+        ]
+      }
+    ];
+
     return (
-      <div>
-        <h2 className="mui-font-style-headline">Checkbox</h2>
-        {this._getCheckboxExample()}
-        <h2 className="mui-font-style-headline">Radio Button</h2>
-        {this._getRadioButtonExample()}
-        <h2 className="mui-font-style-headline">Toggle</h2>
-        {this._getToggleExample()}
-      </div>
+      <ComponentDoc 
+        name="Switches"
+        code={code}
+        desc={desc}
+        componentInfo={componentInfo}>
+
+        <div className="switches-examples">
+          <form>
+            {this._getCheckboxExample()}
+            {this._getRadioButtonExample()}
+            {this._getToggleExample()}
+          </form>
+        </div>
+
+      </ComponentDoc>
     );
   },
 
   _getCheckboxExample: function() {
-    var code = 
-      '<form>\n' +
-      ' <Checkbox name="checkboxName" value="checkboxValue1" />\n' +
-      ' <Checkbox name="checkboxName" value="checkboxValue2" />\n' +
-      ' <Checkbox name="checkboxName" value="checkboxValue3" />\n' +
-      '</form>';
 
     return (
-      <CodeExample code={code}>
-        <form>
+      <div className="switches-example-group">
+
+        <div className="switches-example-container">
+          <h2 className="mui-font-style-headline">Checkbox</h2>
+        </div>
+
+        <div className="switches-example-container">
           <Checkbox
-            name="checkboxName"
+            name="checkboxName1"
             value="checkboxValue1"
             onClick={this._onCheck} />
-          <br />
-
+        </div>
+        <div className="switches-example-container">
           <Checkbox
-            name="checkboxName"
-            value="checkboxValue2"
+            name="checkboxName2"
+            value="checkboxValue2" 
             onClick={this._onCheck} />
-          <br />
-
+        </div>
+       <div className="switches-example-container">
           <Checkbox
-            name="checkboxName"
+            name="checkboxName3"
             value="checkboxValue3"
+            checked={true}
             onClick={this._onCheck} />
-        </form> 
-      </CodeExample>
+        </div>
+
+      </div>
     );
   },
 
   _getToggleExample: function() {
-    var code = 
-      '<Toggle />';
 
     return (
-      <CodeExample code={code}>
-        <Toggle onToggle={this._handleToggle} />
-      </CodeExample>
+      <div className="switches-example-group">
+
+        <div className="switches-example-container">
+          <h2 className="mui-font-style-headline">Toggle</h2>
+        </div>
+
+        <div className="switches-example-container">
+          <Toggle onToggle={this._handleToggle} />
+        </div>
+
+      </div>
     );
   },
 
   _getRadioButtonExample: function() {
-    var code = 
-      '<form>\n' +
-      ' <RadioButton name="shipSpeed" value="light" label="prepare for light speed"/>\n' +
-      ' <RadioButton name="shipSpeed" value="not_light" label="light speed too slow" defaultChecked={true}/>\n' +
-      ' <RadioButton name="shipSpeed" value="ludicrous" label="go to ludicous speed"/>\n' +
-      '</form>';
 
     return (
-      <CodeExample code={code}>
-        <form>
-          <RadioButton
-            name="shipSpeed"
-            value="light"
-            label="prepare for light speed"
-            onClick={this._onRadioButtonClick} />
-          <br />
+      <div className="switches-example-group">
 
-          <RadioButton
-            name="shipSpeed"
-            value="not_light"
-            label="light speed too slow"
-            defaultChecked={true}
-            onClick={this._onRadioButtonClick} />
-          <br />
+        <div className="switches-example-container">
+          <h2 className="mui-font-style-headline">Radio Buttons</h2>
+        </div>
 
-          <RadioButton
-            name="shipSpeed"
-            value="ludicrous"
-            label="go to ludicrous speed"
-            onClick={this._onRadioButtonClick} />
-        </form>
-      </CodeExample>
+      <div className="switches-example-container">
+        <RadioButton
+          name="shipSpeed1"
+          value="light"
+          label="prepare for light speed"
+          onClick={this._onRadioButtonClick} />
+      </div>
+      <div className="switches-example-container">
+        <RadioButton
+          name="shipSpeed2"
+          value="not_light"
+          label="light speed too slow"
+          defaultChecked={true}
+          onClick={this._onRadioButtonClick} />
+      </div>
+      <div className="switches-example-container">
+        <RadioButton
+          name="shipSpeed3"
+          value="ludicrous"
+          label="go to ludicrous speed"
+          onClick={this._onRadioButtonClick} />
+      </div>
+
+    </div>
     );
   },
 

--- a/docs/src/app/components/pages/components/switches.jsx
+++ b/docs/src/app/components/pages/components/switches.jsx
@@ -1,10 +1,10 @@
-var React = require('react'),
-    mui = require('mui'),
-    Checkbox = mui.Checkbox,
-    RadioButton = mui.RadioButton,
-    Toggle = mui.Toggle,
-    CodeExample = require('../../code-example/code-example.jsx'),
-    ComponentDoc = require('../../component-doc.jsx');;
+var React = require('react');
+var mui = require('mui');
+var Checkbox = mui.Checkbox;
+var RadioButton = mui.RadioButton;
+var Toggle = mui.Toggle;
+var CodeExample = require('../../code-example/code-example.jsx');
+var ComponentDoc = require('../../component-doc.jsx');
 
 var SwitchesPage = React.createClass({
 

--- a/docs/src/less/main.less
+++ b/docs/src/less/main.less
@@ -19,6 +19,7 @@
 @import "pages/page-with-nav.less";
 @import "pages/components/component-doc.less";
 @import "pages/components/buttons.less";
+@import "pages/components/switches.less";
 @import "pages/components/icon.less";
 @import "pages/components/paper.less";
 @import "pages/components/toolbar.less";

--- a/docs/src/less/pages/components/switches.less
+++ b/docs/src/less/pages/components/switches.less
@@ -13,6 +13,12 @@
 
   @media @device-medium {
     .switches-example-group {
+      width: 50%;
+    }
+  }
+
+  @media @device-large {
+    .switches-example-group {
       width: 33%;
     }
   }

--- a/docs/src/less/pages/components/switches.less
+++ b/docs/src/less/pages/components/switches.less
@@ -8,7 +8,7 @@
 
   .switches-example-group {
     float: left;
-    width: 50%;
+    width: 100%;
   }
 
   @media @device-medium {

--- a/docs/src/less/pages/components/switches.less
+++ b/docs/src/less/pages/components/switches.less
@@ -1,0 +1,19 @@
+.switches-examples {
+  .clearfix();
+
+  .switches-example-container {
+    text-align: left;
+    margin-bottom: 16px;
+  }
+
+  .switches-example-group {
+    float: left;
+    width: 50%;
+  }
+
+  @media @device-medium {
+    .switches-example-group {
+      width: 33%;
+    }
+  }
+}


### PR DESCRIPTION
Previously the code-examples for pages/switches wrote each component on one line and had separate code-blocks for each mui class. The code-example and js code have been reformatted for better readability and each class (Checkbox, Radio Button, and Toggle) is now displayed side-by-side much like pages/buttons.