### PR TITLE
icon alignment fixes for floating action button links

### DIFF
--- a/docs/src/app/components/pages/components/buttons.jsx
+++ b/docs/src/app/components/pages/components/buttons.jsx
@@ -45,6 +45,7 @@ var ButtonPage = React.createClass({
       '<FloatingActionButton iconClassName="muidocs-icon-action-grade" />\n' +
       '<FloatingActionButton iconClassName="muidocs-icon-action-grade" mini={true} />\n' +
       '<FloatingActionButton iconClassName="muidocs-icon-action-grade" disabled={true} />\n' +
+      '<FloatingActionButton iconClassName="muidocs-icon-custom-github" linkButton={true} href="https://github.com/callemall/material-ui" mini={true} secondary={true}/>' +
       '<FloatingActionButton iconClassName="muidocs-icon-action-grade" mini={true} disabled={true} />\n' +
       '<FloatingActionButton iconClassName="muidocs-icon-action-grade" secondary={true} />\n' +
       '<FloatingActionButton iconClassName="muidocs-icon-action-grade" mini={true} secondary={true} />';
@@ -126,7 +127,7 @@ var ButtonPage = React.createClass({
             type: 'string',
             header: 'optional',
             desc: 'This is the classname of the icon to display inside the button. This only applies to ' +
-              'floating action buttons. An alternative to adding an icon would be to insert a custom svg ' + 
+              'floating action buttons. An alternative to adding an icon would be to insert a custom svg ' +
               'component or FontIcon as a child.'
           },
           {
@@ -223,6 +224,9 @@ var ButtonPage = React.createClass({
             </div>
             <div className="button-example-container">
               <FloatingActionButton iconClassName="muidocs-icon-action-grade" disabled={true} />
+            </div>
+            <div className="button-example-container">
+              <FloatingActionButton iconClassName="muidocs-icon-custom-github" linkButton={true} href="https://github.com/callemall/material-ui" mini={true} secondary={true}/>
             </div>
             <div className="button-example-container">
               <FloatingActionButton iconClassName="muidocs-icon-action-grade" mini={true} disabled={true} />

--- a/src/less/components/floating-action-button.less
+++ b/src/less/components/floating-action-button.less
@@ -12,6 +12,8 @@
     overflow: hidden; 
     background-color: @floating-action-button-color;
     border-radius: 50%;
+    text-align: center;
+    vertical-align: bottom;
 
     //This is need so that ripples do not bleed
     //past border radius.


### PR DESCRIPTION
If I use a floating action button as a link, at least in Chrome the icon alignment is broken, as the icon is not centered when the button element is missing.

![screenshot 2015-04-24 16 59 27](https://cloud.githubusercontent.com/assets/457065/7321608/86c18400-eaa3-11e4-811c-56836e96357e.png)

Added some css to fix that and an example in the demo page.