### PR TITLE
Use external source map file

### DIFF
--- a/docs/gulp/tasks/browserify.js
+++ b/docs/gulp/tasks/browserify.js
@@ -13,6 +13,9 @@ var gulp         = require('gulp');
 var handleErrors = require('../util/handleErrors');
 var source       = require('vinyl-source-stream');
 var config       = require('../config').browserify;
+var buffer       = require('vinyl-buffer');
+var sourcemaps   = require('gulp-sourcemaps');
+var babelify     = require('babelify');
 
 gulp.task('browserify', ['jshint'], function(callback) {
 
@@ -27,9 +30,10 @@ gulp.task('browserify', ['jshint'], function(callback) {
       entries: bundleConfig.entries,
       // Add file extentions to make optional in your requires
       extensions: config.extensions,
-      // Enable source maps!
-      debug: config.debug
-    }).transform('babelify', {stage: 1});
+      // Enable source maps, since they are only loaded on demand there is no need to disable
+      debug: true
+    }).transform(babelify.configure({stage: 1}));
+
 
     var bundle = function() {
       // Log when bundling starts
@@ -43,6 +47,10 @@ gulp.task('browserify', ['jshint'], function(callback) {
         // stream gulp compatible. Specifiy the
         // desired output filename here.
         .pipe(source(bundleConfig.outputName))
+        .pipe(buffer())
+        // Create independent source map file in the build directory
+        .pipe(sourcemaps.init({loadMaps: true}))
+        .pipe(sourcemaps.write('./'))
         // Specify the output destination
         .pipe(gulp.dest(bundleConfig.dest))
         .on('end', reportFinished);

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,11 +21,12 @@
     "gulp-less": "^3.0.0",
     "gulp-notify": "^2.1.0",
     "gulp-shell": "^0.4.1",
-    "gulp-sourcemaps": "^1.2.8",
+    "gulp-sourcemaps": "1.5.2",
     "gulp-util": "^3.0.1",
     "pretty-hrtime": "^0.2.2",
     "require-dir": "^0.1.0",
     "underscore": "^1.7.0",
+    "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.0.0",
     "watchify": "^2.2.1"
   },


### PR DESCRIPTION
Reduce payload of app.js significantly. They are only loaded on demand
for users with the console open and soure maps enabled.

app.js 5mb > 1.9mb