### PR TITLE
Fixed less requirement in docs

### DIFF
--- a/docs/src/less/main.less
+++ b/docs/src/less/main.less
@@ -1,6 +1,5 @@
 /* material-ui */
 @import "../../../src/less/scaffolding.less";
-@import "../../../src/less/components.less";
 
 /* custom font icons */
 @import "font-icons/style.css";


### PR DESCRIPTION
Docs still tried to import ../../../src/less/components.less, which was removed by #482. This removes that import.