### PR TITLE
Update src/index.js to make use of nested index.js files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,13 +30,7 @@ module.exports = {
   ListItem: require('./lists/list-item'),
   Menu: require('./menu/menu'),
   MenuItem: require('./menu/menu-item'),
-  Mixins: {
-    Classable: require('./mixins/classable'),
-    ClickAwayable: require('./mixins/click-awayable'),
-    WindowListenable: require('./mixins/window-listenable'),
-    StylePropable: require('./mixins/style-propable'),
-    StyleResizable: require('./mixins/style-resizable')
-  },
+  Mixins: require('./mixins/'),
   Overlay: require('./overlay'),
   Paper: require('./paper'),
   RadioButton: require('./radio-button'),
@@ -50,18 +44,14 @@ module.exports = {
     NavigationChevronLeft: require('./svg-icons/navigation/chevron-left'),
     NavigationChevronRight: require('./svg-icons/navigation/chevron-right')
   },
-  Styles: {
-    AutoPrefix: require('./styles/auto-prefix'),
-    Colors: require('./styles/colors'),
-    Spacing: require('./styles/spacing'),
-    ThemeManager: require('./styles/theme-manager'),
-    Transitions: require('./styles/transitions'),
-    Typography: require('./styles/typography')
-  },
+  Styles: require('./styles/'),
   Snackbar: require('./snackbar'),
   Tab: require('./tabs/tab'),
-  Table: require('./table/table'),
   Tabs: require('./tabs/tabs'),
+  Table: require('./table/table'),
+  TableFooter: require('./table/table-footer'),
+  TableHeader: require('./table/table-header'),
+  TableHeaderColumn: require('./table/table-header-column'),
   Theme: require('./theme'),
   Toggle: require('./toggle'),
   TimePicker: require('./time-picker'),
@@ -71,14 +61,5 @@ module.exports = {
   ToolbarSeparator: require('./toolbar/toolbar-separator'),
   ToolbarTitle: require('./toolbar/toolbar-title'),
   Tooltip: require('./tooltip'),
-  Utils: {
-    CssEvent: require('./utils/css-event'),
-    Dom: require('./utils/dom'),
-    Events: require('./utils/events'),
-    KeyCode: require('./utils/key-code'),
-    KeyLine: require('./utils/key-line'),
-    ColorManipulator: require('./utils/color-manipulator'),
-    Extend: require('./utils/extend'),
-    UniqueId: require('./utils/unique-id')
-  }
+  Utils: require('./utils/')
 };

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -2,5 +2,6 @@ module.exports = {
   Classable: require('./classable'),
   ClickAwayable: require('./click-awayable'),
   WindowListenable: require('./window-listenable'),
-  StylePropable: require('./style-propable')
+  StylePropable: require('./style-propable'),
+  StyleResizable: require('./style-resizable')
 };

--- a/src/table/index.js
+++ b/src/table/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  Table: require('./table'),
+  TableFooter: require('./table-footer'),
+  TableHeader: require('./table-header'),
+  TableHeaderColumn: require('./table-header-column')
+};


### PR DESCRIPTION
Updated src/index.js to make use of the index files in mixins, styles and utils.

I thought about updated the components (card, table, list) but decided not to for now. If we went the route of exporting the index.js for card/table/list we will have added an additional layer in the import.

Instead of doing
```javascript
import { Card } from 'material-ui';
```
we would have to do
```javascript
import { Card } from 'material-ui';
let { Card } = Card; // or let Card = Card.Card;
```