### PR TITLE
Fix issue where Overlay can prevent the body from scrolling

### DIFF
--- a/src/overlay.jsx
+++ b/src/overlay.jsx
@@ -6,6 +6,8 @@ let Colors = require('./styles/colors');
 
 let Overlay = React.createClass({
 
+  _originalBodyOverflow: '',
+
   mixins: [StylePropable],
 
   propTypes: {
@@ -21,13 +23,16 @@ let Overlay = React.createClass({
     };
   },
 
+  componentDidMount() {
+    this._originalBodyOverflow = document.getElementsByTagName('body')[0].style.oveflow;
+  },
+
   componentDidUpdate() {
     if (this.props.autoLockScrolling) (this.props.show) ? this._preventScrolling() : this._allowScrolling();
   },
 
-
   componentWillUnmount() {
-    this.allowScrolling();
+    this._allowScrolling();
   },
 
   setOpacity(opacity) {
@@ -70,7 +75,6 @@ let Overlay = React.createClass({
   },
 
   render() {
-
     let {
       show,
       style,
@@ -99,7 +103,7 @@ let Overlay = React.createClass({
 
   _allowScrolling() {
     let body = document.getElementsByTagName('body')[0];
-    body.style.overflow = '';
+    body.style.overflow = this._originalBodyOverflow;
   }
 
 });

--- a/src/snackbar.jsx
+++ b/src/snackbar.jsx
@@ -13,7 +13,7 @@ let Snackbar = React.createClass({
   manuallyBindClickAway: true,
 
   // ID of the active timer.
-  autoHideTimerId: undefined,
+  _autoHideTimerId: undefined,
 
   contextTypes: {
     muiTheme: React.PropTypes.object
@@ -143,15 +143,15 @@ let Snackbar = React.createClass({
   },
 
   _clearAutoHideTimer() {
-    if (this.autoHideTimerId !== undefined) {
-      this.autoHideTimerId = clearTimeout(this.autoHideTimerId);
+    if (this._autoHideTimerId !== undefined) {
+      this._autoHideTimerId = clearTimeout(this._autoHideTimerId);
     }
   },
 
   _setAutoHideTimer() {
     if (this.props.autoHideDuration > 0) {
       this._clearAutoHideTimer();
-      this.autoHideTimerId = setTimeout(() => { this.dismiss(); }, this.props.autoHideDuration);
+      this._autoHideTimerId = setTimeout(() => { this.dismiss(); }, this.props.autoHideDuration);
     }
   }
 


### PR DESCRIPTION
Addresses #897 where unmounting an Overlay component can prevent the body from scrolling. Improved Overlay by recording the original body overflow style and reapplying it upon unmount as suggested in the issue.