### PR TITLE
update dropdown menu spacing to reflect material spec

### DIFF
--- a/src/drop-down-menu.jsx
+++ b/src/drop-down-menu.jsx
@@ -86,7 +86,7 @@ let DropDownMenu = React.createClass({
         transition: Transitions.easeOut(),
         position: 'relative',
         display: 'inline-block',
-        height: this.getSpacing().desktopToolbarHeight,
+        height: this.getSpacing().desktopSubheaderHeight,
         fontSize: this.getSpacing().desktopDropDownMenuFontSize,
         outline:'none',
       },


### PR DESCRIPTION
Height of the entire component should be 48, instead of 56. I only noticed when I saw a SelectField and a DropDownMenu side by side and noticed that their spacing was different.

If I'm being dumb and totally missing the mark here, lemme know! :)

![screen shot 2015-07-11 at 3 42 26 am](https://cloud.githubusercontent.com/assets/3118416/8633487/dcd2113e-277f-11e5-9118-d1ce7ffcb89a.png)
![screen shot 2015-07-11 at 3 42 32 am](https://cloud.githubusercontent.com/assets/3118416/8633488/e24df010-277f-11e5-962d-763d683abc77.png)
