### PR TITLE
Use the `rem` unit.

### DIFF
--- a/docs/src/less/color-palette.less
+++ b/docs/src/less/color-palette.less
@@ -6,11 +6,11 @@
   }
 
   .color {
-    padding: 15px;
+    .mui-px-fallback-padding(1.5rem);
 
     .name {
       display: block;
-      margin-bottom: 60px;
+      .mui-px-fallback(margin-bottom, 6rem);
     }
 
     .hex {
@@ -19,8 +19,8 @@
   }
 
   .color-group {
-    padding-top: 16px;
-    padding-bottom: 16px;
+    .mui-px-fallback(padding-top, 1.6rem);
+    .mui-px-fallback(padding-bottom, 1.6rem);
     display: block;
   }
 
@@ -39,10 +39,10 @@
 
     .neutral {
       .color-group {
-        padding-bottom: 216px;
+        .mui-px-fallback(padding-bottom, 21.6rem);
 
         &:last-child {
-          padding-bottom: 16px;
+          .mui-px-fallback(padding-bottom, 1.6rem);
         }
       }
     }
@@ -55,7 +55,7 @@
 
     .neutral {
       .color-group {
-        padding-bottom: 16px;
+        .mui-px-fallback(padding-bottom, 1.6rem);
       }
     }
   }

--- a/docs/src/less/component-info.less
+++ b/docs/src/less/component-info.less
@@ -4,7 +4,7 @@
   width: 100%;
 
   td {
-    padding: 16px 0;
+    .mui-px-fallback-padding(1.6rem, 0);
     vertical-align: top;
   }
 
