### PR TITLE
EnhancedTextarea: access the input textfield using getInputNode().

### DIFF
--- a/src/enhanced-textarea.jsx
+++ b/src/enhanced-textarea.jsx
@@ -108,7 +108,7 @@ let EnhancedTextarea = React.createClass({
   },
 
   setValue(value) {
-    this.refs.input.value = value;
+    this.getInputNode().value = value;
     this._syncHeightWithShadow(value);
   },
 


### PR DESCRIPTION
Fix error when setting the value of the textfield 'input'. Use
getInputMethod() instead of accessing this.refs.input which doesn't
return the DOM element.