### PR TITLE
[datePicker] style do no longer overide the root and the textfield at…

### DIFF
--- a/docs/src/app/components/pages/components/date-picker.jsx
+++ b/docs/src/app/components/pages/components/date-picker.jsx
@@ -45,6 +45,12 @@ class DatePickerPage extends React.Component {
         name: 'Props',
         infoArray: [
           {
+            name: 'autoOk',
+            type: 'bool',
+            header: 'default: false',
+            desc: 'If true, automatically accept and close the picker on select a date.'
+          },
+          {
             name: 'defaultDate',
             type: 'date object',
             header: 'optional',
@@ -58,17 +64,11 @@ class DatePickerPage extends React.Component {
               'the input box. By default, date objects are formatted to M/D/YYYY.'
           },
           {
-            name: 'mode',
-            type: 'one of: portrait, landscape',
-            header: 'default: portrait',
-            desc: 'Tells the component to display the picker in portrait or landscape mode.'
-          },
-          {
-            name: 'minDate',
-            type: 'date object',
+            name: 'hideToolbarYearChange',
+            type: 'boolean',
             header: 'optional',
-            desc: 'The beginning of a range of valid dates. The range includes the startDate. ' +
-              'The default value is current date - 100 years.'
+            desc: 'Hide year change buttons on calendar; good for short time spans. Clicking ' +
+              'the year will always result in selecting a year.'
           },
           {
             name: 'maxDate',
@@ -78,18 +78,24 @@ class DatePickerPage extends React.Component {
               'The default value is current date + 100 years.'
           },
           {
+            name: 'minDate',
+            type: 'date object',
+            header: 'optional',
+            desc: 'The beginning of a range of valid dates. The range includes the startDate. ' +
+              'The default value is current date - 100 years.'
+          },
+          {
+            name: 'mode',
+            type: 'one of: portrait, landscape',
+            header: 'default: portrait',
+            desc: 'Tells the component to display the picker in portrait or landscape mode.'
+          },
+          {
             name: 'shouldDisableDate',
             type: 'function',
             header: 'optional',
             desc: 'Called during render time of a given day. If this method returns false ' +
               'the day is disabled otherwise it is displayed normally.'
-          },
-          {
-            name: 'hideToolbarYearChange',
-            type: 'boolean',
-            header: 'optional',
-            desc: 'Hide year change buttons on calendar; good for short time spans. Clicking ' +
-              'the year will always result in selecting a year.'
           },
           {
             name: 'showYearSelector',
@@ -99,16 +105,16 @@ class DatePickerPage extends React.Component {
               'If false, the year change buttons in the toolbar are hidden.'
           },
           {
-            name: 'autoOk',
-            type: 'bool',
-            header: 'default: false',
-            desc: 'If true, automatically accept and close the picker on select a date.'
-          },
-          {
             name: 'style',
             type: 'object',
             header: 'optional',
             desc: 'Override the inline-styles of DatePicker\'s root element.'
+          },
+          {
+            name: 'textFieldStyle',
+            type: 'object',
+            header: 'optional',
+            desc: 'Override the inline-styles of DatePicker\'s TextField element.'
           }
         ]
       },

--- a/src/date-picker/date-picker.jsx
+++ b/src/date-picker/date-picker.jsx
@@ -11,20 +11,22 @@ let DatePicker = React.createClass({
   mixins: [StylePropable, WindowListenable],
 
   propTypes: {
+    autoOk: React.PropTypes.bool,
     defaultDate: React.PropTypes.object,
     formatDate: React.PropTypes.func,
-    mode: React.PropTypes.oneOf(['portrait', 'landscape', 'inline']),
-    onFocus: React.PropTypes.func,
-    onTouchTap: React.PropTypes.func,
-    onChange: React.PropTypes.func,
-    onShow: React.PropTypes.func,
-    onDismiss: React.PropTypes.func,
-    minDate: React.PropTypes.object,
-    maxDate: React.PropTypes.object,
-    shouldDisableDate: React.PropTypes.func,
     hideToolbarYearChange: React.PropTypes.bool,
-    autoOk: React.PropTypes.bool,
-    showYearSelector: React.PropTypes.bool
+    maxDate: React.PropTypes.object,
+    minDate: React.PropTypes.object,
+    mode: React.PropTypes.oneOf(['portrait', 'landscape', 'inline']),
+    onDismiss: React.PropTypes.func,
+    onChange: React.PropTypes.func,
+    onFocus: React.PropTypes.func,
+    onShow: React.PropTypes.func,
+    onTouchTap: React.PropTypes.func,
+    shouldDisableDate: React.PropTypes.func,
+    showYearSelector: React.PropTypes.bool,
+    style: React.PropTypes.object,
+    textFieldStyle: React.PropTypes.object,
   },
 
   windowListeners: {
@@ -54,16 +56,18 @@ let DatePicker = React.createClass({
 
   render() {
     let {
+      autoOk,
       formatDate,
+      maxDate,
+      minDate,
       mode,
+      onDismiss,
       onFocus,
       onTouchTap,
       onShow,
-      onDismiss,
-      minDate,
-      maxDate,
-      autoOk,
       showYearSelector,
+      style,
+      textFieldStyle,
       ...other
     } = this.props;
     let defaultInputValue;
@@ -73,16 +77,17 @@ let DatePicker = React.createClass({
     }
 
     return (
-      <div style={this.props.style}>
+      <div style={style}>
         <TextField
           {...other}
+          style={textFieldStyle}
           ref="input"
           defaultValue={defaultInputValue}
           onFocus={this._handleInputFocus}
           onTouchTap={this._handleInputTouchTap}/>
         <DatePickerDialog
           ref="dialogWindow"
-          mode={this.props.mode}
+          mode={mode}
           initialDate={this.state.dialogDate}
           onAccept={this._handleDialogAccept}
           onShow={onShow}


### PR DESCRIPTION
… the same time

I have also sorted properties alphabetically 