### PR TITLE
Fix false CSS property value

### DIFF
--- a/src/styles/auto-prefix.js
+++ b/src/styles/auto-prefix.js
@@ -17,7 +17,15 @@ module.exports = {
   },
 
   single(key) {
-    return isBrowser ? Modernizr.prefixed(key) : key;
+    if (isBrowser) {
+      // Windows 7 Firefox has an issue with the implementation of Modernizr.prefixed
+      // and is capturing 'false' as the CSS property name instead of the non-prefixed version.
+      let prefKey = Modernizr.prefixed(key);
+      return prefKey === false ? key : prefKey;
+    }
+    else {
+      return key;
+    }
   },
 
   singleHyphened(key) {


### PR DESCRIPTION
Modernizr.prefixed returns false in testDOMProps. When testing a single property the looping mechanism fails and false is returned. I have only noticed this error on Windows 7 Firefox not on my Mac. Can someone else verify? Please check the date picker #1242.