### PR TITLE
[DropDownMenu] fix warning on the text-field component page

### DIFF
--- a/src/drop-down-menu.jsx
+++ b/src/drop-down-menu.jsx
@@ -159,11 +159,13 @@ let DropDownMenu = React.createClass({
       if (this.props.valueMember && (this.props.valueLink || this.props.value))
       {
         let value = this.props.value || this.props.valueLink.value;
-        for (let i in this.props.menuItems)
+        for (let i = 0; i < this.props.menuItems.length; i++) {
           if (this.props.menuItems[i][this.props.valueMember] === value)
             selectedIndex = i;
+        }
       }
     }
+
 
     let selectedItem = this.props.menuItems[selectedIndex];
     if (selectedItem)

--- a/src/menu/menu.jsx
+++ b/src/menu/menu.jsx
@@ -308,7 +308,6 @@ var Menu = React.createClass({
   _getChildren() {
     let  menuItem,
       itemComponent,
-      isSelected,
       isDisabled;
 
     let styles = this.getStyles();
@@ -319,7 +318,6 @@ var Menu = React.createClass({
 
     for (let i=0; i < this.props.menuItems.length; i++) {
       menuItem = this.props.menuItems[i];
-      isSelected = i === this.props.selectedIndex;
       isDisabled = (menuItem.disabled === undefined) ? false : menuItem.disabled;
 
       let {
@@ -339,7 +337,7 @@ var Menu = React.createClass({
             <LinkMenuItem
               key={i}
               index={i}
-              active={this.state.activeIndex == i}
+              active={this.state.activeIndex === i}
               text={menuItem.text}
               disabled={isDisabled}
               className={this.props.menuItemClassNameLink}
@@ -377,7 +375,7 @@ var Menu = React.createClass({
               key={i}
               index={i}
               nested={true}
-              active={this.state.activeIndex == i}
+              active={this.state.activeIndex === i}
               text={menuItem.text}
               disabled={isDisabled}
               menuItems={menuItem.items}
@@ -394,10 +392,10 @@ var Menu = React.createClass({
           itemComponent = (
             <MenuItem
               {...other}
-              selected={isSelected}
+              selected={this.props.selectedIndex === i}
               key={i}
               index={i}
-              active={this.state.activeIndex == i}
+              active={this.state.activeIndex === i}
               icon={menuItem.icon}
               data={menuItem.data}
               className={this.props.menuItemClassName}


### PR DESCRIPTION
The warning is `Warning: Failed propType: Invalid prop selectedIndex of type string supplied to Menu, expected number. Check the render method of DropDownMenu.`.
Since the selectedIndex was a string, in some cases, the `selected` prop wasn't set correctly.
