### PR TITLE
Prevent closed Menu from being selectable

### DIFF
--- a/src/menu/menu.jsx
+++ b/src/menu/menu.jsx
@@ -449,7 +449,9 @@ var Menu = React.createClass({
         //Open the menu
         el.style.transition = Transitions.easeOut();
         el.style.height = this._getCurrentHeight() + 'px';
-
+        el.style.paddingTop = this.getSpacing().desktopGutterMini + 'px';
+        el.style.paddingBottom = this.getSpacing().desktopGutterMini + 'px';
+        
         //Set the overflow to visible after the animation is done so
         //that other nested menus can be shown
         CssEvent.onTransitionEnd(el, function() {
@@ -463,6 +465,8 @@ var Menu = React.createClass({
 
         //Close the menu
         el.style.height = '0px';
+        el.style.paddingTop = '0px';
+        el.style.paddingBottom = '0px';
 
         //Set the overflow to hidden so that animation works properly
         container.style.overflow = 'hidden';


### PR DESCRIPTION
When a menu is closed, the opacity is set to 0. The height is set to 0 as well. However, due to padding top and bottom being 8, there as a 16px high invisible section present on the screen, which was selectable (the first menu item would get clicked)

To fix this, we need to remove the padding if it is in closed mode.