### PR TITLE
Allow styling of individual menu items

### DIFF
--- a/src/menu/menu.jsx
+++ b/src/menu/menu.jsx
@@ -342,8 +342,8 @@ var Menu = React.createClass({
               active={this.state.activeIndex == i}
               text={menuItem.text}
               disabled={isDisabled}
-              className={this.props.menuItemClassNameLink}
-              style={this.props.menuItemStyleLink}
+              className={menuItem.className || this.props.menuItemClassNameLink}
+              style={menuItem.style || this.props.menuItemStyleLink}
               payload={menuItem.payload}
               target={menuItem.target}/>
           );
@@ -354,8 +354,8 @@ var Menu = React.createClass({
             <SubheaderMenuItem
               key={i}
               index={i}
-              className={this.props.menuItemClassNameSubheader}
-              style={this.mergeAndPrefix(styles.subheader, this.props.menuItemStyleSubheader)}
+              className={menuItem.className || this.props.menuItemClassNameSubheader}
+              style={this.mergeAndPrefix(styles.subheader, menuItem.style || this.props.menuItemStyleSubheader)}
               firstChild={i === 0}
               text={menuItem.text} />
           );
@@ -400,8 +400,8 @@ var Menu = React.createClass({
               active={this.state.activeIndex == i}
               icon={menuItem.icon}
               data={menuItem.data}
-              className={this.props.menuItemClassName}
-              style={this.props.menuItemStyle}
+              className={menuItem.className || this.props.menuItemClassName}
+              style={menuItem.style || this.props.menuItemStyle}
               attribute={menuItem.attribute}
               number={menuItem.number}
               toggle={menuItem.toggle}


### PR DESCRIPTION
I think it could be interesting to be able to add a `className` and `style` to each menu item, instead of using the same `className`/`style` for all of them.

We could add a `className`/`style` property to the `menuItem` object. Then, in the `Menu` component, when creating the `MenuItem`s, we could use that `className`/`style` and, if it's not present, default to the generic one.
