### PR TITLE
Fixes warning displayed in doc/example about invalid prop type #401

### DIFF
--- a/docs/src/app/components/component-doc.jsx
+++ b/docs/src/app/components/component-doc.jsx
@@ -10,7 +10,10 @@ var ComponentDoc = React.createClass({
 
   propTypes: {
     code: React.PropTypes.string.isRequired,
-    desc: React.PropTypes.string,
+    desc: React.PropTypes.oneOfType([
+        React.PropTypes.string,
+        React.PropTypes.element
+    ]),
     name: React.PropTypes.string.isRequired,
     componentInfo: React.PropTypes.array.isRequired
   },


### PR DESCRIPTION
Fixes invalid prop type warning in doc/example to resolve issue #401.