### PR TITLE
[IconMenu] Add #isOpen to IconMenu

### DIFF
--- a/src/menus/icon-menu.jsx
+++ b/src/menus/icon-menu.jsx
@@ -134,6 +134,10 @@ let IconMenu = React.createClass({
       </div>
     );
   },
+  
+  isOpen() {
+    return this.state.open;
+  },
 
   close(isKeyboard) {
     if (this.state.open) {

--- a/src/menus/icon-menu.jsx
+++ b/src/menus/icon-menu.jsx
@@ -134,7 +134,7 @@ let IconMenu = React.createClass({
       </div>
     );
   },
-  
+
   isOpen() {
     return this.state.open;
   },


### PR DESCRIPTION
Adds an isOpen method to an iconMenu. 

The way I'm using this is that I am programmatically opening / closing the menu from a different user action.

```jsx
  _toggleMenuState = () => {
    let isOpen = this.refs.menu.isOpen();
    // weird bug https://github.com/callemall/material-ui/issues/1254
    setTimeout(() => {
      if (isOpen) {
        this.refs.menu.close()
      } else {
        this.refs.menu.open()
      }
    }, 1);
  }
```
There is actually a related bug here: https://github.com/callemall/material-ui/issues/1254 to make this work.