### PR TITLE
Adds componentWillReceiveProps to Toggle component

### DIFF
--- a/src/js/toggle.jsx
+++ b/src/js/toggle.jsx
@@ -17,6 +17,10 @@ var Toggle = React.createClass({
     }
   },
 
+  componentWillReceiveProps: function (nextProps) {
+    if (nextProps.hasOwnProperty('toggled')) this.setState({toggled: nextProps.toggled});
+  },
+
   render: function() {
     var classes = this.getClasses('mui-toggle', {
       'mui-is-toggled': this.state.toggled


### PR DESCRIPTION
Fixes #236. Simply adds `componentWillReceiveProps` so we can pass props to the state for a Toggle component. Feel free to let me know if anything is funky with this! I always love feedback.