### PR TITLE
Fix Dialog/Overlay Issue #304

### DIFF
--- a/docs/src/app/components/pages/components/date-picker.jsx
+++ b/docs/src/app/components/pages/components/date-picker.jsx
@@ -69,7 +69,7 @@ var DatePickerPage = React.createClass({
 
         <DatePicker
           hintText="Landscape Dialog"
-          mode="landscape"/>
+          mode="landscape" />
 
       </ComponentDoc>
     );

--- a/src/js/dialog-window.jsx
+++ b/src/js/dialog-window.jsx
@@ -40,7 +40,7 @@ var DialogWindow = React.createClass({
 
   componentDidMount: function() {
     this._positionDialog();
-    if (this.props.openImmediately) this._preventScrolling();
+    if (this.props.openImmediately) this.refs.dialogOverlay.preventScrolling();
   },
 
   componentDidUpdate: function (prevProps, prevState) {
@@ -74,10 +74,9 @@ var DialogWindow = React.createClass({
   },
 
   dismiss: function() {
-    var _this = this;
     CssEvent.onTransitionEnd(this.getDOMNode(), function() {
-      _this.refs.dialogOverlay.allowScrolling();
-    });
+      this.refs.dialogOverlay.allowScrolling();
+    }.bind(this));
 
     this.setState({ open: false });
     if (this.props.onDismiss) this.props.onDismiss();

--- a/src/js/dialog-window.jsx
+++ b/src/js/dialog-window.jsx
@@ -40,6 +40,7 @@ var DialogWindow = React.createClass({
 
   componentDidMount: function() {
     this._positionDialog();
+    if (this.props.openImmediately) this._preventScrolling();
   },
 
   componentDidUpdate: function (prevProps, prevState) {
@@ -63,7 +64,7 @@ var DialogWindow = React.createClass({
           {this.props.children}
           {actions}
         </Paper>
-        <Overlay show={this.state.open} onTouchTap={this._handleOverlayTouchTap} />
+        <Overlay ref="dialogOverlay" show={this.state.open} autoLockScrolling={false} onTouchTap={this._handleOverlayTouchTap} />
       </div>
     );
   },
@@ -73,11 +74,9 @@ var DialogWindow = React.createClass({
   },
 
   dismiss: function() {
-
+    var _this = this;
     CssEvent.onTransitionEnd(this.getDOMNode(), function() {
-      //allow scrolling
-      var body = document.getElementsByTagName('body')[0];
-      body.style.overflow = '';
+      _this.refs.dialogOverlay.allowScrolling();
     });
 
     this.setState({ open: false });
@@ -85,9 +84,7 @@ var DialogWindow = React.createClass({
   },
 
   show: function() {
-    //prevent scrolling
-    var body = document.getElementsByTagName('body')[0];
-    body.style.overflow = 'hidden';
+    this.refs.dialogOverlay.preventScrolling();
 
     this.setState({ open: true });
     if (this.props.onShow) this.props.onShow();

--- a/src/js/overlay.jsx
+++ b/src/js/overlay.jsx
@@ -6,7 +6,18 @@ var Overlay = React.createClass({
   mixins: [Classable],
 
   propTypes: {
-    show: React.PropTypes.bool
+    show: React.PropTypes.bool,
+    autoLockScrolling: React.PropTypes.bool
+  },
+  
+  getDefaultProps: function() {
+    return {
+      autoLockScrolling: true
+    };
+  },
+  
+  componentDidUpdate: function(prevProps, prevState) {
+    if (this.props.autoLockScrolling) (this.props.show) ? this._preventScrolling() : this._allowScrolling();
   },
 
   render: function() {
@@ -22,6 +33,24 @@ var Overlay = React.createClass({
     return (
       <div {...other} className={classes} />
     );
+  },
+  
+  preventScrolling: function() {
+    if (!this.props.autoLockScrolling) this._preventScrolling();
+  },
+  
+  allowScrolling: function() {
+    if (!this.props.autoLockScrolling) this._allowScrolling();
+  },
+  
+  _preventScrolling: function() {
+    var body = document.getElementsByTagName('body')[0];
+    body.style.overflow = 'hidden';
+  },
+  
+  _allowScrolling: function() {
+    var body = document.getElementsByTagName('body')[0];
+    body.style.overflow = '';
   }
 
 });


### PR DESCRIPTION
Fixes issue reported in #304. Overlays now control scroll un/locking; dialog-window has been refactored to use Overlay as the controller of scroll un/locking. Undocked left-navs now also prevent scrolling of body content when left-nav is displayed.