### PR TITLE
Inline style fix & custom colors enhancement for RaisedButton

### DIFF
--- a/docs/src/app/components/pages/components/buttons.jsx
+++ b/docs/src/app/components/pages/components/buttons.jsx
@@ -192,6 +192,30 @@ class ButtonPage extends React.Component {
             desc: 'If true, the button will use the secondary button colors.'
           },
           {
+            name: 'backgroundColor',
+            type: 'string',
+            header: 'optional',
+            desc: 'Override the background color. Always takes precedence unless the button is disabled.'
+          },
+          {
+            name: 'labelColor',
+            type: 'string',
+            header: 'optional',
+            desc: 'Override the label color. Always takes precedence unless the button is disabled.'
+          },
+          {
+            name: 'disabledBackgroundColor',
+            type: 'string',
+            header: 'optional',
+            desc: 'Override the background color if the button is disabled.'
+          },
+          {
+            name: 'disabledLabelColor',
+            type: 'string',
+            header: 'optional',
+            desc: 'Override the label color if the button is disabled.'
+          },
+          {
             name: 'style',
             type: 'object',
             header: 'optional',

--- a/src/raised-button.jsx
+++ b/src/raised-button.jsx
@@ -37,6 +37,8 @@ let RaisedButton = React.createClass({
     labelStyle: React.PropTypes.object,
     backgroundColor: React.PropTypes.string,
     labelColor: React.PropTypes.string,
+    disabledBackgroundColor: React.PropTypes.string,
+    disabledLabelColor: React.PropTypes.string,
   },
 
   getInitialState() {
@@ -58,7 +60,10 @@ let RaisedButton = React.createClass({
   },
 
   _getBackgroundColor() {
-    return  this.props.disabled ? this.getTheme().disabledColor :
+    let disabledColor = this.props.disabledBackgroundColor ? this.props.disabledBackgroundColor :
+      this.getTheme().disabledColor;
+
+    return  this.props.disabled ? disabledColor :
       this.props.backgroundColor ? this.props.backgroundColor :
       this.props.primary ? this.getTheme().primaryColor :
       this.props.secondary ? this.getTheme().secondaryColor :
@@ -66,7 +71,10 @@ let RaisedButton = React.createClass({
   },
 
   _getLabelColor() {
-    return  this.props.disabled ? this.getTheme().disabledTextColor :
+    let disabledColor = this.props.disabledLabelColor ? this.props.disabledLabelColor :
+      this.getTheme().disabledTextColor;
+
+    return  this.props.disabled ? disabledColor :
       this.props.labelColor ? this.props.labelColor :
       this.props.primary ? this.getTheme().primaryTextColor :
       this.props.secondary ? this.getTheme().secondaryTextColor :

--- a/src/raised-button.jsx
+++ b/src/raised-button.jsx
@@ -59,17 +59,17 @@ let RaisedButton = React.createClass({
 
   _getBackgroundColor() {
     return  this.props.disabled ? this.getTheme().disabledColor :
+      this.props.backgroundColor ? this.props.backgroundColor :
       this.props.primary ? this.getTheme().primaryColor :
       this.props.secondary ? this.getTheme().secondaryColor :
-      this.props.backgroundColor ? this.props.backgroundColor :
       this.getTheme().color;
   },
 
   _getLabelColor() {
     return  this.props.disabled ? this.getTheme().disabledTextColor :
+      this.props.labelColor ? this.props.labelColor :
       this.props.primary ? this.getTheme().primaryTextColor :
       this.props.secondary ? this.getTheme().secondaryTextColor :
-      this.props.labelColor ? this.props.labelColor :
       this.getTheme().textColor;
   },
 

--- a/src/raised-button.jsx
+++ b/src/raised-button.jsx
@@ -35,6 +35,8 @@ let RaisedButton = React.createClass({
     primary: React.PropTypes.bool,
     secondary: React.PropTypes.bool,
     labelStyle: React.PropTypes.object,
+    backgroundColor: React.PropTypes.string,
+    labelColor: React.PropTypes.string,
   },
 
   getInitialState() {
@@ -59,6 +61,7 @@ let RaisedButton = React.createClass({
     return  this.props.disabled ? this.getTheme().disabledColor :
       this.props.primary ? this.getTheme().primaryColor :
       this.props.secondary ? this.getTheme().secondaryColor :
+      this.props.backgroundColor ? this.props.backgroundColor :
       this.getTheme().color;
   },
 
@@ -66,6 +69,7 @@ let RaisedButton = React.createClass({
     return  this.props.disabled ? this.getTheme().disabledTextColor :
       this.props.primary ? this.getTheme().primaryTextColor :
       this.props.secondary ? this.getTheme().secondaryTextColor :
+      this.props.labelColor ? this.props.labelColor :
       this.getTheme().textColor;
   },
 

--- a/src/toolbar/toolbar-group.jsx
+++ b/src/toolbar/toolbar-group.jsx
@@ -92,24 +92,24 @@ let ToolbarGroup = React.createClass({
       switch (currentChild.type.displayName) {
         case 'DropDownMenu' :
           return React.cloneElement(currentChild, {
-            style: styles.dropDownMenu.root,
+            style: this.mergeStyles(styles.dropDownMenu.root, currentChild.props.style),
             styleControlBg: styles.dropDownMenu.controlBg,
             styleUnderline: styles.dropDownMenu.underline
           });
         case 'DropDownIcon' :
           return React.cloneElement(currentChild, {
-            style: {float: 'left'},
+            style: this.mergeStyles({float: 'left'}, currentChild.props.style),
             iconStyle: styles.icon.root,
             onMouseOver: this._handleMouseOverDropDownMenu,
             onMouseOut: this._handleMouseOutDropDownMenu
           });
         case 'RaisedButton' : case 'FlatButton' :
           return React.cloneElement(currentChild, {
-            style: styles.button
+            style: this.mergeStyles(styles.button, currentChild.props.style),
           });
         case 'FontIcon' :
           return React.cloneElement(currentChild, {
-            style: styles.icon.root,
+            style: this.mergeStyles(styles.icon.root, currentChild.props.style),
             onMouseOver: this._handleMouseOverFontIcon,
             onMouseOut: this._handleMouseOutFontIcon
           });


### PR DESCRIPTION
Custom inline styles would not work for certain elements that were contained inside a toolbar, this is fixed.

Also, I've added custom color overrides for the RaisedButton, for both the label and background and seperate options for when the button is disabled.