### PR TITLE
cosmetic fixes to textfield/select-field

### DIFF
--- a/docs/gulp/tasks/eslint.js
+++ b/docs/gulp/tasks/eslint.js
@@ -3,5 +3,5 @@ var shell = require('gulp-shell');
 var handleErrors = require('../util/handleErrors');
 
 gulp.task('eslint', shell.task([
-  '../node_modules/.bin/eslint ../src/**'
+  '"../node_modules/.bin/eslint" ../src'
 ])).on('error', handleErrors);

--- a/docs/src/app/components/pages/components/table.jsx
+++ b/docs/src/app/components/pages/components/table.jsx
@@ -200,7 +200,7 @@ let footerCols = {id: {content: 'ID'}, name: {content: 'Name'}, status: {content
             desc: 'If true, multiple table rows can be selected. CTRL/CMD+Click and SHIFT+Click are valid actions. The default value is false.'
           },
           {
-            name: 'showRowSelectCheckbox',
+            name: 'displayRowCheckbox',
             type: 'boolean',
             header: 'optional',
             desc: 'Controls the display of the row checkbox. The default value is true.'

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "prebuild": "rm -rf lib",
-    "eslint": "eslint src/**",
+    "eslint": "eslint src",
     "build": "npm run eslint && babel --stage 1 ./src --out-dir ./lib",
     "prepublish": "npm run build"
   },

--- a/src/menu/menu.jsx
+++ b/src/menu/menu.jsx
@@ -245,9 +245,6 @@ var Menu = React.createClass({
     //Set the menu width
     this._setKeyWidth(el);
 
-    //Save the initial menu item height for later
-    this._initialMenuItemHeight = el.offsetHeight / Math.max(1, this.props.menuItems.length);
-
     //Show or Hide the menu according to visibility
     this._renderVisibility();
   },
@@ -271,7 +268,8 @@ var Menu = React.createClass({
         paddingTop: this.getSpacing().desktopGutterMini,
         paddingBottom: this.getSpacing().desktopGutterMini,
         transition: Transitions.easeOut(null, 'height'),
-        outline:'none !important'
+        outline:'none !important',
+        height:34
       },
       subheader: {
         paddingLeft: this.context.muiTheme.component.menuSubheader.padding,
@@ -433,8 +431,9 @@ var Menu = React.createClass({
   },
 
   _getCurrentHeight() {
-    let totalItens = Math.max(1, this.props.menuItems.length);
-    let newHeight = this._initialMenuItemHeight * totalItens;
+    let totalItems = Math.max(1, this.props.menuItems.length);
+    let styles = this.getStyles();
+    let newHeight = styles.root.height * totalItems;
 
     return newHeight;
   },

--- a/src/menu/menu.jsx
+++ b/src/menu/menu.jsx
@@ -268,8 +268,7 @@ var Menu = React.createClass({
         paddingTop: this.getSpacing().desktopGutterMini,
         paddingBottom: this.getSpacing().desktopGutterMini,
         transition: Transitions.easeOut(null, 'height'),
-        outline:'none !important',
-        height:34
+        outline:'none !important'
       },
       subheader: {
         paddingLeft: this.context.muiTheme.component.menuSubheader.padding,
@@ -281,6 +280,9 @@ var Menu = React.createClass({
         position: 'absolute',
         top: 0,
         zIndex: 1
+      },
+      item: {
+        height:34
       }
     };
     return styles;
@@ -433,7 +435,8 @@ var Menu = React.createClass({
   _getCurrentHeight() {
     let totalItems = Math.max(1, this.props.menuItems.length);
     let styles = this.getStyles();
-    let newHeight = styles.root.height * totalItems;
+    debugger
+    let newHeight = styles.item.height * totalItems;
 
     return newHeight;
   },
@@ -451,7 +454,7 @@ var Menu = React.createClass({
         el.style.height = this._getCurrentHeight() + 'px';
         el.style.paddingTop = this.getSpacing().desktopGutterMini + 'px';
         el.style.paddingBottom = this.getSpacing().desktopGutterMini + 'px';
-        
+
         //Set the overflow to visible after the animation is done so
         //that other nested menus can be shown
         CssEvent.onTransitionEnd(el, () => {

--- a/src/select-field.jsx
+++ b/src/select-field.jsx
@@ -64,7 +64,9 @@ let SelectField = React.createClass({
   },
 
   onChange(e, index, payload) {
-    e.target.value = payload;
+    if (payload)
+      e.target.value = payload[this.props.valueMember] || payload;
+
     if (this.props.onChange)
       this.props.onChange(e)
   },

--- a/src/styles/theme-manager.js
+++ b/src/styles/theme-manager.js
@@ -29,7 +29,7 @@ let ThemeManager = () => {
       this.setComponentThemes(newTheme.getComponentThemes(newTheme.getPalette()));
     },
 
-    setSpacingsetSpacing(newSpacing) {
+    setSpacing(newSpacing) {
       this.spacing = Extend(this.spacing, newSpacing);
       this.component = Extend(this.component, this.template.getComponentThemes(this.palette, this.spacing));
     },

--- a/src/table/table.jsx
+++ b/src/table/table.jsx
@@ -30,7 +30,7 @@ let Table = React.createClass({
     showRowHover: React.PropTypes.bool,
     selectable: React.PropTypes.bool,
     multiSelectable: React.PropTypes.bool,
-    showRowSelectCheckbox: React.PropTypes.bool,
+    displayRowCheckbox: React.PropTypes.bool,
     canSelectAll: React.PropTypes.bool,
     displaySelectAll: React.PropTypes.bool,
     onRowSelection: React.PropTypes.func,
@@ -50,7 +50,7 @@ let Table = React.createClass({
       stripedRows: false,
       showRowHover: false,
       selectable: true,
-      showRowSelectCheckbox: true,
+      displayRowCheckbox: true,
       multiSelectable: false,
       canSelectAll: false,
       displaySelectAll: true
@@ -195,6 +195,7 @@ let Table = React.createClass({
           columns={rowData}
           selected={selected}
           striped={striped}
+          displayRowCheckbox={displayRowCheckbox}
           hoverable={this.props.showRowHover}
           displayBorder={border}
           selectable={this.props.selectable}

--- a/src/text-field.jsx
+++ b/src/text-field.jsx
@@ -62,7 +62,7 @@ let TextField = React.createClass({
     let hasErrorProp = nextProps.hasOwnProperty('errorText');
     let newState = {};
 
-    if (hasErrorProp) newState.errorText = nextProps.errorText;
+    newState.errorText = nextProps.errorText;
     if (nextProps.children && nextProps.children.props) {
       nextProps = nextProps.children.props;
     }


### PR DESCRIPTION
1. unsetting errorText prop should remove error text
2. When selecting an item from select-field e.target.value should be the value not the payload
3. Menu calculation didn't work when menuItems are changed/supplied after mount.