### PR TITLE
Make sure dialog is fully rendered before calling onShow

### DIFF
--- a/src/dialog.jsx
+++ b/src/dialog.jsx
@@ -233,8 +233,7 @@ let Dialog = React.createClass({
 
   show() {
     this.refs.dialogOverlay.preventScrolling();
-    this.setState({ open: true });
-    this._onShow();
+    this.setState({ open: true }, this._onShow);
   },
 
   _getAction(actionJSON, key) {


### PR DESCRIPTION
This will prevent undefined refs issue when using the onShow property.