### PR TITLE
[Dialog] Fix dialog maxHeight math.

### DIFF
--- a/src/dialog.jsx
+++ b/src/dialog.jsx
@@ -325,7 +325,7 @@ let Dialog = React.createClass({
       // Force a height if the dialog is taller than clientHeight
       if (this.props.autoDetectWindowHeight || this.props.autoScrollBodyContent) {
         let styles = this.getStyles();
-        let maxDialogContentHeight = clientHeight - 2 * (styles.body.padding + paddingTop + 64);
+        let maxDialogContentHeight = clientHeight - 2 * (styles.body.padding + 64);
 
         if (this.props.title) maxDialogContentHeight -= dialogContent.previousSibling.offsetHeight;
         if (this.props.actions) maxDialogContentHeight -= dialogContent.nextSibling.offsetHeight;


### PR DESCRIPTION
* paddingTop is already a function of clientHeight (and the Dialog's
  own current height). Among other things, this makes it impossible
  for the Dialog's maxHeight to ever reduce; demonstrated by
  resizing window down and back up (Dialog stays tiny). Also,
  this made it impossible for the Dialog to grow in response
  to changing dimensions of its rendered children.