### PR TITLE
Show right icon even if showMenuIconButton false

### DIFF
--- a/src/app-bar.jsx
+++ b/src/app-bar.jsx
@@ -155,39 +155,39 @@ let AppBar = React.createClass({
           </IconButton>
         );
       }
+    }
 
-      if (props.iconElementRight) {
-        let iconElementRight = props.iconElementRight;
+    if (props.iconElementRight) {
+      let iconElementRight = props.iconElementRight;
 
-        switch (iconElementRight.type.displayName) {
-          case 'IconButton':
-            iconElementRight = React.cloneElement(iconElementRight, {
-              iconStyle: this.mergeAndPrefix(styles.iconButton.iconStyle),
-            });
-            break;
+      switch (iconElementRight.type.displayName) {
+        case 'IconButton':
+          iconElementRight = React.cloneElement(iconElementRight, {
+            iconStyle: this.mergeAndPrefix(styles.iconButton.iconStyle),
+          });
+          break;
 
-          case 'FlatButton':
-            iconElementRight = React.cloneElement(iconElementRight, {
-              style: this.mergeStyles(styles.flatButton, iconElementRight.props.style),
-            });
-            break;
-        }
-
-        menuElementRight = (
-          <div style={iconRightStyle}>
-            {iconElementRight}
-          </div>
-        );
-      } else if (props.iconClassNameRight) {
-        menuElementRight = (
-          <IconButton
-            style={iconRightStyle}
-            iconStyle={this.mergeAndPrefix(styles.iconButton.iconStyle)}
-            iconClassName={props.iconClassNameRight}
-            onTouchTap={this._onRightIconButtonTouchTap}>
-          </IconButton>
-        );
+        case 'FlatButton':
+          iconElementRight = React.cloneElement(iconElementRight, {
+            style: this.mergeStyles(styles.flatButton, iconElementRight.props.style),
+          });
+          break;
       }
+
+      menuElementRight = (
+        <div style={iconRightStyle}>
+          {iconElementRight}
+        </div>
+      );
+    } else if (props.iconClassNameRight) {
+      menuElementRight = (
+        <IconButton
+          style={iconRightStyle}
+          iconStyle={this.mergeAndPrefix(styles.iconButton.iconStyle)}
+          iconClassName={props.iconClassNameRight}
+          onTouchTap={this._onRightIconButtonTouchTap}>
+        </IconButton>
+      );
     }
 
     return (


### PR DESCRIPTION
This is in line with the docs, which state:

> showMenuIconButton: Determines whether or not to display the Menu icon next to the title. Setting this prop to false will hide the icon.

Nowhere do the docs suggest that hiding the menu icon also hides the right icon button.

This is a fix for #1182. Thanks for the fantastic library!

