### PR TITLE
[TimePicker] Got the clock handles working on Firefox.

### DIFF
--- a/src/time-picker/clock-hours.jsx
+++ b/src/time-picker/clock-hours.jsx
@@ -63,17 +63,17 @@ var ClockHours = React.createClass({
     this.setClock(e, false);
   },
   setClock: function(e, finish){
-
+    var ne = e.nativeEvent;
      
-     var pos = {
-        x: e.nativeEvent.offsetX,
-        y: e.nativeEvent.offsetY
-     };
+    var pos = {
+      x: ne.offsetX==undefined ? ne.layerX : ne.offsetX,
+      y: ne.offsetY==undefined ? ne.layerY : ne.offsetY
+    };
   
     var hours = this.getHours(pos.x, pos.y);
  
     this.props.onChange(hours, finish);
-     
+
   },
   getHours: function(x, y){
 

--- a/src/time-picker/clock-hours.jsx
+++ b/src/time-picker/clock-hours.jsx
@@ -66,8 +66,8 @@ var ClockHours = React.createClass({
     var ne = e.nativeEvent;
      
     var pos = {
-      x: ne.offsetX==undefined ? ne.layerX : ne.offsetX,
-      y: ne.offsetY==undefined ? ne.layerY : ne.offsetY
+      x: ne.offsetX === undefined ? ne.layerX : ne.offsetX,
+      y: ne.offsetY === undefined ? ne.layerY : ne.offsetY
     };
   
     var hours = this.getHours(pos.x, pos.y);

--- a/src/time-picker/clock-minutes.jsx
+++ b/src/time-picker/clock-minutes.jsx
@@ -70,9 +70,11 @@ var ClockMinutes = React.createClass({
      e.preventDefault();
      if(this.isMousePressed(e) != 1 ) return;
      
+     var ne = e.nativeEvent;
+
      var pos = {
-        x: e.nativeEvent.offsetX,
-        y: e.nativeEvent.offsetY
+        x: ne.offsetX==undefined ? ne.layerX : ne.offsetX,
+        y: ne.offsetY==undefined ? ne.layerY : ne.offsetY
      };
   
      var minutes = this.getMinutes(pos.x, pos.y)

--- a/src/time-picker/clock-minutes.jsx
+++ b/src/time-picker/clock-minutes.jsx
@@ -73,8 +73,8 @@ var ClockMinutes = React.createClass({
      var ne = e.nativeEvent;
 
      var pos = {
-        x: ne.offsetX==undefined ? ne.layerX : ne.offsetX,
-        y: ne.offsetY==undefined ? ne.layerY : ne.offsetY
+        x: ne.offsetX === undefined ? ne.layerX : ne.offsetX,
+        y: ne.offsetY === undefined ? ne.layerY : ne.offsetY
      };
   
      var minutes = this.getMinutes(pos.x, pos.y)


### PR DESCRIPTION
Uses MouseEvent.layerX when MouseEvent.offsetX is not available (i.e. on Firefox 39 and before).