### PR TITLE
Add WebkitFontSmoothing style to Canvas

### DIFF
--- a/src/js/app-canvas.jsx
+++ b/src/js/app-canvas.jsx
@@ -18,17 +18,21 @@ var AppCanvas = React.createClass({
 
     React.Children.forEach(this.props.children, function(currentChild) {
       switch (currentChild.type.displayName) {
-        case 'AppBar' : 
+        case 'AppBar' :
           currentChild.props.style = {
-            position: 'fixed', 
+            position: 'fixed',
             height: CustomVariables.appBarHeight
           };
           break;
       }
     });
 
+    styles = {
+      WebkitFontSmoothing: 'antialiased'
+    }
+
     return (
-      <div className={classes}>
+      <div className={classes} style={styles}>
         {this.props.children}
       </div>
     );


### PR DESCRIPTION
When core.less was removed, the font smoothing applied to the html selector was removed. This affects the font rendering slightly. This adds that CSS property back by adding it as a style to the top-level canvas element.

This was the most elegant solution I could come up with to solve this.