### PR TITLE
Don’t modify Array.prototype

### DIFF
--- a/src/utils/extend.js
+++ b/src/utils/extend.js
@@ -1,6 +1,6 @@
 // http://stackoverflow.com/questions/1187518/javascript-array-difference
-Array.prototype.diff = function(a) {
-    return this.filter(function(i) {return a.indexOf(i) < 0;});
+var arrayDiff = function(a, b) {
+  return a.filter(function(i) {return b.indexOf(i) < 0;});
 };
 
 /** 
@@ -36,7 +36,7 @@ var extend = function(object, overrides) {
 
   // Overrides not defined in object are immediately added.
   if (overrides && typeof(overrides) === 'object' && !Array.isArray(overrides)) {
-    Object.keys(overrides).diff(Object.keys(object)).forEach(function(currentDiff) {
+    arrayDiff(Object.keys(overrides), Object.keys(object)).forEach(function(currentDiff) {
       mergeObject[currentDiff] = overrides[currentDiff];
     });
   }


### PR DESCRIPTION
I ran into an issue trying to use https://github.com/rtfeldman/seamless-immutable (https://github.com/rtfeldman/seamless-immutable/issues/39) as you are extending Array.prototype.

This removes the modification to Array.prototype.