### PR TITLE
[DropDownMenu/SelectField] Call "onChange" when closed and Keyboard is used

### DIFF
--- a/src/drop-down-menu.jsx
+++ b/src/drop-down-menu.jsx
@@ -249,7 +249,7 @@ let DropDownMenu = React.createClass({
     switch(e.which) {
       case KeyCode.UP:
         if (!this.state.open) {
-          this._selectPreviousItem();
+          this._selectPreviousItem(e);
         }
         else {
           if (e.altKey) {
@@ -263,7 +263,7 @@ let DropDownMenu = React.createClass({
             this.setState({open:true});
           }
           else {
-            this._selectNextItem();
+            this._selectNextItem(e);
           }
         }
         break;
@@ -312,12 +312,16 @@ let DropDownMenu = React.createClass({
     this.setState({isHovered: false});
   },
 
-  _selectPreviousItem() {
-    this.setState({selectedIndex: Math.max(this.state.selectedIndex - 1, 0)});
+  _selectPreviousItem(e) {
+    let index = Math.max(this.state.selectedIndex - 1, 0);
+    this.setState({selectedIndex: index});
+    this.props.onChange(e, index, this.props.menuItems[index]);
   },
 
-  _selectNextItem() {
-    this.setState({selectedIndex: Math.min(this.state.selectedIndex + 1, this.props.menuItems.length - 1)});
+  _selectNextItem(e) {
+    let index = Math.min(this.state.selectedIndex + 1, this.props.menuItems.length - 1);
+    this.setState({selectedIndex: index});
+    this.props.onChange(e, index, this.props.menuItems[index]);
   },
 
   _handleOverlayTouchTap() {


### PR DESCRIPTION
Using the Keyboard for a SelectField to change the value (next/previous) didn't call onchange from the DropDownMenu to the SelectField. This pr now calls onChange if the DropDown is closed and the selectedIndex is changed via Keyboard.

Without this the SelectField wasn't aware of any Change to the underlying DropDownBox.
You can reproduce by going to the showcase TextField page, click on the SelectField with the "Hint Text", press Escape without changing anything and then use UP/DOWN arrows to change the value. The Hint Text does not vanish. Same happens for Floating Labels as well as the current selected index was never send back to the SelectField causing inconsistencies.