### PR TITLE
Updated CHANGELOG.md and package.json for v0.8.0 prerelease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+## 0.8.0 (Pre-release)
+###### _TBD_
+
+##### Breaking Changes
+- Refactored all CSS into Javascript (#30, #316)
+  - All Material-UI components now have their styles defined inline. This solves 
+    many problems with CSS as mentions in [@vjeux's presentation](https://speakerdeck.com/vjeux/react-css-in-js) 
+    such polluting the global namespace with classes that really should be 
+    component specific. In addition to the benefits mentioned in the 
+    presentation, inline styles allow Material-UI to become CSS preprocessor 
+    agnostic and make Themeing much more dynamic and simple.
+    [Read our CSS in JS discussion](https://github.com/callemall/material-ui/issues/30)
+  - Upgrade path:
+    - *If you are overriding component CSS classes:* Redefine your overrides as 
+      an object following [React's inline styles format](https://facebook.github.io/react/tips/inline-styles.html),
+      then pass it into the material-ui component via the `style` prop. These 
+      changes are applied to the root element of the component. If you are 
+      overriding a nested element of the component, check the component's
+      documentation and see if there is a style prop available for that nested 
+      element. If a style prop does not exist for the component's nested element 
+      that you are trying to override, [submit an issue](https://github.com/callemall/material-ui/issues/new) 
+      requesting to have it added.
+    - *If you are using any of Material-UI's Less files:* These files have been 
+      refactored into their [own javascript files](https://github.com/callemall/material-ui/tree/css-in-js/src/styles) 
+      and can be accessed like so `var FILENAME = require('material-ui').Styles.FILENAME;`.
+      Material-UI has moved away from being a CSS Framework to being simply a 
+      set of React components.
+
+##### General
+- Themes have been added (#202)
+- Requiring individual components is now supported (#363)
+  - An example would be: `var SvgIcon = require('material-ui/lib/svg-icon);`
+  - The `/lib` folder in Material-UI contains the file structure needed when referencing individual components. 
+
 ## 0.7.4
 ###### _Apr. 21, 2015_
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "material-ui-docs",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "description": "Documentation site for material-ui",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "material-ui",
   "author": "Call-em-all Engineering Team",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "description": "Material Design UI components built with React",
   "main": "./lib",
   "scripts": {


### PR DESCRIPTION
**This is a pre-release for v0.8.0. The docs site will not update just yet.**

**To see the new documentation with the changes made in v0.8.0, run gulp in the docs folder to have the docs site build on your local host.** 

- All CSS has been refactored into Javascript
  - Inline styles can be overriden via the `style` prop. (#30)
  - Material-UI no longer depends on Less (Resolves #316)
- Themes have been added (Resolves #202) 
- It is possible to require individual components (Resolves #363)