### PR TITLE
Fixed WebkitTapHighlightColor warning in console

### DIFF
--- a/src/js/date-picker/day-button.jsx
+++ b/src/js/date-picker/day-button.jsx
@@ -27,7 +27,7 @@ var DayButton = React.createClass({
     var styles = {
       root: {
         boxSizing: 'border-box',
-        webkitTapHighlightColor: 'rgba(0,0,0,0)', 
+        WebkitTapHighlightColor: 'rgba(0,0,0,0)', 
         position: 'relative',
         float: 'left',
         width: 36,

--- a/src/js/dialog-window.jsx
+++ b/src/js/dialog-window.jsx
@@ -58,7 +58,7 @@ var DialogWindow = React.createClass({
     var style = {
       position: 'fixed',
       boxSizing: 'border-box',
-      webkitTapHighlightColor: 'rgba(0,0,0,0)', 
+      WebkitTapHighlightColor: 'rgba(0,0,0,0)',
       zIndex: 10,
       top: 0,
       left: -10000,
@@ -78,9 +78,9 @@ var DialogWindow = React.createClass({
   },
 
   _contents: function() {
-    var style = { 
+    var style = {
       boxSizing: 'border-box',
-      webkitTapHighlightColor: 'rgba(0,0,0,0)', 
+      WebkitTapHighlightColor: 'rgba(0,0,0,0)',
       transition: Transitions.easeOut(),
       position: 'relative',
       width: '75%',
@@ -148,7 +148,7 @@ var DialogWindow = React.createClass({
         key={key}
         secondary={true}
         onClick={onClickHandler}
-        label={actionJSON.text} 
+        label={actionJSON.text}
         style={styles}/>
     );
   },
@@ -158,7 +158,7 @@ var DialogWindow = React.createClass({
     var actionObjects = [];
     var actionStyle = {
       boxSizing: 'border-box',
-      webkitTapHighlightColor: 'rgba(0,0,0,0)', 
+      WebkitTapHighlightColor: 'rgba(0,0,0,0)',
       padding: 8,
       marginBottom: 8,
       width: '100%',
@@ -187,30 +187,30 @@ var DialogWindow = React.createClass({
     return actionContainer;
   },
 
-  _positionDialog: function() {   
+  _positionDialog: function() {
 
     var container = this.getDOMNode();
-    var dialogWindow = this.refs.dialogWindow.getDOMNode(); 
+    var dialogWindow = this.refs.dialogWindow.getDOMNode();
     var containerHeight = container.offsetHeight;
-   
-    //Reset the height in case the window was resized.   
-    dialogWindow.style.height = '';    
-    var dialogWindowHeight = dialogWindow.offsetHeight;  
 
-    var paddingTop = ((containerHeight - dialogWindowHeight) / 2) - 64; 
+    //Reset the height in case the window was resized.
+    dialogWindow.style.height = '';
+    var dialogWindowHeight = dialogWindow.offsetHeight;
 
-    //Vertically center the dialog window, but make sure it doesn't    
-    //transition to that position.   
-    if (this.props.repositionOnUpdate || !container.style.paddingTop) {  
+    var paddingTop = ((containerHeight - dialogWindowHeight) / 2) - 64;
+
+    //Vertically center the dialog window, but make sure it doesn't
+    //transition to that position.
+    if (this.props.repositionOnUpdate || !container.style.paddingTop) {
       container.style.paddingTop = paddingTop + 'px';
     }
- 
+
   },
-  
+
   _onShow: function() {
     if (this.props.onShow) this.props.onShow();
   },
-  
+
   _onDismiss: function() {
     if (this.props.onDismiss) this.props.onDismiss();
   },

--- a/src/js/paper.jsx
+++ b/src/js/paper.jsx
@@ -28,7 +28,7 @@ var Paper = React.createClass({
     return this.mergeAndPrefix({
       boxSizing: 'border-box',
       fontFamily: CustomVariables.contentFontFamily,
-      webkitTapHighlightColor: 'rgba(0,0,0,0)', 
+      WebkitTapHighlightColor: 'rgba(0,0,0,0)', 
       boxShadow: this.getZDepthShadows(this.props.zDepth).boxShadow,
       borderRadius: this.props.circle ? '50%' : 
                     this.props.rounded ? '2px' :
@@ -42,7 +42,7 @@ var Paper = React.createClass({
       height: '100%',
       boxSizing: 'border-box',
       fontFamily: CustomVariables.contentFontFamily,
-      webkitTapHighlightColor: 'rgba(0,0,0,0)', 
+      WebkitTapHighlightColor: 'rgba(0,0,0,0)', 
       boxShadow: this.getZDepthShadows(this.props.zDepth).bottomBoxShadow,
       borderRadius: this.props.circle ? '50%' : 
                     this.props.rounded ? '2px' :

--- a/src/js/text-field.jsx
+++ b/src/js/text-field.jsx
@@ -124,7 +124,7 @@ var TextField = React.createClass({
   _input: function() {
     var style = {
       boxSizing: 'border-box',
-      webkitTapHighlightColor: 'rgba(0,0,0,0)', 
+      WebkitTapHighlightColor: 'rgba(0,0,0,0)',
       position: 'relative',
       width: '100%',
       height: '100%',

--- a/src/js/toolbar/toolbar.jsx
+++ b/src/js/toolbar/toolbar.jsx
@@ -14,7 +14,7 @@ var Toolbar = React.createClass({
   _main: function() {
     return this.mergeAndPrefix({
       boxSizing: 'border-box',
-      webkitTapHighlightColor: 'rgba(0,0,0,0)', 
+      WebkitTapHighlightColor: 'rgba(0,0,0,0)', 
       backgroundColor: CustomVariables.toolbarBackgroundColor,
       height: CustomVariables.toolbarHeight,
       width: '100%',


### PR DESCRIPTION
The style `webkitTapHighlightColor` was giving a warning in the console, since React expects it to be named `WebkitTapHighlightColor`.

As well, this fixes some whitespace issues.