### PR TITLE
Allows requiring individual components

### DIFF
--- a/src/date-picker/index.js
+++ b/src/date-picker/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./date-picker');

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ module.exports = {
   RadioButtonGroup: require('./radio-button-group'),
   RaisedButton: require('./raised-button'),
   Slider: require('./slider'),
-  SvgIcon: require('./svg-icons/svg-icon'),
+  SvgIcon: require('./svg-icon'),
   Icons: {
     NavigationMenu: require('./svg-icons/navigation-menu'),
     NavigationChevronLeft: require('./svg-icons/navigation-chevron-left'),

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,8 @@ module.exports = {
   Mixins: {
     Classable: require('./mixins/classable'),
     ClickAwayable: require('./mixins/click-awayable'),
-    WindowListenable: require('./mixins/window-listenable')
+    WindowListenable: require('./mixins/window-listenable'),
+    StylePropable: require('./mixins/style-propable')
   },
   Paper: require('./paper'),
   RadioButton: require('./radio-button'),
@@ -32,9 +33,12 @@ module.exports = {
     NavigationChevronRight: require('./svg-icons/navigation-chevron-right')
   },
   Styles: {
+    AutoPrefix: require('./styles/auto-prefix'),
     Colors: require('./styles/colors'),
     Spacing: require('./styles/spacing'),
-    ThemeManager: require('./styles/theme-manager')
+    ThemeManager: require('./styles/theme-manager'),
+    Transitions: require('./styles/transitions'),
+    Typography: require('./styles/typography')
   },
   Snackbar: require('./snackbar'),
   Tab: require('./tabs/tab'),
@@ -53,5 +57,7 @@ module.exports = {
     KeyCode: require('./utils/key-code'),
     KeyLine: require('./utils/key-line'),
     ColorManipulator: require('./utils/color-manipulator'),
+    Extend: require('./utils/extend'),
+    UniqueId: require('./utils/unique-id')
   }
 };

--- a/src/menu/index.js
+++ b/src/menu/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  Menu: require('./menu'),
+  MenuItem: require('./menu-item'),
+  LinkMenuItem: require('./link-menu-item'),
+  SubheaderMenuItem: require('./subheader-menu-item')
+};

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  Classable: require('./classable'),
+  ClickAwayable: require('./click-awayable'),
+  WindowListenable: require('./window-listenable'),
+  StylePropable: require('./style-propable')	
+};

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -1,0 +1,8 @@
+module.exports = {
+  AutoPrefix: require('./auto-prefix'),
+  Colors: require('./colors'),
+  Spacing: require('./spacing'),
+  ThemeManager: require('./theme-manager'),
+  Transitions: require('./transitions'),
+  Typography: require('./typography')
+};

