### PR TITLE
[FlatButton] Add labelPosition prop.

### DIFF
--- a/docs/src/app/components/pages/components/buttons.jsx
+++ b/docs/src/app/components/pages/components/buttons.jsx
@@ -135,6 +135,12 @@ class ButtonPage extends React.Component {
             'This only applies to flat and raised buttons.'
           },
           {
+            name: 'labelPosition',
+            type: 'string',
+            header: 'default: "right"',
+            desc: 'Place label before or after the passed children'
+          }
+          {
             name: 'labelStyle',
             type: 'object',
             header: 'optional',

--- a/docs/src/app/components/pages/components/buttons.jsx
+++ b/docs/src/app/components/pages/components/buttons.jsx
@@ -139,7 +139,7 @@ class ButtonPage extends React.Component {
             type: 'string',
             header: 'default: "right"',
             desc: 'Place label before or after the passed children'
-          }
+          },
           {
             name: 'labelStyle',
             type: 'object',

--- a/docs/src/app/components/pages/components/buttons.jsx
+++ b/docs/src/app/components/pages/components/buttons.jsx
@@ -136,8 +136,8 @@ class ButtonPage extends React.Component {
           },
           {
             name: 'labelPosition',
-            type: 'string',
-            header: 'default: "right"',
+            type: 'oneOf ["before", "after"]',
+            header: 'default: "before"',
             desc: 'Place label before or after the passed children'
           },
           {

--- a/src/flat-button.jsx
+++ b/src/flat-button.jsx
@@ -131,7 +131,7 @@ const FlatButton = React.createClass({
       <FlatButtonLabel label={label} style={labelStyle} />
     ) : undefined;
     // Place label before or after children.
-    const childrenFragment = labelPosition === 'before' ? { labelElement, children, } : { children, labelElement, };
+    const childrenFragment = labelPosition === 'before' ? { labelElement, children } : { children, labelElement };
     const enhancedButtonChildren = Children.create(childrenFragment);
 
 

--- a/src/flat-button.jsx
+++ b/src/flat-button.jsx
@@ -28,6 +28,7 @@ const FlatButton = React.createClass({
     disabled: React.PropTypes.bool,
     hoverColor: React.PropTypes.string,
     label: validateLabel,
+    labelPosition: React.PropTypes.oneOf(['before', 'after']),
     labelStyle: React.PropTypes.object,
     onKeyboardFocus: React.PropTypes.func,
     onMouseEnter: React.PropTypes.func,
@@ -41,6 +42,7 @@ const FlatButton = React.createClass({
   getDefaultProps() {
     return {
       labelStyle: {},
+      labelPosition: 'before',
       onKeyboardFocus: () => {},
       onMouseEnter: () => {},
       onMouseLeave: () => {},
@@ -79,6 +81,7 @@ const FlatButton = React.createClass({
       hoverColor,
       label,
       labelStyle,
+      labelPosition,
       onKeyboardFocus,
       onMouseLeave,
       onMouseEnter,
@@ -127,10 +130,10 @@ const FlatButton = React.createClass({
     const labelElement = label ? (
       <FlatButtonLabel label={label} style={labelStyle} />
     ) : undefined;
-    const enhancedButtonChildren = Children.create({
-      labelElement,
-      children,
-    });
+    // Place label before or after children.
+    const childrenFragment = labelPosition === 'before' ? { labelElement, children, } : { children, labelElement, };
+    const enhancedButtonChildren = Children.create(childrenFragment);
+
 
     return (
       <EnhancedButton


### PR DESCRIPTION
At the moment FlatButtons always render the label before any passed children.

I've added a ```labelPosition``` prop to allow changing the order of the elements.
Defaults to ```right``` as I thought the most common use is adding a FontIcon or similar which is normally placed on the left hand side of the button.