### PR TITLE
Allow nesting in Raised/Flat Buttons

### DIFF
--- a/docs/src/app/components/pages/components/buttons.jsx
+++ b/docs/src/app/components/pages/components/buttons.jsx
@@ -14,11 +14,19 @@ var ButtonPage = React.createClass({
       '<FlatButton label="Default" />\n' +
       '<FlatButton label="Primary" primary={true} />\n' +
       '<FlatButton label="Secondary" secondary={true} />\n' +
+      '<FlatButton secondary={true}>\n' +
+      '  <span className="mui-flat-button-label image-button">Choose an Image</span>\n' +
+      '  <input type="file" id="imageButton" className="image-input"></input>\n' +
+      '</FlatButton>\n' +
       '<FlatButton label="Disabled" disabled={true} />\n\n' +
       '//Raised Buttons\n' + 
       '<RaisedButton label="Default" />\n' +
       '<RaisedButton label="Primary" primary={true} />\n' +
       '<RaisedButton label="Secondary" secondary={true} />\n' +
+      '<RaisedButton secondary={true}>\n' +
+      '  <span className="mui-raised-button-label image-button">Choose an Image</span>\n' +
+      '  <input type="file" id="imageButton" className="image-input"></input>\n' +
+      '</RaisedButton>\n' +
       '<RaisedButton label="Disabled" disabled={true} />\n\n' +
       '//Floating Action Buttons\n' +
       '<FloatingActionButton iconClassName="muidocs-icon-action-grade" />\n' +
@@ -37,11 +45,13 @@ var ButtonPage = React.createClass({
         name: 'Flat Button',
         infoArray: [
           {
-            name: 'label',
-            type: 'string',
+            name: 'label or children',
+            type: 'string (label) or HTML/React elements (children)',
             header: 'required',
-            desc: 'This is the text to display inside the button. This only applies to flat and ' +
-              'raised buttons.'
+            desc: 'This is what will be displayed inside the button. If a label is specified, the text within the label prop will be displayed.'+
+            ' Otherwise, the component will expect children which will then be displayed (in our example, we are nesting an <input type="file" />'+
+            'and a span that acts as our label to be displayed.) '+
+            'This only applies to flat and raised buttons.'
           },
           {
             name: 'linkButton',
@@ -67,11 +77,13 @@ var ButtonPage = React.createClass({
         name: 'Raised Button',
         infoArray: [
           {
-            name: 'label',
-            type: 'string',
+            name: 'label or children',
+            type: 'string (label) or HTML/React elements (children)',
             header: 'required',
-            desc: 'This is the text to display inside the button. This only applies to flat and ' +
-              'raised buttons.'
+            desc: 'This is what will be displayed inside the button. If a label is specified, the text within the label prop will be displayed.'+
+            ' Otherwise, the component will expect children which will then be displayed (in our example, we are nesting an <input type="file" />'+
+            'and a span that acts as our label to be displayed.) '+
+            'This only applies to flat and raised buttons.'
           },
           {
             name: 'linkButton',
@@ -146,6 +158,12 @@ var ButtonPage = React.createClass({
               <FlatButton label="Secondary" secondary={true} />
             </div>
             <div className="button-example-container">
+              <FlatButton secondary={true}>
+                <span className="mui-flat-button-label example-image-button">Choose an Image</span>
+                <input type="file" id="imageButton" className="example-image-input"></input>
+              </FlatButton>
+            </div>
+            <div className="button-example-container">
               <FlatButton label="Disabled" disabled={true} />
             </div>
           </div>
@@ -159,6 +177,12 @@ var ButtonPage = React.createClass({
             </div>
             <div className="button-example-container">
               <RaisedButton label="Secondary" secondary={true} />
+            </div>
+            <div className="button-example-container">
+              <RaisedButton secondary={true}>
+                <span className="mui-raised-button-label example-image-button">Choose an Image</span>
+                <input type="file" id="imageButton" className="example-image-input"></input>
+              </RaisedButton>
             </div>
             <div className="button-example-container">
               <RaisedButton label="Disabled" disabled={true} />

--- a/docs/src/app/components/pages/components/buttons.jsx
+++ b/docs/src/app/components/pages/components/buttons.jsx
@@ -3,6 +3,7 @@ var mui = require('mui');
 var FlatButton = mui.FlatButton;
 var FloatingActionButton = mui.FloatingActionButton;
 var RaisedButton = mui.RaisedButton;
+var FontIcon = mui.FontIcon;
 var ComponentDoc = require('../../component-doc.jsx');
 
 var ButtonPage = React.createClass({
@@ -15,18 +16,30 @@ var ButtonPage = React.createClass({
       '<FlatButton label="Primary" primary={true} />\n' +
       '<FlatButton label="Secondary" secondary={true} />\n' +
       '<FlatButton secondary={true}>\n' +
-      '  <span className="mui-flat-button-label image-button">Choose an Image</span>\n' +
-      '  <input type="file" id="imageButton" className="image-input"></input>\n' +
+      '  <span className="mui-flat-button-label example-image-button">Choose an Image</span>\n' +
+      '  <input type="file" id="imageButton" className="example-image-input"></input>\n' +
       '</FlatButton>\n' +
+      '<div className="button-example-container">\n' +
+      '  <FlatButton linkButton={true} href="https://github.com/callemall/material-ui" secondary={true}>\n' +
+      '    <FontIcon className="muidocs-icon-custom-github example-flat-button-icon"/>\n' +
+      '    <span className="mui-flat-button-label">Github</span>\n' +
+      '  </FlatButton>\n' +
+      '</div>\n' +
       '<FlatButton label="Disabled" disabled={true} />\n\n' +
       '//Raised Buttons\n' + 
       '<RaisedButton label="Default" />\n' +
       '<RaisedButton label="Primary" primary={true} />\n' +
       '<RaisedButton label="Secondary" secondary={true} />\n' +
       '<RaisedButton secondary={true}>\n' +
-      '  <span className="mui-raised-button-label image-button">Choose an Image</span>\n' +
-      '  <input type="file" id="imageButton" className="image-input"></input>\n' +
+      '  <span className="mui-raised-button-label example-image-button">Choose an Image</span>\n' +
+      '  <input type="file" id="imageButton" className="example-image-input"></input>\n' +
       '</RaisedButton>\n' +
+      '<div className="button-example-container">\n' +
+      '  <RaisedButton linkButton={true} href="https://github.com/callemall/material-ui" secondary={true}>\n' +
+      '    <FontIcon className="muidocs-icon-custom-github example-button-icon"/>\n' +
+      '    <span className="mui-raised-button-label example-icon-button-label">Github</span>\n' +
+      '  </RaisedButton>\n' +
+      '</div>\n' +
       '<RaisedButton label="Disabled" disabled={true} />\n\n' +
       '//Floating Action Buttons\n' +
       '<FloatingActionButton iconClassName="muidocs-icon-action-grade" />\n' +
@@ -164,6 +177,12 @@ var ButtonPage = React.createClass({
               </FlatButton>
             </div>
             <div className="button-example-container">
+              <FlatButton linkButton={true} href="https://github.com/callemall/material-ui" secondary={true}>
+                <FontIcon className="muidocs-icon-custom-github example-flat-button-icon"/>
+                <span className="mui-flat-button-label">Github</span>
+              </FlatButton>
+            </div>
+            <div className="button-example-container">
               <FlatButton label="Disabled" disabled={true} />
             </div>
           </div>
@@ -181,7 +200,13 @@ var ButtonPage = React.createClass({
             <div className="button-example-container">
               <RaisedButton secondary={true}>
                 <span className="mui-raised-button-label example-image-button">Choose an Image</span>
-                <input type="file" id="imageButton" className="example-image-input"></input>
+                <input type="file" className="example-image-input"></input>
+              </RaisedButton>
+            </div>
+            <div className="button-example-container">
+              <RaisedButton linkButton={true} href="https://github.com/callemall/material-ui" secondary={true}>
+                <FontIcon className="muidocs-icon-custom-github example-button-icon"/>
+                <span className="mui-raised-button-label example-icon-button-label">Github</span>
               </RaisedButton>
             </div>
             <div className="button-example-container">

--- a/docs/src/less/pages/components/buttons.less
+++ b/docs/src/less/pages/components/buttons.less
@@ -17,3 +17,28 @@
     }
   }
 }
+
+.example-image-button {
+  white-space: pre;
+  cursor: pointer;
+  position: relative;
+  text-align: center;
+  line-height: 24px;
+  width: 50%;
+  top: 0px;
+  left: 0px;
+  margin-top: 24px;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.example-image-input {
+  cursor: pointer;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  width: 100%;
+  opacity: 0;
+}

--- a/docs/src/less/pages/components/buttons.less
+++ b/docs/src/less/pages/components/buttons.less
@@ -42,3 +42,24 @@
   width: 100%;
   opacity: 0;
 }
+
+.example-button-icon {
+  .mui-text-full-white;
+  height: 100%;
+  display: inline-block;
+  vertical-align: middle;
+  float: left;
+  padding-left: 6px;
+  line-height: 36px;
+}
+
+.example-icon-button-label {
+  padding-left: 6px!important; 
+}
+
+.example-flat-button-icon {
+  display: inline-block;
+  float: left;
+  line-height: 36px;
+  padding-right: 6px; 
+}

--- a/src/js/enhanced-button.jsx
+++ b/src/js/enhanced-button.jsx
@@ -52,7 +52,9 @@ var EnhancedButton = React.createClass({
       <TouchRipple
         ref="touchRipple"
         key="touchRipple"
-        centerRipple={centerRipple} />
+        centerRipple={centerRipple}>
+        {this.props.children}
+        </TouchRipple>
     );
     var focusRipple = (
       <FocusRipple
@@ -67,8 +69,7 @@ var EnhancedButton = React.createClass({
       onTouchTap: this._handleTouchTap
     };
     var buttonChildren = [
-      this.props.children,
-      disabled || disableTouchRipple ? null : touchRipple,
+      disabled || disableTouchRipple ? this.props.children : touchRipple,
       disabled || disableFocusRipple ? null : focusRipple
     ];
 

--- a/src/js/flat-button.jsx
+++ b/src/js/flat-button.jsx
@@ -8,7 +8,11 @@ var FlatButton = React.createClass({
 
   propTypes: {
     className: React.PropTypes.string,
-    label: React.PropTypes.string.isRequired,
+    label: function(props, propName, componentName){
+      if (!props.children && !props.label) {
+        return new Error('Warning: Required prop `label` or `children` was not specified in `'+ componentName + '`.')
+      }
+    },
     primary: React.PropTypes.bool,
     secondary: React.PropTypes.bool
   },
@@ -24,11 +28,15 @@ var FlatButton = React.createClass({
       'mui-is-primary': primary,
       'mui-is-secondary': !primary && secondary
     });
+    var children;
+
+    if (label) children = <span className="mui-flat-button-label">{label}</span>;
+    else children = this.props.children;
 
     return (
       <EnhancedButton {...other}
         className={classes}>
-        <span className="mui-flat-button-label">{label}</span>
+        {children}
       </EnhancedButton>
     );
   }

--- a/src/js/raised-button.jsx
+++ b/src/js/raised-button.jsx
@@ -9,7 +9,11 @@ var RaisedButton = React.createClass({
 
   propTypes: {
     className: React.PropTypes.string,
-    label: React.PropTypes.string.isRequired,
+    label: function(props, propName, componentName){
+      if (!props.children && !props.label) {
+        return new Error('Warning: Required prop `label` or `children` was not specified in `'+ componentName + '`.')
+      }
+    },
     onMouseDown: React.PropTypes.func,
     onMouseUp: React.PropTypes.func,
     onMouseOut: React.PropTypes.func,
@@ -45,6 +49,10 @@ var RaisedButton = React.createClass({
       'mui-is-primary': primary,
       'mui-is-secondary': !primary && secondary
     });
+    var children;
+
+    if (label) children = <span className="mui-raised-button-label">{label}</span>;
+    else children = this.props.children;
 
     return (
       <Paper className={classes} zDepth={this.state.zDepth}>
@@ -55,7 +63,7 @@ var RaisedButton = React.createClass({
           onMouseOut={this._handleMouseOut}
           onTouchStart={this._handleTouchStart}
           onTouchEnd={this._handleTouchEnd}>
-          <span className="mui-raised-button-label">{label}</span>
+          {children}
         </EnhancedButton>
       </Paper>
     );

--- a/src/js/ripples/touch-ripple.jsx
+++ b/src/js/ripples/touch-ripple.jsx
@@ -35,14 +35,16 @@ var TouchRipple = React.createClass({
 
     return (
       <div
-        className={classes}
         onMouseUp={this._handleMouseUp}
         onMouseDown={this._handleMouseDown}
         onMouseOut={this._handleMouseOut}
         onTouchStart={this._handleTouchStart}
         onTouchEnd={this._handleTouchEnd}>
-        {this._getRippleElements()}
-        <div style={shieldStyle} />
+        <div className={classes}>
+          {this._getRippleElements()}
+          <div style={shieldStyle} />
+        </div>
+        {this.props.children}
       </div>
     );
   },

--- a/src/js/ripples/touch-ripple.jsx
+++ b/src/js/ripples/touch-ripple.jsx
@@ -25,14 +25,6 @@ var TouchRipple = React.createClass({
   render: function() {
     var classes = this.getClasses('mui-touch-ripple');
 
-    //This is needed to keep click events from getting lost
-    //in safari. Without it, onClick won't fire.
-    var shieldStyle = {
-      position: 'absolute',
-      height: '100%',
-      width: '100%'
-    };
-
     return (
       <div
         onMouseUp={this._handleMouseUp}
@@ -42,7 +34,6 @@ var TouchRipple = React.createClass({
         onTouchEnd={this._handleTouchEnd}>
         <div className={classes}>
           {this._getRippleElements()}
-          <div style={shieldStyle} />
         </div>
         {this.props.children}
       </div>


### PR DESCRIPTION
Allows for user to pass down children as opposed to a label to allow for things like creating a material-ui input type='file' and Icon + Text buttons (issue #189). Label or children are required - however, will not accept both. Instead, the children should include the label element or something thereof. This will give the user more control over the button components. Updated docs with examples as well.

It should be noted that in the case of nested elements - the user is responsible for all stylings (ie - all stylings in examples of nested children are not referenced in mui-src. So, if a user wanted to take the input type='file' example, they would want to copy over the stylings in the buttons.less on the docs site.)