--- a/src/svg-icon.jsx
+++ b/src/svg-icon.jsx
@@ -9,30 +9,18 @@ var SvgIcon = React.createClass({
     theme: React.PropTypes.object
   },
 
-  getInitialState: function() {
-    return {
-      isHovered: false,
-    };
-  },
-
   getTheme: function() {
     return this.context.theme.palette;
   },
 
   getStyles: function() {
-    var styles = {
-      root: {
-        display: 'inline-block',
-        height: '24px',
-        width: '24px',
-        userSelect: 'none',
-        fill: this.getTheme().textColor
-      },
-      rootWhenHovered: {
-
-      }
+    return {
+      display: 'inline-block',
+      height: '24px',
+      width: '24px',
+      userSelect: 'none',
+      fill: this.getTheme().textColor
     };
-    return styles;
   },
 
   render: function() {
@@ -48,7 +36,7 @@ var SvgIcon = React.createClass({
         {...other}
         viewBox="0 0 24 24"
         style={this.mergeAndPrefix(
-          this.getStyles().root, 
+          this.getStyles(), 
           this.props.style)}>
             {this.props.children}
       </svg>

--- a/src/svg-icons/drop-down-arrow.jsx
+++ b/src/svg-icons/drop-down-arrow.jsx
@@ -1,5 +1,5 @@
 var React = require('react');
-var SvgIcon = require('./svg-icon');
+var SvgIcon = require('../svg-icon');
 
 var DropDownArrow = React.createClass({
 

--- a/src/svg-icons/navigation-chevron-left.jsx
+++ b/src/svg-icons/navigation-chevron-left.jsx
@@ -1,5 +1,5 @@
 var React = require('react');
-var SvgIcon = require('./svg-icon');
+var SvgIcon = require('../svg-icon');
 
 var NavigationChevronLeft = React.createClass({
 

--- a/src/svg-icons/navigation-chevron-right.jsx
+++ b/src/svg-icons/navigation-chevron-right.jsx
@@ -1,5 +1,5 @@
 var React = require('react');
-var SvgIcon = require('./svg-icon');
+var SvgIcon = require('../svg-icon');
 
 var NavigationChevronLeft = React.createClass({
 

--- a/src/svg-icons/navigation-menu.jsx
+++ b/src/svg-icons/navigation-menu.jsx
@@ -1,5 +1,5 @@
 var React = require('react');
-var SvgIcon = require('./svg-icon');
+var SvgIcon = require('../svg-icon');
 
 var NavigationMenu = React.createClass({
 

--- a/src/svg-icons/toggle-check-box-checked.jsx
+++ b/src/svg-icons/toggle-check-box-checked.jsx
@@ -1,5 +1,5 @@
 var React = require('react');
-var SvgIcon = require('./svg-icon');
+var SvgIcon = require('../svg-icon');
 
 var ToggleCheckBoxChecked = React.createClass({
 

--- a/src/svg-icons/toggle-check-box-outline-blank.jsx
+++ b/src/svg-icons/toggle-check-box-outline-blank.jsx
@@ -1,5 +1,5 @@
 var React = require('react');
-var SvgIcon = require('./svg-icon');
+var SvgIcon = require('../svg-icon');
 
 var ToggleCheckBoxOutlineBlank = React.createClass({
 

--- a/src/svg-icons/toggle-radio-button-off.jsx
+++ b/src/svg-icons/toggle-radio-button-off.jsx
@@ -1,5 +1,5 @@
 var React = require('react');
-var SvgIcon = require('./svg-icon');
+var SvgIcon = require('../svg-icon');
 
 var RadioButtonOff = React.createClass({
 

--- a/src/svg-icons/toggle-radio-button-on.jsx
+++ b/src/svg-icons/toggle-radio-button-on.jsx
@@ -1,5 +1,5 @@
 var React = require('react');
-var SvgIcon = require('./svg-icon');
+var SvgIcon = require('../svg-icon');
 
 var RadioButtonOn = React.createClass({
 

--- a/src/tabs/index.js
+++ b/src/tabs/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+	Tab: require('tab'),
+	Tabs: require('tabs')
+};

--- a/src/toolbar/index.js
+++ b/src/toolbar/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  Toolbar: require('./toolbar'),
+  ToolbarGroup: require('./toolbar-group'),
+  ToolbarSeparator: require('./toolbar-separator'),
+  ToolbarTitle: require('./toolbar-title')
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,10 @@
+module.exports = {
+  CssEvent: require('./css-event'),
+  Dom: require('./dom'),
+  Events: require('./events'),
+  KeyCode: require('./key-code'),
+  KeyLine: require('./key-line'),
+  ColorManipulator: require('./color-manipulator'),
+  Extend: require('./extend'),
+  UniqueId: require('./unique-id')
+};


### PR DESCRIPTION
- **Fixes #363**
- Users can now require individual components like so:

```
var Checkbox = require('material-ui/Checkbox');
var EnhancedButton = require('material-ui/EnhancedButton');
```
instead of
```
var {Checkbox, EnhancedButton) = require('material-ui');
```

- Some components return an `index.js` and require an additional step, for example:
```
var MenuComponents = require('material-ui/menu'); // Returns an object pointing to Menu components
var Menu = MenuComponents.Menu;
var MenuItem = MenuComponents.MenuItem;
...
var {Menu, MenuItem} = require('material-ui/menu'); // Alternative approach using destructuring
```
these include
  - Menu
  - Styles
  - Tabs
  - Toolbar
  - Utils
