### PR TITLE
Fix percentage in initial state for Slider

### DIFF
--- a/src/js/slider.jsx
+++ b/src/js/slider.jsx
@@ -36,7 +36,7 @@ var Slider = React.createClass({
   getInitialState: function() {
     var value = this.props.value;
     if (value == null) value = this.props.defaultValue;
-    var percent = value / this.props.max;
+    var percent = (value - this.props.min) / (this.props.max - this.props.min);
     if (isNaN(percent)) percent = 0;
     return {
       value: value,


### PR DESCRIPTION
getInitialState() in Slider doesn't compute percentage value correctly, like setValue() does.  This is only apparent if min is non-zero.