### PR TITLE
[Dialog] offsetTop option

### DIFF
--- a/docs/src/app/components/pages/components/dialog.jsx
+++ b/docs/src/app/components/pages/components/dialog.jsx
@@ -22,39 +22,73 @@ class DialogPage extends React.Component {
 
   render() {
     let code =
-      '//Standard Actions\n' +
-      'let standardActions = [\n' +
-      '  { text: \'Cancel\' },\n' +
-      '  { text: \'Submit\', onTouchTap: this._onDialogSubmit, ref: \'submit\' }\n' +
-      '];\n\n' +
-      '<Dialog\n' +
-      '  title="Dialog With Standard Actions"\n' +
-      '  actions={standardActions}\n' +
-      '  actionFocus="submit"\n' +
-      '  modal={this.state.modal}>\n' +
-      '  The actions in this window are created from the json that\'s passed in. \n' +
-      '</Dialog>\n\n' +
-      '//Custom Actions\n' +
-      'let customActions = [\n' +
-      '  <FlatButton\n' +
-      '    label="Cancel"\n' +
-      '    secondary={true}\n' +
-      '    onTouchTap={this._handleCustomDialogCancel} />,\n' +
-      '  <FlatButton\n' +
-      '    label="Submit"\n' +
-      '    primary={true}\n' +
-      '    onTouchTap={this._handleCustomDialogSubmit} />\n' +
-      '];\n\n' +
-      '<Dialog\n' +
-      '  title="Dialog With Custom Actions"\n' +
-      '  actions={customActions}\n' +
-      '  modal={this.state.modal}>\n' +
-      '  The actions in this window were passed in as an array of react objects.\n' +
-      '</Dialog>\n\n' +
-      '<Dialog title="Dialog With Scrollable Content" actions={customActions}\n' +
-      '  autoDetectWindowHeight={true} autoScrollBodyContent={true}>\n' +
-      '    <div style={{height: \'2000px\'}}>Really long content</div>\n' +
-      '</Dialog>\n';
+    `
+    let standardActions = [
+      { text: 'Cancel' },
+      { text: 'Submit', onTouchTap: this._onDialogSubmit, ref: 'submit' }
+    ];
+
+    let customActions = [
+      <FlatButton
+        key={1}
+        label="Cancel"
+        secondary={true}
+        onTouchTap={this._handleCustomDialogCancel} />,
+      <FlatButton
+        key={2}
+        label="Submit"
+        primary={true}
+        onTouchTap={this._handleCustomDialogSubmit} />
+    ];
+    let scrollableCustomActions = [
+      <FlatButton
+        key={1}
+        label="Cancel"
+        secondary={true}
+        onTouchTap={this._handleScrollableDialogCancel} />,
+      <FlatButton
+        key={2}
+        label="Submit"
+        primary={true}
+        onTouchTap={this._handleScrollableDialogSubmit} />
+    ];
+
+    <Dialog
+      ref="standardDialog"
+      title="Dialog With Standard Actions"
+      actions={standardActions}
+      actionFocus="submit"
+      modal={this.state.modal}>
+      The actions in this window are created from the json that&#39;s passed in.
+    </Dialog>
+
+    <Dialog
+      ref="customDialog"
+      title="Dialog With Custom Actions"
+      actions={customActions}
+      modal={this.state.modal}>
+      The actions in this window were passed in as an array of react objects.
+    </Dialog>
+    <div style={{width: '300px', margin: '0 auto', paddingTop: '20px'}}>
+      <Toggle
+        label="Is Modal"
+        onToggle={this._handleToggleChange}
+        defaultToggled={this.state.modal}/>
+    </div>
+    <Dialog
+      ref="scrollableContentDialog"
+      title="Dialog With Scrollable Content"
+      actions={scrollableCustomActions}
+      modal={this.state.modal}
+      autoDetectWindowHeight={true}
+      autoScrollBodyContent={true}
+      offsetTop={0}
+      >
+      <div style={{height: '1000px'}}>
+        Really long content
+      </div>
+    </Dialog>
+  `;
 
     let componentInfo = [
       {
@@ -121,6 +155,11 @@ class DialogPage extends React.Component {
             type: 'bool',
             header: 'default: false',
             desc: 'If set to true, the body content of the dialog will be scrollable.'
+          },
+          {
+            name: 'offsetTop',
+            type: 'number',
+            desc: 'The height in pixels to set the dialog top offset to.  Can be useful to override the theme in mobile views.'
           }
         ]
       },
@@ -226,7 +265,9 @@ class DialogPage extends React.Component {
           actions={scrollableCustomActions}
           modal={this.state.modal}
           autoDetectWindowHeight={true}
-          autoScrollBodyContent={true}>
+          autoScrollBodyContent={true}
+          offsetTop={0}
+          >
           <div style={{height: '1000px'}}>
             Really long content
           </div>

--- a/src/dialog.jsx
+++ b/src/dialog.jsx
@@ -17,6 +17,10 @@ let TransitionItem = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
+  propTypes: {
+    offsetTop: React.PropTypes.number,
+  },
+
   getInitialState() {
     return {
       style: {},
@@ -25,11 +29,11 @@ let TransitionItem = React.createClass({
 
   componentWillEnter(callback) {
     let spacing = this.context.muiTheme.spacing;
-
+    let offset = isNaN(this.props.offsetTop) ? Infinity : this.props.offsetTop;
     this.setState({
       style: {
         opacity: 1,
-        transform: 'translate3d(0, ' + spacing.desktopKeylineIncrement + 'px, 0)',
+        transform: 'translate3d(0, ' + Math.min(offset, spacing.desktopKeylineIncrement) + 'px, 0)',
       },
     });
 
@@ -80,6 +84,7 @@ let Dialog = React.createClass({
     openImmediately: React.PropTypes.bool,
     onClickAway: React.PropTypes.func,
     onDismiss: React.PropTypes.func,
+    offsetTop: React.PropTypes.number,
     onShow: React.PropTypes.func,
     repositionOnUpdate: React.PropTypes.bool,
     title: React.PropTypes.node,
@@ -197,6 +202,7 @@ let Dialog = React.createClass({
           {this.state.open &&
             <TransitionItem
               className={this.props.contentClassName}
+              offsetTop={this.props.offsetTop}
               style={styles.content}>
               <Paper
                 style={styles.paper}
@@ -307,13 +313,16 @@ let Dialog = React.createClass({
       let dialogWindow = this.refs.dialogWindow.getDOMNode();
       let dialogContent = this.refs.dialogContent.getDOMNode();
       let minPaddingTop = 16;
+      let spacing = this.context.muiTheme.spacing;
+      let offset = isNaN(this.props.offsetTop) ? Infinity : this.props.offsetTop;
+      let offsetTop = Math.min(offset, spacing.desktopKeylineIncrement);
 
       //Reset the height in case the window was resized.
       dialogWindow.style.height = '';
       dialogContent.style.height = '';
 
       let dialogWindowHeight = dialogWindow.offsetHeight;
-      let paddingTop = ((clientHeight - dialogWindowHeight) / 2) - 64;
+      let paddingTop = ((clientHeight - dialogWindowHeight) / 2) - offsetTop;
       if (paddingTop < minPaddingTop) paddingTop = minPaddingTop;
 
       //Vertically center the dialog window, but make sure it doesn't
@@ -325,7 +334,7 @@ let Dialog = React.createClass({
       // Force a height if the dialog is taller than clientHeight
       if (this.props.autoDetectWindowHeight || this.props.autoScrollBodyContent) {
         let styles = this.getStyles();
-        let maxDialogContentHeight = clientHeight - 2 * (styles.body.padding + 64);
+        let maxDialogContentHeight = clientHeight - 2 * (styles.body.padding + offsetTop);
 
         if (this.props.title) maxDialogContentHeight -= dialogContent.previousSibling.offsetHeight;
         if (this.props.actions) maxDialogContentHeight -= dialogContent.nextSibling.offsetHeight;


### PR DESCRIPTION
Had a problem with dialog mobile landscape view, which I wanted it to work in.

![image](https://cloud.githubusercontent.com/assets/145466/9058982/9ec455c4-3a9d-11e5-8dc8-eaa9e4ee8832.png)

This PR adds an `offsetTop` override property, and fixes the calculation, so the dialog can fit better.

![image](https://cloud.githubusercontent.com/assets/145466/9058986/a3617bd4-3a9d-11e5-95cf-338291be9ce1.png)
