### PR TITLE
Since JSX transformations are now automatically done by MUI, change README and docs "Getting Started" to reflect this

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Material-UI](http://callemall.github.io/material-ui/)
+#[Material-UI](http://callemall.github.io/material-ui/)
 
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/callemall/material-ui?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -16,8 +16,7 @@ Material-UI is available as an [npm package](https://www.npmjs.org/package/mater
 ```sh
 npm install material-ui
 ```
-
-Use [browserify](http://browserify.org/) and [reactify](https://github.com/andreypopp/reactify) for dependency management and JSX transformation. 
+After npm install, you'll find all the .jsx files in the /src folder and their compiled versions in the /lib folder.
 
 ### React-Tap-Event-Plugin
 Some components use [react-tap-event-plugin](https://github.com/zilverline/react-tap-event-plugin) to

--- a/docs/src/app/components/pages/get-started.jsx
+++ b/docs/src/app/components/pages/get-started.jsx
@@ -86,8 +86,7 @@ class GetStarted extends React.Component {
           <h2 style={styles.headline}>Installation</h2>
           <p>
             Material-UI is available as an <a href="https://www.npmjs.org/package/material-ui">npm package</a>.
-            Use <a href="http://browserify.org/">browserify</a> and <a href="https://github.com/andreypopp/reactify">reactify</a> for
-            dependency management and JSX transformation. 
+            After npm install, you will find all the .jsx files in the /src folder and their compiled versions in the /lib folder.
           </p>
 
           <h3 style={styles.title}>React-Tap-Event-Plugin</h3>


### PR DESCRIPTION
Fixed description for browserify and reactify

README.md description of browserify and reactify added

Modified README.md to show update on JSX transformations already being part of MUI

Modified README.md to show update on JSX transformations already being part of MUI

changed get started page to reflect README.md