### PR TITLE
assigning a NaN to a width attr causes the slider to have an incorrect width on a re-render.

### DIFF
--- a/src/slider.jsx
+++ b/src/slider.jsx
@@ -214,8 +214,6 @@ let Slider = React.createClass({
       width: ((1 - this.state.percent) * 100) + (this.props.disabled ? -1 : 0) + '%',
     });
 
-    styles.percentZeroRemaining.width = styles.remaining.width - styles.percentZeroRemaining.left;
-
     return styles;
   },
 


### PR DESCRIPTION
Should styles.percentZeroRemaining.width be computed and provided a value at all?