### PR TITLE
Addresses root level clickawayable bug

### DIFF
--- a/src/js/mixins/click-awayable.js
+++ b/src/js/mixins/click-awayable.js
@@ -20,7 +20,7 @@ module.exports = {
     if (this.isMounted() && 
       e.target != el &&
       !Dom.isDescendant(el, e.target) &&
-      document.contains(e.target)) {
+      document.documentElement.contains(e.target)) {
       if (this.componentClickAway) this.componentClickAway();
     }
   },


### PR DESCRIPTION
Addresses scenario in which document.contains is undefined and document.body does not take up entire screen.