### PR TITLE
dialog: allow to hide dialog with openImmediately set

### DIFF
--- a/src/dialog-window.jsx
+++ b/src/dialog-window.jsx
@@ -53,9 +53,7 @@ var DialogWindow = React.createClass({
   componentDidMount: function() {
     this._positionDialog();
     if (this.props.openImmediately) {
-      this.refs.dialogOverlay.preventScrolling();
-      this._onShow();
-      this._focusOnAction();
+      this.show();
     }
   },
 


### PR DESCRIPTION
was broken by https://github.com/callemall/material-ui/commit/f8bdaf347da3cfd12be0f85a5a9d8bdbbd5a3e95
does it make sense to call setState({open: true}) in that case?

