### PR TITLE
Document input focus and blur events

### DIFF
--- a/docs/src/app/components/pages/components/inputs.jsx
+++ b/docs/src/app/components/pages/components/inputs.jsx
@@ -167,6 +167,16 @@ var InputsPage = React.createClass({
             name: 'onChange',
             header: 'function(e, value)',
             desc: 'Fired when the input is changed.'
+          },
+          {
+            name: 'onFocus',
+            header: 'function(e)',
+            desc: 'Fired when the input has received focus.'
+          },
+          {
+            name: 'onBlur',
+            header: 'function(e)',
+            desc: 'Fired when the input has lost focus.'
           }
         ]
       }


### PR DESCRIPTION
This documents the `onFocus` and `onBlur` events for `Input` components.  I'm not sure if you want to explicitly document these or just link to the React docs for events or other supported properties where spread attributes are used.  When I didn't see them in the docs, I initially assumed they weren't supported.