### PR TITLE
Add 'border-radius: 0' to LeftNav menu style.

### DIFF
--- a/src/left-nav.jsx
+++ b/src/left-nav.jsx
@@ -108,6 +108,7 @@ let LeftNav = React.createClass({
         overflowY: 'auto',
         overflowX: 'hidden',
         height: '100%',
+        borderRadius: '0',
       },
       menuItem: {
         height: this.context.muiTheme.spacing.desktopLeftNavMenuItemHeight,


### PR DESCRIPTION
This improve a nice bit of performence when menu scroll.

I paste two screenshots from chrome dev Timeline tool. 

* menu `border-radius: 2px`. Paint performence when scroll the menu.
![borderradius2](https://cloud.githubusercontent.com/assets/1581998/8638226/c104a1a2-28e6-11e5-936a-09a7c3a6911b.png)

* menu `border-radius: 0`. Pain performence when scroll the menu.
![borderradius0](https://cloud.githubusercontent.com/assets/1581998/8638232/1b76b3d2-28e7-11e5-9aa2-3fb7df268360.png)

As you see. When `border-radius: 0` applied, the repaint area is very small and simple. This achives almost 8 times performence improvement. 