### PR TITLE
Add "Theme" high order component and "theme" decorator

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,7 @@ module.exports = {
   Snackbar: require('./snackbar'),
   Tab: require('./tabs/tab'),
   Tabs: require('./tabs/tabs'),
+  Theme: require('./theme'),
   Toggle: require('./toggle'),
   TimePicker: require('./time-picker'),
   TextField: require('./text-field'),

--- a/src/theme.jsx
+++ b/src/theme.jsx
@@ -1,0 +1,61 @@
+var React = require('react');
+var ThemeManager = require('./styles/theme-manager');
+
+
+var Theme = React.createClass({
+
+  propTypes: {
+    theme: React.PropTypes.object
+  },
+
+  childContextTypes: {
+    muiTheme: React.PropTypes.object.isRequired
+  },
+
+  getChildContext: function() {
+    return {
+      muiTheme: this.themeManager.getCurrentTheme()
+    };
+  },
+
+  componentWillMount: function() {
+    this.themeManager = new ThemeManager();
+
+    if (this.props.theme) {
+      this.themeManager.setTheme(this.props.theme);
+    }
+  },
+
+  render: function() {
+    return this.props.children({themeManager: this.themeManager});
+  }
+});
+
+
+function getDisplayName(Component) {
+  return Component.displayName || Component.name || 'Component';
+}
+
+function theme(obj) {
+  return function(Component) {
+    return React.createClass({
+
+      displayName: 'Theme(' + getDisplayName(Component) + ')',
+
+      render: function() {
+        return (
+          <Theme theme={obj}>
+            {
+              function(props) {
+                return (<Component {...this.props} {...props}/>);
+              }
+            }
+          </Theme>
+        );
+      }
+    });
+  }
+}
+
+module.exports = Theme;
+module.exports.theme = theme;

--- a/src/theme.jsx
+++ b/src/theme.jsx
@@ -9,12 +9,14 @@ var Theme = React.createClass({
   },
 
   childContextTypes: {
-    muiTheme: React.PropTypes.object.isRequired
+    muiTheme: React.PropTypes.object.isRequired,
+    themeManager: React.PropTypes.object.isRequired
   },
 
   getChildContext: function() {
     return {
       muiTheme: this.themeManager.getCurrentTheme()
+      themeManager: this.themeManager
     };
   },
 
@@ -27,7 +29,10 @@ var Theme = React.createClass({
   },
 
   render: function() {
-    return this.props.children({themeManager: this.themeManager});
+    return this.props.children({
+      muiTheme: this.themeManager.getCurrentTheme(),
+      themeManager: this.themeManager
+    });
   }
 });
 
@@ -36,7 +41,7 @@ function getDisplayName(Component) {
   return Component.displayName || Component.name || 'Component';
 }
 
-function theme(obj) {
+function theme(customTheme) {
   return function(Component) {
     return React.createClass({
 
@@ -44,7 +49,7 @@ function theme(obj) {
 
       render: function() {
         return (
-          <Theme theme={obj}>
+          <Theme theme={customTheme}>
             {
               function(props) {
                 return (<Component {...this.props} {...props}/>);

--- a/src/theme.jsx
+++ b/src/theme.jsx
@@ -15,7 +15,7 @@ var Theme = React.createClass({
 
   getChildContext: function() {
     return {
-      muiTheme: this.themeManager.getCurrentTheme()
+      muiTheme: this.themeManager.getCurrentTheme(),
       themeManager: this.themeManager
     };
   },

--- a/src/theme.jsx
+++ b/src/theme.jsx
@@ -48,7 +48,7 @@ function theme(obj) {
             {
               function(props) {
                 return (<Component {...this.props} {...props}/>);
-              }
+              }.bind(this)
             }
           </Theme>
         );

--- a/src/theme.jsx
+++ b/src/theme.jsx
@@ -10,13 +10,13 @@ var Theme = React.createClass({
 
   childContextTypes: {
     muiTheme: React.PropTypes.object.isRequired,
-    themeManager: React.PropTypes.object.isRequired
+    muiThemeManager: React.PropTypes.object.isRequired
   },
 
   getChildContext: function() {
     return {
       muiTheme: this.themeManager.getCurrentTheme(),
-      themeManager: this.themeManager
+      muiThemeManager: this.themeManager
     };
   },
 
@@ -31,7 +31,7 @@ var Theme = React.createClass({
   render: function() {
     return this.props.children({
       muiTheme: this.themeManager.getCurrentTheme(),
-      themeManager: this.themeManager
+      muiThemeManager: this.themeManager
     });
   }
 });


### PR DESCRIPTION
You can use it to set the theme and the context required by material-ui.

There is two ways to use it.

1) High order component

```js
// ES6 syntax

import React from 'react';
import {Theme, Styles, RaisedButton} from 'material-ui';

const myTheme = {
  getPalette: () => ({
    accent1Color: Styles.Colors.deepOrange500
  }),
  getComponentThemes: () => ({})
};

export default class App extends React.Component {
  render() {
    return (
      <Theme theme={myTheme}>
        {props => // props contains the ThemeManager instance in "themeManager" property (also added to context)
          <RaisedButton label='Super Button' primary={true}/>
        }
      </Theme>
    );
  }
}
```

2) Decorator
```js
// ES6 syntax

import React from 'react';
import {Styles, RaisedButton} from 'material-ui';
import {theme} from 'material-ui/lib/theme';

const myTheme = {
  getPalette: () => ({
    accent1Color: Styles.Colors.deepOrange500
  }),
  getComponentThemes: () => ({})
};

@theme(myTheme)
export default class App extends React.Component {
  render() {
    return (
      <RaisedButton label='Super Button' primary={true}/>
    );
  }
}
```