### PR TITLE
Underline to support error coloring

### DIFF
--- a/docs/src/app/components/pages/components/text-fields.jsx
+++ b/docs/src/app/components/pages/components/text-fields.jsx
@@ -1,7 +1,7 @@
 let React = require('react/addons');
-let { ClearFix, Mixins, SelectField, TextField } = require('material-ui');
+let { ClearFix, Mixins, SelectField, TextField, Styles } = require('material-ui');
 let ComponentDoc = require('../../component-doc');
-
+let { Colors } = Styles;
 let { StyleResizable } = Mixins;
 
 
@@ -57,6 +57,7 @@ let TextFieldsPage = React.createClass({
       <TextField
         hintText="Hint Text"
         value={this.state.propValue}
+        underlineStyle={{borderColor:Colors.green500}}
         onChange={this._handleInputChange} />
       <TextField
         hintText="Hint Text"
@@ -75,10 +76,11 @@ let TextFieldsPage = React.createClass({
         errorText={this.state.errorText}
         onChange={this._handleErrorInputChange} />
       <TextField
-        hintText="Hint Text"
+        hintText="Hint Text (custom error color)"
         errorText={this.state.error2Text}
+        errorStyle={{color:'orange'}}
         onChange={this._handleError2InputChange}
-        defaultValue="abc" />
+        defaultValue="Custom error color" />
       <TextField
         hintText="Disabled Hint Text"
         disabled={true} />
@@ -207,6 +209,12 @@ let TextFieldsPage = React.createClass({
             desc: 'Override the inline-styles of the TextField\'s root element.'
           },
           {
+            name: 'underlineStyle',
+            type: 'object',
+            header: 'optional',
+            desc: 'Override the inline-styles of the TextField\'s underline element.'
+          },
+          {
             name: 'type',
             type: 'string',
             header: 'optional',
@@ -308,8 +316,9 @@ let TextFieldsPage = React.createClass({
               defaultValue="Default Value" /><br/>
             <TextField
               style={styles.textfield}
-              hintText="Hint Text"
+              hintText="Custom Underline Color"
               value={this.state.propValue}
+              underlineStyle={{borderColor:Colors.green500}}
               onChange={this._handleInputChange} /><br/>
             <TextField
               style={styles.textfield}
@@ -334,10 +343,11 @@ let TextFieldsPage = React.createClass({
               onChange={this._handleErrorInputChange} /><br/>
             <TextField
               style={styles.textfield}
-              hintText="Hint Text"
+              hintText="Hint Text (custom error color)"
               errorText={this.state.error2Text}
+              errorStyle={{color:Colors.orange500}}
               onChange={this._handleError2InputChange}
-              defaultValue="abc" /><br/>
+              defaultValue="Custom error color" /><br/>
             <TextField
               style={styles.textfield}
               hintText="Disabled Hint Text"

--- a/src/text-field.jsx
+++ b/src/text-field.jsx
@@ -40,6 +40,7 @@ let TextField = React.createClass({
     onKeyDown: React.PropTypes.func,
     rows: React.PropTypes.number,
     type: React.PropTypes.string,
+    underlineStyle: React.PropTypes.object,
   },
 
   getDefaultProps() {
@@ -158,6 +159,9 @@ let TextField = React.createClass({
       },
     };
 
+    styles.error = this.mergeAndPrefix(styles.error, props.errorStyle);
+    styles.underline = this.mergeAndPrefix(styles.underline, props.underlineStyle);
+
     styles.floatingLabel = this.mergeStyles(styles.hint, {
       lineHeight: '22px',
       top: 38,
@@ -203,11 +207,11 @@ let TextField = React.createClass({
       styles.hint.lineHeight = props.style.height;
     }
 
-    if (this.state.errorText && this.state.isFocused) styles.floatingLabel.color = theme.errorColor;
+    if (this.state.errorText && this.state.isFocused) styles.floatingLabel.color = styles.error.color;
     if (props.floatingLabelText && !props.multiLine) styles.input.paddingTop = 26;
 
     if (this.state.errorText) {
-      styles.focusUnderline.borderColor = theme.errorColor;
+      styles.focusUnderline.borderColor = styles.error.color;
       styles.focusUnderline.transform = 'scaleX(1)';
     }
 
@@ -237,7 +241,7 @@ let TextField = React.createClass({
     let inputId = id || this._uniqueId;
 
     let errorTextElement = this.state.errorText ? (
-      <div style={this.mergeAndPrefix(styles.error, errorStyle)}>{this.state.errorText}</div>
+      <div style={styles.error}>{this.state.errorText}</div>
     ) : null;
 
     let hintTextElement = hintText ? (


### PR DESCRIPTION
Noticed that we could style the underline for a particular text-field, and we didn't have quite enough control over the line colour on error.