### PR TITLE
Fix for ignoring defaultSwitched change

### DIFF
--- a/src/enhanced-switch.jsx
+++ b/src/enhanced-switch.jsx
@@ -90,6 +90,8 @@ var EnhancedSwitch = React.createClass({
       newState.switched = nextProps.toggled;
     } else if (hasCheckedLinkProp) {
       newState.switched = nextProps.checkedLink.value;
+    } else if (hasNewDefaultProp) {
+      newState.switched = nextProps.defaultSwitched;
     }
 
     if (newState.switched != undefined && (newState.switched != this.props.switched)) this.props.onParentShouldUpdate(newState.switched);


### PR DESCRIPTION
Without this change it isn't possible to specify before rendering if the component should be switched on or off still keeping it active. Using switched/toggled attribute sets correct state, but blocks changing the state on click.