### PR TITLE
Fix left-nav behavior in full-screen

### DIFF
--- a/docs/src/app/components/app-left-nav.jsx
+++ b/docs/src/app/components/app-left-nav.jsx
@@ -41,7 +41,7 @@ class AppLeftNav extends React.Component {
 
   render() {
     var header = (
-      <div style={this.getStyles()} onClick={this._onHeaderClick}>
+      <div style={this.getStyles()} onTouchTap={this._onHeaderClick}>
         material ui
       </div>
     );

--- a/src/left-nav.jsx
+++ b/src/left-nav.jsx
@@ -162,7 +162,7 @@ var LeftNav = React.createClass({
               menuItemStyleLink={this.mergeAndPrefix(styles.menuItemLink)}
               menuItemStyleSubheader={this.mergeAndPrefix(styles.menuItemSubheader)}
               selectedIndex={selectedIndex}
-              onItemClick={this._onMenuItemClick} />
+              onItemTap={this._onMenuItemClick} />
         </Paper>
       </div>
     );


### PR DESCRIPTION
Fixes #366.

The problem is that the click event is fired *after* left-nav opens.
We're safe though if we just replace it with onTouchTap.