### PR TITLE
Make it possible to pass an onTouchTap handler to a dialog action

### DIFF
--- a/docs/src/app/components/pages/components/dialog.jsx
+++ b/docs/src/app/components/pages/components/dialog.jsx
@@ -25,7 +25,7 @@ class DialogPage extends React.Component {
       '//Standard Actions\n' +
       'var standardActions = [\n' +
       '  { text: \'Cancel\' },\n' +
-      '  { text: \'Submit\', onClick: this._onDialogSubmit, ref: \'submit\' }\n' +
+      '  { text: \'Submit\', onTouchTap: this._onDialogSubmit, ref: \'submit\' }\n' +
       '];\n\n' +
       '<Dialog\n' +
       '  title="Dialog With Standard Actions"\n' +
@@ -147,7 +147,7 @@ class DialogPage extends React.Component {
 
     var standardActions = [
       { text: 'Cancel' },
-      { text: 'Submit', onClick: this._onDialogSubmit, ref: 'submit' }
+      { text: 'Submit', onTouchTap: this._onDialogSubmit, ref: 'submit' }
     ];
 
     var customActions = [
@@ -200,6 +200,10 @@ class DialogPage extends React.Component {
       </ComponentDoc>
     );
 
+  }
+
+  _onDialogSubmit() {
+    console.log('Submitting');
   }
 
   _handleCustomDialogCancel() {

--- a/src/dialog-window.jsx
+++ b/src/dialog-window.jsx
@@ -156,12 +156,19 @@ var DialogWindow = React.createClass({
   },
 
   _getAction: function(actionJSON, key) {
-    var onClickHandler = actionJSON.onClick ? actionJSON.onClick : this.dismiss;
     var styles = {marginRight: 8};
     var props = {
       key: key,
       secondary: true,
-      onClick: onClickHandler,
+      onClick: actionJSON.onClick,
+      onTouchTap: () => {
+        if (actionJSON.onTouchTap) {
+          actionJSON.onTouchTap.call(undefined);
+        }
+        if (!(actionJSON.onClick || actionJSON.onTouchTap)) {
+          this.dismiss();
+        }
+      },
       label: actionJSON.text,
       style: styles
     };


### PR DESCRIPTION
The dialog actions could not react to the onTouchTap event.
This commit makes it possible.
It's also still possible to pass onClick.
If neither onClick nor onTouchTap is present on an action, then
the dialog is dismissed on touchTap.
