### PR TITLE
Move DropDownMenu bottom border 1px up to align with toolbar height.

### DIFF
--- a/src/drop-down-menu.jsx
+++ b/src/drop-down-menu.jsx
@@ -104,7 +104,7 @@ var DropDownMenu = React.createClass({
       },
       underline: {
         borderTop: 'solid 1px ' + accentColor,
-        margin: '0 ' + this.getSpacing().desktopGutter + 'px'
+        margin: '-1px ' + this.getSpacing().desktopGutter + 'px'
       },
       menuItem: {
         paddingRight: this.getSpacing().iconSize +


### PR DESCRIPTION
Check the Toolbar demo; the DropDownMenu is one pixel below the actual toolbar. Moving it one pixel up fixes it.