### PR TITLE
Allow removal of debug code in production builds

### DIFF
--- a/src/js/enhanced-switch.jsx
+++ b/src/js/enhanced-switch.jsx
@@ -199,7 +199,7 @@ var EnhancedSwitch = React.createClass({
     if (!this.props.hasOwnProperty('checked') || this.props.checked == false) {
       this.setState({switched: newSwitchedValue});  
       this.refs.checkbox.getDOMNode().checked = newSwitchedValue;
-    } else {
+    } else if (process.NODE_ENV !== 'production') {
       var message = 'Cannot call set method while checked is defined as a property.';
       console.error(message);
     }

--- a/src/js/floating-action-button.jsx
+++ b/src/js/floating-action-button.jsx
@@ -29,11 +29,13 @@ var RaisedButton = React.createClass({
   },
 
   componentDidMount: function() {
-    if (this.props.iconClassName && this.props.children) {
-      var warning = 'You have set both an iconClassName and a child icon. ' +
-                    'It is recommended you use only one method when adding ' +
-                    'icons to FloatingActionButtons.';
-      console.warn(warning);
+    if (process.NODE_ENV !== 'production') {
+      if (this.props.iconClassName && this.props.children) {
+        var warning = 'You have set both an iconClassName and a child icon. ' +
+                      'It is recommended you use only one method when adding ' +
+                      'icons to FloatingActionButtons.';
+        console.warn(warning);
+      }
     }
   },
 

--- a/src/js/icon-button.jsx
+++ b/src/js/icon-button.jsx
@@ -28,12 +28,13 @@ var IconButton = React.createClass({
     if (this.props.tooltip) {
       this._positionTooltip();
     }
-
-    if (this.props.iconClassName && this.props.children) {
-      var warning = 'You have set both an iconClassName and a child icon. ' +
-                    'It is recommended you use only one method when adding ' +
-                    'icons to IconButtons.';
-      console.warn(warning);
+    if (process.NODE_ENV !== 'production') {
+      if (this.props.iconClassName && this.props.children) {
+        var warning = 'You have set both an iconClassName and a child icon. ' +
+                      'It is recommended you use only one method when adding ' +
+                      'icons to IconButtons.';
+        console.warn(warning);
+      }
     }
   },
 

--- a/src/js/input.jsx
+++ b/src/js/input.jsx
@@ -35,7 +35,9 @@ var Input = React.createClass({
   },
 
   componentDidMount: function() {
-    console.warn('Input has been deprecated. Please use TextField instead. See http://material-ui.com/#/components/text-fields');
+    if (process.NODE_ENV !== 'production') {
+      console.warn('Input has been deprecated. Please use TextField instead. See http://material-ui.com/#/components/text-fields');
+    }
   },
 
   render: function() {

--- a/src/js/radio-button-group.jsx
+++ b/src/js/radio-button-group.jsx
@@ -79,10 +79,10 @@ var RadioButtonGroup = React.createClass({
   _updateRadioButtons: function(newSelection) {
     if (this.state.numberCheckedRadioButtons == 0) {
       this.setState({selected: newSelection});
-    } else {
-        var message = "Cannot select a different radio button while another radio button " + 
-                      "has the 'checked' property set to true.";
-        console.error(message);
+    } else if (process.NODE_ENV !== 'production') {
+      var message = "Cannot select a different radio button while another radio button " + 
+                    "has the 'checked' property set to true.";
+      console.error(message);
     }
   },
 

--- a/src/js/text-field.jsx
+++ b/src/js/text-field.jsx
@@ -158,7 +158,7 @@ var TextField = React.createClass({
   },
 
   setErrorText: function(newErrorText) {
-    if (this.props.hasOwnProperty('errorText')) {
+    if (process.NODE_ENV !== 'production' && this.props.hasOwnProperty('errorText')) {
       console.error('Cannot call TextField.setErrorText when errorText is defined as a property.');
     } else if (this.isMounted()) {
       this.setState({errorText: newErrorText});
@@ -166,7 +166,7 @@ var TextField = React.createClass({
   },
 
   setValue: function(newValue) {
-    if (this._isControlled()) {
+    if (process.NODE_ENV !== 'production' && this._isControlled()) {
       console.error('Cannot call TextField.setValue when value or valueLink is defined as a property.');
     } else if (this.isMounted()) {
       this._getInputNode().value = newValue;


### PR DESCRIPTION
By wrapping debug code in conditions with `process.NODE_ENV !== 'production'`, people using compressors that do dead code removal can generate production builds without the debug code.

This is possible using Browserify with the `envify` transform before running code through Uglify (with `--compress dead_code=true`).  React itself uses this same pattern.