### PR TITLE
Moved reactify and browserify to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,10 @@
     "react-tap-event-plugin": "^0.1.3"
   },
   "devDependencies": {
-    "browserify": "^7.0.3",
-    "reactify": "^0.17.1",
     "react-router": "^0.11.6"
+  },
+  "peerDependencies": {
+    "browserify": "^7.0.3",
+    "reactify": "^0.17.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-router": "^0.11.6"
   },
   "peerDependencies": {
-    "browserify": "^7.0.3",
+    "browserify": "^8.1.3",
     "reactify": "^0.17.1"
   }
 }


### PR DESCRIPTION
#215 
Those libraries should be installed as peer- instead of dev- dependencies.