### PR TITLE
[Avatar] rollback, use ligter border color

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ icon-builder/jsx
 
 # Exclude IDE project folders
 .idea
+
+# OS files
+.DS_STORE

--- a/docs/src/app/components/pages/components/lists.jsx
+++ b/docs/src/app/components/pages/components/lists.jsx
@@ -14,7 +14,6 @@ let ContentSend = require('svg-icons/content/send');
 let EditorInsertChart = require('svg-icons/editor/insert-chart');
 let FileFolder = require('svg-icons/file/folder');
 let MoreVertIcon = require('svg-icons/navigation/more-vert');
-let ToggleStarBorder = require('svg-icons/toggle/star-border');
 
 let {
   Avatar,

--- a/src/avatar.jsx
+++ b/src/avatar.jsx
@@ -43,7 +43,6 @@ let Avatar = React.createClass({
         height: size,
         width: size,
         userSelect: 'none',
-        backgroundColor: backgroundColor,
         borderRadius: '50%',
         display: 'inline-block',
       },
@@ -63,6 +62,7 @@ let Avatar = React.createClass({
       return <img {...other} src={src} style={this.mergeAndPrefix(styles.root, style)} />;
     } else {
       styles.root = this.mergeStyles(styles.root, {
+        backgroundColor: backgroundColor,
         textAlign: 'center',
         lineHeight: size + 'px',
         fontSize: size / 2 + 4,

--- a/src/avatar.jsx
+++ b/src/avatar.jsx
@@ -11,9 +11,9 @@ let Avatar = React.createClass({
   },
 
   propTypes: {
-    icon: React.PropTypes.element,
     backgroundColor: React.PropTypes.string,
     color: React.PropTypes.string,
+    icon: React.PropTypes.element,
     size: React.PropTypes.number,
     src: React.PropTypes.string,
     style: React.PropTypes.object,
@@ -28,19 +28,15 @@ let Avatar = React.createClass({
   },
 
   render() {
-
     let {
-      icon,
       backgroundColor,
       color,
+      icon,
       size,
       src,
       style,
       ...other,
     } = this.props;
-
-    const boxShadow = (style && style.boxShadow) ? style.boxShadow : '0 0 1px 0 rgba(0, 0, 0, 0.2) inset';
-    const borderRadius = (style && style.borderRadius) ? style.borderRadius : '50%';
 
     let styles = {
       root: {
@@ -48,55 +44,41 @@ let Avatar = React.createClass({
         width: size,
         userSelect: 'none',
         backgroundColor: backgroundColor,
-        boxShadow: src ? null : boxShadow, // Doesn't apply above an img
-        borderRadius: borderRadius,
+        borderRadius: '50%',
         display: 'inline-block',
+      },
+    };
 
-        //Needed for img
-        position: 'relative',
+    if (src) {
+      const borderColor = this.context.muiTheme.component.avatar.borderColor;
 
-        //Needed for letter avatars
+      if(borderColor) {
+        styles.root = this.mergeStyles(styles.root, {
+          height: size - 2,
+          width: size - 2,
+          border: 'solid 1px ' + borderColor,
+        });
+      }
+
+      return <img {...other} src={src} style={this.mergeAndPrefix(styles.root, style)} />;
+    } else {
+      styles.root = this.mergeStyles(styles.root, {
         textAlign: 'center',
         lineHeight: size + 'px',
         fontSize: size / 2 + 4,
         color: color,
-      },
-    };
+      });
 
-    let mergedRootStyles = this.mergeAndPrefix(styles.root, style);
-
-    if (src) {
-      const styleImg = {
-        height: size,
-        width: size,
-        borderRadius: borderRadius,
-      };
-
-      const styleImgShadow = {
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        width: '100%',
-        height: '100%',
-        boxShadow: boxShadow,
-        borderRadius: borderRadius,
-      };
-
-      return <div {...other} style={mergedRootStyles} >
-          <img src={src} style={styleImg} />
-          <div style={this.mergeAndPrefix(styleImgShadow)} />
-        </div>;
-    } else {
       const styleIcon = {
         margin: 8,
       };
 
-      let iconElement = icon ? React.cloneElement(icon, {
+      const iconElement = icon ? React.cloneElement(icon, {
         color: color,
         style: this.mergeStyles(styleIcon, icon.props.style),
       }) : null;
 
-      return <div {...other} style={mergedRootStyles}>
+      return <div {...other} style={this.mergeAndPrefix(styles.root, style)}>
         {iconElement}
         {this.props.children}
       </div>;

--- a/src/styles/themes/dark-theme.js
+++ b/src/styles/themes/dark-theme.js
@@ -15,6 +15,9 @@ let DarkTheme = {
   getComponentThemes(palette) {
     let cardColor = Colors.grey800;
     return {
+      avatar: {
+        borderColor: 'rgba(0, 0, 0, 0.5)',
+      },
       floatingActionButton: {
         disabledColor: ColorManipulator.fade(palette.textColor, 0.12),
       },

--- a/src/styles/themes/light-theme.js
+++ b/src/styles/themes/light-theme.js
@@ -34,6 +34,9 @@ let LightTheme = {
         textColor: Colors.darkWhite,
         height: spacing.desktopKeylineIncrement,
       },
+      avatar: {
+        borderColor: 'rgba(0, 0, 0, 0.08)',
+      },
       button: {
         height: 36,
         minWidth: 88,


### PR DESCRIPTION
Follow discusion in #1204.
Better rendering performance.
Add a new `avatar.borderColor` theme property. If set to null, no border is displayed.