### PR TITLE
Added in onNavOpen/ onNavClose properties to LeftNav

### DIFF
--- a/src/js/left-nav.jsx
+++ b/src/js/left-nav.jsx
@@ -15,7 +15,9 @@ var LeftNav = React.createClass({
     header: React.PropTypes.element,
     onChange: React.PropTypes.func,
     menuItems: React.PropTypes.array.isRequired,
-    selectedIndex: React.PropTypes.number
+    selectedIndex: React.PropTypes.number,
+    onNavOpen: React.PropTypes.func,
+    onNavClose: React.PropTypes.func
   },
 
   windowListeners: {
@@ -41,11 +43,13 @@ var LeftNav = React.createClass({
 
   close: function() {
     this.setState({ open: false });
+    if (this.props.onNavClose) this.props.onNavClose();
     return this;
   },
 
   open: function() {
     this.setState({ open: true });
+    if (this.props.onNavOpen) this.props.onNavOpen();
     return this;
   },
 


### PR DESCRIPTION
New optional properties `onNavOpen` and `onNavClose` which get called when the left nav opens and closes.

Solution to #489.