### PR TITLE
sync height with new props.value ( #355)

### DIFF
--- a/src/js/enhanced-textarea.jsx
+++ b/src/js/enhanced-textarea.jsx
@@ -100,6 +100,12 @@ var EnhancedTextarea = React.createClass({
     }
 
     if (this.props.onChange) this.props.onChange(e);
+  },
+  
+  componentWillReceiveProps: function(nextProps) {
+    if (nextProps.value != this.props.value) {
+      this._syncHeightWithShadow(nextProps.value);
+    }
   }
 });
 


### PR DESCRIPTION
When a value is provided as a prop to EnhancedTextarea, the height should be synced. Fixes part II of #355.