### PR TITLE
[docs] Tweak to LeftNav docs - show user how to toggle LeftNav component

### DIFF
--- a/docs/src/app/components/pages/components/left-nav.jsx
+++ b/docs/src/app/components/pages/components/left-nav.jsx
@@ -48,10 +48,12 @@ class LeftNavPage extends React.Component {
       '     disabled: true \n' +
       '  },\n' +
       '];\n\n' +
+      '//Toggle the LeftNav\n'+
+      'this.refs.leftNav.toggle();\n\n'+
       '//Docked Left Nav\n' +
-      '<LeftNav menuItems={menuItems} />\n\n' +
+      '<LeftNav ref="leftNav" menuItems={menuItems} />\n\n' +
       '//Hideable Left Nav\n' +
-      '<LeftNav docked={false} menuItems={menuItems} />\n\n';
+      '<LeftNav ref="leftNav" docked={false} menuItems={menuItems} />\n\n';
 
     let componentInfo = [
       {


### PR DESCRIPTION
When I initially tried to use the LeftNav component, I couldn't toggle it open/closed.  

I tweaked the LeftNav docs to give the reader a hint of how to do this.  Perhaps it will save some frustration.