### PR TITLE
Allow specifying target for LINK menu item

### DIFF
--- a/src/js/menu.jsx
+++ b/src/js/menu.jsx
@@ -173,7 +173,7 @@ var Menu = React.createClass({
 
         case MenuItem.Types.LINK:
           itemComponent = (
-            <a key={i} index={i} className="mui-menu-item" href={menuItem.payload}>{menuItem.text}</a>
+            <a key={i} index={i} className="mui-menu-item" href={menuItem.payload} target={menuItem.target}>{menuItem.text}</a>
           );
         break;
 


### PR DESCRIPTION
Main use case is being able to open a link from the left nav menu in a separate window/tab.