### PR TITLE
[DatePicker] Made sure we don't close the date picker when switching months with the autoOk prop set to true

### DIFF
--- a/src/date-picker/calendar.jsx
+++ b/src/date-picker/calendar.jsx
@@ -212,7 +212,8 @@ var Calendar = React.createClass({
   },
 
   _addSelectedMonths: function(months) {
-    this._setSelectedDate(DateTime.addMonths(this.state.selectedDate, months));
+    var isNavigation = true;
+    this._setSelectedDate(DateTime.addMonths(this.state.selectedDate, months), null, isNavigation);
   },
 
   _addSelectedYears: function(years) {
@@ -232,7 +233,7 @@ var Calendar = React.createClass({
     }
   },
 
-  _setSelectedDate: function(date, e) {
+  _setSelectedDate: function(date, e, isNavigation) {
     var adjustedDate = date;
     if (DateTime.isBeforeDate(date, this.props.minDate)) {
       adjustedDate = this.props.minDate;
@@ -249,7 +250,7 @@ var Calendar = React.createClass({
         selectedDate: adjustedDate
       });
     }
-    if(this.props.onSelectedDate) this.props.onSelectedDate(e, date);
+    if(this.props.onSelectedDate) this.props.onSelectedDate(e, date, isNavigation);
   },
 
   _handleDayTouchTap: function(e, date) {

--- a/src/date-picker/date-picker-dialog.jsx
+++ b/src/date-picker/date-picker-dialog.jsx
@@ -116,8 +116,8 @@ var DatePickerDialog = React.createClass({
     this.refs.dialogWindow.dismiss();
   },
 
-  _onSelectedDate: function(e) {
-    if(this.props.autoOk) {
+  _onSelectedDate: function(e, date, isNavigation) {
+    if(this.props.autoOk && !isNavigation) {
       setTimeout(this._handleOKTouchTap, 300);
     }
   },


### PR DESCRIPTION
Did not refactor the weird func(date, e) and func(e, date) in some functions since I'm not aware of how it's used throughout the library.