### PR TITLE
fix warning when passing element to Dialog title

### DIFF
--- a/docs/src/app/components/pages/components/dialog.jsx
+++ b/docs/src/app/components/pages/components/dialog.jsx
@@ -57,9 +57,9 @@ var DialogPage = React.createClass({
           },
           {
             name: 'title',
-            type: 'string',
+            type: 'node',
             header: 'optional',
-            desc: 'The title string to display on the dialog.'
+            desc: 'The title to display on the dialog. Could be number, string, element or an array containing these types.'
           }
         ]
       },

--- a/src/js/dialog.jsx
+++ b/src/js/dialog.jsx
@@ -7,7 +7,7 @@ var Dialog = React.createClass({
   mixins: [Classable],
 
   propTypes: {
-    title: React.PropTypes.string
+    title: React.PropTypes.node
   },
 
   render: function() {


### PR DESCRIPTION
Allow using font icons etc. in Dialog title without warning in console.