### PR TITLE
Allow doc server to be run without installing gulp globally

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,10 +9,9 @@ cd <project folder>/material-ui
 npm install
 cd <project folder>/material-ui/docs
 npm install
-npm install -g gulp
 ```
 
 Now you can run your local server:
 ```
-gulp
+npm start
 ```

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,6 +2,9 @@
   "name": "material-ui-docs",
   "version": "0.0.1",
   "description": "Documentation site for material-ui",
+  "scripts": {
+    "start": "gulp"
+  },
   "browser": {
     "mui": "../src/index.js"
   },


### PR DESCRIPTION
Instead of having people install `gulp` globally, you can use the version installed as a doc dependency.  [npm scripts](https://docs.npmjs.com/misc/scripts) will put it on the path for you.

So instead of this:
```
npm install
npm install -g gulp
gulp
```

The doc server can be run with this:
```
npm install
npm start
```
