### PR TITLE
TimePicker now correctly checks for defaultTime instead of defaultDate

### DIFF
--- a/src/time-picker/time-picker.jsx
+++ b/src/time-picker/time-picker.jsx
@@ -73,7 +73,7 @@ var TimePicker = React.createClass({
 
     var defaultInputValue;
 
-    if (this.props.defaultDate) {
+    if (this.props.defaultTime) {
       defaultInputValue = this.formatTime(this.props.defaultTime);
     }
 


### PR DESCRIPTION
The defaultTime prop wasn't working since we checked for defaultDate before setting the default input value.