### PR TITLE
Fixes Dom.withoutTransition()

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -56,8 +56,10 @@ module.exports = {
   },
 
   withoutTransition(el, callback) {
+    let originalTransition = el.style.transition;
+
     //turn off transition
-    el.style.transition = 'none';
+    el.style.transition = null;
 
     callback();
 
@@ -65,7 +67,7 @@ module.exports = {
     this.forceRedraw(el);
 
     //put the transition back
-    el.style.transition = '';
+    el.style.transition = originalTransition;
   }
 
 };


### PR DESCRIPTION
Related to https://github.com/callemall/material-ui/pull/1014

This makes the `Dom.withoutTransition` method behave the way its name suggests. It will now keep track of the original transition applied to an element, temporarily disable it, then put it back the way it was.