### PR TITLE
Proper version.

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -36,7 +36,7 @@
     "watchify": "^2.2.1"
   },
   "dependencies": {
-    "material-ui": ">=0.7",
+    "material-ui": ">=0.8",
     "react": ">=0.13",
     "react-tap-event-plugin": "^0.1.3"
   }


### PR DESCRIPTION
Otherwise `mui.Styles` won't be available, but with this version isn't released, would it be better to turn off the code that is using mui.Style for now?

As in:

```js
.....
var SvgIcon = mui.SvgIcon;
//var ThemeManager = new mui.Styles.ThemeManager();

var Main = React.createClass({

  // childContextTypes: {
  //   muiTheme: React.PropTypes.object
  // },
  //
  // getChildContext: function() {
  //   return {
  //     muiTheme: ThemeManager.getCurrentTheme()
  //   };
  // },
......
......
```

//cc @callemall