### PR TITLE
When nested menu item Tapped call tap handler instead of click handler

### DIFF
--- a/src/js/menu/menu.jsx
+++ b/src/js/menu/menu.jsx
@@ -228,7 +228,7 @@ var Menu = React.createClass({
               menuItems={menuItem.items}
               zDepth={this.props.zDepth}
               onItemClick={this._onNestedItemClick}
-              onItemTap={this._onNestedItemClick} />
+              onItemTap={this._onNestedItemTap} />
           );
           this._nestedChildren.push(i);
           break;


### PR DESCRIPTION
Currently when nested menu item clicked, click handler is called twice. The reason is that when item is clicked both tap event and click event are fired but these events have the same hander `_onNestedItemClick`. Tap event should have `_onNestedItemTap ` handler.