### PR TITLE
fix missing spaces between attributes

### DIFF
--- a/docs/src/app/components/pages/components/lists.jsx
+++ b/docs/src/app/components/pages/components/lists.jsx
@@ -45,8 +45,8 @@ class ListsPage extends React.Component {
         <ListItem primaryText="Inbox" leftIcon={<ContentInbox />} />
         <ListItem primaryText="Starred" leftIcon={<ActionGrade />} />
         <ListItem primaryText="Sent mail" leftIcon={<ContentSend />} />
-        <ListItem primaryText="Drafts"leftIcon={<ContentDrafts />} />
-        <ListItem primaryText="Inbox"leftIcon={<ContentInbox />} />
+        <ListItem primaryText="Drafts" leftIcon={<ContentDrafts />} />
+        <ListItem primaryText="Inbox" leftIcon={<ContentInbox />} />
       </List>
       <ListDivider />
       <List>


### PR DESCRIPTION
add spaces for better syntax highlighting on docs [page](http://material-ui.com/#/components/lists)