### PR TITLE
AppBar title: node instead of string (update)

### DIFF
--- a/src/js/app-bar.jsx
+++ b/src/js/app-bar.jsx
@@ -11,7 +11,7 @@ var AppBar = React.createClass({
   propTypes: {
     onMenuIconButtonTouchTap: React.PropTypes.func,
     showMenuIconButton: React.PropTypes.bool,
-    title : React.PropTypes.string,
+    title : React.PropTypes.node,
     zDepth: React.PropTypes.number
   },
 
@@ -33,7 +33,11 @@ var AppBar = React.createClass({
       title, menuIconButton;
 
     if (this.props.title) {
-      title = <h1 className="mui-app-bar-title">{this.props.title}</h1>;
+      // If the title is a string, wrap in an h1 tag.
+      // If not, just use it as a node.
+      title = toString.call(this.props.title) === '[object String]' ?
+        <h1 className="mui-app-bar-title">{this.props.title}</h1> :
+        this.props.title;
     }
 
 


### PR DESCRIPTION
This allows for a more generic title, e.g. an image