### PR TITLE
Merge snackbar styles when closed as well as open

### DIFF
--- a/src/snackbar.jsx
+++ b/src/snackbar.jsx
@@ -113,8 +113,9 @@ let Snackbar = React.createClass({
       );
     }
 
-    let rootStyles = styles.root;
-    if (this.state.open) rootStyles = this.mergeStyles(styles.root, styles.rootWhenOpen, this.props.style);
+    let rootStyles = this.state.open ?
+      this.mergeStyles(styles.root, styles.rootWhenOpen, this.props.style) :
+      this.mergeStyles(styles.root, this.props.style);
 
     return (
       <span style={rootStyles}>


### PR DESCRIPTION
Inline styles aren't being overridden when the snackbar is closing because they were only merged when it was open. This fixes that. It still doesn't give a good way to add your own, different styles for opening and closing though.