### PR TITLE
raisedButton will reset state when receives new props

### DIFF
--- a/src/js/raised-button.jsx
+++ b/src/js/raised-button.jsx
@@ -27,6 +27,14 @@ var RaisedButton = React.createClass({
     };
   },
 
+  componentWillReceiveProps: function(nextProps) {
+    var zDepth = nextProps.disabled ? 0 : 1;
+    this.setState({
+      zDepth: zDepth,
+      initialZDepth: zDepth
+    });
+  },
+
   render: function() {
     var {
       label,


### PR DESCRIPTION
Fixes #256 
When `props.disabled == true`:
![image](https://cloud.githubusercontent.com/assets/2849183/5832780/1c0ec9f8-a0ff-11e4-9108-eaf3dae108c7.png)

When `props.disabled == false`:
![image](https://cloud.githubusercontent.com/assets/2849183/5832782/2381005c-a0ff-11e4-853f-9da942b60a60.png)
