### PR TITLE
Keep state in tabs

### DIFF
--- a/docs/src/app/components/pages/components/tabs.jsx
+++ b/docs/src/app/components/pages/components/tabs.jsx
@@ -5,7 +5,7 @@ var Router = require('react-router');
 var ComponentDoc = require('../../component-doc.jsx');
 var RouteHandler = Router.RouteHandler;
 
-var {Tabs, Tab} = mui;
+var {Tabs, Tab, Slider} = mui;
 var Typography = mui.Styles.Typography;
 
 class TabsPage extends React.Component {
@@ -150,8 +150,9 @@ class TabsPage extends React.Component {
                   This is an example of a tab template!
                 </p>
                 <p>
-                  You can put any sort of HTML or react component in here.
+                  You can put any sort of HTML or react component in here. It even keeps the componet state!
                 </p>
+                <Slider name="slider0" defaultValue={0.5} />
               </div>
             </Tab>
             <Tab label='Item Two' >

--- a/src/tabs/tabTemplate.jsx
+++ b/src/tabs/tabTemplate.jsx
@@ -5,13 +5,17 @@ var TabTemplate = React.createClass({
   render: function(){
 
     var styles = {
-      'display': 'none',
+      'height': '0px',
+      'overflow': 'hidden',
       'width': '100%',
       'position': 'relative',
       'textAlign': 'initial'
     };
 
-    if(this.props.selected) styles.display = 'block';
+    if(this.props.selected) {
+      delete styles.height
+      delete styles.overflow
+    }
 
     return (
       <div style={styles}>

--- a/src/tabs/tabTemplate.jsx
+++ b/src/tabs/tabTemplate.jsx
@@ -5,14 +5,16 @@ var TabTemplate = React.createClass({
   render: function(){
 
     var styles = {
-      'display': 'block',
+      'display': 'none',
       'width': '100%',
       'position': 'relative',
-      'text-align': 'initial'
+      'textAlign': 'initial'
     };
 
+    if(this.props.selected) styles.display = 'block';
+
     return (
-      <div styles={styles}>
+      <div style={styles}>
         {this.props.children}
       </div>
     );

--- a/src/tabs/tabs.jsx
+++ b/src/tabs/tabs.jsx
@@ -83,17 +83,18 @@ var Tabs = React.createClass({
   render: function(){
     var styles = this.getStyles();
 
+    var tabContent = []
     var width = this.state.fixedWidth ?
       100 / this.props.children.length +'%' :
       this.props.tabWidth + 'px';
 
     var left = 'calc(' + width + '*' + this.state.selectedIndex + ')';
 
-    var currentTemplate;
-    var tabs = React.Children.map(this.props.children, function(tab, index) {
-      if (tab.type.displayName === "Tab") {
-        if (this.state.selectedIndex === index) currentTemplate = tab.props.children;
-         return React.addons.cloneWithProps(tab, {
+    var tabs = React.Children.map(this.props.children, function(tab, index){
+      if(tab.type.displayName === "Tab") {
+
+        if(tab.props.children) {
+          tabContent.push(React.createElement(TabTemplate, {
             key: index,
             selected: this.state.selectedIndex === index,
             tabIndex: index,
@@ -106,16 +107,15 @@ var Tabs = React.createClass({
               type + ' as child number ' + (index + 1) + ' of Tabs';
       }
     }, this);
-
     return (
       <div style={this.mergeAndPrefix(styles.root, this.props.style)}>
         <div style={this.mergeAndPrefix(styles.tabItemContainer, this.props.tabItemContainerStyle)}>
           {tabs}
         </div>
-        <InkBar left={left} width={width}/>
-        <TabTemplate>
-          {currentTemplate}
-        </TabTemplate>
+        <InkBar left={left} width={width} />
+        <div className='mui-tab-template-container'>
+          {tabContent}
+        </div>
       </div>
     )
   },

--- a/src/tabs/tabs.jsx
+++ b/src/tabs/tabs.jsx
@@ -96,8 +96,7 @@ var Tabs = React.createClass({
         if(tab.props.children) {
           tabContent.push(React.createElement(TabTemplate, {
             key: index,
-            selected: this.state.selectedIndex === index,
-            tabIndex: index
+            selected: this.state.selectedIndex === index
           }, tab.props.children));
         } else {
           tabContent.push(undefined)
@@ -122,7 +121,7 @@ var Tabs = React.createClass({
           {tabs}
         </div>
         <InkBar left={left} width={width} />
-        <div className='mui-tab-template-container'>
+        <div>
           {tabContent}
         </div>
       </div>

--- a/src/tabs/tabs.jsx
+++ b/src/tabs/tabs.jsx
@@ -97,10 +97,19 @@ var Tabs = React.createClass({
           tabContent.push(React.createElement(TabTemplate, {
             key: index,
             selected: this.state.selectedIndex === index,
-            tabIndex: index,
-            width: width,
-            handleTouchTap: this.handleTouchTap
-          })
+            tabIndex: index
+          }, tab.props.children));
+        } else {
+          tabContent.push(undefined)
+        }
+
+        return React.addons.cloneWithProps(tab, {
+          key: index,
+          selected: this.state.selectedIndex === index,
+          tabIndex: index,
+          width: width,
+          handleTouchTap: this.handleTouchTap
+        });
       } else {
         var type = tab.type.displayName || tab.type;
         throw 'Tabs only accepts Tab Components as children. Found ' +


### PR DESCRIPTION
This is in reference to issue #450. This allows components inside tabs to keep their state.


This appears to be breaking the nested menus...
![side-effect](https://cloud.githubusercontent.com/assets/4096772/7853460/9eb1ca68-04dc-11e5-9c55-8291613075ca.png)

This behavior is not happening on the live doc site, so it is likely that this commit introduced this bug.
Plus the fact that the nested menu example shown is inside a Tab.

I'll look into a fix if I can find some time
