### PR TITLE
Add prop disableSwipe to LeftNav

### DIFF
--- a/src/left-nav.jsx
+++ b/src/left-nav.jsx
@@ -58,15 +58,15 @@ let LeftNav = React.createClass({
 
   componentDidMount() {
     this._updateMenuHeight();
-    if (this.props.disableSwipe === false){
-      this._enableSwipeHandling();
+    if (this.props.disableSwipe === true){
+      this._enableSwipeHandlingOnClose();
     }
   },
 
   componentDidUpdate() {
     this._updateMenuHeight();
     if (this.props.disableSwipe === false){
-      this._enableSwipeHandling();
+      this._enableSwipeHandlingOnClose();
     }
   },
 
@@ -226,7 +226,16 @@ let LeftNav = React.createClass({
   _getTranslateMultiplier() {
     return this.props.openRight ? 1 : -1;
   },
-
+  _enableSwipeHandlingOnClose() {
+    if (!this.props.docked && this.state.opening) {
+      document.body.addEventListener('touchstart', this._onBodyTouchStart);
+      if (!openNavEventHandler) {
+        openNavEventHandler = this._onBodyTouchStart;
+      }
+    } else {
+      this._disableSwipeHandling();
+    }
+  },
   _enableSwipeHandling() {
     if (!this.props.docked) {
       document.body.addEventListener('touchstart', this._onBodyTouchStart);

--- a/src/left-nav.jsx
+++ b/src/left-nav.jsx
@@ -40,7 +40,7 @@ let LeftNav = React.createClass({
   getDefaultProps() {
     return {
       docked: true,
-      disableSwipe: true,
+      disableSwipe: false,
     };
   },
 

--- a/src/left-nav.jsx
+++ b/src/left-nav.jsx
@@ -29,6 +29,7 @@ let LeftNav = React.createClass({
     onNavClose: React.PropTypes.func,
     openRight: React.PropTypes.bool,
     selectedIndex: React.PropTypes.number,
+    disableSwipe: React.PropTypes.bool,
   },
 
   windowListeners: {
@@ -39,6 +40,7 @@ let LeftNav = React.createClass({
   getDefaultProps() {
     return {
       docked: true,
+      disableSwipe: true,
     };
   },
 
@@ -56,16 +58,22 @@ let LeftNav = React.createClass({
 
   componentDidMount() {
     this._updateMenuHeight();
-    this._enableSwipeHandling();
+    if (this.props.disableSwipe === false){
+      this._enableSwipeHandling();
+    }
   },
 
   componentDidUpdate() {
     this._updateMenuHeight();
-    this._enableSwipeHandling();
+    if (this.props.disableSwipe === false){
+      this._enableSwipeHandling();
+    }
   },
 
   componentWillUnmount() {
-    this._disableSwipeHandling();
+    if (this.props.disableSwipe === false){
+      this._disableSwipeHandling();
+    }
   },
 
   toggle() {

--- a/src/left-nav.jsx
+++ b/src/left-nav.jsx
@@ -29,7 +29,7 @@ let LeftNav = React.createClass({
     onNavClose: React.PropTypes.func,
     openRight: React.PropTypes.bool,
     selectedIndex: React.PropTypes.number,
-    disableSwipe: React.PropTypes.bool,
+    disableSwipeOut: React.PropTypes.bool,
   },
 
   windowListeners: {
@@ -65,13 +65,13 @@ let LeftNav = React.createClass({
 
   componentDidUpdate() {
     this._updateMenuHeight();
-    if (this.props.disableSwipe === false){
+    if (this.props.disableSwipeOut === false){
       this._enableSwipeHandlingOnClose();
     }
   },
 
   componentWillUnmount() {
-    if (this.props.disableSwipe === false){
+    if (this.props.disableSwipeOut === false){
       this._disableSwipeHandling();
     }
   },

--- a/src/left-nav.jsx
+++ b/src/left-nav.jsx
@@ -58,7 +58,7 @@ let LeftNav = React.createClass({
 
   componentDidMount() {
     this._updateMenuHeight();
-    if (this.props.disableSwipe === true){
+    if (this.props.disableSwipeOut === true){
       this._enableSwipeHandlingOnClose();
     }
   },


### PR DESCRIPTION
When setting props disableSwipe to true, the swipe behavior only affects when the LeftNav is opening, and we cannot open LeftNav by swiping.