### PR TITLE
for suppressing warning when checked props on radio-button is missing.

### DIFF
--- a/src/radio-button.jsx
+++ b/src/radio-button.jsx
@@ -93,7 +93,7 @@ var RadioButton = React.createClass({
     var enhancedSwitchProps = {
       ref: "enhancedSwitch",
       inputType: "radio",
-      switched: this.props.checked,
+      switched: this.props.checked || false,
       switchElement: radioButtonElement,
       rippleColor: rippleColor,
       iconStyle: styles.icon,


### PR DESCRIPTION
trivial fix.

EnhancedSwitch requires switched property, but RadioButton may not have it, so put default value.

```
[Warning] Warning: Failed propType: Required prop `switched` was not specified in `EnhancedSwitch`. Check the render method of `RadioButton`.
```