### PR TITLE
Avoid breaking native input placeholder

### DIFF
--- a/src/less/components/input.less
+++ b/src/less/components/input.less
@@ -177,10 +177,10 @@
   }
   
   &.mui-disabled { opacity: 0.4 }
-}
 
-::-webkit-input-placeholder {
-  //color: red !important;
-  position: absolute !important;
-  top: -20px !important;
+  &::-webkit-input-placeholder {
+    position: absolute !important;
+    top: -20px !important;
+  }
+
 }


### PR DESCRIPTION
The `::-webkit-input-placeholder` selector in `input.less` applies to all `<input>` elements with a placeholder.  The `position: absolute !important;` makes it so the placeholder isn't removed when the user enters text in the input element.

This may not be the correct fix, but the `::-webkit-input-placeholder` selector is too broad, and without a change to `input.less`, anybody who imports `components.less` will have broken native `<input>` elements in their applications.