### PR TITLE
Minimize use of react/addons

### DIFF
--- a/docs/src/app/components/pages/components/text-fields.jsx
+++ b/docs/src/app/components/pages/components/text-fields.jsx
@@ -1,4 +1,4 @@
-var React = require('react');
+var React = require('react/addons');
 var mui = require('mui');
 var TextField = mui.TextField;
 var ComponentDoc = require('../../component-doc.jsx');

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "react": "^0.12.2",
+    "react-classset": "0.0.2",
     "react-draggable2": "^0.4.2",
     "react-tap-event-plugin": "^0.1.3"
   },

--- a/src/js/input.jsx
+++ b/src/js/input.jsx
@@ -1,8 +1,8 @@
 /** @jsx React.DOM */
 
-var React = require('react/addons');
+var React = require('react');
 var Classable = require('./mixins/classable.js');
-var classSet = React.addons.classSet;
+var classSet = require('react-classset');
 
 var Input = React.createClass({
 

--- a/src/js/mixins/classable.js
+++ b/src/js/mixins/classable.js
@@ -1,5 +1,5 @@
-var React = require('react/addons');
-var classSet = React.addons.classSet;
+var React = require('react');
+var classSet = require('react-classset');
 
 module.exports = {
 

--- a/src/js/tabs/tabs.jsx
+++ b/src/js/tabs/tabs.jsx
@@ -1,4 +1,4 @@
-var React = require('react');
+var React = require('react/addons');
 var Tab = require('./tab.jsx');
 var TabTemplate = require('./tabTemplate.jsx');
 var InkBar = require('../ink-bar.jsx');


### PR DESCRIPTION
For people looking to create smaller builds, it would be nice if the use of `react/addons` were minimized.

The [`react-classset` package](https://www.npmjs.com/package/react-classset) provides a nice stand-alone replacement for `React.addons.classSet`.  By requiring `react-classset` instead of `react/addons`, most of Material UI can be used without requiring the addons.

In addition, this updates the tabs component to explicitly require `react/addons` (this was previously only working because the classable component was requiring the addons).

With these changes, only the date picker and tabs pull in all of the addons.  People who don't use these components can generate builds without the addons.

