### PR TITLE
performance fix for code (Also textinput lag on docs)

### DIFF
--- a/docs/src/app/components/code-example/code-block.jsx
+++ b/docs/src/app/components/code-example/code-block.jsx
@@ -12,6 +12,10 @@ class CodeBlock extends React.Component {
     this.componentDidUpdate = this.componentDidUpdate.bind(this);
   }
 
+  shouldComponentUpdate({children}, nextState){
+    return this.props.children !== children;
+  }
+
   componentDidMount() {
     hljs.highlightBlock(React.findDOMNode(this));
   }


### PR DESCRIPTION
This is related to issue [#1040](https://github.com/callemall/material-ui/issues/1040).

When text input is updated, it renders the `<CodeBlock />` over and over again causing slow downs on the page

[Related: Belle issue](https://github.com/nikgraf/belle/issues/1)
[Related: Belle fix](https://github.com/nikgraf/belle/pull/129)