### PR TITLE
Update click-awayable.js, removing isMounted check

### DIFF
--- a/src/mixins/click-awayable.js
+++ b/src/mixins/click-awayable.js
@@ -18,11 +18,9 @@ module.exports = {
     var el = React.findDOMNode(this); 
     
     // Check if the target is inside the current component
-    if (this.isMounted() && 
-      e.target != el &&
-      !Dom.isDescendant(el, e.target) &&
-      document.documentElement.contains(e.target)) {
-      
+    if (e.target != el &&
+        !Dom.isDescendant(el, e.target) &&
+        document.documentElement.contains(e.target)) {
       if (this.componentClickAway) this.componentClickAway();
     }
   },


### PR DESCRIPTION
- this.isMounted is deprecated
- using "this" is causing problems in React ES6, since there is no auto-binding anymore, so "this" is the window object and doesn't have isMounted
- We are adding the eventlistener on ComponentDidMount, which means the component is always mounted