### PR TITLE
Add background-clip: padding-box to slider handle

### DIFF
--- a/src/less/components/slider.less
+++ b/src/less/components/slider.less
@@ -58,6 +58,7 @@
     z-index: 1;
     margin: (@slider-track-size / 2) 0 0 0;
 
+    background-clip: padding-box;
     border-radius: 50%;
     transform: translate(-50%, -50%);
     transition:


### PR DESCRIPTION
Removing lesshat caused that same graphical glitch [solved](https://github.com/gpbl/material-ui-sass/issues/15#issuecomment-68546791) with `background-clip`:

<img src="https://cloud.githubusercontent.com/assets/120693/5693370/c4ae44fa-9919-11e4-9aa7-488cc517957c.png" width="75">

vs.

<img src="https://cloud.githubusercontent.com/assets/120693/5693371/c4f2c1ca-9919-11e4-83c1-072621795ecd.png" width="75">

