### PR TITLE
Pass selected tab to `onChange` event

### DIFF
--- a/docs/src/app/components/pages/components/tabs.jsx
+++ b/docs/src/app/components/pages/components/tabs.jsx
@@ -8,7 +8,7 @@ var Tabs = mui.Tabs;
 var Tab= mui.Tab;
 
 var TabsPage = React.createClass({
-  
+
   mixins: [Router.Navigation, Router.State],
 
   render: function(){
@@ -51,7 +51,7 @@ var TabsPage = React.createClass({
       'If you need to access a tab directly - you can do so with the first argument of onActive or ' +
       'by accessing the props.children array by passing refs to the Tabs container.';
 
-         
+
 
     var componentInfo = [
       {
@@ -70,7 +70,7 @@ var TabsPage = React.createClass({
         infoArray: [
           {
             name: 'onChange',
-            type: 'function',
+            type: 'function(tabIndex, tab)',
             header: 'optional',
             desc: 'Fired on touch or tap of a tab.'
           }

--- a/src/js/tabs/tabs.jsx
+++ b/src/js/tabs/tabs.jsx
@@ -40,7 +40,10 @@ var Tabs = React.createClass({
   },
 
   handleTouchTap: function(tabIndex, tab){
-    if (this.props.onChange && this.state.selectedIndex !== tabIndex) this.props.onChange(tab);
+    if (this.props.onChange && this.state.selectedIndex !== tabIndex) {
+      this.props.onChange(tabIndex, tab);
+    }
+
     this.setState({selectedIndex: tabIndex});
     //default CB is _onActive. Can be updated in tab.jsx
     if(tab.props.onActive) tab.props.onActive(tab);

--- a/src/js/tabs/tabs.jsx
+++ b/src/js/tabs/tabs.jsx
@@ -40,14 +40,14 @@ var Tabs = React.createClass({
   },
 
   handleTouchTap: function(tabIndex, tab){
-    if (this.props.onChange && this.state.selectedIndex !== tabIndex) this.props.onChange();
+    if (this.props.onChange && this.state.selectedIndex !== tabIndex) this.props.onChange(tab);
     this.setState({selectedIndex: tabIndex});
     //default CB is _onActive. Can be updated in tab.jsx
     if(tab.props.onActive) tab.props.onActive(tab);
   },
 
   render: function(){
-    var _this = this; 
+    var _this = this;
     var width = this.state.fixed ?
       this.state.width/this.props.children.length :
       this.props.tabWidth;


### PR DESCRIPTION
The `Tabs` object has an `onChange` event that has no context
when the event is fired. This will pass in the new tab into the
event so that it now has some context.