### PR TITLE
Add 'swipe away' functionality to the left / right nav

### DIFF
--- a/docs/src/app/components/pages/components/paper.jsx
+++ b/docs/src/app/components/pages/components/paper.jsx
@@ -104,6 +104,12 @@ class PaperPage extends React.Component {
             type: 'number (0-5)',
             header: 'default: 1',
             desc: 'This number represents the zDepth of the paper shadow.'
+          },
+          {
+            name: 'transitionEnabled',
+            type: 'bool',
+            header: 'default: true',
+            desc: 'Set to false to disable CSS transitions for the paper element.'
           }
         ]
       },

--- a/src/overlay.jsx
+++ b/src/overlay.jsx
@@ -1,4 +1,5 @@
 var React = require('react');
+var Modernizr = require('./utils/modernizr.custom');
 var StylePropable = require('./mixins/style-propable');
 var Transitions = require('./styles/transitions');
 var Colors = require('./styles/colors');
@@ -9,17 +10,24 @@ var Overlay = React.createClass({
 
   propTypes: {
     show: React.PropTypes.bool,
-    autoLockScrolling: React.PropTypes.bool
+    autoLockScrolling: React.PropTypes.bool,
+    transitionEnabled: React.PropTypes.bool
   },
   
   getDefaultProps: function() {
     return {
-      autoLockScrolling: true
+      autoLockScrolling: true,
+      transitionEnabled: true
     };
   },
   
   componentDidUpdate: function(prevProps, prevState) {
     if (this.props.autoLockScrolling) (this.props.show) ? this._preventScrolling() : this._allowScrolling();
+  },
+
+  setOpacity(opacity) {
+    var overlay = React.findDOMNode(this);
+    overlay.style[Modernizr.prefixed('opacity')] = opacity;
   },
 
   getStyles: function() {
@@ -31,17 +39,25 @@ var Overlay = React.createClass({
         zIndex: 9,
         top: 0,
         left: '-100%',
-        backgroundColor: Colors.transparent,
+        opacity: 0,
+        backgroundColor: Colors.lightBlack,
+
+        // Two ways to promote overlay to its own render layer
+        willChange: 'opacity',
+        transform: 'translateZ(0)',
+
         transition:
+          this.props.transitionEnabled &&
           Transitions.easeOut('0ms', 'left', '400ms') + ',' +
-          Transitions.easeOut('400ms', 'backgroundColor')
+          Transitions.easeOut('400ms', 'opacity')
       },
       rootWhenShown: {
         left: '0',
-        backgroundColor: Colors.lightBlack,
+        opacity: 1,
         transition:
+          this.props.transitionEnabled &&
           Transitions.easeOut('0ms', 'left') + ',' +
-          Transitions.easeOut('400ms', 'backgroundColor')
+          Transitions.easeOut('400ms', 'opacity')
       }
     };
     return styles;

--- a/src/overlay.jsx
+++ b/src/overlay.jsx
@@ -41,6 +41,7 @@ var Overlay = React.createClass({
         left: '-100%',
         opacity: 0,
         backgroundColor: Colors.lightBlack,
+        WebkitTapHighlightColor: 'rgba(0, 0, 0, 0)',
 
         // Two ways to promote overlay to its own render layer
         willChange: 'opacity',

--- a/src/overlay.jsx
+++ b/src/overlay.jsx
@@ -1,5 +1,4 @@
 var React = require('react');
-var Modernizr = require('./utils/modernizr.custom');
 var StylePropable = require('./mixins/style-propable');
 var Transitions = require('./styles/transitions');
 var Colors = require('./styles/colors');
@@ -27,7 +26,7 @@ var Overlay = React.createClass({
 
   setOpacity(opacity) {
     var overlay = React.findDOMNode(this);
-    overlay.style[Modernizr.prefixed('opacity')] = opacity;
+    overlay.style.opacity = opacity;
   },
 
   getStyles: function() {

--- a/src/paper.jsx
+++ b/src/paper.jsx
@@ -16,13 +16,15 @@ var Paper = React.createClass({
     innerStyle: React.PropTypes.object,
     rounded: React.PropTypes.bool,
     zDepth: React.PropTypes.oneOf([0,1,2,3,4,5]),
+    transitionEnabled: React.PropTypes.bool
   },
 
   getDefaultProps: function() {
     return {
       innerClassName: '',
       rounded: true,
-      zDepth: 1
+      zDepth: 1,
+      transitionEnabled: true
     };
   },
 
@@ -30,7 +32,7 @@ var Paper = React.createClass({
     var styles = {
       root: {
         backgroundColor: this.context.muiTheme.component.paper.backgroundColor,
-        transition: Transitions.easeOut(),
+        transition: this.props.transitionEnabled && Transitions.easeOut(),
         boxSizing: 'border-box',
         fontFamily: this.context.muiTheme.contentFontFamily,
         WebkitTapHighlightColor: 'rgba(0,0,0,0)', 


### PR DESCRIPTION
Resolves #411.

If a user opens the nav on a touch device, they can use the swipe
gesture they're used to to close the nav.

Technical details: I initially tried setting nav's translateX and
overlay's opacity using setState, but turns out that on mobile devices
re-rendering the component on every touchmove event is costly and
leads to laggy animations.
So I resorted to directly manipulating elements' styles, which is
a lot faster.