### PR TITLE
added inner style to paper to admit inline styling

### DIFF
--- a/src/js/paper.jsx
+++ b/src/js/paper.jsx
@@ -8,6 +8,7 @@ var Paper = React.createClass({
   propTypes: {
     circle: React.PropTypes.bool,
     innerClassName: React.PropTypes.string,
+    innerStyle: React.PropTypes.object,
     rounded: React.PropTypes.bool,
     zDepth: React.PropTypes.oneOf([0,1,2,3,4,5])
   },
@@ -41,7 +42,7 @@ var Paper = React.createClass({
 
     return (
       <div {...other} className={classes}>
-        <div ref="innerContainer" className={insideClasses}>
+        <div ref="innerContainer" className={insideClasses} style={this.props.innerStyle || {}}>
           {this.props.children}
         </div>
       </div>


### PR DESCRIPTION
Does this make sense as a way of styling the inner container in `Paper` if I'm using inline styles e.g. 
```
<Paper
  style={{width:'100%', height:'100%'}}
  innerStyle={{width:'100%', height:'100%'}}>
```