### PR TITLE
Icon Builder: handle user-specified SVG collections (not just material-ui-icon)

### DIFF
--- a/icon-builder/README.md
+++ b/icon-builder/README.md
@@ -1,15 +1,39 @@
-#Material-UI-Icons
+# Material-UI-Icons
 
 This tool crawls the [material-design-icons](https://github.com/google/material-design-icons) repo
 and generates react svg icon components for each icon.
 
 ## Running the build
-```
+```sh
 npm install
 npm run build
+```
+
+Alternatively:
+
+```sh
+node build.sh --mui-icon-opts
 ```
 
 ## Generated folders
 The build script walks through all of the svg icons in the material-design-icons folder and generates the appropriate
 `.jsx` files in the `./jsx` folder. It'll also compile the `.jsx` files and create the cooresponding `.js` equivalent
 in the `./js` folder.
+
+## Advanced usage and Custom builds
+
+`node build.sh --help` can be used to pull up options available for building.
+
+You can build your own SVG icons as well as collections like [game-icons](http://game-icons.net/) through environmental variables.
+
+* `OUTPUT_DIR` - directory to output jsx components
+* `SVG_DIR` - SVG directory
+* `INNER_PATH` - "Reach into" subdirs, since libraries like material-design-icons
+  use arbitrary build directories to organize icons
+  e.g. "action/svg/production/icon_3d_rotation_24px.svg"
+* `FILE_SUFFIX` - Filter only files ending with a suffix (pretty much only
+  for material-ui-icons)
+
+If you experience any issues building icons or would like a feature added,
+[file and issue](https://github.com/callemall/material-ui/issues) and let us
+know.

--- a/icon-builder/README.md
+++ b/icon-builder/README.md
@@ -9,12 +9,6 @@ npm install
 npm run build
 ```
 
-Alternatively:
-
-```sh
-node build.sh --mui-icon-opts
-```
-
 ## Generated folders
 The build script walks through all of the svg icons in the material-design-icons folder and generates the appropriate
 `.jsx` files in the `./jsx` folder. It'll also compile the `.jsx` files and create the cooresponding `.js` equivalent
@@ -26,12 +20,12 @@ in the `./js` folder.
 
 You can build your own SVG icons as well as collections like [game-icons](http://game-icons.net/) through environmental variables.
 
-* `OUTPUT_DIR` - directory to output jsx components
-* `SVG_DIR` - SVG directory
-* `INNER_PATH` - "Reach into" subdirs, since libraries like material-design-icons
+* `--output-dir` - directory to output jsx components
+* `--svg-dir` - SVG directory
+* `--inner-path` - "Reach into" subdirs, since libraries like material-design-icons
   use arbitrary build directories to organize icons
   e.g. "action/svg/production/icon_3d_rotation_24px.svg"
-* `FILE_SUFFIX` - Filter only files ending with a suffix (pretty much only
+* `--file-suffix` - Filter only files ending with a suffix (pretty much only
   for material-ui-icons)
 
 If you experience any issues building icons or would like a feature added,

--- a/icon-builder/build.js
+++ b/icon-builder/build.js
@@ -1,75 +1,157 @@
+#! /usr/bin/env node
+/**
+ * Material UI Icon Builder
+ * ========================
+ * 
+ * Flags
+ *
+ * -h, --help   Print this help dialog.
+ * --mui-icon-opts    Shortcut to build material-ui-icons
+ *
+ * Environmental Settings: 
+ *
+ * OUTPUT_DIR - directory to output jsx components
+ * SVG_DIR - SVG directory
+ * INNER_PATH - "Reach into" subdirs, since libraries like material-design-icons
+ *   use arbitrary build directories to organize icons
+ *   e.g. "action/svg/production/icon_3d_rotation_24px.svg"
+ * FILE_SUFFIX - Filter only files ending with a suffix (pretty much only
+ *   for material-ui-icons)
+ * 
+ * Usage:
+ *
+ * node ./build.js --help
+ *
+ * node ./build.js --mui-icon-opts
+ *
+ * SVG_DIR=./node_modules/material-design-icons/ OUTPUT_DIR=./jsx INNER_PATH=/svg/production ./build.js 
+ *
+ */
 var fs = require('fs');
 var path = require('path');
 var rimraf = require('rimraf');
 
-console.log('** Starting Build');
+var options = {};
 
-var jsxFolder = __dirname + '/jsx';
-var iconRootPath = __dirname + '/node_modules/material-design-icons';
-var folders = fs.readdirSync(iconRootPath);
+var MUI_ICONS_OPTS = {
+  outputDir: __dirname + '/jsx',
+  svgDir: __dirname + '/node_modules/material-design-icons',
+  iconInnerPath: '/svg/production',
+  fileSuffix: '_24px.svg'
+}
 
-//Clean old files
-rimraf(jsxFolder, function() {
-  //Process each folder
-  fs.mkdirSync(jsxFolder);
-  folders.forEach(processFolder);
-});
+var DEFAULT_OPTS = {
+  outputDir: process.env.OUTPUT_DIR,
+  svgDir: process.env.SVG_DIR,
+  iconInnerPath: process.env.INNER_PATH,
+  fileSuffix: process.env.FILE_SUFFIX
+}
 
-function processFolder(folderName) {
+
+function print_help() {
+  var fs = require('fs'),
+      readline = require('readline');
+
+  var rd = readline.createInterface({
+      input: fs.createReadStream(__filename),
+      output: process.stdout,
+      terminal: false
+  });
+
+  rd.on('line', function(line) {
+    if (line.indexOf("*/") !== -1) {
+      process.exit()
+    }
+    var COMMENT_REGEX = /^ ?(\/\*|\w\*|\*|\#\!.*)*/
+
+    var l = line.replace(COMMENT_REGEX, "")
+    if (l.length > 0) console.log(l);
+  });
+}
+
+if (process.argv.indexOf('--help') !== -1 || process.argv.indexOf('-h') !== -1) {
+  print_help();
+} else {
+  if (process.argv.indexOf('--mui-icon-opts') !== -1) {
+    run(MUI_ICONS_OPTS);
+  } else {
+    run(DEFAULT_OPTS);
+  }
+}
+
+function run(options) {
+  console.log('** Starting Build');
+
+  //Clean old files
+  rimraf(options.outputDir, function() {
+    //Process each folder
+    var dirs = fs.readdirSync(options.svgDir);
+    fs.mkdirSync(options.outputDir);
+    dirs.forEach(function(dirName) {
+      processDir(dirName, options.svgDir, options.outputDir, options.iconInnerPath, options.fileSuffix) 
+    });
+  });
+}
+
+function processDir(dirName, svgDir, outputDir, iconInnerPath, fileSuffix) {
+  var newIconDirPath = path.join(outputDir, dirName);
+  var svgIconDirPath = path.join(svgDir, dirName, iconInnerPath);
+  if (!fs.existsSync(svgIconDirPath)) { return false; }
+  if (!fs.lstatSync(svgIconDirPath).isDirectory()) { return false; }
   try {
+    var files = fs.readdirSync(svgIconDirPath);
 
-    var newIconFolderPath = jsxFolder + '/' + folderName;
-    var svgIconFolderPath = iconRootPath + '/' + folderName + '/svg/production';
-
-    var files = fs.readdirSync(svgIconFolderPath);
-
-    rimraf(newIconFolderPath, function() {
-      console.log('\n ' + folderName);
-      fs.mkdirSync(newIconFolderPath);
+    rimraf(newIconDirPath, function() {
+      console.log('\n ' + dirName);
+      fs.mkdirSync(newIconDirPath);
 
       files.forEach(function(fileName) {
-        processFile(folderName, fileName, newIconFolderPath, svgIconFolderPath);
+        processFile(dirName, fileName, newIconDirPath, svgIconDirPath, fileSuffix);
       });
     });
 
   } catch (err) {
-    return;
+    throw (err);
   }
 }
 
-function processFile(folderName, fileName, folderPath, svgFolderPath) {
+function processFile(dirName, fileName, dirPath, svgDirPath, fileSuffix) {
   //Only process 24px files
-  var svgFilePath = svgFolderPath + '/' + fileName;
-  var suffix = '_24px.svg';
-  var newFilename;
+  var svgFilePath = svgDirPath + '/' + fileName;
   var newFile;
-
-  if (fileName.indexOf(suffix, fileName.length - suffix.length) !== -1) {
-    newFilename = fileName.replace(suffix, '.jsx');
-    newFilename = newFilename.slice(3);
-    newFilename = newFilename.replace(/_/g, '-');
-    if (newFilename.indexOf('3d') === 0) {
-      newFilename = 'three-d' + newFilename.slice(2);
+  if (fileSuffix) {
+    if (fileName.indexOf(fileSuffix, fileName.length - fileSuffix.length) !== -1) {
+      fileName = fileName.replace(fileSuffix, '.jsx');
+      fileName = fileName.slice(3);
+      fileName = fileName.replace(/_/g, '-');
+      if (fileName.indexOf('3d') === 0) {
+        fileName = 'three-d' + fileName.slice(2);
+      }
+    } else {
+      return;
     }
-    newFile = folderPath + '/' + newFilename;
-
-    //console.log('writing ' + newFile);
-    getJsxString(folderName, newFilename, svgFilePath, function(fileString) {
-      fs.writeFileSync(newFile, fileString);
-    });
   }
+  newFile = path.join(dirPath, fileName);
+
+  //console.log('writing ' + newFile);
+  getJsxString(dirName, fileName, svgFilePath, function(fileString) {
+    fs.writeFileSync(newFile, fileString);
+  });
 }
 
-function getJsxString(folderName, newFilename, svgFilePath, callback) {
+function getJsxString(dirName, newFilename, svgFilePath, callback) {
   var className = newFilename.replace('.jsx', '');
-  className = folderName + '-' + className;
+  className = dirName + '-' + className;
   className = pascalCase(className);
   
   console.log('  ' + className);
 
   //var parser = new xml2js.Parser();
-  fs.readFile(svgFilePath, {encoding: 'utf8'}, function(err, data) {
 
+  fs.readFile(svgFilePath, {encoding: 'utf8'}, function(err, data) {
+    if (err) {
+      throw err;
+    }
     //Extract the paths from the svg string
     var paths = data.slice(data.indexOf('>') + 1);
     paths = paths.slice(0, -6);

--- a/icon-builder/build.js
+++ b/icon-builder/build.js
@@ -110,7 +110,7 @@ function getJsxString(dirName, newFilename, svgFilePath, muiRequire, callback) {
     paths = paths.replace('xlink:href="#c"', '');
 
     // Node acts wierd if we put this directly into string concatenation
-    var muiRequireStmt = muiRequire === "relative" ? "let SvgIcon = require('../../svg-icon');\n\n" : "let SvgIcon = require('material-ui').SvgIcon;\n\n";
+    var muiRequireStmt = muiRequire === "relative" ? "let SvgIcon = require('../../svg-icon');\n\n" : "let SvgIcon = require('material-ui/lib/svg-icon');\n\n";
 
     callback(
       "let React = require('react');\n" +

--- a/icon-builder/build.js
+++ b/icon-builder/build.js
@@ -3,99 +3,43 @@
  * Material UI Icon Builder
  * ========================
  * 
- * Flags
- *
- * -h, --help   Print this help dialog.
- * --mui-icon-opts    Shortcut to build material-ui-icons
- *
- * Environmental Settings: 
- *
- * OUTPUT_DIR - directory to output jsx components
- * SVG_DIR - SVG directory
- * INNER_PATH - "Reach into" subdirs, since libraries like material-design-icons
- *   use arbitrary build directories to organize icons
- *   e.g. "action/svg/production/icon_3d_rotation_24px.svg"
- * FILE_SUFFIX - Filter only files ending with a suffix (pretty much only
- *   for material-ui-icons)
- * 
- * Usage:
+ * Usage: 
  *
  * node ./build.js --help
- *
- * node ./build.js --mui-icon-opts
- *
- * SVG_DIR=./node_modules/material-design-icons/ OUTPUT_DIR=./jsx INNER_PATH=/svg/production ./build.js 
  *
  */
 var fs = require('fs');
 var path = require('path');
 var rimraf = require('rimraf');
+var argv = require('yargs')
+    .usage('Build JSX components from SVG\'s.\nUsage: $0')
+    .demand('output-dir')
+    .describe('output-dir', 'Directory to output jsx components')
+    .demand('svg-dir')
+    .describe('svg-dir', 'SVG directory')
+    .describe('inner-path', '"Reach into" subdirs, since libraries like material-design-icons' +
+      ' use arbitrary build directories to organize icons' +
+      ' e.g. "action/svg/production/icon_3d_rotation_24px.svg"')
+    .describe('file-suffix', 'Filter only files ending with a suffix (pretty much only' +
+     ' for material-ui-icons)')
+    .describe('mui-icons-opts', 'Shortcut to use MUI icons options')
+    .boolean('mui-icons-opts')
+    .argv;
 
-var options = {};
-
-var MUI_ICONS_OPTS = {
-  outputDir: __dirname + '/jsx',
-  svgDir: __dirname + '/node_modules/material-design-icons',
-  iconInnerPath: '/svg/production',
-  fileSuffix: '_24px.svg'
-}
-
-var DEFAULT_OPTS = {
-  outputDir: process.env.OUTPUT_DIR,
-  svgDir: process.env.SVG_DIR,
-  iconInnerPath: process.env.INNER_PATH,
-  fileSuffix: process.env.FILE_SUFFIX
-}
-
-
-function print_help() {
-  var fs = require('fs'),
-      readline = require('readline');
-
-  var rd = readline.createInterface({
-      input: fs.createReadStream(__filename),
-      output: process.stdout,
-      terminal: false
-  });
-
-  rd.on('line', function(line) {
-    if (line.indexOf("*/") !== -1) {
-      process.exit()
-    }
-    var COMMENT_REGEX = /^ ?(\/\*|\w\*|\*|\#\!.*)*/
-
-    var l = line.replace(COMMENT_REGEX, "")
-    if (l.length > 0) console.log(l);
-  });
-}
-
-if (process.argv.indexOf('--help') !== -1 || process.argv.indexOf('-h') !== -1) {
-  print_help();
-} else {
-  if (process.argv.indexOf('--mui-icon-opts') !== -1) {
-    run(MUI_ICONS_OPTS);
-  } else {
-    run(DEFAULT_OPTS);
-  }
-}
-
-function run(options) {
+//Clean old files
+rimraf(argv.outputDir, function() {
   console.log('** Starting Build');
-
-  //Clean old files
-  rimraf(options.outputDir, function() {
-    //Process each folder
-    var dirs = fs.readdirSync(options.svgDir);
-    fs.mkdirSync(options.outputDir);
-    dirs.forEach(function(dirName) {
-      processDir(dirName, options.svgDir, options.outputDir, options.iconInnerPath, options.fileSuffix) 
-    });
+  //Process each folder
+  var dirs = fs.readdirSync(argv.svgDir);
+  fs.mkdirSync(argv.outputDir);
+  dirs.forEach(function(dirName) {
+    processDir(dirName, argv.svgDir, argv.outputDir, argv.innerPath, argv.fileSuffix) 
   });
-}
+});
 
-function processDir(dirName, svgDir, outputDir, iconInnerPath, fileSuffix) {
+function processDir(dirName, svgDir, outputDir, innerPath, fileSuffix) {
   var newIconDirPath = path.join(outputDir, dirName);
-  var svgIconDirPath = path.join(svgDir, dirName, iconInnerPath);
+  var svgIconDirPath = path.join(svgDir, dirName, innerPath);
   if (!fs.existsSync(svgIconDirPath)) { return false; }
   if (!fs.lstatSync(svgIconDirPath).isDirectory()) { return false; }
   try {

--- a/icon-builder/package.json
+++ b/icon-builder/package.json
@@ -4,7 +4,7 @@
   "description": "Material Design Svg Icons converted to React components.",
   "scripts": {
     "prebuild": "rm -rf js",
-    "createMuiIconsJsx": "node build.js --mui-icon-opts",
+    "createMuiIconsJsx": "node build.js --output-dir jsx --svg-dir ./node_modules/material-design-icons --inner-path /svg/production/ --file-suffix _24px.svg",
     "build": "npm run createMuiIconsJsx && babel --stage 1 ./jsx --out-dir ./js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -23,9 +23,9 @@
   "author": "Hai Nguyen",
   "license": "MIT",
   "dependencies": {
+    "yargs": "^3.15.0"
   },
-  "peerDependencies": {
-  },
+  "peerDependencies": {},
   "devDependencies": {
     "babel": "^5.6.1",
     "material-design-icons": "^2.0.0",

--- a/icon-builder/package.json
+++ b/icon-builder/package.json
@@ -4,8 +4,8 @@
   "description": "Material Design Svg Icons converted to React components.",
   "scripts": {
     "prebuild": "rm -rf js",
-    "createJsx": "node build.js",
-    "build": "npm run createJsx && babel --stage 1 ./jsx --out-dir ./js",
+    "createMuiIconsJsx": "node build.js --mui-icon-opts",
+    "build": "npm run createMuiIconsJsx && babel --stage 1 ./jsx --out-dir ./js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [

--- a/icon-builder/package.json
+++ b/icon-builder/package.json
@@ -4,7 +4,7 @@
   "description": "Material Design Svg Icons converted to React components.",
   "scripts": {
     "prebuild": "rm -rf js",
-    "createMuiIconsJsx": "node build.js --output-dir jsx --svg-dir ./node_modules/material-design-icons --inner-path /svg/production/ --file-suffix _24px.svg",
+    "createMuiIconsJsx": "node build.js --output-dir jsx --svg-dir ./node_modules/material-design-icons --inner-path /svg/production/ --file-suffix _24px.svg --mui-require relative",
     "build": "npm run createMuiIconsJsx && babel --stage 1 ./jsx --out-dir ./js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
There's a limitation with icon builder hard coded to only build ``SvgIcon`` for material-ui-icon.

The scope of this is to expand functionality of icon builder to allow building of arbitrary SVG's, while not adding any additional dependencies.

Some questions:

- What's the outlook on the use of icon-builder? Is it going to be a major part of building releases in upcoming versions?
- Is there a need to build utility scripts for any other things?
- If icon builder is an essential part of the project, is it ok to add a dependency or two for icon-builder (like optimist).
- Anything inside of here I forget? I'm still testing it out and will follow up too.

## Changes
- Use path.join on directories
- Accept Environmental arguments:
    OUTPUT_DIR - output directory for jsx components
    SVG_DIR - target directory of svg files
    INNER_DIR - for "reaching into" build directories in
    icon libraries
- Help dialog with -h or --help
- build.js --mui-icon-opts to automatically build for
  mui-icon-opts
- Replace wholesale try-catch where possible for debugging,
  check if file exists / is directory when iterating through
  folders.
- Use "dir" convention for consistency