### PR TITLE
[Tabs] Allow style override of tab content's container

### DIFF
--- a/docs/src/app/components/pages/components/tabs.jsx
+++ b/docs/src/app/components/pages/components/tabs.jsx
@@ -87,7 +87,13 @@ class TabsPage extends React.Component {
             name: 'tabItemContainerStyle',
             type: 'object',
             header: 'optional',
-            desc: 'Override the inline-styles of the tabs container.'
+            desc: 'Override the inline-styles of the tab-labels container.'
+          },
+          {
+            name: 'contentContainerStyle',
+            type: 'object',
+            header: 'optional',
+            desc: 'Override the inline-styles of the content\'s container.'
           },
           {
             name: 'tabWidth',

--- a/src/tabs/tabs.jsx
+++ b/src/tabs/tabs.jsx
@@ -17,7 +17,8 @@ let Tabs = React.createClass({
     initialSelectedIndex: React.PropTypes.number,
     onActive: React.PropTypes.func,
     tabWidth: React.PropTypes.number,
-    tabItemContainerStyle: React.PropTypes.object
+    tabItemContainerStyle: React.PropTypes.object,
+    contentContainerStyle: React.PropTypes.object,
   },
 
   getInitialState(){
@@ -120,7 +121,7 @@ let Tabs = React.createClass({
           {tabs}
         </div>
         <InkBar left={left} width={width} />
-        <div>
+        <div style={this.mergeAndPrefix(this.props.contentContainerStyle)}>
           {tabContent}
         </div>
       </div>


### PR DESCRIPTION
So that you can customize the inline styles of the container, that surrounds the content of the currently active tab.