### PR TITLE
Allows explicit null or empty string values to override

### DIFF
--- a/src/utils/extend.js
+++ b/src/utils/extend.js
@@ -14,6 +14,8 @@ Array.prototype.diff = function(a) {
 var extend = function(object, overrides) {
   var mergeObject = {};
 
+  function isNull(value) { return value === '' || value === null; }
+
   Object.keys(object).forEach(function(currentKey) {
 
     // Arrays and null are also objects, 
@@ -23,7 +25,7 @@ var extend = function(object, overrides) {
     if (typeof(object[currentKey]) === 'object' && overridesIsValidObject) {
       mergeObject[currentKey] = extend(object[currentKey], overrides[currentKey]);
     } else {
-      if (overrides && overrides[currentKey]) {
+      if (overrides && (overrides[currentKey] || isNull(overrides[currentKey]))) {
         mergeObject[currentKey] = overrides[currentKey];
       } else {
         mergeObject[currentKey] = object[currentKey];


### PR DESCRIPTION
I'd like to be able to disable inline styles for certain properties. This would allow it to use whatever is defined in css instead.

More details here: https://github.com/callemall/material-ui/issues/760
