### PR TITLE
Update package.json to use latest mui version

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -29,7 +29,7 @@
     "watchify": "^2.2.1"
   },
   "dependencies": {
-    "material-ui": "^0.4.1",
+    "material-ui": "^0.6",
     "react": "^0.12.2",
     "react-tap-event-plugin": "^0.1.3"
   }


### PR DESCRIPTION
The dependency in the /example project to material-ui was out of date, so certain components could not be used as in the following link:

[text fields #285](https://github.com/callemall/material-ui/issues/285)