### PR TITLE
TextField minimum rows can now be sensibly set.

### DIFF
--- a/src/text-field.jsx
+++ b/src/text-field.jsx
@@ -77,7 +77,7 @@ var TextField = React.createClass({
         fontSize: '16px',
         lineHeight: '24px',
         width: (64 * 4),
-        height: (this.props.floatingLabelText) ? 72 : 48,
+        height: (this.props.rows - 1) * 24 + (this.props.floatingLabelText ? 72 : 48),
         display: 'inline-block',
         position: 'relative',
         fontFamily: this.context.muiTheme.contentFontFamily,


### PR DESCRIPTION
By passing a number of **rows** as a prop to `TextField`, the minimum number of rows occupied by a Text Field may now be set:

    <TextField floatingLabelText="Detailed Feedback" rows={3} multiLine={true}/>

This is useful, since the greater space occupied by a field in a text form encourages users to type more into it. 

Observe the effect of this change on the above example:

**Before:**
![Before](https://cloud.githubusercontent.com/assets/1463145/7823475/f8f6c1ea-03fb-11e5-8d1d-421d3aaa1845.gif)

**After:**
![after](https://cloud.githubusercontent.com/assets/1463145/7823479/0f938488-03fc-11e5-9d29-c8fb78ac00a4.gif)
