### PR TITLE
Fix dialog window centered on small screens

### DIFF
--- a/src/js/dialog-window.jsx
+++ b/src/js/dialog-window.jsx
@@ -152,8 +152,8 @@ var DialogWindow = React.createClass({
 
       //Vertically center the dialog window, but make sure it doesn't
       //transition to that position.
-      if (this.props.repositionOnUpdate || !container.style.paddingTop) {
-        container.style.paddingTop = 
+      if (this.props.repositionOnUpdate || !container.style.marginTop) {
+        container.style.marginTop = 
           ((containerHeight - dialogWindowHeight) / 2) - 64 + 'px';
       }
     }


### PR DESCRIPTION
Since the padding can't be negative, the window isn't well centered on small devices.