### PR TITLE
Updated mui to use peer dependency changes.

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "material-ui-docs",
-  "version": "0.6.1",
+  "version": "0.7.2",
   "description": "Documentation site for material-ui",
   "repository": {
     "type": "git",

--- a/docs/src/app/components/app-left-nav.jsx
+++ b/docs/src/app/components/app-left-nav.jsx
@@ -46,16 +46,16 @@ var AppLeftNav = React.createClass({
 
     for (var i = menuItems.length - 1; i >= 0; i--) {
       currentItem = menuItems[i];
-      if (currentItem.route && this.isActive(currentItem.route)) return i;
+      if (currentItem.route && this.context.router.isActive(currentItem.route)) return i;
     };
   },
 
   _onLeftNavChange: function(e, key, payload) {
-    this.transitionTo(payload.route);
+    this.context.router.transitionTo(payload.route);
   },
 
   _onHeaderClick: function() {
-    this.transitionTo('root');
+    this.context.router.transitionTo('root');
     this.refs.leftNav.close();
   }
 

--- a/docs/src/app/components/master.jsx
+++ b/docs/src/app/components/master.jsx
@@ -15,9 +15,9 @@ var Master = React.createClass({
   render: function() {
 
     var title = 
-      this.isActive('get-started') ? 'Get Started' :
-      this.isActive('css-framework') ? 'Css Framework' :
-      this.isActive('components') ? 'Components' : '';
+      this.context.router.isActive('get-started') ? 'Get Started' :
+      this.context.router.isActive('css-framework') ? 'Css Framework' :
+      this.context.router.isActive('components') ? 'Components' : '';
     var githubButton = (
       <IconButton
         className="github-icon-button"

--- a/docs/src/app/components/pages/components/tabs.jsx
+++ b/docs/src/app/components/pages/components/tabs.jsx
@@ -42,10 +42,10 @@ var TabsPage = React.createClass({
                 '</Tabs> \n' +
                 '\n' +
                 '_onActive: function(tab){ \n' +
-                '  this.transitionTo(tab.props.route); \n' +
+                '  this.context.router.transitionTo(tab.props.route); \n' +
                 '}';
 
-    var desc = 'Refs cannont be set on individual Tab components as cloneWithProps is being ' +
+    var desc = 'Refs cannot be set on individual Tab components as cloneWithProps is being ' +
       'used to extend the individual tab components under the hood. However, ' +
       'refs can be passed to the Tabs container and to any element or component within the template. ' +
       'If you need to access a tab directly - you can do so with the first argument of onActive or ' +
@@ -155,7 +155,7 @@ var TabsPage = React.createClass({
   },
 
   _onActive: function(tab){
-    this.transitionTo(tab.props.route);
+    this.context.router.transitionTo(tab.props.route);
   }
 });
 

--- a/docs/src/app/components/pages/home.jsx
+++ b/docs/src/app/components/pages/home.jsx
@@ -64,7 +64,7 @@ var HomePage = React.createClass({
   },
 
   _onDemoClick: function() {
-    this.transitionTo('components');
+    this.context.router.transitionTo('components');
   }
 
 });

--- a/docs/src/app/components/pages/page-with-nav.jsx
+++ b/docs/src/app/components/pages/page-with-nav.jsx
@@ -36,12 +36,12 @@ var PageWithNav = React.createClass({
 
     for (var i = menuItems.length - 1; i >= 0; i--) {
       currentItem = menuItems[i];
-      if (currentItem.route && this.isActive(currentItem.route)) return i;
+      if (currentItem.route && this.context.router.isActive(currentItem.route)) return i;
     };
   },
 
   _onMenuItemClick: function(e, index, item) {
-    this.transitionTo(item.route);
+    this.context.router.transitionTo(item.route);
   }
   
 });

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "http://material-ui.com/",
   "dependencies": {
-    "react-classset": "0.0.2",
+    "classnames": "^1.2.0",
     "react-draggable2": "^0.5.1"
   },
   "peerDependencies": {

--- a/src/js/input.jsx
+++ b/src/js/input.jsx
@@ -1,6 +1,6 @@
 var React = require('react');
 var Classable = require('./mixins/classable');
-var classSet = require('react-classset');
+var ClassNames = require('classnames');
 
 var Input = React.createClass({
 
@@ -47,10 +47,10 @@ var Input = React.createClass({
     });
     var placeholder = this.props.inlinePlaceholder ? this.props.placeholder : "";
     var inputIsNotEmpty = !!this.state.value;
-    var inputClassName = classSet({
+    var inputClassName = ClassNames({
       'mui-is-not-empty': inputIsNotEmpty
     });
-    var textareaClassName = classSet({
+    var textareaClassName = ClassNames({
       'mui-input-textarea': true,
       'mui-is-not-empty': inputIsNotEmpty
     });

--- a/src/js/mixins/classable.js
+++ b/src/js/mixins/classable.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var classSet = require('react-classset');
+var classNames = require('classnames');
 
 module.exports = {
 
@@ -15,16 +15,16 @@ module.exports = {
 
     //Add in initial classes
     if (typeof initialClasses === 'object') {
-      classString += ' ' + classSet(initialClasses);
+      classString += ' ' + classNames(initialClasses);
     } else {
       classString += ' ' + initialClasses;
     }
 
     //Add in additional classes
-    if (additionalClassObj) classString += ' ' + classSet(additionalClassObj);
+    if (additionalClassObj) classString += ' ' + classNames(additionalClassObj);
 
     //Convert the class string into an object and run it through the class set
-    return classSet(this.getClassSet(classString));
+    return classNames(this.getClassSet(classString));
   },
 
   getClassSet: function(classString) {

--- a/src/js/mixins/dom-idable.js
+++ b/src/js/mixins/dom-idable.js
@@ -1,7 +1,7 @@
 module.exports = {
 
   getDomId: function() {
-    return 'dom_id' + this._rootNodeID.replace(/\./g, '_');
+  	return 'dom_id' + this._reactInternalInstance._rootNodeID.replace(/\./g, '_');
   }
   
 }


### PR DESCRIPTION
- Switched peer dependency `classSet` to [`className`](https://github.com/JedWatson/classnames), see [React's note on Class Name Manipulation](http://facebook.github.io/react/docs/class-name-manipulation.html) for more info.
  - mui.Input component was updated to use classSet. However, it is still scheduled to be removed for v0.8.0.
- Fixed `dom-idable` issue #448 thanks to @irium's solution.
