### PR TITLE
Fixed DatePicker year/month navigation buttons

### DIFF
--- a/src/date-picker/calendar-toolbar.jsx
+++ b/src/date-picker/calendar-toolbar.jsx
@@ -67,10 +67,6 @@ let CalendarToolbar = React.createClass({
         width: '100%',
         fontWeight: '500',
         textAlign: 'center',
-        zIndex: 0,
-      },
-      button: {
-        zIndex:1,
       },
     };
   },
@@ -84,6 +80,12 @@ let CalendarToolbar = React.createClass({
 
     return (
       <Toolbar className="mui-date-picker-calendar-toolbar" style={styles.root} noGutter={true}>
+        <SlideInTransitionGroup
+          style={styles.title}
+          direction={this.state.transitionDirection}>
+          <div key={month + '_' + year}>{month} {year}</div>
+        </SlideInTransitionGroup>
+
         <ToolbarGroup key={0} float="left">
           {prevYearChangeButton}
 
@@ -105,12 +107,6 @@ let CalendarToolbar = React.createClass({
 
           {nextYearChangeButton}
         </ToolbarGroup>
-
-        <SlideInTransitionGroup
-          style={styles.title}
-          direction={this.state.transitionDirection}>
-          <div key={month + '_' + year}>{month} {year}</div>
-        </SlideInTransitionGroup>
       </Toolbar>
     );
   },

--- a/src/svg-icon.jsx
+++ b/src/svg-icon.jsx
@@ -44,18 +44,15 @@ let SvgIcon = React.createClass({
       style && style.fill ? style.fill : this.context.muiTheme.palette.textColor;
     let onColor = hoverColor ? hoverColor : offColor;
 
-    //remove the fill prop so that it doesn't override our computed
-    //fill from above
-    if (style) delete style.fill;
-
     let mergedStyles = this.mergeAndPrefix({
       display: 'inline-block',
       height: 24,
       width: 24,
       userSelect: 'none',
       transition: Transitions.easeOut(),
-      fill: this.state.hovered ? onColor : offColor,
-    }, style);
+    },
+    style,
+    {fill: this.state.hovered ? onColor : offColor}); // Make sure our fill color overrides fill provided in props.style
 
     return (
       <svg

--- a/src/svg-icon.jsx
+++ b/src/svg-icon.jsx
@@ -50,9 +50,10 @@ let SvgIcon = React.createClass({
       width: 24,
       userSelect: 'none',
       transition: Transitions.easeOut(),
-    },
-    style,
-    {fill: this.state.hovered ? onColor : offColor}); // Make sure our fill color overrides fill provided in props.style
+    }, style, {
+      // Make sure our fill color overrides fill provided in props.style
+      fill: this.state.hovered ? onColor : offColor,
+    });
 
     return (
       <svg


### PR DESCRIPTION
In svg-icons there was a command to delete the fill property from this.props.style. This is destructive behavior on something that should be treated as immutable. This issue presented itself as soon as I hovered over one of the year/month buttons in the DatePicker that was disabled.

Also fixed a z-indexing issue with the month year being displayed between the month/year buttons.