### PR TITLE
[DatePicker] Supports value link and openDialog() method

### DIFF
--- a/docs/src/app/components/pages/components/date-picker.jsx
+++ b/docs/src/app/components/pages/components/date-picker.jsx
@@ -60,7 +60,8 @@ class DatePickerPage extends React.Component {
             name: 'defaultDate',
             type: 'date object',
             header: 'optional',
-            desc: 'This is the initial date value of the component.'
+            desc: 'This is the initial date value of the component. If either `value` or `valueLink` ' +
+            'is provided they will override this prop with `value` taking precedence.'
           },
           {
             name: 'formatDate',
@@ -136,6 +137,18 @@ class DatePickerPage extends React.Component {
             name: 'setDate',
             header: 'DatePicker.setDate(d)',
             desc: 'Sets the date value to d, where d is a date object.'
+          },
+          {
+            name: 'openDialog',
+            header: 'DatePicker.openDialog()',
+            desc: 'Opens the date-picker dialog programmatically. Use this if you want to open the ' +
+            'dialog in response to some event other than focus/tap on the input field, such as an ' +
+            'external button click.'
+          },
+          {
+            name: 'focus',
+            header: 'DatePicker.focus()',
+            desc: 'An alias for the `openDialog()` method to allow more generic use alongside `TextField`.'
           }
         ]
       },

--- a/src/date-picker/date-picker.jsx
+++ b/src/date-picker/date-picker.jsx
@@ -58,11 +58,13 @@ let DatePicker = React.createClass({
   },
 
   /**
-   * Rather than checking all the possible dates for changes ourselves,
-   * just assign the current props date and let setState do the checking.
+   * If this is a controlled input, rather than checking all the possible dates for changes
+   * ourselves, just assign the current props date and let setState do the checking.
    */
   componentWillReceiveProps(nextProps) {
-    this.setDate(this._getPropsDate(nextProps));
+    if (nextProps.hasOwnProperty('value') || nextProps.hasOwnProperty('valueLink')) {
+      this.setDate(this._getPropsDate(nextProps));
+    }
   },
 
   render() {

--- a/src/date-picker/date-picker.jsx
+++ b/src/date-picker/date-picker.jsx
@@ -124,6 +124,24 @@ let DatePicker = React.createClass({
     });
   },
 
+  /**
+   * Open the date-picker dialog programmatically from a parent.
+   */
+  openDialog() {
+    this.setState({
+      dialogDate: this.getDate(),
+      // State changes aren't always handled immediately,
+      // better to wait on the callback.
+    }, () => this.refs.dialogWindow.show());
+  },
+
+  /**
+   * Alias for `openDialog()` for an api consistent with TextField.
+   */
+  focus() {
+    this.openDialog();
+  },
+
   _handleDialogAccept(d) {
     this.setDate(d);
     if (this.props.onChange) this.props.onChange(null, d);
@@ -140,11 +158,7 @@ let DatePicker = React.createClass({
   },
 
   _handleInputTouchTap(e) {
-    this.setState({
-      dialogDate: this.getDate(),
-    });
-
-    this.refs.dialogWindow.show();
+    this.openDialog();
     if (this.props.onTouchTap) this.props.onTouchTap(e);
   },
 

--- a/src/utils/date-time.js
+++ b/src/utils/date-time.js
@@ -152,6 +152,10 @@ module.exports = {
             !(this.isAfterDate(dateToCheck, endDate)));
   },
 
+  isDateObject(d) {
+    return d instanceof Date;
+  },
+
   monthDiff(d1, d2) {
     let m;
     m = (d1.getFullYear() - d2.getFullYear()) * 12;


### PR DESCRIPTION
First-off, this PR adds support for `valueLink` as requested in #1196. The implementation is based on how this is handled in `TextField` and supporting controlled inputs previously added in #1170 is now much cleaner, in my opinion, as well.

Secondly, perhaps as an alternative to #1206 and #1210, perhaps in addition, two methods are exposed to parent components: `openDialog()` and `focus()`. The function of the former is obvious from the name, the latter is an alias for the same method matching the `TextField` api for more generic handling in higher order components. This is quite an effective way to open the dialog when a button is clicked etc. Since the date should (always?) be displayed thereafter, I think it makes sense to tie the dialog closely to a text field, but perhaps there are other use cases that do warrant exposing the dialog as in #1210.

(I guess this should technically have been separate PRs, if you like one change but not the other I'll change it accordingly.)

I've looked at also opening the dialog on focus as the comment in the code suggests should be done. This turned out to be rather tricky though: With the focus on the text field being blurred again immediately tabbing breaks down as focus shifts to the `body`, and one can also not detect if `this` was the tabbed to input in `_handleWindowKeyUp()`. Opening the modal in `_handleInputFocus` causes it to open briefly and then close again, I couldn't really figure out why. The trouble, I guess, is the dual focus and tap events that are triggered. I got it working by delaying response to the focus event for 150ms and clearing the timer if the tap event also occurs, but this hardly seems ideal. My final thoughts are that it might be best to leave the `focus` on the text field, and the pass down custom styling to it so it doesn't look like it's focused which I'm guessing is the intended outcome. Not entirely sure why though?

In addition to @hai-cea, I'd love to hear your comments @JAStanton and @gappture.

(I'll be adding docs for these changes as well before this gets merged if it is decided to do so.)