### PR TITLE
Add snackbar callbacks for onShow and onDismiss with documentation

### DIFF
--- a/docs/src/app/components/pages/components/snackbar.jsx
+++ b/docs/src/app/components/pages/components/snackbar.jsx
@@ -86,6 +86,16 @@ class SnackbarPage extends React.Component {
             name: 'onActionTouchTap',
             header: 'function(e)',
             desc: 'Fired when the action button is touchtapped.'
+          },
+          {
+            name: 'onDismiss',
+            header: 'function()',
+            desc: 'Fired when the snackbar is dismissed.'
+          },
+          {
+            name: 'onShow',
+            header: 'function()',
+            desc: 'Fired when the snackbar is shown.'
           }
         ]
       }
@@ -104,7 +114,7 @@ class SnackbarPage extends React.Component {
         <br />
 
         <TextField
-          floatingLabelText="Auto Hide Duration"
+          floatingLabelText="Auto Hide Duration in ms"
           value={this.state.autoHideDuration}
           onChange={this._updateAutoHideDuration} />
 

--- a/src/snackbar.jsx
+++ b/src/snackbar.jsx
@@ -24,6 +24,8 @@ const Snackbar = React.createClass({
     action: React.PropTypes.string,
     autoHideDuration: React.PropTypes.number,
     onActionTouchTap: React.PropTypes.func,
+    onShow: React.PropTypes.func,
+    onDismiss: React.PropTypes.func,
     openOnMount: React.PropTypes.bool,
   },
 
@@ -151,11 +153,13 @@ const Snackbar = React.createClass({
 
   show() {
     this.setState({ open: true });
+    if (this.props.onShow) this.props.onShow();
   },
 
   dismiss() {
     this._clearAutoHideTimer();
     this.setState({ open: false });
+    if (this.props.onDismiss) this.props.onDismiss();
   },
 
   _clearAutoHideTimer() {


### PR DESCRIPTION
The material design guidelines say that there shouldn't be more than one snackbar at a time.
To implement this guideline I created a flux store with all messages. These messages are in a queue.

Making it work properly, I need to have the `onShow()` and `onDismiss()` callbacks on the snackbar.
