### PR TITLE
Add contentContainerClassName to Tabs

### DIFF
--- a/docs/src/app/components/pages/components/tabs.jsx
+++ b/docs/src/app/components/pages/components/tabs.jsx
@@ -102,6 +102,12 @@ class TabsPage extends React.Component {
             desc: 'Override the inline-styles of the content\'s container.'
           },
           {
+            name: 'contentContainerClassName',
+            type: 'string',
+            header: 'optional',
+            desc: 'The className to add to the content\'s container.'
+          },
+          {
             name: 'tabWidth',
             type: 'number',
             header: 'optional',

--- a/src/tabs/tabs.jsx
+++ b/src/tabs/tabs.jsx
@@ -20,7 +20,7 @@ let Tabs = React.createClass({
     tabItemContainerStyle: React.PropTypes.object,
     contentContainerStyle: React.PropTypes.object,
     inkBarStyle: React.PropTypes.object,
-    contentContainerClassName: React.PropTypes.string
+    contentContainerClassName: React.PropTypes.string,
   },
 
   getInitialState(){

--- a/src/tabs/tabs.jsx
+++ b/src/tabs/tabs.jsx
@@ -20,6 +20,7 @@ let Tabs = React.createClass({
     tabItemContainerStyle: React.PropTypes.object,
     contentContainerStyle: React.PropTypes.object,
     inkBarStyle: React.PropTypes.object,
+    contentContainerClassName: React.PropTypes.string
   },
 
   getInitialState(){
@@ -126,7 +127,7 @@ let Tabs = React.createClass({
           {tabs}
         </div>
         <InkBar left={left} width={width} style={this.props.inkBarStyle}/>
-        <div style={this.mergeAndPrefix(this.props.contentContainerStyle)}>
+        <div style={this.mergeAndPrefix(this.props.contentContainerStyle)} className={this.props.contentContainerClassName}>
           {tabContent}
         </div>
       </div>


### PR DESCRIPTION
It would be nice to be able to specify a class for the content container.

This adds the contentContainerClassName to the tabs, and updates the documentation accordingly. 