### PR TITLE
IconButton FontIcon child hover styling

### DIFF
--- a/docs/src/app/components/pages/components/icons.jsx
+++ b/docs/src/app/components/pages/components/icons.jsx
@@ -69,7 +69,36 @@ class FontIconPage extends React.Component {
       </p>
     );
 
-    var componentInfo = [];
+    var componentInfo = [
+      {
+        name: 'Properties',
+        infoArray: [
+          {
+            name: 'className',
+            type: 'string',
+            header: 'optional',
+            desc: 'If you are using a stylesheet for your icons, enter the ' +
+                  'class name for the icon to be used here.'
+          },
+          {
+            name: 'style',
+            type: 'object',
+            header: 'optional',
+            desc: 'Override the inline-styles of the icon\'s root element.'
+          },
+          {
+            name: 'hoverColor',
+            type: 'string',
+            header: 'optional',
+            desc: 'Override the inline hover color of the icons\'s root element.'
+          }
+        ]
+      },
+      {
+        name: 'Properties',
+        infoArray: [],
+      }
+    ];
 
     return (
       <div>
@@ -77,14 +106,14 @@ class FontIconPage extends React.Component {
           name="Font Icons"
           code={fontIconCode}
           desc={fontIconDesc}
-          componentInfo={componentInfo}>
+          componentInfo={componentInfo.slice(0,1)}>
             <FontIcon className="muidocs-icon-action-home"/>
         </ComponentDoc>
         <ComponentDoc
           name="SVG Icons"
           code={svgIconCode}
           desc={svgIconDesc}
-          componentInfo={componentInfo}>
+          componentInfo={componentInfo.slice(1,2)}>
             <ActionHome/>
         </ComponentDoc>
       </div>

--- a/src/font-icon.jsx
+++ b/src/font-icon.jsx
@@ -1,6 +1,7 @@
 var React = require('react');
 var StylePropable = require('./mixins/style-propable');
 var Spacing = require('./styles/spacing');
+var Transitions = require('./styles/transitions');
 
 var FontIcon = React.createClass({
 
@@ -10,41 +11,67 @@ var FontIcon = React.createClass({
     muiTheme: React.PropTypes.object
   },
 
+  propTypes: {
+    className: React.PropTypes.string,
+    hoverColor: React.PropTypes.string
+  },
+
   getInitialState: function() {
     return {
-      isHovered: false,
+      hovered: false,
     };
   },
 
-  getTheme: function() {
-    return this.context.muiTheme.palette;
-  },
-
   getStyles: function() {
+    var theme = this.context.muiTheme.palette;
     var styles = {
       position: 'relative',
       fontSize: Spacing.iconSize + 'px',
       display: 'inline-block',
-      userSelect: 'none'  
+      userSelect: 'none',
+      transition: Transitions.easeOut()
     };
+
     if (!styles.color && !this.props.className) {
-      styles.color = this.getTheme().textColor;
+      styles.color = theme.textColor;
     }
+
     return styles;
   },
 
   render: function() {
     var {
+      onMouseOut,
+      onMouseOver,
       style,
       ...other
     } = this.props;
+    var hoverStyle = this.props.hoverColor ? {color: this.props.hoverColor} : {};
 
     return (
-      <span {...other} 
+      <span
+        {...other}
+        onMouseOut={this._handleMouseOut}
+        onMouseOver={this._handleMouseOver}
         style={this.mergeAndPrefix(
           this.getStyles(),
-          this.props.style)} />
+          this.props.style,
+          this.state.hovered && hoverStyle)} />
     );
+  },
+
+  _handleMouseOut: function(e) {
+    this.setState({hovered: false});
+    if (this.props.onMouseOut) {
+      this.props.onMouseOut(e);
+    }
+  },
+
+  _handleMouseOver: function(e) {
+    this.setState({hovered: true});
+    if (this.props.onMouseOver) {
+      this.props.onMouseOver(e);
+    }
   }
 });
 

--- a/src/icon-button.jsx
+++ b/src/icon-button.jsx
@@ -26,7 +26,7 @@ var IconButton = React.createClass({
 
   getInitialState: function() {
     return {
-      tooltipShown: false 
+      tooltipShown: false
     };
   },
 
@@ -112,18 +112,21 @@ var IconButton = React.createClass({
           label={tooltip}
           show={this.state.tooltipShown}
           touch={touch}
-          style={this.mergeAndPrefix(styles.tooltip)}/>
+          style={this.mergeStyles(styles.tooltip)}/>
       );
     }
 
     if (this.props.iconClassName) {
+      var { iconHoverColor, ...iconStyle } = this.props.iconStyle;
+
       fonticon = (
-        <FontIcon 
-          className={this.props.iconClassName} 
-          style={this.mergeAndPrefix(
-            styles.icon, 
+        <FontIcon
+          className={this.props.iconClassName}
+          hoverColor={iconHoverColor}
+          style={this.mergeStyles(
+            styles.icon,
             this.props.disabled && styles.iconWhenDisabled,
-            this.props.iconStyle
+            iconStyle
           )}/>
       );
     }
@@ -135,13 +138,13 @@ var IconButton = React.createClass({
           fill: this.getDisabledColor(),
         }
       }, this);
-    } 
+    }
 
     return (
       <EnhancedButton {...other}
         ref="button"
         centerRipple={true}
-        style={this.mergeAndPrefix(styles.root, this.props.style)}
+        style={this.mergeStyles(styles.root, this.props.style)}
         onBlur={this._handleBlur}
         onFocus={this._handleFocus}
         onMouseOut={this._handleMouseOut}


### PR DESCRIPTION
Provides a way to pass down hover style to the FontIcon child in IconButton.

[Use case](https://github.com/troutowicz/geoshare/blob/css-in-js/app/components/GithubButton.jsx)