### PR TITLE
Option to prevent menu close on itemclick

### DIFF
--- a/src/js/drop-down-icon.jsx
+++ b/src/js/drop-down-icon.jsx
@@ -14,12 +14,18 @@ var DropDownIcon = React.createClass({
   propTypes: {
     onChange: React.PropTypes.func,
     menuItems: React.PropTypes.array.isRequired,
-    preventCloseOnMenuItemClick: React.PropTypes.bool
+    closeOnMenuItemClick: React.PropTypes.bool
   },
 
   getInitialState: function() {
     return {
       open: false
+    }
+  },
+  
+  getDefaultProps: function() {
+    return {
+      closeOnMenuItemClick: true
     }
   },
 
@@ -53,7 +59,7 @@ var DropDownIcon = React.createClass({
   _onMenuItemClick: function(e, key, payload) {
     if (this.props.onChange) this.props.onChange(e, key, payload);
     
-    if (!this.props.preventCloseOnMenuItemClick) {
+    if (this.props.closeOnMenuItemClick) {
       this.setState({ open: false });
     }
   }

--- a/src/js/drop-down-icon.jsx
+++ b/src/js/drop-down-icon.jsx
@@ -13,7 +13,8 @@ var DropDownIcon = React.createClass({
 
   propTypes: {
     onChange: React.PropTypes.func,
-    menuItems: React.PropTypes.array.isRequired
+    menuItems: React.PropTypes.array.isRequired,
+    preventCloseOnMenuItemClick: React.PropTypes.bool
   },
 
   getInitialState: function() {
@@ -51,7 +52,10 @@ var DropDownIcon = React.createClass({
 
   _onMenuItemClick: function(e, key, payload) {
     if (this.props.onChange) this.props.onChange(e, key, payload);
-    this.setState({ open: false });
+    
+    if (!this.props.preventCloseOnMenuItemClick) {
+      this.setState({ open: false });
+    }
   }
 
 });


### PR DESCRIPTION
I would like to have the option to prevent menu closing when clicking on items, for example in case of using toggles it's annoying the menu closes on every click. Current PR only focuses on the `drop-down-icon` component, however, if useful, may be applied to other menu components as well.