### PR TITLE
Don't crash dropdown menu when selectedIndex is less than 0

### DIFF
--- a/src/js/drop-down-menu.jsx
+++ b/src/js/drop-down-menu.jsx
@@ -38,7 +38,13 @@ var DropDownMenu = React.createClass({
 
   componentWillReceiveProps: function(nextProps) {
     if (nextProps.hasOwnProperty('selectedIndex')) {
-      this.setState({selectedIndex: nextProps.selectedIndex});
+      let selectedIndex = nextProps.selectedIndex;
+
+      if (process.NODE_ENV !== 'production' && selectedIndex < 0) {
+        console.warn('Cannot set selectedIndex to a negative index.', selectedIndex);
+      }
+
+      this.setState({selectedIndex: (selectedIndex > -1) ? selectedIndex : 0});
     }
   },
 
@@ -47,14 +53,12 @@ var DropDownMenu = React.createClass({
       'mui-open': this.state.open
     });
 
-    var selectedIndex = this.state.selectedIndex > -1 ? this.state.selectedIndex : 0;
-
     return (
       <div className={classes}>
         <div className="mui-menu-control" onClick={this._onControlClick}>
           <Paper className="mui-menu-control-bg" zDepth={0} />
           <div className="mui-menu-label">
-            {this.props.menuItems[selectedIndex].text}
+            {this.props.menuItems[this.state.selectedIndex].text}
           </div>
           <DropDownArrow className="mui-menu-drop-down-icon" />
           <div className="mui-menu-control-underline" />

--- a/src/js/drop-down-menu.jsx
+++ b/src/js/drop-down-menu.jsx
@@ -34,18 +34,11 @@ var DropDownMenu = React.createClass({
 
   componentDidMount: function() {
     if (this.props.autoWidth) this._setWidth();
+    if (this.props.hasOwnProperty('selectedIndex')) this._setSelectedIndex(this.props);
   },
 
   componentWillReceiveProps: function(nextProps) {
-    if (nextProps.hasOwnProperty('selectedIndex')) {
-      let selectedIndex = nextProps.selectedIndex;
-
-      if (process.NODE_ENV !== 'production' && selectedIndex < 0) {
-        console.warn('Cannot set selectedIndex to a negative index.', selectedIndex);
-      }
-
-      this.setState({selectedIndex: (selectedIndex > -1) ? selectedIndex : 0});
-    }
+    if (props.hasOwnProperty('selectedIndex')) this._setSelectedIndex(nextProps);
   },
 
   render: function() {
@@ -80,6 +73,16 @@ var DropDownMenu = React.createClass({
       menuItemsDom = this.refs.menuItems.getDOMNode();
 
     el.style.width = menuItemsDom.offsetWidth + 'px';
+  },
+
+  _setSelectedIndex: function(props) {
+    let selectedIndex = props.selectedIndex;
+
+    if (process.NODE_ENV !== 'production' && selectedIndex < 0) {
+      console.warn('Cannot set selectedIndex to a negative index.', selectedIndex);
+    }
+
+    this.setState({selectedIndex: (selectedIndex > -1) ? selectedIndex : 0});
   },
 
   _onControlClick: function(e) {

--- a/src/js/drop-down-menu.jsx
+++ b/src/js/drop-down-menu.jsx
@@ -47,12 +47,14 @@ var DropDownMenu = React.createClass({
       'mui-open': this.state.open
     });
 
+    var selectedIndex = this.state.selectedIndex > -1 ? this.state.selectedIndex : 0;
+
     return (
       <div className={classes}>
         <div className="mui-menu-control" onClick={this._onControlClick}>
           <Paper className="mui-menu-control-bg" zDepth={0} />
           <div className="mui-menu-label">
-            {this.props.menuItems[this.state.selectedIndex].text}
+            {this.props.menuItems[selectedIndex].text}
           </div>
           <DropDownArrow className="mui-menu-drop-down-icon" />
           <div className="mui-menu-control-underline" />


### PR DESCRIPTION
Fixes 'Uncaught TypeError: Cannot read property 'text' of undefined' when passing an index of -1.