### PR TITLE
Text-Field: fix _getInputNode

### DIFF
--- a/src/text-field.jsx
+++ b/src/text-field.jsx
@@ -309,7 +309,7 @@ var TextField = React.createClass({
 
   _getInputNode: function() {
     return this.props.multiLine ?
-      this.refs[this._getRef()].getInputNode() : React.findDOMNode(this._getRef());
+      this.refs[this._getRef()].getInputNode() : React.findDOMNode(this.refs[this._getRef()]);
   },
 
   _handleInputBlur: function(e) {


### PR DESCRIPTION
React.findDOMNode take a ref not a string.