### PR TITLE
Dialog action focus

### DIFF
--- a/docs/src/app/components/pages/components/dialog.jsx
+++ b/docs/src/app/components/pages/components/dialog.jsx
@@ -20,11 +20,12 @@ var DialogPage = React.createClass({
       '//Standard Actions\n' +
       'var standardActions = [\n' +
       '  { text: \'Cancel\' },\n' +
-      '  { text: \'Submit\', onClick: this._onDialogSubmit }\n' +
+      '  { text: \'Submit\', onClick: this._onDialogSubmit, ref: \'submit\' }\n' +
       '];\n\n' +
       '<Dialog\n' +
       '  title="Dialog With Standard Actions"\n' +
       '  actions={standardActions}\n' +
+      '  actionFocus="submit"\n' +
       '  modal={this.state.modal}\n' +
       '  dismissOnClickAway={this.state.dismissOnClickAway}>\n' +
       '  The actions in this window are created from the json that\'s passed in. \n' +
@@ -57,6 +58,12 @@ var DialogPage = React.createClass({
             type: 'array',
             header: 'optional',
             desc: 'This prop can be either a JSON object containing the actions to render, or an array of react objects.'
+          },
+          {
+            name: 'actionFocus',
+            type: 'string',
+            header: 'optional',
+            desc: 'The ref of the action to focus on when the dialog is displayed.'
           },
           {
             name: 'contentClassName',
@@ -118,7 +125,7 @@ var DialogPage = React.createClass({
 
     var standardActions = [
       { text: 'Cancel' },
-      { text: 'Submit', onClick: this._onDialogSubmit }
+      { text: 'Submit', onClick: this._onDialogSubmit, ref: 'submit' }
     ];
 
     var customActions = [
@@ -148,6 +155,7 @@ var DialogPage = React.createClass({
           ref="standardDialog"
           title="Dialog With Standard Actions"
           actions={standardActions}
+          actionFocus="submit"
           modal={this.state.modal}>
           The actions in this window are created from the json that's passed in.
         </Dialog>

--- a/src/js/dialog-window.jsx
+++ b/src/js/dialog-window.jsx
@@ -13,6 +13,7 @@ var DialogWindow = React.createClass({
 
   propTypes: {
     actions: React.PropTypes.array,
+    actionFocus: React.PropTypes.string,
     contentClassName: React.PropTypes.string,
     openImmediately: React.PropTypes.bool,
     onClickAway: React.PropTypes.func,
@@ -45,11 +46,13 @@ var DialogWindow = React.createClass({
     if (this.props.openImmediately) {
       this.refs.dialogOverlay.preventScrolling();
       this._onShow();
+      this._focusOnAction();
     }
   },
 
   componentDidUpdate: function (prevProps, prevState) {
     this._positionDialog();
+    this._focusOnAction();
   },
 
   render: function() {
@@ -89,6 +92,7 @@ var DialogWindow = React.createClass({
 
   show: function() {
     this.refs.dialogOverlay.preventScrolling();
+    this._focusOnAction();
 
     this.setState({ open: true });
     this._onShow();
@@ -102,13 +106,20 @@ var DialogWindow = React.createClass({
   },
 
   _getAction: function(actionJSON, key) {
-    var onClickHandler = actionJSON.onClick ? actionJSON.onClick : this.dismiss;
+    var props = {
+      key: key,
+      secondary: true,
+      onClick: actionJSON.onClick ? actionJSON.onClick : this.dismiss,
+      label: actionJSON.text
+    };
+    if (actionJSON.ref) {
+      props.ref = actionJSON.ref;
+      props.keyboardFocused = actionJSON.ref === this.props.actionFocus;
+    }
+    
     return (
       <FlatButton
-        key={key}
-        secondary={true}
-        onClick={onClickHandler}
-        label={actionJSON.text} />
+        {...props} />
     );
   },
 
@@ -158,6 +169,12 @@ var DialogWindow = React.createClass({
         container.style.paddingTop = 
           ((containerHeight - dialogWindowHeight) / 2) - 64 + 'px';
       }
+    }
+  },
+  
+  _focusOnAction: function() {
+    if (this.props.actionFocus) {
+      this.refs[this.props.actionFocus].getDOMNode().focus();
     }
   },
   

--- a/src/js/enhanced-button.jsx
+++ b/src/js/enhanced-button.jsx
@@ -15,6 +15,7 @@ var EnhancedButton = React.createClass({
     disabled: React.PropTypes.bool,
     disableFocusRipple: React.PropTypes.bool,
     disableTouchRipple: React.PropTypes.bool,
+    keyboardFocused: React.PropTypes.bool,
     linkButton: React.PropTypes.bool,
     onBlur: React.PropTypes.func,
     onFocus: React.PropTypes.func,
@@ -28,7 +29,7 @@ var EnhancedButton = React.createClass({
 
   getInitialState: function() {
     return {
-      isKeyboardFocused: false 
+      isKeyboardFocused: !this.props.disabled && this.props.keyboardFocused
     };
   },
 


### PR DESCRIPTION
Satisfies #546.

Can specify an action button to receive focus when a dialog is displayed. Also sets the keyboardFocus state of the underlying button to trigger the ripple.