@@ -16,7 +16,7 @@
 
   .component-info-type {
     .mui-text-light-black;
-    padding-right: @desktop-gutter;
+    .mui-px-fallback(padding-right, @desktop-gutter);
   }
 
   .component-info-header {
@@ -26,8 +26,8 @@
 
   .component-info-desc {
     width: 100%;
-    padding-top: 48px;
-    border-bottom: solid 1px @border-color;
+    .mui-px-fallback(padding-top, 4.8rem);
+    .mui-px-fallback-border-bottom(0.1rem, solid, @border-color);
 
     p {
       margin: 0;
@@ -43,24 +43,24 @@
   @media @device-medium {
     .component-info-name {
       position: inherit;
-      padding-right: @desktop-gutter;
+      .mui-px-fallback(padding-right, @desktop-gutter);
     }
     .component-info-desc {
-      padding-top: 16px;
+      .mui-px-fallback(padding-top, 1.6rem);
     }
   }
 
   @media @device-large {
     td {
-      padding: 32px 0;
+      .mui-px-fallback-padding(3.2rem, 0);
     }
 
     .component-info-name {
-      min-width: 128px;
+      .mui-px-fallback(min-width, 12.8rem);
     }
 
     .component-info-desc {
-      padding-top: 32px;
+      .mui-px-fallback(padding-top, 3.2rem);
     }
   }
 }

--- a/docs/src/less/font-icons/demo-files/demo.css
+++ b/docs/src/less/font-icons/demo-files/demo.css
@@ -1,14 +1,17 @@
+html {
+	font-size: 62.5%;
+}
 body {
 	padding: 0;
 	margin: 0;
 	font-family: sans-serif;
-	font-size: 1em;
+	font-size: 1.6rem;
 	line-height: 1.5;
 	color: #555;
 	background: #fff;
 }
 h1 {
-	font-size: 1.5em;
+	font-size: 2.4rem;
 	font-weight: normal;
 }
 small {
@@ -19,16 +22,16 @@ a {
 	text-decoration: none;
 }
 a:hover, a:focus {
-	box-shadow: 0 1px #e74c3c;
+	box-shadow: 0 0.1rem #e74c3c;
 }
 .bshadow0, input {
-	box-shadow: inset 0 -2px #e7e7e7;
+	box-shadow: inset 0 -0.2rem #e7e7e7;
 }
 input:hover {
-	box-shadow: inset 0 -2px #ccc;
+	box-shadow: inset 0 -0.2rem #ccc;
 }
 input, fieldset {
-	font-size: 1em;
+	font-size: 1.6rem;
 	margin: 0;
 	padding: 0;
 	border: 0;
@@ -36,15 +39,15 @@ input, fieldset {
 input {
 	color: inherit;
 	line-height: 1.5;
-	height: 1.5em;
-	padding: .25em 0;
+	height: 2.4rem;
+	padding: 0.4rem 0;
 }
 input:focus {
 	outline: none;
-	box-shadow: inset 0 -2px #449fdb;
+	box-shadow: inset 0 -0.2rem #449fdb;
 }
 .glyph {
-	font-size: 16px;
+	font-size: 1.6rem;
 	width: 15em;
 	padding-bottom: 1em;
 	margin-right: 4em;
@@ -72,8 +75,8 @@ input:focus {
 	color: #000;
 }
 p {
-	margin-top: 1em;
-	margin-bottom: 1em;
+	margin-top: 1.6rem;
+	margin-bottom: 1.6rem;
 }
 .mvm {
 	margin-top: .75em;
@@ -133,18 +136,18 @@ p {
 .textbox0 {
 	width: 3em;
 	background: #f1f1f1;
-	padding: .25em .5em;
+	padding: 0.4rem 0.5em;
 	line-height: 1.5;
-	height: 1.5em;
+	height: 2.4rem;
 }
 #testDrive {
 	display: block;
-	padding-top: 24px;
+	padding-top: 2.4rem;
 	line-height: 1.5;
 }
 .fs0 {
-	font-size: 16px;
+	font-size: 1.6rem;
 }
 .fs1 {
-	font-size: 24px;
+	font-size: 2.4rem;
 }

--- a/docs/src/less/footer.less
+++ b/docs/src/less/footer.less
@@ -11,7 +11,7 @@
     margin: 0 auto;
     padding: 0;
     .mui-text-light-white;
-    max-width: 335px;
+    .mui-px-fallback(max-width, 33.5rem);
   }
 
   .mui-icon-button {

--- a/docs/src/less/layout/full-width-section.less
+++ b/docs/src/less/layout/full-width-section.less
@@ -3,17 +3,17 @@
   .clearfix();
 
   .full-width-section-content {
-    max-width: 1200px;
+    .mui-px-fallback(max-width, 120rem);
     margin: 0 auto;
   }
 
   @media @device-small {
-    padding-top: (@desktop-gutter * 2);
-    padding-bottom: (@desktop-gutter * 2);
+    .mui-px-fallback(padding-top, (@desktop-gutter * 2));
+    .mui-px-fallback(padding-bottom, (@desktop-gutter * 2));
   }
 
   @media @device-large {
-    padding-top: (@desktop-gutter * 3);
-    padding-bottom: (@desktop-gutter * 3);
+    .mui-px-fallback(padding-top, (@desktop-gutter * 3));
+    .mui-px-fallback(padding-bottom, (@desktop-gutter * 3));
   }
 }

--- a/docs/src/less/main.less
+++ b/docs/src/less/main.less
@@ -44,7 +44,7 @@ a {
   .mui-app-bar {
     .github-icon-button {
       float: right;
-      margin-right: -16px;
+      .mui-px-fallback(margin-right, -1.6rem);
     }
   }
 }
@@ -53,12 +53,12 @@ a {
   cursor: pointer;
   .mui-font-style-headline;
   .mui-text-full-white;
-  line-height: @app-bar-height;
+  .mui-px-fallback(line-height, @app-bar-height);
   .mui-font-weight-light;
   background-color: @primary-1-color;
-  padding-left: @desktop-gutter;
+  .mui-px-fallback(padding-left, @desktop-gutter);
   padding-top: 0;
-  margin-bottom: @desktop-gutter-mini;
+  .mui-px-fallback(margin-bottom, @desktop-gutter-mini);
 }
 
 .baseline-grid {
@@ -67,35 +67,35 @@ a {
 
 .code-example {
   background-color: @white;
-  margin-bottom: 32px;
+  .mui-px-fallback(margin-bottom, 3.2rem);
 
   .example-label {
     .mui-font-style-menu;
     display: inline-block;
     text-transform: uppercase;
     color: @min-black;
-    padding: @desktop-gutter-mini;
-    border-right: solid 1px @border-color;
-    border-bottom: solid 1px @border-color;
+    .mui-px-fallback-padding(@desktop-gutter-mini);
+    .mui-px-fallback-border-right(0.1rem, solid, @border-color);
+    .mui-px-fallback-border-bottom(0.1rem, solid, @border-color);
     margin-bottom: 0;
-    border-radius: 0 0 2px 0;
+    .mui-px-fallback-border-radius(0, 0, 0.2rem, 0);
   }
 
   .example-block,
   .code-block {
-    padding: @desktop-gutter;
+    .mui-px-fallback-padding(@desktop-gutter);
   }
 
   .code-block {
-    border-top: solid 1px @border-color;
-    border-radius: 0 0 2px 2px;
+    .mui-px-fallback-border-top(0.1rem, solid, @border-color);
+    .mui-px-fallback-border-radius(0, 0, 0.2rem, 0.2rem);
   }
 }
 
 .example-menu {
-  width: (64px * 4);
+  .mui-px-fallback(width, (6.4rem * 4));
 }
 
 .example-menu-nested {
-  width: (64px * 3);
+  .mui-px-fallback(width, (6.4rem * 3));
 }

--- a/docs/src/less/pages/components/buttons.less
+++ b/docs/src/less/pages/components/buttons.less
@@ -3,7 +3,7 @@
 
   .button-example-container {
     text-align: center;
-    margin-bottom: 16px;
+    .mui-px-fallback(margin-bottom, 1.6rem);
   }
 
   .button-example-group {
@@ -18,7 +18,7 @@
   }
 
   .example-icon-button-label {
-    padding-left: 8px; 
+    .mui-px-fallback(padding-left, .8rem); 
   }
 }
 
@@ -27,11 +27,11 @@
   cursor: pointer;
   position: relative;
   text-align: center;
-  line-height: 24px;
+  .mui-px-fallback(line-height, 2.4rem);
   width: 50%;
-  top: 0px;
-  left: 0px;
-  margin-top: 24px;
+  top: 0em;
+  left: 0em;
+  .mui-px-fallback(margin-top, 2.4rem);
   margin-right: auto;
   margin-left: auto;
 }
@@ -53,13 +53,13 @@
   display: inline-block;
   vertical-align: middle;
   float: left;
-  padding-left: 12px;
-  line-height: 36px;
+  .mui-px-fallback(padding-left, 1.2rem);
+  .mui-px-fallback(line-height, 3.6rem);
 }
 
 .example-flat-button-icon {
   display: inline-block;
   float: left;
-  line-height: 36px;
-  padding-left: 12px; 
+  .mui-px-fallback(line-height, 3.6rem);
+  .mui-px-fallback(padding-left, 1.2rem); 
 }

--- a/docs/src/less/pages/components/component-doc.less
+++ b/docs/src/less/pages/components/component-doc.less
@@ -1,21 +1,21 @@
 .component-doc {
 
   .component-doc-desc {
-    border-bottom: solid 1px @border-color;
-    padding-top: 8px;
-    padding-bottom: 40px;
-    margin-bottom: 24px;
+    .mui-px-fallback-border-bottom(0.1rem, solid, @border-color);
+    .mui-px-fallback(padding-top, .8rem);
+    .mui-px-fallback(padding-bottom, 4.0rem);
+    .mui-px-fallback(margin-bottom, 2.4rem);
 
     ol {
-      font-size: 13px;
-      padding-left: 48px;
+      .mui-px-fallback(font-size, 1.3rem);
+      padding-left: 3.6923em;
     }
   }
 
   .component-info {
-    border-top: solid 1px @border-color;
-    padding-top: 24px;
-    margin-top: 24px;
+    .mui-px-fallback-border-top(0.1rem, solid, @border-color);
+    .mui-px-fallback(padding-top, 2.4rem);
+    .mui-px-fallback(margin-top, 2.4rem);
 
     &:first-child {
       border-top: none;

--- a/docs/src/less/pages/components/icon.less
+++ b/docs/src/less/pages/components/icon.less
@@ -2,15 +2,15 @@
   .clearfix();
 
   .icon-example {
-    width: 141px;
-    padding: 16px 8px;
+    .mui-px-fallback(width, 14.1rem);
+    .mui-px-fallback-padding(1.6rem, 0.8rem);
     float: left;
     text-align: center;
 
     .icon-name {
       display: block;
-      padding-top: 8px;
-      height: 48px;
+      .mui-px-fallback(padding-top, .8rem);
+      .mui-px-fallback(height, 4.8rem);
     }
   }
 }

--- a/docs/src/less/pages/components/paper.less
+++ b/docs/src/less/pages/components/paper.less
@@ -1,15 +1,15 @@
 .paper-examples {
 
   .mui-paper {
-    height: 100px;
-    width: 100px;
+    .mui-px-fallback(height, 10rem);
+    .mui-px-fallback(width, 10rem);
     margin: 0 auto;
-    margin-bottom: 64px;
+    .mui-px-fallback(margin-bottom, 6.4rem);
   }
   .mui-paper-container {
     text-align: center;
     p {
-      line-height: 80px;
+      .mui-px-fallback(line-height, 8rem);
       height: 100%;
     }
   }

--- a/docs/src/less/pages/components/switches.less
+++ b/docs/src/less/pages/components/switches.less
@@ -3,14 +3,14 @@
 
   .switches-example-container {
     text-align: left;
-    margin-bottom: 16px;
-    min-height: 24px;
+    .mui-px-fallback(margin-bottom, 1.6rem);
+    .mui-px-fallback(min-height, 2.4rem);
   }
 
   .switches-example-group {
     float: left;
     width: 100%;
-    padding: 0 50px;
+    .mui-px-fallback-padding(0, 5rem);
   }
 
   @media @device-medium {

--- a/docs/src/less/pages/components/text-fields.less
+++ b/docs/src/less/pages/components/text-fields.less
@@ -5,7 +5,7 @@
   .text-field-example-group {
     width: 100%;
     float: left;
-    margin-bottom: 32px;
+    .mui-px-fallback(margin-bottom, 3.2rem);
 
     @media @device-large {
       width: 50%;
@@ -14,7 +14,7 @@
 
   .text-field-example-single-line {
     .mui-text-field {
-      margin-top: 24px;
+      .mui-px-fallback(margin-top, 2.4rem);
     }
   }
 }

--- a/docs/src/less/pages/get-started-page.less
+++ b/docs/src/less/pages/get-started-page.less
@@ -1,6 +1,6 @@
 .get-started-page {
   .full-width-section {
-    max-width: 650px;
+    max-width: 50em;
     margin: 0 auto;
   }
 }

--- a/docs/src/less/pages/home-contribute.less
+++ b/docs/src/less/pages/home-contribute.less
@@ -10,7 +10,7 @@
   }
 
   .mui-raised-button {
-    margin-top: 32px;
+    .mui-px-fallback(margin-top, 3.2rem);
   }
 
 }

--- a/docs/src/less/pages/home-features.less
+++ b/docs/src/less/pages/home-features.less
@@ -8,12 +8,12 @@
     text-align: center;
     margin: 0;
     padding: 0;
-    line-height: @desktop-keyline-increment;
+    .mui-px-fallback(line-height, @desktop-keyline-increment);
   }
 
   .home-feature {
-    max-width: 300px;
-    margin: 0 auto @desktop-gutter auto;
+    max-width: 23.0769em;
+    .mui-px-fallback-margin(0, auto, @desktop-gutter, auto);
 
     &:last-child {
       margin-bottom: 0;
@@ -23,30 +23,30 @@
   .home-feature-image {
     //Not sure why this is needed but it fixes a display
     //issue in chrome
-    margin-bottom: -6px;
+    margin-bottom: -0.6rem;
   }
 
   @media @device-medium {
 
     .feature-container {
       .clearfix();
-      max-width: 906px;
+      max-width: 69.6923em;
     }
 
     .home-feature {
       float: left;
       width: 33%;
-      margin-right: 4px;
+      .mui-px-fallback(margin-right, 0.4rem);
       margin-bottom: 0;
 
       &:first-child {
-        margin-left: -2px;
+        .mui-px-fallback(margin-left, -0.2rem);
       }
 
       &:last-child {
         margin-right: 0;
       }
     }
-    
+
   }
 }

--- a/docs/src/less/pages/home-page-hero.less
+++ b/docs/src/less/pages/home-page-hero.less
@@ -3,14 +3,14 @@
   overflow: hidden;
 
   .svg-logo {
-    margin-left: calc(~'50% - 97px');
-    width: 420px;
+    margin-left: calc(~'50% - 9.7rem');
+    .mui-px-fallback(width, 42rem);
   }
 
   .tagline {
-    margin: 16px auto 0 auto;
+    .mui-px-fallback-margin(1.6rem, auto, 0, auto);
     text-align: center;
-    max-width: 575px;
+    max-width: 44.2308em;
 
     h2 {
       .mui-font-style-title;
@@ -22,8 +22,8 @@
     }
 
     .demo-button, .github-button {
-      margin-right: 32px;
-      margin-top: 16px;
+      .mui-px-fallback(margin-right, 3.2rem);
+      .mui-px-fallback(margin-top, 1.6rem);
 
       .mui-raised-button-label {
         color: @primary-1-color;
@@ -35,10 +35,10 @@
     }
 
     @media @device-large {
-      margin-top: 32px;
+      .mui-px-fallback(margin-top, 3.2rem);
 
       h1 {
-        font-size: 56px;
+        .mui-px-fallback(font-size, 5.6rem);
       }
 
       h2 {

--- a/docs/src/less/pages/home-purpose.less
+++ b/docs/src/less/pages/home-purpose.less
@@ -2,7 +2,7 @@
   background-color: @grey-200;
 
   .full-width-section-content {
-    max-width: 700px;
+    max-width: 35em;
   }
 
   p {

--- a/docs/src/less/pages/page-with-nav.less
+++ b/docs/src/less/pages/page-with-nav.less
@@ -1,13 +1,13 @@
 .page-with-nav {
 
   .page-with-nav-secondary-nav {
-    border-top: solid 1px @grey-300;
+    .mui-px-fallback-border-top(0.1rem, solid, @grey-300);
     overflow: hidden;
   }
 
   .page-with-nav-content {
-    padding: @desktop-gutter;
-    max-width: (@desktop-keyline-increment * 14);
+    .mui-px-fallback(padding, @desktop-gutter);
+    .mui-px-fallback(max-width, (@desktop-keyline-increment * 14));
   }
 
   @media @device-medium {
@@ -18,14 +18,14 @@
     .page-with-nav-secondary-nav {
       border-top: none;
       position: absolute;
-      top: 64px;
-      width: @subNavWidth;
+      .mui-px-fallback(top, 6.4rem);
+      .mui-px-fallback(width, @subNavWidth);
     }
 
     .page-with-nav-content {
-      margin-left: @subNavWidth;
-      border-left: solid 1px @grey-300;
-      min-height: 800px;
+      .mui-px-fallback(margin-left, @subNavWidth);
+      .mui-px-fallback-border-left(0.1rem, solid, @grey-300);
+      .mui-px-fallback(min-height, 80rem);
     }
   }
 }

--- a/example/src/less/main.less
+++ b/example/src/less/main.less
@@ -9,5 +9,5 @@
 //Your custom app styles
 .example-page {
   text-align: center;
-  padding-top: 200px;
+  padding-top: 20rem;
 }

--- a/src/less/components/app-bar.less
+++ b/src/less/components/app-bar.less
@@ -1,17 +1,17 @@
 .mui-app-bar {
   width: 100%;
-  min-height: @desktop-keyline-increment;
-  
+  .mui-px-fallback(min-height, @desktop-keyline-increment);
+
   background-color: @app-bar-color;
   z-index: 5;
 
   .mui-paper-container {
-    padding-left: @desktop-gutter;
-    padding-right: @desktop-gutter;
+    .mui-px-fallback(padding-left, @desktop-gutter);
+    .mui-px-fallback(padding-right, @desktop-gutter);
   }
 
   .mui-icon-button {
-    margin-top: ((@app-bar-height - @icon-button-size) / 2);
+    .mui-px-fallback(margin-top, ((@app-bar-height - @icon-button-size) / 2));
     * {
       fill: @app-bar-text-color;
       color: @app-bar-text-color;
@@ -22,16 +22,16 @@
     .mui-font-style-headline;
     color: @app-bar-text-color;
     padding-top: 0;
-    line-height: @desktop-keyline-increment;
+    .mui-px-fallback(line-height, @desktop-keyline-increment);
     float: left;
   }
 
   .mui-app-bar-navigation-icon-button {
     float: left;
 
-    margin-right: 8px;
+    .mui-px-fallback(margin-right, 0.8rem);
 
-    margin-left: -16px;
+    .mui-px-fallback(margin-left, -1.6rem);
   }
 
 }

--- a/src/less/components/card.less
+++ b/src/less/components/card.less
@@ -1,20 +1,20 @@
 .mui-card {
-  @card-padding: 24px;
+  @card-padding: 2.4rem;
 
   background-color: @white;
-  padding: @card-padding;
+  .mui-px-fallback(padding, @card-padding);
   //.border-radius;
 
   .mui-card-toolbar {
-    margin-top: (@card-padding * -1);
-    margin-left: (@card-padding * -1);
-    margin-right: (@card-padding * -1);
-    margin-bottom: @card-padding;
+    .mui-px-fallback(margin-top, (@card-padding * -1));
+    .mui-px-fallback(margin-left, (@card-padding * -1));
+    .mui-px-fallback(margin-right, (@card-padding * -1));
+    .mui-px-fallback(margin-bottom, @card-padding);
     //border-bottom: solid 1px @border-color;
-    line-height: 56px;
-    height: 56px;
-    padding-left: @card-padding;
-    padding-right: @card-padding;
+    .mui-px-fallback(line-height, 5.6);
+    .mui-px-fallback(height, 5.6);
+    .mui-px-fallback(padding-left, @card-padding);
+    .mui-px-fallback(padding-right, @card-padding);
     .mui-font-style-menu;
   }
 }

--- a/src/less/components/checkbox.less
+++ b/src/less/components/checkbox.less
@@ -1,10 +1,10 @@
 .mui-checkbox {
   .mui-checkbox-icon {
-    @checkbox-size: 24px;
+    @checkbox-size: 2.4rem;
 
-    height: @checkbox-size;
-    width: @checkbox-size;
-    margin-right: @desktop-gutter-less;
+    .mui-px-fallback(height, @checkbox-size);
+    .mui-px-fallback(width, @checkbox-size);
+    .mui-px-fallback(margin-right, @desktop-gutter-less);
 
     .mui-checkbox-check {
       position: absolute;
@@ -34,7 +34,7 @@
         .ease-out(@duration: .45s; @delay: 0s);
         opacity: 1;
         transform: scale(1);
-        transform-origin: 50% 50%; 
+        transform-origin: 50% 50%;
 
         transition:
           opacity 0ms @ease-out-function 0ms,
@@ -43,7 +43,7 @@
       .mui-checkbox-box {
         .ease-out(@duration: 100s; @delay: 0ms);
         * { fill: @checkbox-checked-color; }
-      } 
+      }
     }
   }
 
@@ -60,7 +60,7 @@
     .mui-checkbox-icon {
       .mui-checkbox-box {
         * { fill: @checkbox-required-color; }
-      } 
+      }
     }
   }
 }

--- a/src/less/components/date-picker/calendar-month.less
+++ b/src/less/components/date-picker/calendar-month.less
@@ -1,8 +1,8 @@
 .mui-date-picker-calendar-month {
 
-  line-height: 32px;
+  .mui-px-fallback(line-height, 3.2rem);
   text-align: center;
-  padding: 8px 14px 0 14px;
+  .mui-px-fallback-padding(0.8rem, 1.4rem, 0);
   background-color: @white;
 
   .mui-date-picker-calendar-month-week {

--- a/src/less/components/date-picker/calendar-toolbar.less
+++ b/src/less/components/date-picker/calendar-toolbar.less
@@ -1,10 +1,10 @@
 .mui-date-picker-calendar-toolbar {
-  height: 48px;
+  .mui-px-fallback(height, 4.8rem);
   position: relative;
 
   .mui-date-picker-calendar-toolbar-title {
-    line-height: 48px;
-    font-size: 14px;
+    .mui-px-fallback(line-height, 4.8rem);
+    .mui-px-fallback(font-size, 1.4rem);
     text-align: center;
     .mui-font-weight-medium;
   }

--- a/src/less/components/date-picker/calendar.less
+++ b/src/less/components/date-picker/calendar.less
@@ -1,21 +1,21 @@
 .mui-date-picker-calendar {
-  font-size: 12px;
+  .mui-px-fallback(font-size, 1.2rem);
 
   .mui-date-picker-calendar-week-title {
     .clearfix();
     .mui-font-weight-medium;
     color: fade(@date-picker-calendar-text-color, 50%);
-    
-    line-height: 12px;
-    padding: 0 14px;
+
+    .mui-px-fallback(line-height, 1.2rem);
+    padding: 0 1.1667em;
   }
 
   .mui-date-picker-calendar-week-title-day {
     list-style: none;
     float: left;
-    width: 32px;
+    width: 2.6667em;
     text-align: center;
-    margin: 0 2px;
+    margin: 0 0.1667em;
   }
 
   .mui-date-picker-calendar-container {
@@ -24,19 +24,19 @@
 
   &.mui-is-4week {
     .mui-date-picker-calendar-container {
-      height: 228px;
+      .mui-px-fallback(height, 22.8rem);
     }
   }
 
   &.mui-is-5week {
     .mui-date-picker-calendar-container {
-      height: 268px;
+      .mui-px-fallback(height, 26.8rem);
     }
-  } 
+  }
 
   &.mui-is-6week {
     .mui-date-picker-calendar-container {
-      height: 308px;
+      .mui-px-fallback(height, 30.8rem);
     }
   }
 }
@@ -47,13 +47,13 @@
   }
 
   .mui-date-picker-calendar-date-display {
-    width: 280px;
+    width: 23.3333em;
     height: 100%;
     float: left;
   }
 
   .mui-date-picker-calendar-container {
-    width: 280px;
+    width: 23.3333em;
     float: right;
   }
 }

--- a/src/less/components/date-picker/date-display.less
+++ b/src/less/components/date-picker/date-display.less
@@ -3,33 +3,33 @@
   position: relative;
 
   .mui-date-picker-date-display-dow {
-    font-size: 13px;
-    height: 32px;
-    line-height: 32px;
+    .mui-px-fallback(font-size, 1.3rem);
+    .mui-px-fallback(height, 3.2rem);
+    .mui-px-fallback(line-height, 3.2rem);
     background-color: @date-picker-select-color;
     color: @date-picker-select-text-color;
-    border-radius: 2px 2px 0 0;
+    .mui-px-fallback-border-radius(0.2rem, 0.2rem, 0, 0);
   }
 
   .mui-date-picker-date-display-date {
-    padding: 16px 0;
+    .mui-px-fallback-padding(1.6rem, 0);
     background-color: @date-picker-color;
     color: @date-picker-text-color;
   }
 
   .mui-date-picker-date-display-month,
   .mui-date-picker-date-display-year {
-    font-size: 22px;
-    line-height: 24px;
-    height: 24px;
+    .mui-px-fallback(font-size, 2.2rem);
+    .mui-px-fallback(line-height, 2.4rem);
+    .mui-px-fallback(height, 2.4rem);
     text-transform: uppercase;
   }
 
   .mui-date-picker-date-display-day {
-    margin: 6px 0;
-    line-height: 58px;
-    height: 58px;
-    font-size: 58px;
+    .mui-px-fallback-margin(0.6rem, 0);
+    .mui-px-fallback(line-height, 5.8rem);
+    .mui-px-fallback(height, 5.8rem);
+    .mui-px-fallback(font-size, 5.8rem);
   }
 
   .mui-date-picker-date-display-year {
@@ -44,41 +44,41 @@
   }
 
   .mui-date-picker-date-display-dow {
-    border-radius: 2px 0 0 0;
+    .mui-px-fallback-border-radius(0.2rem, 0, 0, 0);
   }
 
   .mui-date-picker-date-display-date {
-    padding: 24px 0;
+    .mui-px-fallback-padding(2.4rem, 0);
   }
 
   .mui-date-picker-date-display-day {
-    font-size: 76px;
-    line-height: 76px;
-    height: 76px;
+    .mui-px-fallback(font-size, 7.6rem);
+    .mui-px-fallback(line-height, 7.6rem);
+    .mui-px-fallback(height, 7.6rem);
   }
 
   .mui-date-picker-date-display-month,
   .mui-date-picker-date-display-year {
-     font-size: 26px;
-     line-height: 26px;
-     height: 26px;
+     .mui-px-fallback(font-size, 2.6rem);
+     .mui-px-fallback(line-height, 2.6rem);
+     .mui-px-fallback(height, 2.6rem);
   }
 
   .mui-is-5week {
     .mui-date-picker-date-display-date {
-      padding: 30px 0;
+      .mui-px-fallback-padding(3rem, 0);
     }
     .mui-date-picker-date-display-day {
-      margin: 24px 0;
+      .mui-px-fallback-margin(2.4rem, 0);
     }
   }
 
   .mui-is-6week {
     .mui-date-picker-date-display-date {
-      padding: 50px 0;
+      .mui-px-fallback-padding(5rem, 0);
     }
     .mui-date-picker-date-display-day {
-      margin: 24px 0;
+      .mui-px-fallback-margin(2.4rem, 0);
     }
-  } 
+  }
 }

--- a/src/less/components/date-picker/date-picker-dialog.less
+++ b/src/less/components/date-picker/date-picker-dialog.less
@@ -1,10 +1,10 @@
 .mui-date-picker-dialog {
-  font-size: 14px;
+  .mui-px-fallback(font-size, 1.4rem);
   color: @date-picker-calendar-text-color;
 
   .mui-date-picker-dialog-window {
     &.mui-dialog-window-contents {
-      width: 280px;
+      width: 20em;
     }
   }
 }
@@ -12,7 +12,7 @@
 .mui-is-landscape {
   .mui-date-picker-dialog-window {
     &.mui-dialog-window-contents {
-      width: 560px;
+      width: 40em;
     }
   }
 }

--- a/src/less/components/date-picker/day-button.less
+++ b/src/less/components/date-picker/day-button.less
@@ -1,14 +1,14 @@
 .mui-date-picker-day-button {
   position: relative;
   float: left;
-  width: 36px;
-  padding: 4px 2px;
+  .mui-px-fallback(width, 3.6rem);
+  .mui-px-fallback-padding(0.4rem, 0.2rem);
 
   .mui-date-picker-day-button-select {
     position: absolute;
     background-color: @date-picker-select-color;
-    height: 32px;
-    width: 32px;
+    .mui-px-fallback(height, 3.2rem);
+    .mui-px-fallback(width, 3.2rem);
     opacity: 0;
     border-radius: 50%;
     transform: scale(0);

--- a/src/less/components/dialog-window.less
+++ b/src/less/components/dialog-window.less
@@ -1,8 +1,8 @@
 .mui-dialog-window {
   position: fixed;
   z-index: 10;
-  top: 0px;
-  left: -10000px;
+  top: 0em;
+  .mui-px-fallback(left, -1000rem);
   width: 100%;
   height: 100%;
   transition: left 0ms @ease-out-function 450ms;
@@ -11,7 +11,7 @@
     .ease-out();
     position: relative;
     width: 75%;
-    max-width: (@desktop-keyline-increment * 12);
+    .mui-px-fallback(max-width, (@desktop-keyline-increment * 12));
     margin: 0 auto;
     z-index: 10;
     background: @canvas-color;
@@ -19,23 +19,23 @@
   }
 
   .mui-dialog-window-actions {
-    padding: 8px;
-    margin-bottom: 8px;
+    .mui-px-fallback(padding, 0.8rem);
+    .mui-px-fallback(margin-bottom, 0.8rem);
     width: 100%;
     text-align: right;
 
     .mui-dialog-window-action {
-      margin-right: 8px;
+      .mui-px-fallback(margin-right, 0.8rem);
     }
   }
 
   &.mui-is-shown {
-    left: 0px;
+    left: 0em;
     transition: left 0ms @ease-out-function 0ms;
 
     .mui-dialog-window-contents {
       opacity: 1;
-      top: 0px;
+      top: 0em;
       transform: translate3d(0, @desktop-keyline-increment, 0);
     }
   }

--- a/src/less/components/dialog.less
+++ b/src/less/components/dialog.less
@@ -1,10 +1,11 @@
 .mui-dialog {
   .mui-dialog-title {
-    padding: @desktop-gutter @desktop-gutter 0 @desktop-gutter;
+    .mui-px-fallback-padding(
+      @desktop-gutter, @desktop-gutter, 0, @desktop-gutter);
     margin-bottom: 0;
   }
 
   .mui-dialog-content {
-    padding: @desktop-gutter;
+    .mui-px-fallback(padding, @desktop-gutter);
   }
 }

--- a/src/less/components/drop-down-icon.less
+++ b/src/less/components/drop-down-icon.less
@@ -1,11 +1,11 @@
-@icon-width: 48px;
+@icon-width: 4.8rem;
 
 .mui-drop-down-icon {
   display: inline-block;
-  width: @icon-width !important;
+  .mui-px-fallback(width, @icon-width) !important;
   position: relative;
-  height: @desktop-toolbar-height;
-  font-size: @desktop-drop-down-menu-font-size;
+  .mui-px-fallback(height, @desktop-toolbar-height);
+  .mui-px-fallback(font-size, @desktop-drop-down-menu-font-size);
   cursor: pointer;
 
   &.mui-open {
@@ -19,7 +19,7 @@
         opacity: 0;
       }
       .mui-menu-label {
-        top: (@desktop-toolbar-height / 2);
+        .mui-px-fallback(top, (@desktop-toolbar-height / 2));
         opacity: 0;
       }
     }
@@ -31,13 +31,13 @@
 
   .mui-menu {
     .ease-out;
-    right: -14px !important;
-    top: 9px !important;
+    right: 0.9333em !important;
+    .mui-px-fallback(top, 0.9rem) !important;
 
     .mui-menu-item {
-      padding-right: (@icon-size + (@desktop-gutter-less*2));
-      height: @desktop-drop-down-menu-item-height;
-      line-height: @desktop-drop-down-menu-item-height;
+      .mui-px-fallback(padding-right, (@icon-size + (@desktop-gutter-less*2)));
+      .mui-px-fallback(height, @desktop-drop-down-menu-item-height);
+      .mui-px-fallback(line-height, @desktop-drop-down-menu-item-height);
     }
   }
 }

--- a/src/less/components/drop-down-menu.less
+++ b/src/less/components/drop-down-menu.less
@@ -4,8 +4,8 @@
 
   position: relative;
   display: inline-block;
-  height: @desktop-toolbar-height;
-  font-size: @desktop-drop-down-menu-font-size;
+  .mui-px-fallback(height, @desktop-toolbar-height);
+  .mui-px-fallback(font-size, @desktop-drop-down-menu-font-size);
 
   &.mui-open {
     .mui-menu-control,
@@ -14,7 +14,7 @@
         opacity: 0;
       }
       .mui-menu-label {
-        top: (@desktop-toolbar-height / 2);
+        .mui-px-fallback(top, (@desktop-toolbar-height / 2));
         opacity: 0;
       }
     }
@@ -43,33 +43,35 @@
     }
 
     .mui-menu-label {
-      line-height: @desktop-toolbar-height;
+      .mui-px-fallback(line-height, @desktop-toolbar-height);
       position: absolute;
-      padding-left: @desktop-gutter;
+      .mui-px-fallback(padding-left, @desktop-gutter);
       top: 0;
       opacity: 1;
     }
 
     .mui-menu-drop-down-icon {
       position: absolute;
-      top: ((@desktop-toolbar-height - 24px) / 2);
-      right: @desktop-gutter-less;
+      .mui-px-fallback(top, ((@desktop-toolbar-height - 2.4rem) / 2));
+      .mui-px-fallback(right, @desktop-gutter-less);
       * {
         fill: @drop-down-menu-icon-color;
       }
     }
 
     .mui-menu-control-underline {
-      border-top: solid 1px @border-color;
-      margin: 0 @desktop-gutter;
+      .mui-px-fallback-border-top(0.1rem, solid, @border-color);
+      .mui-px-fallback-margin(0, @desktop-gutter);
     }
   }
 
   .mui-menu {
     .mui-menu-item {
-      padding-right: (@icon-size + @desktop-gutter-less + @desktop-gutter-mini);
-      height: @desktop-drop-down-menu-item-height;
-      line-height: @desktop-drop-down-menu-item-height;
+      .mui-px-fallback(
+        padding-right,
+        (@icon-size + @desktop-gutter-less + @desktop-gutter-mini));
+      .mui-px-fallback(height, @desktop-drop-down-menu-item-height);
+      .mui-px-fallback(line-height, @desktop-drop-down-menu-item-height);
       white-space: nowrap;
     }
   }

--- a/src/less/components/enhanced-switch.less
+++ b/src/less/components/enhanced-switch.less
@@ -1,5 +1,5 @@
 .mui-enhanced-switch {
-  @mui-switch-width: 60px;
+  @mui-switch-width: 6rem;
 
   position: relative;
   cursor: pointer;
@@ -26,21 +26,21 @@
     display: table-column;
 
 
-    .mui-touch-ripple, 
+    .mui-touch-ripple,
     .mui-focus-ripple-inner {
         width: 200%;
         height: 200%;
-        top: -12px;
-        left: -12px;
+        .mui-px-fallback(top, -1.2rem);
+        .mui-px-fallback(bottom, -1.2rem);
     }
   }
-  
+
   .mui-switch-label {
     float: left;
     position: relative;
     display: table-column;
     width: calc(~"100% - @{mui-switch-width}");
-    line-height: 24px;
+    .mui-px-fallback(line-height, 2.4rem);
   }
 
   &.mui-is-switched {

--- a/src/less/components/flat-button.less
+++ b/src/less/components/flat-button.less
@@ -2,15 +2,15 @@
 
   .ease-out();
   .mui-font-style-button;
-  border-radius: 2px;
+  .mui-px-fallback-border-radius(0.2rem);
   user-select: none;
 
   position: relative;
   overflow: hidden;
   background-color: @flat-button-color;
   color: @flat-button-text-color;
-  line-height: @button-height;
-  min-width: @button-min-width;
+  .mui-px-fallback(line-height, @button-height);
+  .mui-px-fallback(min-width, @button-min-width);
   padding: 0;
   margin: 0;
 
@@ -33,7 +33,7 @@
 
   .mui-flat-button-label {
     position: relative;
-    padding: 0 @desktop-gutter-less;
+    .mui-px-fallback-padding(0, @desktop-gutter-less);
   }
 
   &:hover,

--- a/src/less/components/floating-action-button.less
+++ b/src/less/components/floating-action-button.less
@@ -6,10 +6,10 @@
 
   .mui-floating-action-button-container {
     position: relative;
-    height: @floating-action-button-size;
-    width: @floating-action-button-size;
+    .mui-px-fallback(height, @floating-action-button-size);
+    .mui-px-fallback(width, @floating-action-button-size);
     padding: 0;
-    overflow: hidden; 
+    overflow: hidden;
     background-color: @floating-action-button-color;
     border-radius: 50%;
 
@@ -37,7 +37,7 @@
   }
 
   .mui-floating-action-button-icon {
-    line-height: @floating-action-button-size;
+    .mui-px-fallback(line-height, @floating-action-button-size);
     color: @floating-action-button-icon-color;
     fill: @floating-action-button-icon-color;
   }
@@ -56,12 +56,12 @@
 
   &.mui-is-mini {
     .mui-floating-action-button-container {
-      height: @floating-action-button-mini-size;
-      width: @floating-action-button-mini-size;
+      .mui-px-fallback(height, @floating-action-button-mini-size);
+      .mui-px-fallback(width, @floating-action-button-mini-size);
     }
 
     .mui-floating-action-button-icon {
-      line-height: @floating-action-button-mini-size;
+      .mui-px-fallback(line-height, @floating-action-button-mini-size);
     }
   }
 

--- a/src/less/components/font-icon.less
+++ b/src/less/components/font-icon.less
@@ -1,6 +1,6 @@
 .mui-font-icon {
   position: relative;
-  font-size: @icon-size;
+  .mui-px-fallback(font-size, @icon-size);
   display: inline-block;
   user-select: none;
 }

--- a/src/less/components/icon-button.less
+++ b/src/less/components/icon-button.less
@@ -4,22 +4,24 @@
 
   * { .ease-out(); }
   position: relative;
-  padding: (@icon-size / 2);
-  width: @icon-size*2;
-  height: @icon-size*2;
+  .mui-px-fallback-padding(@icon-size / 2);
+  .mui-px-fallback(width, @icon-size * 2);
+  .mui-px-fallback(height, @icon-size * 2);
 
   .mui-focus-ripple {
     .mui-focus-ripple-inner {
       background-color: rgba(0,0,0,0.1);
-      box-shadow: 0px 0px 0px 1px rgba(0,0,0,0.1);
-      border: solid 6px @transparent;
+      .mui-px-fallback-box-shadow(0rem, 0rem, 0rem, 0.1rem, rgba(0, 0, 0, 0.1));
+      .mui-px-fallback(border-width, 6rem);
+      border-style: solid;
+      border-color: @transparent;
       background-clip: padding-box;
       .pulsate(icon-button-focus-ripple-pulsate);
     }
   }
 
-  .mui-icon-button-tooltip {  
-    margin-top: (@icon-button-size + 4);
+  .mui-icon-button-tooltip {
+    .mui-px-fallback(margin-top, (@icon-button-size + 0.4rem));
   }
 
   &.mui-is-disabled {
@@ -40,7 +42,8 @@
   .mui-focus-ripple {
     .mui-focus-ripple-inner {
       background-color: rgba(255,255,255,0.3);
-      box-shadow: 0px 0px 0px 1px rgba(255,255,255,0.3);
+      .mui-px-fallback-box-shadow(
+        0rem, 0rem, 0rem, 0.1rem, rgba(255, 255, 255, 255, 0.3));
     }
   }
 }

--- a/src/less/components/ink-bar.less
+++ b/src/less/components/ink-bar.less
@@ -2,8 +2,8 @@
   bottom: 0;
   display: block;
   background-color: yellow;
-  height: 2px;
-  margin-top: -2px;
+  .mui-px-fallback(height, 0.2rem);
+  .mui-px-fallback(margin-top, -0.2rem);
   position: relative;
   .ease-out(1s, left);
 }

--- a/src/less/components/input.less
+++ b/src/less/components/input.less
@@ -1,21 +1,21 @@
 .mui-input {
   position: relative;
-  margin-top: 24px;
-  margin-bottom: 48px;
+  .mui-px-fallback(margin-top, 2.4rem);
+  .mui-px-fallback(margin-bottom, 4.8rem);
 
   input, textarea {
     background-color: transparent;
-    font-size: @input-font-size;
+    .mui-px-fallback(font-size, @input-font-size);
     border: 0;
     outline: none;
-    border-bottom: 1px solid lightgray;
+    .mui-px-fallback-border-bottom(0.1rem, solid, lightgray);
     padding: 0;
     box-sizing: border-box;
-    padding-bottom: 14px;
+    .mui-px-fallback(padding-bottom, 1.4rem);
 
     &[type='text'], &[type='password'], &[type='email'] {
       display: block;
-      width: @input-width;
+      .mui-px-fallback(width, @input-width);
     }
 
     &:focus, &.mui-is-not-empty, &:disabled[value]:not([value=""]) {
@@ -23,9 +23,9 @@
       box-shadow: none;
       &~.mui-input-placeholder {
         color: blue;
-        font-size: @input-placeholder-size !important;
+        .mui-px-fallback(font-size, @input-placeholder-size) !important;
         font-weight: 300;
-        top: -32px;
+        .mui-px-fallback(top, -3.2rem);
         .ease-out;
       }
       &~.mui-input-highlight {
@@ -63,10 +63,10 @@
     }
 
     &+.mui-input-placeholder {
-      font-size: @input-font-size;
+      .mui-px-fallback(font-size, @input-font-size);
       color: gray;
       position: absolute;
-      top: -4px;
+      .mui-px-fallback(top, -0.4rem);
       //z-index: -1;
       .ease-out;
     }
@@ -77,21 +77,21 @@
     position: absolute;
     background-color: transparent;
     opacity: 0.25;
-    height: 19px;
-    top: -3px;
-    width: (@input-width/2);
+    .mui-px-fallback(height, 1.9rem);
+    .mui-px-fallback(top, -0.3rem);
+    .mui-px-fallback(width, (@input-width)/2);
     z-index: -1;
   }
 
   .mui-input-bar {
     position: relative;
     display: block;
-    width: @input-width;
+    .mui-px-fallback(width, @input-width);
 
     &::before, &::after {
       content: '';
-      height: @input-bar-height;
-      top: (-1 * @input-bar-height);
+      .mui-px-fallback(height, @input-bar-height);
+      .mui-px-fallback(top, (-1 * @input-bar-height));
       width: 0;
       position: absolute;
       .ease-out;
@@ -150,15 +150,15 @@
   }
 
   &.mui-floating {
-    margin-top: @desktop-gutter;
+    .mui-px-fallback(margin-top, @desktop-gutter);
     input, textarea {
       &:focus {
         &+.mui-input-placeholder {
           display: block;
           color: gray;
-          font-size: 16px !important;
+          .mui-px-fallback(font-size, 1.6rem) !important;
           font-weight: 400;
-          top: -4px;
+          .mui-px-fallback(top, 0.4rem);
         }
 
         &.mui-is-not-empty {
@@ -175,12 +175,12 @@
       }
     }
   }
-  
+
   &.mui-disabled { opacity: 0.4 }
 
   &::-webkit-input-placeholder {
     position: absolute !important;
-    top: -20px !important;
+    .mui-px-fallback(top, -2rem) !important;
   }
 
 }

--- a/src/less/components/left-nav.less
+++ b/src/less/components/left-nav.less
@@ -3,17 +3,17 @@
   .mui-left-nav-menu {
     height: 100%;
     position: fixed;
-    width: @left-nav-width;
+    .mui-px-fallback(width, @left-nav-width);
     background-color: @left-nav-color;
     z-index: 10;
-    left: 0px;
-    top: 0px;
+    left: 0em;
+    top: 0em;
     .ease-out();
 
     .mui-menu {
       .mui-menu-item {
-        height: @desktop-left-nav-menu-item-height;
-        line-height: @desktop-left-nav-menu-item-height;
+        .mui-px-fallback(height, @desktop-left-nav-menu-item-height);
+        .mui-px-fallback(line-height, @desktop-left-nav-menu-item-height);
       }
       a.mui-menu-item {
         display: block;
@@ -25,7 +25,8 @@
 
   &.mui-closed {
     .mui-left-nav-menu {
-      transform: translate3d((-1 * @left-nav-width) - 10px, 0, 0);
+      @negative-left-nav-width: -1 * @left-nav-width;
+      transform: translate3d(calc(~'@{negative-left-nav-width} - 1rem'), 0, 0);
     }
   }
 }

--- a/src/less/components/menu-item.less
+++ b/src/less/components/menu-item.less
@@ -1,11 +1,11 @@
 .mui-menu-item {
 
   * { user-select: none }
-  
+
   cursor: pointer;
-  line-height: @menu-item-height;
-  padding-left: @menu-item-padding;
-  padding-right: @menu-item-padding;
+  .mui-px-fallback(line-height, @menu-item-height);
+  .mui-px-fallback(padding-left, @menu-item-padding);
+  .mui-px-fallback(padding-right, @menu-item-padding);
   background-color: fade(@menu-item-hover-color, 0%);
 
   &:hover {
@@ -16,7 +16,7 @@
 
   .mui-menu-item-number {
     float: right;
-    width: 24px;
+    .mui-px-fallback(width, 2.4rem);
     text-align: center;
   }
 
@@ -25,42 +25,42 @@
   }
 
   .mui-menu-item-icon-right {
-    line-height: @menu-item-height;
+    .mui-px-fallback(line-height, @menu-item-height);
     float: right;
   }
 
   .mui-menu-item-icon {
     float: left;
-    line-height: @menu-item-height;
-    margin-right: @desktop-gutter;
+    .mui-px-fallback(line-height, @menu-item-height);
+    .mui-px-fallback(margin-right, @desktop-gutter);
   }
 
   .mui-menu-item-data {
     display: block;
-    padding-left: (@desktop-gutter * 2);
-    line-height: @menu-item-data-height;
-    height: @menu-item-data-height;
+    .mui-px-fallback(padding-left, (@desktop-gutter * 2));
+    .mui-px-fallback(line-height, @menu-item-data-height);
+    .mui-px-fallback(height, @menu-item-data-height);
     vertical-align: top;
-    top: -12px;
+    .mui-px-fallback(top, -1.2rem);
     position: relative;
     .mui-font-weight-light;
   }
 
   .muidocs-icon-custom-arrow-drop-right {
-    margin-right: (@desktop-gutter-mini * -1);
+    .mui-px-fallback(margin-right, (@desktop-gutter-mini * -1));
     color: @drop-down-menu-icon-color;
   }
 
   .mui-toggle {
-    margin-top: ((@menu-item-height - @radio-button-size) / 2);
+    .mui-px-fallback(margin-top, ((@menu-item-height - @radio-button-size) / 2));
     float: right;
-    width: 42px;
+    .mui-px-fallback(width, 4.2rem);
   }
 
   &.mui-is-selected {
     color: @menu-item-selected-text-color;
   }
-    
+
   &.mui-is-disabled {
     color: @disabled-color !important;
     cursor: default;

--- a/src/less/components/menu.less
+++ b/src/less/components/menu.less
@@ -17,25 +17,25 @@
 
     &.mui-visible {
       & > .mui-paper-container {
-        padding-top: @desktop-gutter-mini;
-        padding-bottom: @desktop-gutter-mini;
+        .mui-px-fallback(padding-top, @desktop-gutter-mini);
+        .mui-px-fallback(padding-bottom, @desktop-gutter-mini);
       }
     }
   }
 
   .mui-paper-container {
-    padding-top: @desktop-gutter-mini;
-    padding-bottom: @desktop-gutter-mini;
+    .mui-px-fallback(padding-top, @desktop-gutter-mini);
+    .mui-px-fallback(padding-bottom, @desktop-gutter-mini);
   }
 
   .mui-subheader {
-    padding-left: @menu-subheader-padding;
-    padding-right: @menu-subheader-padding;
+    .mui-px-fallback(padding-left, @menu-subheader-padding);
+    .mui-px-fallback(padding-right, @menu-subheader-padding);
   }
 
   .mui-nested-menu-item {
     position: relative;
-      
+
     &.mui-is-disabled {
         color: @disabled-color;
         cursor: default;

--- a/src/less/components/overlay.less
+++ b/src/less/components/overlay.less
@@ -3,7 +3,7 @@
   height: 100%;
   width: 100%;
   z-index: 9;
-  top: 0px;
+  top: 0em;
 
   left: -100%;
   background-color: rgba(0, 0, 0, 0);
@@ -12,7 +12,7 @@
     background-color 400ms @ease-out-function 0ms;
 
   &.mui-is-shown {
-    left: 0px;
+    left: 0em;
     background-color: @light-black;
     transition:
       left 0ms @ease-out-function 0ms,

--- a/src/less/components/paper.less
+++ b/src/less/components/paper.less
@@ -1,10 +1,10 @@
 .mui-paper {
 
   &.mui-rounded {
-    border-radius: 2px;
+    .mui-px-fallback(border-radius, 0.2rem);
 
     & > .mui-paper-container {
-      border-radius: 2px;
+      .mui-px-fallback(border-radius, 0.2rem);
     }
   }
 
@@ -22,37 +22,37 @@
   }
 
   &.mui-z-depth-1 {
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.24);
+    .mui-px-fallback-box-shadow(0, 0.1rem, 0.4rem, 0, rgba(0, 0, 0, 0.24));
     & > .mui-z-depth-bottom {
-      box-shadow: 0 1px 6px rgba(0, 0, 0, 0.12);
+      .mui-px-fallback-box-shadow(0, 0.1rem, 0.6rem, 0, rgba(0, 0, 0, 0.12));
     }
   }
 
   &.mui-z-depth-2 {
-    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.23);
+    .mui-px-fallback-box-shadow(0, 0.3rem, 1rem, 0, rgba(0, 0, 0, 0.23));
     & > .mui-z-depth-bottom {
-      box-shadow: 0 3px 10px rgba(0, 0, 0, 0.16);
+      .mui-px-fallback-box-shadow(0, 0.3rem, 1rem, 0, rgba(0, 0, 0, 0.23));
     }
   }
 
   &.mui-z-depth-3 {
-    box-shadow: 0 6px 10px rgba(0, 0, 0, 0.23);
+    .mui-px-fallback-box-shadow(0, 0.6rem, 1rem, 0, rgba(0, 0, 0, 0.23));
     & > .mui-z-depth-bottom {
-      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.19);
+      .mui-px-fallback-box-shadow(0, 1rem, 3rem, 0, rgba(0, 0, 0, 0.19));
     }
   }
 
   &.mui-z-depth-4 {
-    box-shadow: 0 10px 18px rgba(0, 0, 0, 0.22);
+    .mui-px-fallback-box-shadow(0, 1rem, 1.8rem, 0, rgba(0, 0, 0, 0.22));
     & > .mui-z-depth-bottom {
-      box-shadow: 0 14px 45px rgba(0, 0, 0, 0.25);
+      .mui-px-fallback-box-shadow(0, 1.4rem, 4.5rem, 0, rgba(0, 0, 0, 0.25));
     }
   }
 
   &.mui-z-depth-5 {
-    box-shadow: 0 15px 20px rgba(0, 0, 0, 0.22);
+    .mui-px-fallback-box-shadow(0, 1.5rem, 2rem, 0, rgba(0, 0, 0, 0.22));
     & > .mui-z-depth-bottom {
-      box-shadow: 0 19px 60px rgba(0, 0, 0, 0.30);
+      .mui-px-fallback-box-shadow(0, 1.9rem, 6rem, 0, rgba(0, 0, 0, 0.30));
     }
   }
 

--- a/src/less/components/radio-button.less
+++ b/src/less/components/radio-button.less
@@ -1,10 +1,10 @@
 .mui-radio-button {
   .mui-radio-button-icon {
-    @radio-button-size: 24px;
+    @radio-button-size: 2.4rem;
 
-    height: @radio-button-size;
-    width: @radio-button-size;
-    margin-right: @desktop-gutter-less;
+    .mui-px-fallback(height, @radio-button-size);
+    .mui-px-fallback(width, @radio-button-size);
+    .mui-px-fallback(margin-right, @desktop-gutter-less);
     
 
     .mui-radio-button-fill {

--- a/src/less/components/raised-button.less
+++ b/src/less/components/raised-button.less
@@ -1,8 +1,8 @@
 .mui-raised-button {
 
   display: inline-block;
-  min-width: @button-min-width;
-  height: @button-height;
+  .mui-px-fallback(min-width, @button-min-width);
+  .mui-px-fallback(height, @button-height);
 
   &, * { .ease-out(); }
 
@@ -11,9 +11,9 @@
     width: 100%;
     padding: 0;
     overflow: hidden;
-    border-radius: 2px;
+    .mui-px-fallback(border-radius, 0.2rem);
     background-color: @raised-button-color;
-    
+
     //This is need so that ripples do not bleed
     //past border radius.
     //See: http://stackoverflow.com/questions/17298739/css-overflow-hidden-not-working-in-chrome-when-parent-has-border-radius-and-chil
@@ -52,9 +52,9 @@
     position: relative;
     .mui-font-style-button;
     margin: 0;
-    padding: 0 @desktop-gutter-less;
+    .mui-px-fallback-padding(0, @desktop-gutter-less);
     user-select: none;
-    line-height: @button-height;
+    .mui-px-fallback(line-height, @button-height);
     color: @raised-button-text-color;
   }
 

--- a/src/less/components/slider.less
+++ b/src/less/components/slider.less
@@ -7,20 +7,21 @@
 
   -webkit-touch-callout: none;
   cursor: default;
-  height: @slider-handle-size-active;
+  .mui-px-fallback(height, @slider-handle-size-active);
   position: relative;
 
   .handle-size(@size) {
-    width: @size;
-    height: @size;
+    .mui-px-fallback(width, @size);
+    .mui-px-fallback(height, @size);
   }
 
   .mui-slider-track {
     position: absolute;
-    top: (@slider-handle-size-active - @slider-track-size) / 2;
+    .mui-px-fallback(
+      top, (@slider-handle-size-active - @slider-track-size) / 2);
     left: 0;
     width: 100%;
-    height: @slider-track-size;
+    .mui-px-fallback(height, @slider-track-size);
   }
 
   .mui-slider-selection {
@@ -39,7 +40,7 @@
 
     .mui-slider-selection-fill {
       background-color: @slider-selection-color;
-      margin-right: @fill-gutter;
+      .mui-px-fallback(margin-right, @fill-gutter);
     }
   }
 
@@ -48,7 +49,7 @@
 
     .mui-slider-selection-fill {
       background-color: @slider-track-color;
-      margin-left: @fill-gutter;
+      .mui-px-fallback(margin-left, @fill-gutter);
     }
   }
 
@@ -58,7 +59,7 @@
     top: 0;
     left: 0%;
     z-index: 1;
-    margin: (@slider-track-size / 2) 0 0 0;
+    .mui-px-fallback-margin((@slider-track-size / 2), 0, 0, 0);
 
     background-clip: padding-box;
     border-radius: 50%;
@@ -77,7 +78,7 @@
 
   &:not(.mui-disabled) {
     .mui-slider-handle {
-      border: 0px solid transparent;
+      border: 0em solid transparent;
       background-color: @slider-selection-color;
       &:active {
         .handle-size(@slider-handle-size-active);
@@ -93,7 +94,8 @@
 
       &:not(.mui-slider-zero) {
         .mui-slider-handle:not(:active) {
-          border: @slider-handle-size solid fade(@slider-selection-color, 20%);
+          .mui-px-fallback-border(
+            @slider-handle-size, solid, fade(@slider-selection-color, 20%));
           .handle-size(@slider-handle-size-active + @slider-handle-size);
         }
       }
@@ -101,21 +103,21 @@
 
     &.mui-slider-zero {
       .mui-slider-handle {
-        border: @slider-track-size solid @slider-track-color;
+        .mui-px-fallback-border(@slider-track-size, solid, @slider-track-color);
         background-color: transparent;
         box-shadow: none;
 
         &:active {
           border-color: @slider-track-color-selected;
-          width: @slider-handle-size-active !important;
-          height: @slider-handle-size-active !important;
+          .mui-px-fallback(width, @slider-handle-size-active) !important;
+          .mui-px-fallback(height, @slider-handle-size-active) !important;
           transition:
             background-color 450ms @ease-out-function,
             width 450ms @ease-out-function,
             height 450ms @ease-out-function;
 
           & ~ .mui-slider-selection-high .mui-slider-selection-fill {
-            margin-left: @slider-handle-size !important;
+            .mui-px-fallback(margin-left, @slider-handle-size) !important;
             .ease-out(@property: margin);
           }
         }
@@ -124,9 +126,10 @@
       &:hover, &:focus {
         .mui-slider-handle {
           @size: @slider-handle-size + @slider-track-size;
-          border: @slider-track-size solid @slider-handle-color-zero;
-          width: @size;
-          height: @size;
+          .mui-px-fallback-border(
+            @slider-track-size, solid, @slider-handle-color-zero);
+          .mui-px-fallback(width, @size);
+          .mui-px-fallback(height, @size);
         }
       }
     }
@@ -149,13 +152,13 @@
 
     &.mui-slider-zero {
       .mui-slider-selection-low .mui-slider-selection-fill {
-        margin-right: @gutter;
+        .mui-px-fallback(margin-right, @gutter);
       }
       .mui-slider-selection-high .mui-slider-selection-fill {
-        margin-left: @gutter;
+        .mui-px-fallback(margin-left, @gutter);
       }
       .mui-slider-handle {
-        border: @slider-track-size solid @slider-track-color;
+        .mui-px-fallback-border(@slider-track-size, solid, @slider-track-color);
         background-color: transparent;
       }
     }

--- a/src/less/components/snackbar.less
+++ b/src/less/components/snackbar.less
@@ -2,21 +2,21 @@
 
   color: @mui-snackbar-text-color;
   background-color: @mui-snackbar-background-color;
-  border-radius: 2px;
-  padding: 0 @desktop-gutter;
-  height: @desktop-subheader-height;
-  line-height: @desktop-subheader-height;
-  min-width: 288px;
-  max-width: 568px;
+  .mui-px-fallback(border-radius, 0.2rem);
+  .mui-px-fallback-padding(0, @desktop-gutter);
+  .mui-px-fallback(height, @desktop-subheader-height);
+  .mui-px-fallback(line-height, @desktop-subheader-height);
+  .mui-px-fallback(min-width, 28.8rem);
+  .mui-px-fallback(max-width, 56.8rem);
 
   position: fixed;
   z-index: 10;
-  bottom: @desktop-gutter;
-  margin-left: @desktop-gutter;
+  .mui-px-fallback(bottom, @desktop-gutter);
+  .mui-px-fallback(margin-left, @desktop-gutter);
 
-  left: -10000px;
+  .mui-px-fallback(left, -1000.0rem);
   opacity: 0;
-  transform: translate3d(0, 20px, 0);
+  transform: translate3d(0, 2rem, 0);
   transition:
     left 0ms @ease-out-function 400ms,
     opacity 400ms @ease-out-function 0ms,
@@ -25,9 +25,9 @@
   .mui-snackbar-action {
     color: @mui-snackbar-action-color;
     float: right;
-    margin-top: 6px;
-    margin-right: -16px;
-    margin-left: @desktop-gutter;
+    .mui-px-fallback(margin-top, 0.6rem);
+    .mui-px-fallback(margin-right, -1.6rem);
+    .mui-px-fallback(margin-left, @desktop-gutter);
     background-color: transparent;
   }
 

--- a/src/less/components/subheader.less
+++ b/src/less/components/subheader.less
@@ -1,15 +1,15 @@
 .mui-subheader {
   .mui-font-style-body-2;
   margin: 0;
-  height: @desktop-subheader-height + @desktop-gutter-mini;
-  line-height: @desktop-subheader-height;
+  .mui-px-fallback(height, @desktop-subheader-height + @desktop-gutter-mini);
+  .mui-px-fallback(line-height, @desktop-subheader-height);
   color: @subheader-text-color;
-  border-top: solid 1px @subheader-border-color;
-  padding-top: @desktop-gutter-mini;
-  margin-top: @desktop-gutter-mini;
+  .mui-px-fallback-border-top(0.1rem, solid, @subheader-border-color);
+  .mui-px-fallback(padding-top, @desktop-gutter-mini);
+  .mui-px-fallback(margin-top, @desktop-gutter-mini);
 
   &:first-child {
-    height: @desktop-subheader-height;
+    .mui-px-fallback(height, @desktop-subheader-height);
     border-top: none;
     padding-top: 0;
     margin-top: 0;

--- a/src/less/components/svg-icon.less
+++ b/src/less/components/svg-icon.less
@@ -1,7 +1,7 @@
 .mui-svg-icon {
   position: relative;
-  height: @icon-size;
-  width: @icon-size;
+  .mui-px-fallback(height, @icon-size);
+  .mui-px-fallback(width, @icon-size);
   display: inline-block;
   user-select: none;
 

--- a/src/less/components/table.less
+++ b/src/less/components/table.less
@@ -1,25 +1,25 @@
-@column-width: 200px;
+@column-width: 20rem;
 
 .mui-table {
   //background-color: darken(green, 10%);
-  padding: 0 @desktop-gutter;
+  .mui-px-fallback-padding(0, @desktop-gutter);
 
   .mui-table-header {
     //background-color: green;
 
     .mui-table-header-column {
       display: inline-block;
-      height: 48px;
-      line-height: 48px;
+      .mui-px-fallback(height, 4.8rem);
+      .mui-px-fallback(line-height, 4.8rem);
       //background-color: lighten(green, 10%);
-      width: @column-width;
+      .mui-px-fallback(width, @column-width);
     }
 
     .mui-table-header-pagify {
       display: inline-block;
       //background-color: lighten(green, 25%);
-      height: 48px;
-      line-height: 48px;
+      .mui-px-fallback(height, 4.8rem);
+      .mui-px-fallback(line-height, 4.8rem);
       float: right;
     }
   }
@@ -28,16 +28,16 @@
     //background-color: lighten(green, 20%);
 
     .mui-table-rows-item {
-      height: 48px;
-      line-height: 48px;
+      .mui-px-fallback(height, 4.8rem);
+      .mui-px-fallback(line-height, 4.8rem);
       //background-color: lighten(green, 30%);
       display: block;
       width: 100%;
     }
 
     .mui-table-rows-actions {
-      height: 48px;
-      line-height: 48px;
+      .mui-px-fallback(height, 4.8rem);
+      .mui-px-fallback(line-height, 4.8rem);
       display: inline-block;
       //background-color: lighten(green, 25%);
       float: right;

--- a/src/less/components/tabs.less
+++ b/src/less/components/tabs.less
@@ -5,7 +5,7 @@
     margin: 0;
     padding: 0;
     width: 100%;
-    height: 48px;
+    .mui-px-fallback(height, 4.8rem);
     background-color: #00bcd4;
     white-space: nowrap;
     display: block;
@@ -16,7 +16,7 @@
       height: 100%;
       cursor: pointer;
       text-align: center;
-      line-height: 48px;
+      .mui-px-fallback(line-height, 4.8rem);
       color: #fff;
       opacity: .6;
       font-size: 14sp;

--- a/src/less/components/text-field.less
+++ b/src/less/components/text-field.less
@@ -2,11 +2,11 @@
   @disabled-text-color: fade(@body-text-color, 30%);
   @error-color: @red-500;
 
-	font-size: 16px;
-  line-height: 24px;
-  
-  width: (64px * 4);
-  height: 48px;
+	.mui-px-fallback(font-size, 1.6rem);
+  .mui-px-fallback(line-height, 2.4rem);
+
+  width: (4em * 4);
+  .mui-px-fallback(height, 4.8rem);
   display: inline-block;
   position: relative;
   .ease-out(@property: height, @duration: 200ms);
@@ -16,7 +16,7 @@
   .mui-text-field-hint,
   .mui-text-field-floating-label {
     position: absolute;
-    line-height: 48px;
+    .mui-px-fallback(line-height, 4.8rem);
     color: @disabled-text-color;
     opacity: 1;
     .ease-out();
@@ -24,9 +24,9 @@
 
   .mui-text-field-error {
     position: absolute;
-    bottom: -10px;
-    font-size: 12px;
-    line-height: 12px;
+    .mui-px-fallback(bottom, -1.0rem);
+    .mui-px-fallback(font-size, 1.2rem);
+    .mui-px-fallback(line-height, 1.2rem);
     color: @error-color;
     .ease-out();
   }
@@ -43,20 +43,20 @@
   }
 
   .mui-text-field-textarea {
-    margin-top: 12px;
+    .mui-px-fallback(margin-top, 1.2rem);
   }
 
   .mui-text-field-underline,
   .mui-text-field-focus-underline {
     position: absolute;
     width: 100%;
-    bottom: 8px;
+    .mui-px-fallback(bottom, 0.8rem);
     margin: 0;
   }
 
   .mui-text-field-focus-underline {
     border-color: @primary-1-color;
-    border-bottom-width: 2px;
+    .mui-px-fallback(border-bottom-width, 0.2rem);
     transform: scaleX(0);
     .ease-out();
   }
@@ -82,7 +82,7 @@
 
     .mui-text-field-underline {
       border: none;
-      height: 40px;
+      .mui-px-fallback(height, 4rem);
       overflow: hidden;
 
       //hack because border style dotted just doesn't look right
@@ -90,7 +90,7 @@
       &:after {
         content: '..............................................................................................................................................................................................................................................................................................................................................................';
         position: absolute;
-        top: 23px;
+        .mui-px-fallback(top, 2.3rem);
         color: @disabled-text-color;
       }
     }
@@ -105,21 +105,21 @@
   //Floating Label Text Field Styles
   //--------------------------------
   &.mui-has-floating-labels {
-    height: 72px;
+    .mui-px-fallback(height, 7.2rem);
 
     .mui-text-field-floating-label {
-      top: 24px;
+      .mui-px-fallback(top, 2.4rem);
       transform: scale(1) translate3d(0, 0, 0);
       transform-origin: left top;
     }
 
     .mui-text-field-hint {
-      top: 24px;
+      .mui-px-fallback(top, 2.4rem);
       opacity: 0;
     }
 
     .mui-text-field-input {
-      padding-top: 24px;
+      .mui-px-fallback(padding-top, 2.4rem);
     }
 
     &.mui-has-value,

--- a/src/less/components/toggle.less
+++ b/src/less/components/toggle.less
@@ -1,42 +1,42 @@
 .mui-toggle {
-  @mui-switch-width: 60px;
-  
+  @mui-switch-width: 6rem;
+
   .mui-toggle-icon {
-    @toggle-track-width: 36px;
+    @toggle-track-width: 3.6rem;
     @toggle-padding-right: calc(@mui-switch-width - @toggle-track-width);
 
-    padding: 4px 0px 6px 2px;
-    margin-right: @desktop-gutter-mini;
+    .mui-px-fallback-padding(0.4rem, 0rem, 0.6rem 0.2rem);
+    .mui-px-fallback(margin-right, @desktop-gutter-mini);
 
     .mui-toggle-track {
       .ease-out;
-      width: @toggle-track-width;
-      height: 14px;
-      border-radius: 30px;
+      .mui-px-fallback(width, @toggle-track-width);
+      .mui-px-fallback(height, 1.4rem);
+      .mui-px-fallback(border-radius, 3rem);
       background-color: @toggle-track-off-color;
     }
 
     .mui-toggle-thumb {
       .ease-out;
       position: absolute;
-      top: 1px;
-      left: 2px;
-      width: @toggle-size;
-      height: @toggle-size;
-      line-height: 24px;
+      .mui-px-fallback(top, 0.1rem);
+      .mui-px-fallback(left, 0.2rem);
+      .mui-px-fallback(width, @toggle-size);
+      .mui-px-fallback(height, @toggle-size);
+      .mui-px-fallback(line-height, 2.4rem);
       border-radius: 50%;
       background-color: @toggle-thumb-off-color;
 
       .mui-paper-container {
         border-radius: 50%;
       }
-      
-      .mui-touch-ripple, 
+
+      .mui-touch-ripple,
       .mui-focus-ripple-inner {
         width: 200%;
         height: 200%;
-        top: -10px;
-        left: -10px;
+        .mui-px-fallback(top, -1rem);
+        .mui-px-fallback(left, -1rem);
       }
     }
   }
@@ -47,7 +47,7 @@
         background-color: @toggle-track-on-color;
       }
       .mui-toggle-thumb {
-        left: 18px;
+        .mui-px-fallback(left, 1.8rem);
         background-color: @toggle-thumb-on-color;
       }
     }
@@ -77,7 +77,4 @@
     }
   }
 }
-
-
-
 

--- a/src/less/components/toolbar.less
+++ b/src/less/components/toolbar.less
@@ -1,38 +1,38 @@
 .mui-toolbar {
   background-color: @toolbar-background-color;
-  height: @toolbar-height;
+  .mui-px-fallback(height, @toolbar-height);
   width: 100%;
-  padding: 0 @desktop-gutter;
+  .mui-px-fallback-padding(0, @desktop-gutter);
 
   .mui-toolbar-group {
     position: relative;
 
     .mui-toolbar-title {
-      padding-right: @desktop-gutter-less;
-      line-height: @toolbar-height;
+      .mui-px-fallback(padding-right, @desktop-gutter-less);
+      .mui-px-fallback(line-height, @toolbar-height);
     }
 
     .mui-toolbar-separator {
       background-color: @toolbar-separator-color;
       display: inline-block;
-      height: @desktop-gutter-more;
-      margin-left: @desktop-gutter;
+      .mui-px-fallback(height, @desktop-gutter-more);
+      .mui-px-fallback(margin-left, @desktop-gutter);
       position: relative;
-      top: ((@toolbar-height - @desktop-gutter-more) / 2);
-      width: 1px;
+      .mui-px-fallback(top, ((@toolbar-height - @desktop-gutter-more) / 2));
+      .mui-px-fallback(width, 0.1rem);
     }
 
     .mui-raised-button,
     .mui-flat-button {
-      margin: 0 @desktop-gutter;
-      margin-top: ((@toolbar-height - @button-height) / 2);
+      .mui-px-fallback-margin(0, @desktop-gutter);
+      .mui-px-fallback(margin-top, ((@toolbar-height - @button-height) / 2));
       position: relative;
     }
 
     .mui-drop-down-menu {
       color: @light-black;
       display: inline-block;
-      margin-right: @desktop-gutter;
+      .mui-px-fallback(margin-right, @desktop-gutter);
 
       .mui-menu-control-bg {
         background-color: @toolbar-menu-hover-color;
@@ -55,8 +55,8 @@
     .mui-font-icon {
       color: @toolbar-icon-color;
       cursor: pointer;
-      line-height: @toolbar-height;
-      padding-left: @desktop-gutter;
+      .mui-px-fallback(line-height, @toolbar-height);
+      .mui-px-fallback(padding-left, @desktop-gutter);
 
       &:hover {
         color: @dark-black;
@@ -72,10 +72,10 @@
       }
 
       &:first-child {
-        margin-left: -24px;
+        .mui-px-fallback(margin-left, -2.4rem);
 
         .mui-toolbar-title {
-          margin-left: 24px;
+          .mui-px-fallback(margin-left, 2.4rem);
         }
       }
     }
@@ -88,7 +88,7 @@
       }
 
       &:last-child {
-        margin-right: -24px;
+        .mui-px-fallback(margin-right, -2.4rem);
       }
     }
   }

--- a/src/less/components/tooltip.less
+++ b/src/less/components/tooltip.less
@@ -2,14 +2,14 @@
   position: absolute;
 
   font-family: @contentFontFamily;
-  font-size: 10px;
-  line-height: 22px;
-  padding: 0 8px;
+  .mui-px-fallback(font-size, 1.0rem);
+  .mui-px-fallback(line-height, 2.2rem);
+  .mui-px-fallback-padding(0, 0.8rem);
   color: @white;
   overflow: hidden;
-  top: -10000px;
+  .mui-px-fallback(top, -1000rem);
 
-  border-radius: 2px;
+  .mui-px-fallback-border-radius(0.2rem);
   user-select: none;
   opacity: 0;
 
@@ -26,7 +26,7 @@
   .mui-tooltip-ripple {
     position: absolute;
     left: 50%;
-    top: 0px;
+    top: 0em;
 
     transform: translate(-50%, -50%);
     border-radius: 50%;
@@ -39,12 +39,12 @@
   }
 
   &.mui-is-shown {
-    top: -16px;
+    .mui-px-fallback(top, -1.6rem);
     opacity: 1;
-    transform: translate3d(0px, 16px, 0px);
+    transform: translate3d(0rem, 1.6rem, 0rem);
 
     transition:
-      top 0ms @ease-out-function 0ms, 
+      top 0ms @ease-out-function 0ms,
       transform 450ms @ease-out-function 0ms,
       opacity 450ms @ease-out-function 0ms;
 
@@ -59,14 +59,14 @@
   }
 
   &.mui-is-touch {
-    font-size: 14px;
-    line-height: 44px;
-    padding: 0 16px;
+    .mui-px-fallback(font-size, 1.4rem);
+    .mui-px-fallback(line-height, 4.4rem);
+    padding: 0 1.1429em;
 
     &.mui-is-shown {
       .mui-tooltip-ripple {
-        height: 105px;
-        width: 105px;
+        .mui-px-fallback(height, 10.5rem);
+        .mui-px-fallback(width, 10.5rem);
       }
     }
   }

--- a/src/less/components/transition-groups/slide-in.less
+++ b/src/less/components/transition-groups/slide-in.less
@@ -7,8 +7,8 @@
     position: absolute;
     height: 100%;
     width: 100%;
-    top: 0px;
-    left: 0px;
+    top: 0em;
+    left: 0em;
     .ease-out();
   }
 

--- a/src/less/core/base.less
+++ b/src/less/core/base.less
@@ -27,5 +27,5 @@ html {
 
 hr {
   border: none;
-  border-bottom: solid 1px @border-color;
+  .mui-px-fallback-border-bottom(0.1rem, solid, @border-color);
 }

--- a/src/less/core/keylines.less
+++ b/src/less/core/keylines.less
@@ -1,9 +1,9 @@
 .mui-keywidth(@width) {
-  width: (@width * @desktop-keyline-increment);
+  .mui-px-fallback(width, (@width * @desktop-keyline-increment));
 }
 
 .mui-keyheight(@height) {
-  height: (@height * @desktop-keyline-increment);
+  .mui-px-fallback(height, (@height * @desktop-keyline-increment));
 }
 
 .mui-key-width-1 { .mui-keywidth(1); }

--- a/src/less/core/layouts.less
+++ b/src/less/core/layouts.less
@@ -1,12 +1,12 @@
 .mui-predefined-layout-1 {
 
   .mui-app-content-canvas {
-    padding-top: (@app-bar-height);
+    .mui-px-fallback(padding-top, (@app-bar-height));
   }
 
   .mui-app-bar {
     position: fixed;
-    height: @app-bar-height;
+    .mui-px-fallback(height, @app-bar-height);
   }
 
 }

--- a/src/less/core/typography.less
+++ b/src/less/core/typography.less
@@ -12,69 +12,69 @@
 
 /* Type Styles */
 .mui-font-style-display-4 {
-  font-size:   112px;
-  line-height: 128px;
-  letter-spacing: -7px;
-  padding-top: 17px;
-  margin-bottom: 15px;
+  .mui-px-fallback(font-size, 11.2rem);
+  .mui-px-fallback(line-height, 12.8rem);
+  letter-spacing: -0.0625em;
+  .mui-px-fallback(padding-top, 1.7rem);
+  .mui-px-fallback(margin-bottom, 1.5rem);
   .mui-font-weight-light;
   .mui-text-light-black;
 }
 
 .mui-font-style-display-3 {
-  font-size: 56px;
-  line-height: 64px;
-  letter-spacing: -2px;
-  padding-top: 8px;
-  margin-bottom: 28px;
+  .mui-px-fallback(font-size, 5.6rem);
+  .mui-px-fallback(line-height, 6.4rem);
+  letter-spacing: -0.0357em;
+  .mui-px-fallback(padding-top, 0.8rem);
+  .mui-px-fallback(margin-bottom, 2.8rem);
   .mui-font-weight-normal;
   .mui-text-light-black;
 }
 
 .mui-font-style-display-2 {
-  font-size: 45px;
-  line-height: 48px;
-  margin-bottom: 11px;
-  letter-spacing: -1px;
+  .mui-px-fallback(font-size, 4.5rem);
+  .mui-px-fallback(line-height, 4.8rem);
+  .mui-px-fallback(margin-bottom, 1.1rem);
+  letter-spacing: -0.0222em;
   .mui-font-weight-normal;
   .mui-text-light-black;
 }
 
 .mui-font-style-display-1 {
-  font-size: 34px;
-  line-height: 40px;
-  padding-top: 8px;
-  margin-bottom: 12px;
-  letter-spacing: -1px;
+  .mui-px-fallback(font-size, 3.4rem);
+  .mui-px-fallback(line-height, 4rem);
+  .mui-px-fallback(padding-top, 0.8rem);
+  .mui-px-fallback(margin-bottom, 1.2rem);
+  letter-spacing: -0.0294em;
   .mui-font-weight-normal;
   .mui-text-light-black;
 }
 
 .mui-font-style-headline {
-  font-size: 24px;
-  line-height: 32px;
-  padding-top: 16px;
-  margin-bottom: 12px;
+  .mui-px-fallback(font-size, 2.4rem);
+  .mui-px-fallback(line-height, 3.2rem);
+  .mui-px-fallback(padding-top, 1.6rem);
+  .mui-px-fallback(margin-bottom, 1.2rem);
   letter-spacing: 0;
   .mui-font-weight-normal;
   .mui-text-dark-black;
 }
 
 .mui-font-style-title {
-  font-size: 20px;
-  line-height: 28px;
-  padding-top: 19px;
-  margin-bottom: 13px;
+  .mui-px-fallback(font-size, 2rem);
+  .mui-px-fallback(line-height, 2.8rem);
+  .mui-px-fallback(padding-top, 1.9rem);
+  .mui-px-fallback(margin-bottom, 1.3rem);
   letter-spacing: 0;
   .mui-font-weight-medium;
   .mui-text-dark-black;
 }
 
 .mui-font-style-subhead-2 {
-  font-size: 15px;
-  line-height: 28px;
-  padding-top: 2px;
-  margin-bottom: 10px;
+  .mui-px-fallback(font-size, 1.5rem);
+  .mui-px-fallback(line-height, 2.8rem);
+  .mui-px-fallback(padding-top, 0.2rem);
+  .mui-px-fallback(margin-bottom, 1rem);
   letter-spacing: 0;
   .mui-font-weight-normal;
   .mui-text-dark-black;
@@ -82,57 +82,57 @@
 
 .mui-font-style-subhead-1 {
   .mui-font-style-subhead-2;
-  line-height: 24px;
-  padding-top: 3px;
-  margin-bottom: 13px;
+  .mui-px-fallback(line-height, 2.4rem);
+  .mui-px-fallback(padding-top, 0.3rem);
+  .mui-px-fallback(margin-bottom, 1.3rem);
   .mui-text-dark-black;
 }
 
 .mui-font-style-body-2 {
-  font-size: 13px;
-  line-height: 24px;
-  padding-top: 4px;
-  margin-bottom: 12px;
+  .mui-px-fallback(font-size, 1.3rem);
+  .mui-px-fallback(line-height, 2.4rem);
+  .mui-px-fallback(padding-top, 0.4rem);
+  .mui-px-fallback(margin-bottom, 1.2rem);
   letter-spacing: 0;
   .mui-font-weight-medium;
   .mui-text-dark-black;
 }
 
 .mui-font-style-body-1 {
-  font-size: 13px;
-  line-height: 20px;
-  padding-top: 6px;
-  margin-bottom: 14px;
+  .mui-px-fallback(font-size, 1.3rem);
+  .mui-px-fallback(line-height, 2rem);
+  .mui-px-fallback(padding-top, 0.6rem);
+  .mui-px-fallback(margin-bottom, 1.4rem);
   letter-spacing: 0;
   .mui-font-weight-normal;
   .mui-text-dark-black;
 }
 
 .mui-font-style-caption {
-  font-size: 12px;
-  line-height: 20px;
-  padding-top: 6px;
-  margin-bottom: 14px;
+  .mui-px-fallback(font-size, 1.2rem);
+  .mui-px-fallback(line-height, 2rem);
+  .mui-px-fallback(padding-top, 0.6rem);
+  .mui-px-fallback(margin-bottom, 1.4rem);
   letter-spacing: 0;
   .mui-font-weight-normal;
   .mui-text-light-black;
 }
 
 .mui-font-style-menu {
-  font-size: 13px;
-  line-height: 20px;
-  padding-top: 6px;
-  margin-bottom: 14px;
+  .mui-px-fallback(font-size, 1.3rem);
+  .mui-px-fallback(line-height, 2rem);
+  .mui-px-fallback(padding-top, 0.6rem);
+  .mui-px-fallback(margin-bottom, 1.4rem);
   letter-spacing: 0;
   .mui-font-weight-medium;
   .mui-text-dark-black;
 }
 
 .mui-font-style-button {
-  font-size: 14px;
-  line-height: 20px;
-  padding-top: 5px;
-  margin-bottom: 15px;
+  .mui-px-fallback(font-size, 1.4rem);
+  .mui-px-fallback(line-height, 2rem);
+  .mui-px-fallback(padding-top, 0.5rem);
+  .mui-px-fallback(margin-bottom, 1.5rem);
   letter-spacing: 0;
   text-transform: uppercase;
   .mui-font-weight-medium;
@@ -140,9 +140,12 @@
 }
 
 /* General HTML Typography */
+html {
+  font-size: @root-font-size;
+}
 body {
-  font-size: 13px;
-  line-height: 20px;
+  .mui-px-fallback(font-size, 1.3rem);
+  .mui-px-fallback(line-height, 2rem);
 }
 
 h1 { .mui-font-style-display-2; }
@@ -154,5 +157,5 @@ h6 { .mui-font-style-body-2; }
 p  { .mui-font-style-body-1; }
 hr {
   margin-top: 0;
-  margin-bottom: 18px;
+  .mui-px-fallback(margin-bottom, 1.8rem);
 }

--- a/src/less/mixins/mixins.less
+++ b/src/less/mixins/mixins.less
@@ -1,3 +1,4 @@
 @import "clearfix.less";
 @import "no-wrap.less";
+@import "px-fallback.less";
 @import "transitions.less";

--- a/src/less/mixins/px-fallback.less
+++ b/src/less/mixins/px-fallback.less
@@ -1,0 +1,255 @@
+.mui-px-fallback(@property; @value) when (get-unit(@value) = rem) {
+  @value-in-px: unit(@value) * @root-font-size;
+  @{property}: @value-in-px;
+  @{property}: @value;
+}
+
+.mui-px-fallback(@property; @value) when (default()) {
+  @{property}: @value;
+}
+
+
+.mui-px-fallback-trbl(@property, @top, @right, @bottom, @left) {
+  .mui-px-fallback(~'@{property}-top', @top);
+  .mui-px-fallback(~'@{property}-right', @right);
+  .mui-px-fallback(~'@{property}-bottom', @bottom);
+  .mui-px-fallback(~'@{property}-left', @left);
+}
+
+.mui-px-fallback-border(@width, @style, @color) {
+  .mui-px-fallback(border-width, @width);
+  border-style: @style;
+  border-color: @color;
+}
+
+.mui-px-fallback-border-top(@width, @style, @color) {
+  .mui-px-fallback(border-top-width, @width);
+  border-top-style: @style;
+  border-top-color: @color;
+}
+
+.mui-px-fallback-border-right(@width, @style, @color) {
+  .mui-px-fallback(border-right-width, @width);
+  border-right-style: @style;
+  border-right-color: @color;
+}
+
+.mui-px-fallback-border-bottom(@width, @style, @color) {
+  .mui-px-fallback(border-bottom-width, @width);
+  border-bottom-style: @style;
+  border-bottom-color: @color;
+}
+
+.mui-px-fallback-border-left(@width, @style, @color) {
+  .mui-px-fallback(border-left-width, @width);
+  border-left-style: @style;
+  border-left-color: @color;
+}
+
+.mui-px-fallback-border-radius(
+    @top-left,
+    @top-right: @top-left,
+    @bottom-right: @top-left,
+    @bottom-left: @top-right) {
+  .mui-px-fallback(border-top-left-radius, @top-left);
+  .mui-px-fallback(border-top-right-radius, @top-right);
+  .mui-px-fallback(border-bottom-left-radius, @bottom-left);
+  .mui-px-fallback(border-bottom-right-radius, @bottom-right);
+}
+
+.mui-px-fallback-box-shadow(
+      @offset-x; @offset-y; @blur-radius; @spread-radius; @color)
+    when (get-unit(@offset-x) = rem)
+    and (get-unit(@offset-y) = rem)
+    and (get-unit(@blur-radius) = rem)
+    and (get-unit(@spread-radius) = rem) {
+  @offset-x-0: unit(@offset-x) * @root-font-size;
+  @offset-y-0: unit(@offset-y) * @root-font-size;
+  @blur-radius-0: unit(@blur-radius) * @root-font-size;
+  @spread-radius-0: unit(@spread-radius) * @root-font-size;
+  box-shadow: @offset-x-0 @offset-y-0 @blur-radius-0 @spread-radius-0 @color;
+  box-shadow: @offset-x @offset-y @blur-radius @spread-radius @color;
+}
+
+.mui-px-fallback-box-shadow(
+      @offset-x; @offset-y; @blur-radius; @spread-radius; @color)
+    when (get-unit(@offset-x) = rem)
+    and (get-unit(@offset-y) = rem)
+    and (get-unit(@blur-radius) = rem)
+    and not (get-unit(@spread-radius) = rem) {
+  @offset-x-0: unit(@offset-x) * @root-font-size;
+  @offset-y-0: unit(@offset-y) * @root-font-size;
+  @blur-radius-0: unit(@blur-radius) * @root-font-size;
+  box-shadow: @offset-x-0 @offset-y-0 @blur-radius-0 @spread-radius @color;
+  box-shadow: @offset-x @offset-y @blur-radius @spread-radius @color;
+}
+
+.mui-px-fallback-box-shadow(
+      @offset-x; @offset-y; @blur-radius; @spread-radius; @color)
+    when (get-unit(@offset-x) = rem)
+    and (get-unit(@offset-y) = rem)
+    and not (get-unit(@blur-radius) = rem)
+    and (get-unit(@spread-radius) = rem) {
+  @offset-x-0: unit(@offset-x) * @root-font-size;
+  @offset-y-0: unit(@offset-y) * @root-font-size;
+  @spread-radius-0: unit(@spread-radius) * @root-font-size;
+  box-shadow: @offset-x-0 @offset-y-0 @blur-radius @spread-radius-0 @color;
+  box-shadow: @offset-x @offset-y @blur-radius @spread-radius @color;
+}
+
+.mui-px-fallback-box-shadow(
+      @offset-x; @offset-y; @blur-radius; @spread-radius; @color)
+    when (get-unit(@offset-x) = rem)
+    and not (get-unit(@offset-y) = rem)
+    and (get-unit(@blur-radius) = rem)
+    and (get-unit(@spread-radius) = rem) {
+  @offset-x-0: unit(@offset-x) * @root-font-size;
+  @blur-radius-0: unit(@blur-radius) * @root-font-size;
+  @spread-radius-0: unit(@spread-radius) * @root-font-size;
+  box-shadow: @offset-x-0 @offset-y @blur-radius-0 @spread-radius-0 @color;
+  box-shadow: @offset-x @offset-y @blur-radius @spread-radius @color;
+}
+
+.mui-px-fallback-box-shadow(
+      @offset-x; @offset-y; @blur-radius; @spread-radius; @color)
+    when not (get-unit(@offset-x) = rem)
+    and (get-unit(@offset-y) = rem)
+    and (get-unit(@blur-radius) = rem)
+    and (get-unit(@spread-radius) = rem) {
+  @offset-y-0: unit(@offset-y) * @root-font-size;
+  @blur-radius-0: unit(@blur-radius) * @root-font-size;
+  @spread-radius-0: unit(@spread-radius) * @root-font-size;
+  box-shadow: @offset-x @offset-y-0 @blur-radius-0 @spread-radius-0 @color;
+  box-shadow: @offset-x @offset-y @blur-radius @spread-radius @color;
+}
+
+.mui-px-fallback-box-shadow(
+      @offset-x; @offset-y; @blur-radius; @spread-radius; @color)
+    when (get-unit(@offset-x) = rem)
+    and (get-unit(@offset-y) = rem)
+    and not (get-unit(@blur-radius) = rem)
+    and not (get-unit(@spread-radius) = rem) {
+  @offset-x-0: unit(@offset-x) * @root-font-size;
+  @offset-y-0: unit(@offset-y) * @root-font-size;
+  box-shadow: @offset-x-0 @offset-y-0 @blur-radius @spread-radius @color;
+  box-shadow: @offset-x @offset-y @blur-radius @spread-radius @color;
+}
+
+.mui-px-fallback-box-shadow(
+      @offset-x; @offset-y; @blur-radius; @spread-radius; @color)
+    when (get-unit(@offset-x) = rem)
+    and not (get-unit(@offset-y) = rem)
+    and (get-unit(@blur-radius) = rem)
+    and not (get-unit(@spread-radius) = rem) {
+  @offset-x-0: unit(@offset-x) * @root-font-size;
+  @blur-radius-0: unit(@blur-radius) * @root-font-size;
+  box-shadow: @offset-x-0 @offset-y @blur-radius-0 @spread-radius @color;
+  box-shadow: @offset-x @offset-y @blur-radius @spread-radius @color;
+}
+
+.mui-px-fallback-box-shadow(
+      @offset-x; @offset-y; @blur-radius; @spread-radius; @color)
+    when not (get-unit(@offset-x) = rem)
+    and (get-unit(@offset-y) = rem)
+    and (get-unit(@blur-radius) = rem)
+    and not (get-unit(@spread-radius) = rem) {
+  @offset-y-0: unit(@offset-y) * @root-font-size;
+  @blur-radius-0: unit(@blur-radius) * @root-font-size;
+  box-shadow: @offset-x @offset-y-0 @blur-radius-0 @spread-radius @color;
+  box-shadow: @offset-x @offset-y @blur-radius @spread-radius @color;
+}
+
+.mui-px-fallback-box-shadow(
+      @offset-x; @offset-y; @blur-radius; @spread-radius; @color)
+    when (get-unit(@offset-x) = rem)
+    and not (get-unit(@offset-y) = rem)
+    and not (get-unit(@blur-radius) = rem)
+    and (get-unit(@spread-radius) = rem) {
+  @offset-x-0: unit(@offset-x) * @root-font-size;
+  @spread-radius-0: unit(@spread-radius) * @root-font-size;
+  box-shadow: @offset-x-0 @offset-y @blur-radius @spread-radius-0 @color;
+  box-shadow: @offset-x @offset-y @blur-radius @spread-radius @color;
+}
+
+.mui-px-fallback-box-shadow(
+      @offset-x; @offset-y; @blur-radius; @spread-radius; @color)
+    when not (get-unit(@offset-x) = rem)
+    and (get-unit(@offset-y) = rem)
+    and not (get-unit(@blur-radius) = rem)
+    and (get-unit(@spread-radius) = rem) {
+  @offset-y-0: unit(@offset-y) * @root-font-size;
+  @spread-radius-0: unit(@spread-radius) * @root-font-size;
+  box-shadow: @offset-x @offset-y-0 @blur-radius @spread-radius-0 @color;
+  box-shadow: @offset-x @offset-y @blur-radius @spread-radius @color;
+}
+
+.mui-px-fallback-box-shadow(
+      @offset-x; @offset-y; @blur-radius; @spread-radius; @color)
+    when not (get-unit(@offset-x) = rem)
+    and not (get-unit(@offset-y) = rem)
+    and (get-unit(@blur-radius) = rem)
+    and (get-unit(@spread-radius) = rem) {
+  @blur-radius-0: unit(@blur-radius) * @root-font-size;
+  @spread-radius-0: unit(@spread-radius) * @root-font-size;
+  box-shadow: @offset-x @offset-y @blur-radius-0 @spread-radius-0 @color;
+  box-shadow: @offset-x @offset-y @blur-radius @spread-radius @color;
+}
+
+.mui-px-fallback-box-shadow(
+      @offset-x; @offset-y; @blur-radius; @spread-radius; @color)
+    when (get-unit(@offset-x) = rem)
+    and not (get-unit(@offset-y) = rem)
+    and not (get-unit(@blur-radius) = rem)
+    and not (get-unit(@spread-radius) = rem) {
+  @offset-x-0: unit(@offset-x) * @root-font-size;
+  box-shadow: @offset-x-0 @offset-y @blur-radius @spread-radius @color;
+  box-shadow: @offset-x @offset-y @blur-radius @spread-radius @color;
+}
+
+.mui-px-fallback-box-shadow(
+      @offset-x; @offset-y; @blur-radius; @spread-radius; @color)
+    when not (get-unit(@offset-x) = rem)
+    and (get-unit(@offset-y) = rem)
+    and not (get-unit(@blur-radius) = rem)
+    and not (get-unit(@spread-radius) = rem) {
+  @offset-y-0: unit(@offset-y) * @root-font-size;
+  box-shadow: @offset-x @offset-y-0 @blur-radius @spread-radius @color;
+  box-shadow: @offset-x @offset-y @blur-radius @spread-radius @color;
+}
+
+.mui-px-fallback-box-shadow(
+      @offset-x; @offset-y; @blur-radius; @spread-radius; @color)
+    when not (get-unit(@offset-x) = rem)
+    and not (get-unit(@offset-y) = rem)
+    and (get-unit(@blur-radius) = rem)
+    and not (get-unit(@spread-radius) = rem) {
+  @blur-radius-0: unit(@blur-radius) * @root-font-size;
+  box-shadow: @offset-x @offset-y @blur-radius-0 @spread-radius @color;
+  box-shadow: @offset-x @offset-y @blur-radius @spread-radius @color;
+}
+
+.mui-px-fallback-box-shadow(
+      @offset-x; @offset-y; @blur-radius; @spread-radius; @color)
+    when not (get-unit(@offset-x) = rem)
+    and not (get-unit(@offset-y) = rem)
+    and not (get-unit(@blur-radius) = rem)
+    and (get-unit(@spread-radius) = rem) {
+  @spread-radius-0: unit(@spread-radius) * @root-font-size;
+  box-shadow: @offset-x @offset-y @blur-radius @spread-radius-0 @color;
+  box-shadow: @offset-x @offset-y @blur-radius @spread-radius @color;
+}
+
+.mui-px-fallback-box-shadow(
+      @offset-x; @offset-y; @blur-radius; @spread-radius; @color)
+    when (default()) {
+  box-shadow: @offset-x @offset-y @blur-radius @spread-radius @color;
+}
+
+.mui-px-fallback-margin(@top, @right: @top, @bottom: @top, @left: @right) {
+  .mui-px-fallback-trbl(margin, @top, @right, @bottom, @left);
+}
+
+.mui-px-fallback-padding(@top, @right: @top, @bottom: @top, @left: @right) {
+  .mui-px-fallback-trbl(padding, @top, @right, @bottom, @left);
+}
+

--- a/src/less/variables/custom-variables.less
+++ b/src/less/variables/custom-variables.less
@@ -4,6 +4,7 @@
 //Typography
 @headingFontFamily: 'Roboto', sans-serif;
 @contentFontFamily: 'Roboto', sans-serif;
+@root-font-size: 62.5%;
 
 //App Colors
 @primary-1-color: @cyan-500;
@@ -40,8 +41,8 @@
 
 // menu
 @menu-background-color: @white;
-@menu-item-data-height: 32px;
-@menu-item-height: 48px;
+@menu-item-data-height: 3.2rem;
+@menu-item-height: 4.8rem;
 @menu-item-hover-color: rgba(0, 0, 0, .035);
 @menu-item-padding: @desktop-gutter;
 @menu-item-selected-text-color: @accent-1-color;
@@ -49,8 +50,8 @@
 @menu-subheader-padding: @desktop-gutter;
 
 // buttons
-@button-height: 36px;
-@button-min-width: 88px;
+@button-height: 3.6rem;
+@button-min-width: 8.8rem;
 
 @flat-button-color: @white;
 @flat-button-hover-color: darken(@flat-button-color, 10%);
@@ -85,8 +86,8 @@
 @raised-button-disabled-color: @raised-button-hover-color;
 @raised-button-disabled-text-color: fade(@raised-button-text-color, 30%);
 
-@floating-action-button-size: 56px;
-@floating-action-button-mini-size: 40px;
+@floating-action-button-size: 5.6rem;
+@floating-action-button-mini-size: 4rem;
 @floating-action-button-color: @accent-1-color;
 @floating-action-button-icon-color: @white;
 @floating-action-button-hover-color: @raised-button-primary-hover-color;
@@ -101,17 +102,17 @@
 @floating-action-button-disabled-text-color: @raised-button-disabled-text-color;
 
 // input
-@input-width: 320px;
-@input-font-size: 16px;
-@input-placeholder-size: 13px;
+@input-width: 32rem;
+@input-font-size: 1.6rem;
+@input-placeholder-size: 1.3rem;
 @input-error-color: red;
-@input-bar-height: 2px;
+@input-bar-height: 0.2rem;
 
 // switches
 @switches-ripple-color: fade(@primary-1-color, 20%);
 
 // radio button
-@radio-button-size: 24px;
+@radio-button-size: 2.4rem;
 @radio-button-border-color:  @body-text-color;
 @radio-button-background-color: white;
 @radio-button-checked-color: @primary-1-color;
@@ -130,7 +131,7 @@
 @mui-snackbar-action-color: @accent-1-color;
 
 // toggle
-@toggle-size: 20px;
+@toggle-size: 2rem;
 @toggle-thumb-on-color: @primary-1-color;
 @toggle-thumb-off-color: @grey-50;
 @toggle-thumb-disabled-color: @grey-400;
@@ -142,19 +143,19 @@
 
 // toolbar
 @toolbar-background-color: darken(#eeeeee, 5%);
-@toolbar-height: 56px;
+@toolbar-height: 5.6rem;
 @toolbar-icon-color: rgba(0, 0, 0, .40);
 @toolbar-separator-color: rgba(0, 0, 0, .175);
 @toolbar-menu-hover-color: rgba(0, 0, 0, .10);
 @toolbar-menu-hover-color: @white;
 
 // slider
-@slider-track-size: 2px;
+@slider-track-size: 0.2rem;
 @slider-track-color: @min-black;
 @slider-track-color-selected: @grey-500;
-@slider-handle-size: 12px;
+@slider-handle-size: 1.2rem;
 @slider-handle-size-active: @slider-handle-size * 2;
-@slider-handle-size-disabled: 8px;
+@slider-handle-size-disabled: 0.8rem;
 @slider-handle-color-zero: @grey-400;
 @slider-selection-color: @primary-3-color;
 

--- a/src/less/variables/media-queries.less
+++ b/src/less/variables/media-queries.less
@@ -1,4 +1,4 @@
-@device-x-large: ~"only screen and (min-width: 1200px)";
-@device-large:   ~"only screen and (min-width: 992px)";
-@device-medium:  ~"only screen and (min-width: 768px)";
-@device-small:   ~"only screen and (min-width: 375px)";
+@device-x-large: ~"only screen and (min-width: 75em)";
+@device-large:   ~"only screen and (min-width: 62em)";
+@device-medium:  ~"only screen and (min-width: 48em)";
+@device-small:   ~"only screen and (min-width: 23.4375em)";

--- a/src/less/variables/spacing.less
+++ b/src/less/variables/spacing.less
@@ -1,16 +1,13 @@
-@icon-size: 24px;
+@icon-size: 2.4rem;
 
-@desktop-gutter: 24px;
-@desktop-gutter-more: 32px;
-@desktop-gutter-less: 16px;
-@desktop-gutter-mini: 8px;
-@desktop-keyline-increment: 64px;
-@desktop-drop-down-menu-item-height: 32px;
-@desktop-drop-down-menu-font-size: 15px;
-@desktop-left-nav-menu-item-height: 48px;
-@desktop-subheader-height: 48px;
-@desktop-toolbar-height: 56px;
-
-
-
+@desktop-gutter: 2.4rem;
+@desktop-gutter-more: 3.2rem;
+@desktop-gutter-less: 1.6rem;
+@desktop-gutter-mini: 0.8rem;
+@desktop-keyline-increment: 6.4rem;
+@desktop-drop-down-menu-item-height: 3.2rem;
+@desktop-drop-down-menu-font-size: 1.5rem;
+@desktop-left-nav-menu-item-height: 4.8rem;
+@desktop-subheader-height: 4.8rem;
+@desktop-toolbar-height: 5.6rem;
 


### PR DESCRIPTION
Specifically, replace usages of the `px` unit with `rem` or, when it seems more appropriate, the `em` unit.

Mixins are used to keep the `px` unit as a fallback, in case browser compatibility is a concern.

A new variable, `@root-font-size`, is used to set the `font-size` of the `html` element to 10px.