### PR TITLE
[DatePicker] avoid handling keyboard event when calendar is not active

### DIFF
--- a/src/date-picker/date-picker-dialog.jsx
+++ b/src/date-picker/date-picker-dialog.jsx
@@ -172,10 +172,12 @@ let DatePickerDialog = React.createClass({
   },
 
   _handleWindowKeyUp(e) {
-    switch (e.keyCode) {
-      case KeyCode.ENTER:
-        this._handleOKTouchTap();
-        break;
+    if (this.state.isCalendarActive) {
+      switch (e.keyCode) {
+        case KeyCode.ENTER:
+          this._handleOKTouchTap();
+          break;
+      }
     }
   },
 


### PR DESCRIPTION
I was getting the same error, this fixes #1224