### PR TITLE
Reposition dialog when window is resized

### DIFF
--- a/src/dialog-window.jsx
+++ b/src/dialog-window.jsx
@@ -49,11 +49,16 @@ var DialogWindow = React.createClass({
 
   componentDidMount: function() {
     this._positionDialog();
+    window.addEventListener('resize', this._positionDialog);
     if (this.props.openImmediately) {
       this.refs.dialogOverlay.preventScrolling();
       this._onShow();
       this._focusOnAction();
     }
+  },
+
+  componentWillUnmount: function() {
+    window.removeEventListener('resize', this._positionDialog);
   },
 
   componentDidUpdate: function(prevProps, prevState) {
@@ -211,7 +216,7 @@ var DialogWindow = React.createClass({
     //Reset the height in case the window was resized.
     dialogWindow.style.height = '';
 
-    var paddingTop = ((containerHeight - dialogWindowHeight) / 2) - 64;
+    var paddingTop = Math.max(((containerHeight - dialogWindowHeight) / 2) - 64, 0);
 
     //Vertically center the dialog window, but make sure it doesn't
     //transition to that position.

--- a/src/dialog-window.jsx
+++ b/src/dialog-window.jsx
@@ -30,7 +30,8 @@ var DialogWindow = React.createClass({
   },
 
   windowListeners: {
-    'keyup': '_handleWindowKeyUp'
+    'keyup': '_handleWindowKeyUp',
+    'resize': '_positionDialog'
   },
 
   getDefaultProps: function() {
@@ -49,16 +50,11 @@ var DialogWindow = React.createClass({
 
   componentDidMount: function() {
     this._positionDialog();
-    window.addEventListener('resize', this._positionDialog);
     if (this.props.openImmediately) {
       this.refs.dialogOverlay.preventScrolling();
       this._onShow();
       this._focusOnAction();
     }
-  },
-
-  componentWillUnmount: function() {
-    window.removeEventListener('resize', this._positionDialog);
   },
 
   componentDidUpdate: function(prevProps, prevState) {


### PR DESCRIPTION
This is particularly useful when there's a text field
in a dialog, and the window becomes twice smaller when
the text field is focused on mobile (because of the
on-screen keyboard).