### PR TITLE
"@jsx React.DOM" no longer required as of React v0.12.0. 

### DIFF
--- a/docs/src/app/components/pages/components/menus.jsx
+++ b/docs/src/app/components/pages/components/menus.jsx
@@ -1,7 +1,3 @@
-/**
- * @jsx React.DOM
- */
- 
 var React = require('react'),
   mui = require('mui'),
   CodeExample = require('../../code-example/code-example.jsx'),


### PR DESCRIPTION
https://github.com/facebook/react/blob/master/CHANGELOG.md#new-features-2