### PR TITLE
Don't close the date picker when switching months with autoOK true

### DIFF
--- a/src/date-picker/calendar.jsx
+++ b/src/date-picker/calendar.jsx
@@ -26,7 +26,7 @@ let Calendar = React.createClass({
     shouldShowMonthDayPickerFirst: React.PropTypes.bool,
     shouldShowYearPickerFirst: React.PropTypes.bool,
     showYearSelector: React.PropTypes.bool,
-    onSelectedDate: React.PropTypes.func,
+	onDayTouchTap: React.PropTypes.func,
   },
 
   windowListeners: {
@@ -230,7 +230,7 @@ let Calendar = React.createClass({
     }
   },
 
-  _setSelectedDate(date, e) {
+  _setSelectedDate(date) {
     let adjustedDate = date;
     if (DateTime.isBeforeDate(date, this.props.minDate)) {
       adjustedDate = this.props.minDate;
@@ -248,11 +248,11 @@ let Calendar = React.createClass({
         selectedDate: adjustedDate,
       });
     }
-    if (this.props.onSelectedDate) this.props.onSelectedDate(e, date);
   },
 
   _handleDayTouchTap(e, date) {
-    this._setSelectedDate(date, e);
+    this._setSelectedDate(date);
+	if (this.props.onDayTouchTap) this.props.onDayTouchTap(e, date);
   },
 
   _handleMonthChange(months) {

--- a/src/date-picker/calendar.jsx
+++ b/src/date-picker/calendar.jsx
@@ -26,7 +26,7 @@ let Calendar = React.createClass({
     shouldShowMonthDayPickerFirst: React.PropTypes.bool,
     shouldShowYearPickerFirst: React.PropTypes.bool,
     showYearSelector: React.PropTypes.bool,
-	onDayTouchTap: React.PropTypes.func,
+    onDayTouchTap: React.PropTypes.func,
   },
 
   windowListeners: {
@@ -252,7 +252,7 @@ let Calendar = React.createClass({
 
   _handleDayTouchTap(e, date) {
     this._setSelectedDate(date);
-	if (this.props.onDayTouchTap) this.props.onDayTouchTap(e, date);
+    if (this.props.onDayTouchTap) this.props.onDayTouchTap(e, date);
   },
 
   _handleMonthChange(months) {

--- a/src/date-picker/date-picker-dialog.jsx
+++ b/src/date-picker/date-picker-dialog.jsx
@@ -101,7 +101,7 @@ let DatePickerDialog = React.createClass({
         repositionOnUpdate={false}>
         <Calendar
           ref="calendar"
-          onSelectedDate={this._onSelectedDate}
+          onDayTouchTap={this._onDayTouchTap}
           initialDate={this.props.initialDate}
           isActive={this.state.isCalendarActive}
           minDate={this.props.minDate}
@@ -123,7 +123,7 @@ let DatePickerDialog = React.createClass({
     this.refs.dialog.dismiss();
   },
 
-  _onSelectedDate() {
+  _onDayTouchTap() {
     if (this.props.autoOk) {
       setTimeout(this._handleOKTouchTap, 300);
     }


### PR DESCRIPTION
This time using onDayTouchTap instead of keeping track of navigation events.