### PR TITLE
Add initialSelectedIndex property to Tabs

### DIFF
--- a/docs/src/app/components/pages/components/tabs.jsx
+++ b/docs/src/app/components/pages/components/tabs.jsx
@@ -58,6 +58,12 @@ var TabsPage = React.createClass({
         name: 'Tabs Props',
         infoArray: [
           {
+            name: 'initialSelectedIndex',
+            type: 'number',
+            header: 'optional',
+            desc: 'Specify initial visible tab index. Initial selected index is set by default to 0. If initialSelectedIndex is set but larger than the total amount of specified tabs, initialSelectedIndex will revert back to default'
+          },
+          {
             name: 'tabWidth',
             type: 'number',
             header: 'optional',

--- a/src/js/tabs/tabs.jsx
+++ b/src/js/tabs/tabs.jsx
@@ -10,8 +10,12 @@ var Tabs = React.createClass({
   },
 
   getInitialState: function(){
+    var selectedIndex = 0;
+    if (this.props.initialSelectedIndex && this.props.initialSelectedIndex < this.props.children.length) {
+      selectedIndex = this.props.initialSelectedIndex;
+    }
     return {
-      selectedIndex: 0
+      selectedIndex: selectedIndex
     };
   },
 

--- a/src/js/tabs/tabs.jsx
+++ b/src/js/tabs/tabs.jsx
@@ -6,7 +6,8 @@ var InkBar = require('../ink-bar');
 var Tabs = React.createClass({
 
   propTypes: {
-    onActive: React.PropTypes.func
+    onActive: React.PropTypes.func,
+    initialSelectedIndex: React.PropTypes.number
   },
 
   getInitialState: function(){

--- a/src/js/tabs/tabs.jsx
+++ b/src/js/tabs/tabs.jsx
@@ -6,8 +6,9 @@ var InkBar = require('../ink-bar');
 var Tabs = React.createClass({
 
   propTypes: {
+    initialSelectedIndex: React.PropTypes.number,
     onActive: React.PropTypes.func,
-    initialSelectedIndex: React.PropTypes.number
+    tabWidth: React.PropTypes.number
   },
 
   getInitialState: function(){


### PR DESCRIPTION
Fixes https://github.com/callemall/material-ui/issues/375. Also checks whether the index is not out of bounds w.r.t. the amount of tab children.