### PR TITLE
[DropDownMenu] Controlled field should clear when value is undefined

### DIFF
--- a/src/drop-down-menu.jsx
+++ b/src/drop-down-menu.jsx
@@ -45,8 +45,7 @@ let DropDownMenu = React.createClass({
     return {
       open: false,
       isHovered: false,
-      selectedIndex: (this.props.hasOwnProperty('value') ||
-        this.props.hasOwnProperty('valueLink')) ? null : (this.props.selectedIndex || 0),
+      selectedIndex: this._isControlled() ? null : (this.props.selectedIndex || 0),
     };
   },
 
@@ -154,7 +153,7 @@ let DropDownMenu = React.createClass({
   render() {
     let _this = this;
     let styles = this.getStyles();
-    let selectedIndex = this.state.selectedIndex;
+    let selectedIndex = this._isControlled() ? null : this.state.selectedIndex;
     let displayValue = "";
     if (selectedIndex) {
       if (process.env.NODE_ENV !== 'production') {
@@ -162,11 +161,13 @@ let DropDownMenu = React.createClass({
       }
     }
     else {
-      if (this.props.valueMember && (this.props.valueLink || this.props.value)) {
-        let value = this.props.value || this.props.valueLink.value;
-        for (let i = 0; i < this.props.menuItems.length; i++) {
-          if (this.props.menuItems[i][this.props.valueMember] === value) {
-            selectedIndex = i;
+      if (this.props.valueMember && this._isControlled()) {
+        let value = this.props.hasOwnProperty('value') ? this.props.value : this.props.valueLink.value;
+        if (value) {
+          for (let i = 0; i < this.props.menuItems.length; i++) {
+            if (this.props.menuItems[i][this.props.valueMember] === value) {
+              selectedIndex = i;
+            }
           }
         }
       }
@@ -324,6 +325,11 @@ let DropDownMenu = React.createClass({
     this.setState({
       open: false,
     });
+  },
+
+  _isControlled() {
+    return this.props.hasOwnProperty('value') ||
+      this.props.hasOwnProperty('valueLink');
   },
 
 });

--- a/src/drop-down-menu.jsx
+++ b/src/drop-down-menu.jsx
@@ -44,7 +44,6 @@ let DropDownMenu = React.createClass({
   getInitialState() {
     return {
       open: false,
-      isHovered: false,
       selectedIndex: this._isControlled() ? null : (this.props.selectedIndex || 0),
     };
   },
@@ -187,8 +186,6 @@ let DropDownMenu = React.createClass({
     return (
       <div
         ref="root"
-        onMouseLeave={this._handleMouseLeave}
-        onMouseEnter={this._handleMouseEnter}
         onKeyDown={this._onKeyDown}
         onFocus={this.props.onFocus}
         onBlur={this.props.onBlur}
@@ -297,20 +294,11 @@ let DropDownMenu = React.createClass({
       selectedIndex: key,
       value: e.target.value,
       open: false,
-      isHovered: false,
     });
   },
 
   _onMenuRequestClose() {
     this.setState({open:false});
-  },
-
-  _handleMouseEnter() {
-    this.setState({isHovered: true});
-  },
-
-  _handleMouseLeave() {
-    this.setState({isHovered: false});
   },
 
   _selectPreviousItem() {

--- a/src/select-field.jsx
+++ b/src/select-field.jsx
@@ -81,15 +81,6 @@ let SelectField = React.createClass({
     return styles;
   },
 
-  onChange(e, index, payload) {
-    if (payload) {
-      e.target.value = payload[this.props.valueMember] || payload;
-    }
-    if (this.props.onChange) {
-      this.props.onChange(e,index,payload);
-    }
-  },
-
   render() {
     let styles = this.getStyles();
     let {
@@ -98,7 +89,6 @@ let SelectField = React.createClass({
       iconStyle,
       underlineStyle,
       selectFieldRoot,
-      onChange,
       menuItems,
       disabled,
       floatingLabelText,
@@ -116,7 +106,6 @@ let SelectField = React.createClass({
       errorText: errorText,
     };
     let dropDownMenuProps = {
-      onChange: this.onChange,
       menuItems: menuItems,
       disabled: disabled,
       style: this.mergeAndPrefix(styles.root, selectFieldRoot),


### PR DESCRIPTION
When `DropDownMenu` is used with a *controlled* `SelectField` the value is updated properly except when the value is `undefined`. In that case it should reset the select to the initial "unselected" state, but instead the last selection is maintained and displayed on top of the hint text. This is a patch to fix that. (I realise `DropDownMenu` will fall away eventually, but I think fixing it now is still worthwhile; this should also be outcome in any future implementation.)

I also noticed that `isHovered` was maintained in the `DropDownMenu` state which, as far as I could see, is never used. This caused a lot of unnecessary re-renders. I've removed that as well, but purposefully added it as the latter commit. If maintaining this status does serve some purpose I'm missing I'll just lop that one off.