### PR TITLE
optional content in left nav

### DIFF
--- a/src/js/left-nav.jsx
+++ b/src/js/left-nav.jsx
@@ -15,7 +15,8 @@ var LeftNav = React.createClass({
     header: React.PropTypes.element,
     onChange: React.PropTypes.func,
     menuItems: React.PropTypes.array.isRequired,
-    selectedIndex: React.PropTypes.number
+    selectedIndex: React.PropTypes.number,
+    optionalContent: React.PropTypes.element
   },
 
   windowListeners: {
@@ -76,6 +77,7 @@ var LeftNav = React.createClass({
             selectedIndex={selectedIndex}
             onItemClick={this._onMenuItemClick} />
 
+        {this.props.optionalContent}
         </Paper>
       </div>
     );


### PR DESCRIPTION
It is now able to add your own react elements into the left-nav.

PS: This is my first pull request ever, so I am not sure if I am doing it correctly.

I also want to say that I am using the left-nav in my own project, and I am using it for something else than a navigation menu. I found that the current solution is a good for adding my own elements into the left-nav. Maybe it is useful for others as well.

![Image of OptionalContent](http://i1350.photobucket.com/albums/p763/johnedvard/Screenshot%202015-03-31%2014.54.43_zpswdv1fgrh.png)

(an example can be seen in the image, where "This is a test" is added as optional content in the left-nav)
