### PR TITLE
Include Overlay in index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ module.exports = {
     StylePropable: require('./mixins/style-propable'),
     StyleResizable: require('./mixins/style-resizable')
   },
+  Overlay: require('./overlay'),
   Paper: require('./paper'),
   RadioButton: require('./radio-button'),
   RadioButtonGroup: require('./radio-button-group'),


### PR DESCRIPTION
Overlay was missing in index.js, this caused problems for browserify/babelify when trying to `import Overlay from 'material-ui'`

With the `Overlay: require('./overlay'),` I have no more errors, and can use the `Overlay` component nicely in code.