### PR TITLE
Position tooltip on value change

### DIFF
--- a/src/tooltip.jsx
+++ b/src/tooltip.jsx
@@ -26,6 +26,10 @@ let Tooltip = React.createClass({
     this._setTooltipPosition();
   },
 
+  componentWillReceiveProps() {
+    this._setTooltipPosition();
+  },
+
   componentDidUpdate() {
     this._setRippleSize();
   },


### PR DESCRIPTION
The tooltip was not centered anymore after a value change (for example, localisation change). Triggering it again fixes it.