### PR TITLE
Prevent the dialog to lose scroll of the page

### DIFF
--- a/src/js/dialog-window.jsx
+++ b/src/js/dialog-window.jsx
@@ -78,7 +78,6 @@ var DialogWindow = React.createClass({
       //allow scrolling
       var body = document.getElementsByTagName('body')[0];
       body.style.overflow = '';
-      body.style.position = '';
     });
 
     this.setState({ open: false });
@@ -89,7 +88,6 @@ var DialogWindow = React.createClass({
     //prevent scrolling
     var body = document.getElementsByTagName('body')[0];
     body.style.overflow = 'hidden';
-    body.style.position = 'fixed';
 
     this.setState({ open: true });
     if (this.props.onShow) this.props.onShow();


### PR DESCRIPTION
When we open a dialog window on a page with a scroll, we lose it once the dialog window is closed.
This can be tested at http://material-ui.com/#/components/dialog