### PR TITLE
allows single radio-button without errors.

### DIFF
--- a/src/radio-button-group.jsx
+++ b/src/radio-button-group.jsx
@@ -26,7 +26,7 @@ var RadioButtonGroup = React.createClass({
   componentWillMount: function() {
     var cnt = 0;
 
-    this.props.children.forEach(function(option) {
+    React.Children.forEach(function(option) {
       if (this._hasCheckAttribute(option)) cnt++;
     }, this);
 
@@ -41,7 +41,7 @@ var RadioButtonGroup = React.createClass({
 
 	render: function() {
 
-    var options = this.props.children.map(function(option) {
+    var options = React.Children.map(function(option) {
 
       var {
         name,


### PR DESCRIPTION
trivial fix, again.

RadioButtonGroup throws an exception if just single RadioButton is in, so try to suppress the error.

see #786.
