### PR TITLE
[SelectField] No longer rely on floatingLabelText to get correct styling

### DIFF
--- a/docs/src/app/components/pages/components/text-fields.jsx
+++ b/docs/src/app/components/pages/components/text-fields.jsx
@@ -19,6 +19,7 @@ let TextFieldsPage = React.createClass({
       floatingPropValue: 'Prop Value',
       valueLinkValue: 'Value Link',
       selectValue: undefined,
+      selectValue2: undefined,
       selectValueLinkValue: 4,
       floatingValueLinkValue: 'Value Link'
     };
@@ -79,15 +80,22 @@ let TextFieldsPage = React.createClass({
       '  disabled={true}\n' +
       '  defaultValue="Disabled With Value" />\n\n' +
 
-      '//Select Fields\n' +
+      '//Select Fields\n'+
       '<SelectField\n'+
       '  value={this.state.selectValue}\n'+
-      '  onChange={this._handleSelectValueChange}\n'+
-      '  hintText="Select Field"\n'+
+      '  onChange={this._handleSelectValueChange.bind(null, "selectValue")}\n'+
+      '  hintText="Hint Text"\n'+
       '  menuItems={menuItems} />\n'+
       '<SelectField\n'+
       '  valueLink={this.linkState("selectValueLinkValue")}\n'+
       '  floatingLabelText="Select Field"\n'+
+      '  valueMember="id"\n'+
+      '  displayMember="name"\n'+
+      '  menuItems={arbitraryArrayMenuItems} />\n'+
+      '<SelectField\n'+
+      '  value={this.state.selectValue2}\n'+
+      '  onChange={this._handleSelectValueChange.bind(null, "selectValue2")}\n'+
+      '  floatingLabelText="Float Label Text"\n'+
       '  valueMember="id"\n'+
       '  displayMember="name"\n'+
       '  menuItems={arbitraryArrayMenuItems} />\n\n'+
@@ -324,14 +332,21 @@ let TextFieldsPage = React.createClass({
               disabled={true}
               defaultValue="Disabled With Value" /><br/>
             <SelectField
+              style={styles.textfield}
               value={this.state.selectValue}
-              onChange={this._handleSelectValueChange}
-              hintText="Select Field"
-              floatingLabelText="Select Field"
+              onChange={this._handleSelectValueChange.bind(null, 'selectValue')}
+              hintText="Hint Text"
               menuItems={menuItems} />
             <SelectField
               valueLink={this.linkState('selectValueLinkValue')}
-              floatingLabelText="Select Field"
+              floatingLabelText="Float Label Text"
+              valueMember="id"
+              displayMember="name"
+              menuItems={arbitraryArrayMenuItems} />
+            <SelectField
+              value={this.state.selectValue2}
+              onChange={this._handleSelectValueChange.bind(null, 'selectValue2')}
+              floatingLabelText="Float Label Text"
               valueMember="id"
               displayMember="name"
               menuItems={arbitraryArrayMenuItems} />
@@ -430,10 +445,10 @@ let TextFieldsPage = React.createClass({
     });
   },
 
-  _handleSelectValueChange(e) {
-    this.setState({
-      selectValue: e.target.value
-    });
+  _handleSelectValueChange(name, e) {
+    let change = {}
+    change[name] = e.target.value
+    this.setState(change);
   },
 
   _handleFloatingInputChange(e) {

--- a/docs/src/app/components/pages/components/text-fields.jsx
+++ b/docs/src/app/components/pages/components/text-fields.jsx
@@ -343,12 +343,13 @@ let TextFieldsPage = React.createClass({
               valueMember="id"
               displayMember="name"
               menuItems={arbitraryArrayMenuItems} />
+            <p>
+              Without <code>hintText</code> or <code>floatingLabelText</code>
+            </p>
             <SelectField
+              style={styles.textfield}
               value={this.state.selectValue2}
               onChange={this._handleSelectValueChange.bind(null, 'selectValue2')}
-              floatingLabelText="Float Label Text"
-              valueMember="id"
-              displayMember="name"
               menuItems={arbitraryArrayMenuItems} />
           </div>
           <div style={styles.group}>

--- a/docs/src/app/components/pages/components/text-fields.jsx
+++ b/docs/src/app/components/pages/components/text-fields.jsx
@@ -95,9 +95,6 @@ let TextFieldsPage = React.createClass({
       '<SelectField\n'+
       '  value={this.state.selectValue2}\n'+
       '  onChange={this._handleSelectValueChange.bind(null, "selectValue2")}\n'+
-      '  floatingLabelText="Float Label Text"\n'+
-      '  valueMember="id"\n'+
-      '  displayMember="name"\n'+
       '  menuItems={arbitraryArrayMenuItems} />\n\n'+
 
       '//Floating Hint Text Labels\n' +

--- a/src/select-field.jsx
+++ b/src/select-field.jsx
@@ -44,32 +44,33 @@ let SelectField = React.createClass({
 
   getStyles() {
     let styles = {
-      selectField:{
-        root: {
-          height:'46px',
-          position:'relative',
-          width:'100%',
-          top: '16px'
-        },
-        label: {
-          paddingLeft:0,
-          top:4,
-          width:'100%'
-        },
-        icon: {
-          top:20,
-          right:0
-        },
-        underline: {
-          borderTop:'none'
-        }
-      }
+      root: {
+        height:'46px',
+        position:'relative',
+        width:'100%',
+        top: '16px'
+      },
+      label: {
+        paddingLeft:0,
+        top:4,
+        width:'100%'
+      },
+      icon: {
+        top:20,
+        right:0
+      },
+      underline: {
+        borderTop:'none'
+      },
+      input: {}
     };
     if(this.props.hintText && !this.props.floatingLabelText) {
-      styles.selectField.root.top = '-5px'
-
-      styles.selectField.label.top = '1px'
-      styles.selectField.icon.top = '17px'
+      styles.root.top = '-5px';
+      styles.label.top = '1px';
+      styles.icon.top = '17px';
+    }
+    if(!this.props.hintText && !this.props.floatingLabelText) {
+      styles.root.top = '-8px';
     }
     return styles;
   },
@@ -85,16 +86,39 @@ let SelectField = React.createClass({
 
   render() {
     let styles = this.getStyles();
+    let {
+      style,
+      labelStyle,
+      iconStyle,
+      underlineStyle,
+      selectFieldRoot,
+      onChange,
+      menuItems,
+      disabled,
+      floatingLabelText,
+      hintText,
+      ...other
+    } = this.props;
+
+    let textFieldProps = {
+      style: this.mergeAndPrefix(styles.input, style),
+      floatingLabelText: floatingLabelText,
+      hintText: (!hintText && !floatingLabelText) ? ' ' : hintText
+    };
+    let dropDownMenuProps = {
+      onChange: this.onChange,
+      menuItems: menuItems,
+      disabled: disabled,
+      style: this.mergeAndPrefix(styles.root, selectFieldRoot),
+      labelStyle: this.mergeAndPrefix(styles.label, labelStyle),
+      iconStyle: this.mergeAndPrefix(styles.icon, iconStyle),
+      underlineStyle: this.mergeAndPrefix(styles.underline),
+      autoWidth: false
+    };
+
     return (
-      <TextField {...this.props}>
-        <DropDownMenu {...this.props}
-          onChange={this.onChange}
-          style={this.mergeAndPrefix(styles.selectField.root, this.props.selectFieldRoot)}
-          labelStyle={this.mergeAndPrefix(styles.selectField.label, this.props.labelStyle)}
-          iconStyle={this.mergeAndPrefix(styles.selectField.icon, this.props.iconStyle)}
-          underlineStyle={this.mergeAndPrefix(styles.selectField.underline, this.props.underlineStyle)}
-          autoWidth={false}
-        />
+      <TextField {...textFieldProps}>
+        <DropDownMenu {...dropDownMenuProps} {...other} />
       </TextField>
     );
   }

--- a/src/select-field.jsx
+++ b/src/select-field.jsx
@@ -20,7 +20,6 @@ let SelectField = React.createClass({
     underlineStyle: React.PropTypes.string,
     labelStyle: React.PropTypes.string,
     hintText: React.PropTypes.string,
-    hintText: React.PropTypes.string,
     id: React.PropTypes.string,
     multiLine: React.PropTypes.bool,
     onBlur: React.PropTypes.func,
@@ -47,10 +46,10 @@ let SelectField = React.createClass({
     let styles = {
       selectField:{
         root: {
-          height:'48px',
+          height:'46px',
           position:'relative',
           width:'100%',
-          top: '18px'
+          top: '16px'
         },
         label: {
           paddingLeft:0,
@@ -66,15 +65,22 @@ let SelectField = React.createClass({
         }
       }
     };
+    if(this.props.hintText && !this.props.floatingLabelText) {
+      styles.selectField.root.top = '-5px'
+
+      styles.selectField.label.top = '1px'
+      styles.selectField.icon.top = '17px'
+    }
     return styles;
   },
 
   onChange(e, index, payload) {
-    if (payload)
+    if (payload) {
       e.target.value = payload[this.props.valueMember] || payload;
-
-    if (this.props.onChange)
+    }
+    if (this.props.onChange) {
       this.props.onChange(e);
+    }
   },
 
   render() {


### PR DESCRIPTION
If you had a `SelectField` component without a `floatingLabelText` prop, you would end up getting a messed up looking component. This fixes that.

Also fixes #934.