### PR TITLE
Check that the document has element on clickaway

### DIFF
--- a/src/js/mixins/click-awayable.js
+++ b/src/js/mixins/click-awayable.js
@@ -19,7 +19,8 @@ module.exports = {
     // Check if the target is inside the current component
     if (this.isMounted() && 
       e.target != el &&
-      !Dom.isDescendant(el, e.target)) {
+      !Dom.isDescendant(el, e.target) &&
+      document.contains(e.target)) {
       if (this.componentClickAway) this.componentClickAway();
     }
   },


### PR DESCRIPTION
This is for the click-away mixin. I have this click-away mixin for one of my components. In this component I am removing an element, and that element is being removed on click.

React removes this element before the event is bubbled up to click-away. I added 'document.contains(e.target)' to make sure the dom element is in the document prior to saying the user clicked away. This might want to be looked at some more...