### PR TITLE
problem with error color customization for inputs

### DIFF
--- a/src/less/components/text-field.less
+++ b/src/less/components/text-field.less
@@ -1,6 +1,6 @@
 .mui-text-field {
   @disabled-text-color: fade(@body-text-color, 30%);
-  @error-color: @red-500;
+  @error-color: @input-error-color;
 
 	font-size: 16px;
   line-height: 24px;


### PR DESCRIPTION
I have tried to customize error messages color by overriding @input-error-color in my less files.
After this I still got @red-500. This request will fix it.