### PR TITLE
Table rows can be selected in the rowData configuration

### DIFF
--- a/docs/src/app/components/pages/components/table.jsx
+++ b/docs/src/app/components/pages/components/table.jsx
@@ -28,9 +28,9 @@ class TablePage extends React.Component {
 
   _getRowData() {
     let rowData = [
-      {id: {content: '1'}, name: {content: 'John Smith'}, status: {content: 'Employed'}},
+      {selected: true, id: {content: '1'}, name: {content: 'John Smith'}, status: {content: 'Employed'}},
       {id: {content: '2'}, name: {content: 'Randal White'}, status: {content: 'Unemployed'}},
-      {id: {content: '3'}, name: {content: 'Stephanie Sanders'}, status: {content: 'Employed'}},
+      {selected: true, id: {content: '3'}, name: {content: 'Stephanie Sanders'}, status: {content: 'Employed'}},
       {id: {content: '4'}, name: {content: 'Steve Brown'}, status: {content: 'Employed'}},
       {id: {content: '5'}, name: {content: 'Joyce Whitten'}, status: {content: 'Employed'}},
       {id: {content: '6'}, name: {content: 'Samuel Roberts'}, status: {content: 'Unemployed'}},
@@ -48,9 +48,9 @@ class TablePage extends React.Component {
     let code =  `
 // Row data
 let rowData = [
-  {id: {content: '1'}, name: {content: 'John Smith'}, status: {content: 'Employed'}},
+  {selected: true, id: {content: '1'}, name: {content: 'John Smith'}, status: {content: 'Employed'}},
   {id: {content: '2'}, name: {content: 'Randal White'}, status: {content: 'Unemployed'}},
-  {id: {content: '3'}, name: {content: 'Stephanie Sanders'}, status: {content: 'Employed'}},
+  {selected: true, id: {content: '3'}, name: {content: 'Stephanie Sanders'}, status: {content: 'Employed'}},
   {id: {content: '4'}, name: {content: 'Steve Brown'}, status: {content: 'Employed'}},
   {id: {content: '5'}, name: {content: 'Joyce Whitten'}, status: {content: 'Employed'}},
   {id: {content: '6'}, name: {content: 'Samuel Roberts'}, status: {content: 'Unemployed'}},
@@ -119,7 +119,13 @@ let footerCols = {id: {content: 'ID'}, name: {content: 'Name'}, status: {content
             name: 'rowData',
             type: 'array',
             header: 'required',
-            desc: 'Specify the row data. If the row data is specified as an array of objects, columnOrder must be provided. If an array of arrays is provided the order is determined by index position. Column data within a row can be represented two ways. The first, as an object with a content key and optionally a style key ({content: \'some data\', style: myStyleObj}). Secondly, if only content is provided simply provide the content with putting it in an object.'
+            desc: 'Specify the row data. If the row data is specified as an array of objects, columnOrder must be provided. If an array of arrays is provided the order is determined by index position. Column data within a row can be represented two ways. The first, as an object with a content key and optionally a style key ({content: \'some data\', style: myStyleObj}). Secondly, if only content is provided simply provide the content without putting it in an object.'
+          },
+          {
+            name: 'canSelectAll',
+            type: 'boolean',
+            header: 'optional',
+            desc: 'Controls whether or not the user can select all of the rows in the table. The default value is false.'
           },
           {
             name: 'columnOrder',
@@ -128,10 +134,40 @@ let footerCols = {id: {content: 'ID'}, name: {content: 'Name'}, status: {content
             desc: 'An array indicating the order that the columns should appear. If this field is provided the data must be objects consisting of these keys so that the data can be displayed in the correct order.'
           },
           {
-            name: 'headerColumns',
-            type: 'object',
+            name: 'defaultColumnWidth',
+            type: 'string',
             header: 'optional',
-            desc: 'An array or object containing the header column information.'
+            desc: 'The default value of a table column. The initial value is 50px.'
+          },
+          {
+            name: 'displayRowCheckbox',
+            type: 'boolean',
+            header: 'optional',
+            desc: 'Controls the display of the row checkbox. The default value is true.'
+          },
+          {
+            name: 'displaySelectAll',
+            type: 'boolean',
+            header: 'optional',
+            desc: 'Controls whether or not the select all checkbox is displayed. The default value is true.'
+          },
+          {
+            name: 'fixedFooter',
+            type: 'boolean',
+            header: 'optional',
+            desc: 'If true, the footer will appear fixed below the table. The default value is true.'
+          },
+          {
+            name: 'fixedHeader',
+            type: 'boolean',
+            header: 'optional',
+            desc: 'If true, the header will appear fixed above the table. The default value is true.'
+          },
+          {
+            name: 'footer',
+            type: 'element',
+            header: 'optional',
+            desc: 'If customization of the footer is required a table-footer elemet can be provided. If this field is provided footerColumns will be ignored.'
           },
           {
             name: 'footerColumns',
@@ -146,10 +182,10 @@ let footerCols = {id: {content: 'ID'}, name: {content: 'Name'}, status: {content
             desc: 'If customization of the header is required a table-header element can be provided. If this field is provided headerColumns will be ignored.'
           },
           {
-            name: 'footer',
-            type: 'element',
+            name: 'headerColumns',
+            type: 'object',
             header: 'optional',
-            desc: 'If customization of the footer is required a table-footer elemet can be provided. If this field is provided footerColumns will be ignored.'
+            desc: 'An array or object containing the header column information.'
           },
           {
             name: 'height',
@@ -158,34 +194,16 @@ let footerCols = {id: {content: 'ID'}, name: {content: 'Name'}, status: {content
             desc: 'The height of the table.'
           },
           {
-            name: 'defaultColumnWidth',
-            type: 'string',
-            header: 'optional',
-            desc: 'The default value of a table column. The initial value is 50px.'
-          },
-          {
-            name: 'fixedHeader',
+            name: 'multiSelectable',
             type: 'boolean',
             header: 'optional',
-            desc: 'If true, the header will appear fixed above the table. The default value is true.'
+            desc: 'If true, multiple table rows can be selected. CTRL/CMD+Click and SHIFT+Click are valid actions. The default value is false.'
           },
           {
-            name: 'fixedFooter',
+            name: 'preScanRowData',
             type: 'boolean',
-            header: 'optional',
-            desc: 'If true, the footer will appear fixed below the table. The default value is true.'
-          },
-          {
-            name: 'stripedRows',
-            type: 'boolean',
-            header: 'optional',
-            desc: 'If true, every other table row starting with the first row will be striped. The default value is false.'
-          },
-          {
-            name: 'showRowHover',
-            type: 'boolean',
-            header: 'optional',
-            desc: 'If true, table rows will be highlighted when the cursor is hovering over the row. The default value is false.'
+            header: 'default: true',
+            desc: 'Controls whether or not the rowData is pre-scanned to determine initial state. If your table has a large number of rows and you are experiencing a delay in rendering, turn off this property.'
           },
           {
             name: 'selectable',
@@ -194,29 +212,22 @@ let footerCols = {id: {content: 'ID'}, name: {content: 'Name'}, status: {content
             desc: 'If true, table rows can be selected. If multiple row selection is desired, enable multiSelectable. The default value is true.'
           },
           {
-            name: 'multiSelectable',
+            name: 'showRowHover',
             type: 'boolean',
             header: 'optional',
-            desc: 'If true, multiple table rows can be selected. CTRL/CMD+Click and SHIFT+Click are valid actions. The default value is false.'
+            desc: 'If true, table rows will be highlighted when the cursor is hovering over the row. The default value is false.'
           },
           {
-            name: 'displayRowCheckbox',
+            name: 'stripedRows',
             type: 'boolean',
             header: 'optional',
-            desc: 'Controls the display of the row checkbox. The default value is true.'
-          },
-          {
-            name: 'canSelectAll',
-            type: 'boolean',
-            header: 'optional',
-            desc: 'Controls whether or not the user can select all of the rows in the table. The default value is false.'
-          },
-          {
-            name: 'displaySelectAll',
-            type: 'boolean',
-            header: 'optional',
-            desc: 'Controls whether or not the select all checkbox is displayed. The default value is true.'
-          },
+            desc: 'If true, every other table row starting with the first row will be striped. The default value is false.'
+          }
+        ]
+      },
+      {
+        name: 'Table Events',
+        infoArray: [
           {
             name: 'onRowSelection',
             type: 'function(selectedRows)',

--- a/src/table/table.jsx
+++ b/src/table/table.jsx
@@ -17,49 +17,66 @@ let Table = React.createClass({
 
   propTypes: {
     rowData: React.PropTypes.array.isRequired,
+    canSelectAll: React.PropTypes.bool,
     columnOrder: React.PropTypes.array,
-    headerColumns: React.PropTypes.object,
+    defaultColumnWidth: React.PropTypes.string,
+    displayRowCheckbox: React.PropTypes.bool,
+    displaySelectAll: React.PropTypes.bool,
+    fixedFooter: React.PropTypes.bool,
+    fixedHeader: React.PropTypes.bool,
+    footer: React.PropTypes.element,
     footerColumns: React.PropTypes.object,
     header: React.PropTypes.element,
-    footer: React.PropTypes.element,
+    headerColumns: React.PropTypes.object,
     height: React.PropTypes.string,
-    defaultColumnWidth: React.PropTypes.string,
-    fixedHeader: React.PropTypes.bool,
-    fixedFooter: React.PropTypes.bool,
-    stripedRows: React.PropTypes.bool,
-    showRowHover: React.PropTypes.bool,
-    selectable: React.PropTypes.bool,
     multiSelectable: React.PropTypes.bool,
-    displayRowCheckbox: React.PropTypes.bool,
-    canSelectAll: React.PropTypes.bool,
-    displaySelectAll: React.PropTypes.bool,
-    onRowSelection: React.PropTypes.func,
     onCellClick: React.PropTypes.func,
+    onCellHover: React.PropTypes.func,
+    onCellHoverExit: React.PropTypes.func,
     onRowHover: React.PropTypes.func,
     onRowHoverExit: React.PropTypes.func,
-    onCellHover: React.PropTypes.func,
-    onCellHoverExit: React.PropTypes.func
+    onRowSelection: React.PropTypes.func,
+    preScanRowData: React.PropTypes.bool,
+    selectable: React.PropTypes.bool,
+    showRowHover: React.PropTypes.bool,
+    stripedRows: React.PropTypes.bool
   },
 
   getDefaultProps() {
     return {
-      fixedHeader: true,
-      fixedFooter: true,
-      height: 'inherit',
-      defaultColumnWidth: '50px',
-      stripedRows: false,
-      showRowHover: false,
-      selectable: true,
-      displayRowCheckbox: true,
-      multiSelectable: false,
       canSelectAll: false,
-      displaySelectAll: true
+      defaultColumnWidth: '50px',
+      displayRowCheckbox: true,
+      displaySelectAll: true,
+      fixedFooter: true,
+      fixedHeader: true,
+      height: 'inherit',
+      multiSelectable: false,
+      preScanRowData: true,
+      selectable: true,
+      showRowHover: false,
+      stripedRows: false
     };
   },
 
   getInitialState() {
+    // Determine what rows are 'pre-selected'.
+    let preSelectedRows = [];
+    if (this.props.selectable && this.props.preScanRowData) {
+      for (let idx = 0; idx < this.props.rowData.length; idx++) {
+        let row = this.props.rowData[idx];
+        if (row.selected !== undefined && row.selected) {
+          preSelectedRows.push(idx);
+
+          if (!this.props.multiSelectable) {
+            break;
+          }
+        }
+      }
+    }
+
     return {
-      selectedRows: []
+      selectedRows: preSelectedRows
     };
   },
 


### PR DESCRIPTION
Updated table so that it pre-scans the rowData property to determine what rows should appear selected. This can be disabled by preventing selection on the table or setting preScanRowData=false. If multiSelection is not enabled on the table and you have more than one row pre-selected only the first pre-selected row will appear selected. This addresses #999.