### PR TITLE
Add docs for missing Dropdown Menu styles

### DIFF
--- a/docs/src/app/components/pages/components/drop-down-menu.jsx
+++ b/docs/src/app/components/pages/components/drop-down-menu.jsx
@@ -57,6 +57,24 @@ class DropDownMenuPage extends React.Component {
             desc: 'Index of the item selected.'
           },
           {
+            name: 'underlineStyle',
+            type: 'object',
+            header: 'optional',
+            desc: 'Overrides the styles of DropDownMenu\'s underline.'
+          },
+          {
+            name: 'iconStyle',
+            type: 'object',
+            header: 'optional',
+            desc: 'Overrides the styles of DropDownMenu\'s icon element.'
+          },
+          {
+            name: 'labelStyle',
+            type: 'object',
+            header: 'optional',
+            desc: 'Overrides the styles of DropDownMenu\'s label when the DropDownMenu is inactive.'
+          },
+          {
             name: 'style',
             type: 'object',
             header: 'optional',

--- a/docs/src/app/components/pages/components/drop-down-menu.jsx
+++ b/docs/src/app/components/pages/components/drop-down-menu.jsx
@@ -30,6 +30,20 @@ class DropDownMenuPage extends React.Component {
         name: 'Props',
         infoArray: [
           {
+            name: 'displayMember',
+            type: 'string',
+            header: 'default: text',
+            desc: 'DropDownMenu will use text as default value, with this ' +
+              'property you can choose another name.'
+          },
+          {
+            name: 'valueMember',
+            type: 'string',
+            header: 'default: payload',
+            desc: 'DropDownMenu will use payload as default value, with this ' +
+              'property you can choose another name.'
+          },
+          {
             name: 'autoWidth',
             type: 'bool',
             header: 'default: true',


### PR DESCRIPTION
I was trying to override the styles and asked in gitter.
@patrykkopycinski gave me the hint.
Seems like it isn't documented yet, so here's my PR.
