### PR TITLE
Fixes width transition for ink bar

### DIFF
--- a/src/less/components/ink-bar.less
+++ b/src/less/components/ink-bar.less
@@ -5,5 +5,5 @@
   height: 2px;
   margin-top: -2px;
   position: relative;
-  .ease-out(1s);
+  .ease-out(1s, left);
 }


### PR DESCRIPTION
When tab width is greater than possible amount of tabs - inkbar doing a transition when adjusting width. Left should be only animated property.