### PR TITLE
Fixed support for custom menuItemStyleSubheader

### DIFF
--- a/src/menu/menu.jsx
+++ b/src/menu/menu.jsx
@@ -355,7 +355,7 @@ var Menu = React.createClass({
               key={i}
               index={i}
               className={this.props.menuItemClassNameSubheader}
-              style={this.mergeAndPrefix(styles.subheader)}
+              style={this.mergeAndPrefix(styles.subheader, this.props.menuItemStyleSubheader)}
               firstChild={i === 0}
               text={menuItem.text} />
           );


### PR DESCRIPTION
When adding a subheader menu item, the style passed by props was being ignored. 