### PR TITLE
DropDownMenu container height not updated while expanded

### DIFF
--- a/src/menu/menu.jsx
+++ b/src/menu/menu.jsx
@@ -248,7 +248,9 @@ var Menu = React.createClass({
   },
 
   componentDidUpdate(prevProps) {
-    if (this.props.visible !== prevProps.visible) this._renderVisibility();
+    if (this.props.visible !== prevProps.visible || this.props.menuItems.length !== prevProps.menuItems.length) {
+      this._renderVisibility();
+    }
   },
 
   componentWillReceiveProps() {


### PR DESCRIPTION
The height of the `Paper` wrapping the drop-down menu items is calculated based on the number of items in the menu in `_expandHideableMenu()`, which is in turn called from `_renderVisibility()`. When the number of menu items changes while the drop-down is open (e.g. showing one item while loading more) this calculated height is not updated, and so the menu items flow out of the container after the re-render.

The problem is that `componentDidUpdate()` checks for a change in the `visible` prop before calling `_renderVisibility()`, but not for a change in the `menuItems.length`. This is fixed here.