### PR TITLE
[LeftNav] add menuItemClassName props to LeftNavi.

### DIFF
--- a/docs/src/app/components/pages/components/left-nav.jsx
+++ b/docs/src/app/components/pages/components/left-nav.jsx
@@ -104,6 +104,24 @@ class LeftNavPage extends React.Component {
             type: 'object',
             header: 'optional',
             desc: 'Override the inline-styles of LeftNav\'s root element.'
+          },
+          {
+            name: 'menuItemClassName',
+            type: 'string',
+            header: 'optional',
+            desc: 'Class name for the menuItem.'
+          },
+          {
+            name: 'menuItemClassNameSubheader',
+            type: 'string',
+            header: 'optional',
+            desc: 'Class name for the subheader menuItem.'
+          },
+          {
+            name: 'menuItemClassNameLink',
+            type: 'string',
+            header: 'optional',
+            desc: 'Class name for the link menuItem.'
           }
         ]
       },

--- a/src/left-nav.jsx
+++ b/src/left-nav.jsx
@@ -30,6 +30,9 @@ let LeftNav = React.createClass({
     onNavClose: React.PropTypes.func,
     openRight: React.PropTypes.bool,
     selectedIndex: React.PropTypes.number,
+    menuItemClassName: React.PropTypes.string,
+    menuItemClassNameSubheader: React.PropTypes.string,
+    menuItemClassNameLink: React.PropTypes.string,
   },
 
   windowListeners: {
@@ -174,6 +177,9 @@ let LeftNav = React.createClass({
               menuItemStyle={this.mergeAndPrefix(styles.menuItem)}
               menuItemStyleLink={this.mergeAndPrefix(styles.menuItemLink)}
               menuItemStyleSubheader={this.mergeAndPrefix(styles.menuItemSubheader)}
+              menuItemClassName={this.props.menuItemClassName}
+              menuItemClassNameSubheader={this.props.menuItemClassNameSubheader}
+              menuItemClassNameLink={this.props.menuItemClassNameLink}
               selectedIndex={selectedIndex}
               onItemTap={this._onMenuItemClick} />
         </Paper>


### PR DESCRIPTION
add menuItemClassName, menuItemClassNameSubheader, menuItemClassNameLink props to LeftNavi.
These props exist in menu/Menu.jsx. but not exist in LeftNavi.