### PR TITLE
Show assertion if 'menuItems' don't contain the 'selectedIndex'

### DIFF
--- a/src/drop-down-menu.jsx
+++ b/src/drop-down-menu.jsx
@@ -128,6 +128,11 @@ var DropDownMenu = React.createClass({
 
   render: function() {
     var styles = this.getStyles();
+    
+    if (process.env.NODE_ENV !== 'production') {
+      console.assert(!!this.props.menuItems[this.state.selectedIndex], 'SelectedIndex of ' + this.state.selectedIndex + ' does not exist in menuItems.');
+    }
+
     return (
       <div 
         ref="root"


### PR DESCRIPTION
I think that this simple line will be super helpful when the **selectedIndex** of a **DropDownMenu** don't match any of the **menuItems**.

#### Before

`Uncaught TypeError: Cannot read property 'text' of undefined`

#### Now

`Assertion failed: The "menuItems" that you have been passed not contains the selectedIndex`