### PR TITLE
Fixes Overriding Theme Variables Bug

### DIFF
--- a/docs/src/app/components/pages/components/menus.jsx
+++ b/docs/src/app/components/pages/components/menus.jsx
@@ -2,6 +2,9 @@ var React = require('react');
 var mui = require('mui');
 var CodeExample = require('../../code-example/code-example.jsx');
 
+
+var ThemeManager = new mui.Styles.ThemeManager();
+
 var labelMenuItems = [
   { payload: '1', text: 'ID', data: '1234567890', icon: 'home' },
   { payload: '2', text: 'Type', data: 'Announcement', icon: 'home' },
@@ -59,12 +62,18 @@ var nestedMenuItems = [
 class MenusPage extends React.Component {
 
   componentWillMount() {
-    this.context.theme.setComponentThemes({
+    ThemeManager.setComponentThemes({
       toggle: {
         thumbOnColor: 'rgb(255,100,0)',
         trackOnColor: 'rgba(255,100,0,0.5)'
       }
     });
+  }
+
+  getChildContext() {
+    return {
+      theme: ThemeManager.getCurrentTheme()
+    };
   }
 
   render() {
@@ -218,6 +227,10 @@ class MenusPage extends React.Component {
 }
 
 MenusPage.contextTypes = {
+  theme: React.PropTypes.object
+};
+
+MenusPage.childContextTypes = {
   theme: React.PropTypes.object
 };
 

--- a/docs/src/app/components/pages/customization/themes.jsx
+++ b/docs/src/app/components/pages/customization/themes.jsx
@@ -203,7 +203,8 @@ class ThemesPage extends React.Component {
           If you would like to make changes to the Theme for a specific pages, include the code 
           below in said page. All components defined on this page along with there children will 
           use your Theme overrides. The toggle buttons in the <a href="#/components/menus">Menus 
-          page</a> is an example of this.
+          page</a> is an example of this. Notice how these changes do not bleed over on to sibling
+          pages such as the <a href="#/components/switches">Switches page</a>.
         </p>
         <Paper>
           <CodeBlock>{this.getOverrideExamplePage()}</CodeBlock>
@@ -583,11 +584,17 @@ class ThemesPage extends React.Component {
 
   getOverrideExamplePage() {
     return (
-      'class MenusPage extends React.Component {\n' +
+      'var React = require(\'react\');\n' +
+      'var mui = require(\'mui\');\n' +
+      'var ThemeManager = new mui.Styles.ThemeManager();\n\n' +
+      'class MenusPage extends React.Component {\n\n' +
+      '  getChildContext() { \n' +
+      '    return {\n' +
+      '      theme: ThemeManager.getCurrentTheme()\n' +
+      '    }\n' +
+      '  }\n\n' +
       '  componentWillMount() {\n' +
-      '    //this.context is valid because the context was defined in the \n' +
-      '    //main page which is MenuPage\'s grandparent.\n' +
-      '    this.context.theme.setComponentThemes({\n' +
+      '    ThemeManager.setComponentThemes({\n' +
       '      toggle: {\n' +
       '        thumbOnColor: String,\n' +
       '        trackOnColor: String,\n' +
@@ -595,7 +602,7 @@ class ThemesPage extends React.Component {
       '    });\n' +
       '  }\n' +
       '}\n\n' +
-      'MenusPage.contextTypes = {\n' +
+      'MenusPage.childContextTypes = {\n' +
       '  theme: React.PropTypes.object\n' +
       '};'
     );


### PR DESCRIPTION
**Bug Description**
The changes made by overriding theme variables for a specific page created site wide changes rather than just the children of said page.

**Reason for bug**
The current approach to overriding theme variables was to invoke [`setComponentThemes'](https://github.com/callemall/material-ui/blob/css-in-js/src/styles/theme-manager.js#L37) on the `ThemeManager` passed by context. This caused site wide changes because the context variable shared between pages pointed to the same `ThemeManager` object.

**Solution**
Simply invoke `setComponentThemes` on a new instance of `ThemeManager`, then override `getChildContext` to pass that new `ThemeManager` rather than the one received from the parent. Now the said page and the rest of the site point to different instances of `ThemeManager`.

**Changes have been reflected in the [Themes doc page](https://github.com/callemall/material-ui/blob/css-in-js/docs/src/app/components/pages/customization/themes.jsx).**