### PR TITLE
[RFC] Added context-pure mixin and tests

### DIFF
--- a/src/mixins/context-pure.js
+++ b/src/mixins/context-pure.js
@@ -1,0 +1,39 @@
+const shallowEqual = require('../utils/shallow-equal');
+
+function contextPropsEqual(classObject, currentContext, nextContext) {
+
+  //Check if current object's context props changed
+  if (classObject.getContextProps) {
+    const currentContextProps = classObject.getContextProps(currentContext);
+    const nextContextProps = classObject.getContextProps(nextContext);
+    if (!shallowEqual(currentContextProps, nextContextProps)) {
+      return false;
+    }
+  }
+
+  //Check if children context props changed
+  if (classObject.getChildrenClasses) {
+    const childrenArray = classObject.getChildrenClasses();
+    for (let i = 0; i < childrenArray.length; i++) {
+      if (!contextPropsEqual(childrenArray[i], currentContext, nextContext)) {
+        return false;
+      }
+    }
+  }
+
+  //Props are equal
+  return true;
+}
+
+module.exports = {
+
+  //Don't update if state, prop, and context are equal
+  shouldComponentUpdate(nextProps, nextState, nextContext) {
+    return (
+      !shallowEqual(this.props, nextProps) ||
+      !shallowEqual(this.state, nextState) ||
+      !contextPropsEqual(this.constructor, this.context, nextContext)
+    );
+  },
+
+};

--- a/src/mixins/context-pure.js
+++ b/src/mixins/context-pure.js
@@ -29,10 +29,16 @@ module.exports = {
 
   //Don't update if state, prop, and context are equal
   shouldComponentUpdate(nextProps, nextState, nextContext) {
+
+    const staticTheme = (
+      this.context.muiTheme &&
+      this.context.muiTheme.static
+    );
+
     return (
       !shallowEqual(this.props, nextProps) ||
       !shallowEqual(this.state, nextState) ||
-      !contextPropsEqual(this.constructor, this.context, nextContext)
+      (!staticTheme && !contextPropsEqual(this.constructor, this.context, nextContext))
     );
   },
 

--- a/src/styles/theme-manager.js
+++ b/src/styles/theme-manager.js
@@ -9,6 +9,13 @@ const Types = {
 
 let ThemeManager = () => {
   return {
+
+    //In most cases, theme variables remain static thoughout the life of an
+    //app. If you plan on mutating theme variables after the theme has been
+    //intialized, set static to false. This will allow components to update
+    //when theme variables change. For more information see issue #1176
+    static: true,
+
     types: Types,
     template: Types.LIGHT,
 

--- a/src/utils/shallow-equal.js
+++ b/src/utils/shallow-equal.js
@@ -1,0 +1,27 @@
+export default function shallowEqual(objA, objB) {
+  if (objA === objB) {
+    return true;
+  }
+
+  if (typeof objA !== 'object' || objA === null ||
+      typeof objB !== 'object' || objB === null) {
+    return false;
+  }
+
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  // Test for A's keys different from B.
+  const bHasOwnProperty = Object.prototype.hasOwnProperty.bind(objB);
+  for (let i = 0; i < keysA.length; i++) {
+    if (!bHasOwnProperty(keysA[i]) || objA[keysA[i]] !== objB[keysA[i]]) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/test/mixin-context-pure-spec.js
+++ b/test/mixin-context-pure-spec.js
@@ -7,13 +7,13 @@ const GrandChildComponent = React.createClass({
   mixins: [ContextPure],
 
   contextTypes: {
-    testContext: React.PropTypes.object,
+    muiTheme: React.PropTypes.object,
   },
 
   statics: {
     getContextProps(context) {
       return {
-        grandChildContextProp: context.testContext.grandChildContextProp,
+        grandChildThemeProp: context.muiTheme.grandChildThemeProp,
       }
     },
   },
@@ -34,7 +34,7 @@ const ChildComponent = React.createClass({
   mixins: [ContextPure],
 
   contextTypes: {
-    testContext: React.PropTypes.object,
+    muiTheme: React.PropTypes.object,
   },
 
   getInitialState: function() {
@@ -46,7 +46,7 @@ const ChildComponent = React.createClass({
   statics: {
     getContextProps(context) {
       return {
-        childContextProp: context.testContext.childContextProp,
+        childThemeProp: context.muiTheme.childThemeProp,
       }
     },
     getChildrenClasses() {
@@ -79,14 +79,15 @@ const ChildComponent = React.createClass({
 const ParentComponent = React.createClass({
 
   childContextTypes: {
-    testContext: React.PropTypes.object,
+    muiTheme: React.PropTypes.object,
   },
 
   getChildContext() {
     return {
-      testContext: {
-        childContextProp: this.state.childContextProp,
-        grandChildContextProp: this.state.grandChildContextProp,
+      muiTheme: {
+        childThemeProp: this.state.childThemeProp,
+        grandChildThemeProp: this.state.grandChildThemeProp,
+        static: this.state.staticTheme,
       },
     };
   },
@@ -94,8 +95,9 @@ const ParentComponent = React.createClass({
   getInitialState() {
     return {
       childProp: 0,
-      childContextProp: 0,
-      grandChildContextProp: 0,
+      childThemeProp: 0,
+      grandChildThemeProp: 0,
+      staticTheme: false,
     };
   },
 
@@ -118,16 +120,22 @@ const ParentComponent = React.createClass({
     return this.renderCount;
   },
 
+  setStaticTheme(value) {
+    this.setState({
+      staticTheme: value,
+    });
+  },
+
   updateChildState(childState) {
     this.refs.child.updateState(childState);
   },
 
-  updateChildContextProp(childContextProp) {
-    this.setState({childContextProp});
+  updateChildContextProp(childThemeProp) {
+    this.setState({childThemeProp});
   },
 
-  updateGrandChildContextProp(grandChildContextProp) {
-    this.setState({grandChildContextProp});
+  updateGrandChildContextProp(grandChildThemeProp) {
+    this.setState({grandChildThemeProp});
   },
 
   updateChildProp(childProp) {
@@ -142,53 +150,115 @@ describe('Mixin-ContextPure', () => {
     parentElement = TestUtils.renderIntoDocument(<ParentComponent />);
   });
 
-  it('should not render when context is updated but did not change', () => {
-    parentElement.updateChildContextProp(0);
-    parentElement.getRenderCount().should.equal(2);
-    parentElement.getChildRenderCount().should.equal(1);
-    parentElement.getGrandChildRenderCount().should.equal(1);
+  describe('when muiTheme.static not set', () => {
+
+    it('should not render when context is updated but did not change', () => {
+      parentElement.updateChildContextProp(0);
+      parentElement.getRenderCount().should.equal(2);
+      parentElement.getChildRenderCount().should.equal(1);
+      parentElement.getGrandChildRenderCount().should.equal(1);
+    });
+
+    it('should not render when prop is updated but did not change', () => {
+      parentElement.updateChildProp(0);
+      parentElement.getRenderCount().should.equal(2);
+      parentElement.getChildRenderCount().should.equal(1);
+      parentElement.getGrandChildRenderCount().should.equal(1);
+    });
+
+    it('should not render when state is updated but did not change', () => {
+      parentElement.updateChildState(0);
+      parentElement.getRenderCount().should.equal(1);
+      parentElement.getChildRenderCount().should.equal(1);
+      parentElement.getGrandChildRenderCount().should.equal(1);
+    });
+
+    it('should render when context props change', () => {
+      parentElement.updateChildContextProp(1);
+      parentElement.getRenderCount().should.equal(2);
+      parentElement.getChildRenderCount().should.equal(2);
+      parentElement.getGrandChildRenderCount().should.equal(1);
+    });
+
+    it('should render when props change', () => {
+      parentElement.updateChildProp(1);
+      parentElement.getRenderCount().should.equal(2);
+      parentElement.getChildRenderCount().should.equal(2);
+      parentElement.getGrandChildRenderCount().should.equal(1);
+    });
+
+    it('should render when state change', () => {
+      parentElement.updateChildState(1);
+      parentElement.getRenderCount().should.equal(1);
+      parentElement.getChildRenderCount().should.equal(2);
+      parentElement.getGrandChildRenderCount().should.equal(1);
+    });
+
+    it('should render grandchild when grandchild context props change', () => {
+      parentElement.updateGrandChildContextProp(1);
+      parentElement.getRenderCount().should.equal(2);
+      parentElement.getChildRenderCount().should.equal(2);
+      parentElement.getGrandChildRenderCount().should.equal(2);
+    });
   });
 
-  it('should not render when prop is updated but did not change', () => {
-    parentElement.updateChildProp(0);
-    parentElement.getRenderCount().should.equal(2);
-    parentElement.getChildRenderCount().should.equal(1);
-    parentElement.getGrandChildRenderCount().should.equal(1);
+  describe('when muiTheme.static is true', () => {
+    beforeEach(() => {
+      parentElement.setStaticTheme(true);
+    });
+
+    it('should not render when context is updated but did not change', () => {
+      parentElement.updateChildContextProp(1);
+      parentElement.getRenderCount().should.equal(3);
+      parentElement.getChildRenderCount().should.equal(1);
+      parentElement.getGrandChildRenderCount().should.equal(1);
+    });
+
+    it('should not render when prop is updated but did not change', () => {
+      parentElement.updateChildProp(0);
+      parentElement.getRenderCount().should.equal(3);
+      parentElement.getChildRenderCount().should.equal(1);
+      parentElement.getGrandChildRenderCount().should.equal(1);
+    });
+
+    it('should not render when state is updated but did not change', () => {
+      parentElement.updateChildState(0);
+      parentElement.getRenderCount().should.equal(2);
+      parentElement.getChildRenderCount().should.equal(1);
+      parentElement.getGrandChildRenderCount().should.equal(1);
+    });
+
+    it('should not render when context props change', () => {
+      parentElement.updateChildContextProp(1);
+      parentElement.getRenderCount().should.equal(3);
+      parentElement.getChildRenderCount().should.equal(1);
+      parentElement.getGrandChildRenderCount().should.equal(1);
+    });
+
+    it('should not render grandchild when grandchild context props change', () => {
+      parentElement.updateGrandChildContextProp(1);
+      parentElement.getRenderCount().should.equal(3);
+      parentElement.getChildRenderCount().should.equal(1);
+      parentElement.getGrandChildRenderCount().should.equal(1);
+    });
+
+    it('should render when props change', () => {
+      parentElement.updateChildProp(1);
+      parentElement.getRenderCount().should.equal(3);
+      parentElement.getChildRenderCount().should.equal(2);
+      parentElement.getGrandChildRenderCount().should.equal(1);
+    });
+
+    it('should render when state change', () => {
+      parentElement.updateChildState(1);
+      parentElement.getRenderCount().should.equal(2);
+      parentElement.getChildRenderCount().should.equal(2);
+      parentElement.getGrandChildRenderCount().should.equal(1);
+    });
+
+
   });
 
-  it('should not render when state is updated but did not change', () => {
-    parentElement.updateChildState(0);
-    parentElement.getRenderCount().should.equal(1);
-    parentElement.getChildRenderCount().should.equal(1);
-    parentElement.getGrandChildRenderCount().should.equal(1);
-  });
 
-  it('should render when context props change', () => {
-    parentElement.updateChildContextProp(1);
-    parentElement.getRenderCount().should.equal(2);
-    parentElement.getChildRenderCount().should.equal(2);
-    parentElement.getGrandChildRenderCount().should.equal(1);
-  });
-
-  it('should render when props change', () => {
-    parentElement.updateChildProp(1);
-    parentElement.getRenderCount().should.equal(2);
-    parentElement.getChildRenderCount().should.equal(2);
-    parentElement.getGrandChildRenderCount().should.equal(1);
-  });
-
-  it('should render when state change', () => {
-    parentElement.updateChildState(1);
-    parentElement.getRenderCount().should.equal(1);
-    parentElement.getChildRenderCount().should.equal(2);
-    parentElement.getGrandChildRenderCount().should.equal(1);
-  });
-
-  it('should render grandchild when grandchild context props change', () => {
-    parentElement.updateGrandChildContextProp(1);
-    parentElement.getRenderCount().should.equal(2);
-    parentElement.getChildRenderCount().should.equal(2);
-    parentElement.getGrandChildRenderCount().should.equal(2);
-  });
 
 });

--- a/test/mixin-context-pure-spec.js
+++ b/test/mixin-context-pure-spec.js
@@ -1,0 +1,194 @@
+import React from 'react/addons';
+import ContextPure from 'mixins/context-pure';
+
+const TestUtils = React.addons.TestUtils;
+
+const GrandChildComponent = React.createClass({
+  mixins: [ContextPure],
+
+  contextTypes: {
+    testContext: React.PropTypes.object,
+  },
+
+  statics: {
+    getContextProps(context) {
+      return {
+        grandChildContextProp: context.testContext.grandChildContextProp,
+      }
+    },
+  },
+
+  renderCount: 0,
+
+  render() {
+    this.renderCount++;
+    return <div />;
+  },
+
+  getRenderCount() {
+    return this.renderCount;
+  },
+});
+
+const ChildComponent = React.createClass({
+  mixins: [ContextPure],
+
+  contextTypes: {
+    testContext: React.PropTypes.object,
+  },
+
+  getInitialState: function() {
+    return {
+      childState: 0,
+    };
+  },
+
+  statics: {
+    getContextProps(context) {
+      return {
+        childContextProp: context.testContext.childContextProp,
+      }
+    },
+    getChildrenClasses() {
+      return [
+        GrandChildComponent,
+      ];
+    },
+  },
+
+  renderCount: 0,
+
+  render() {
+    this.renderCount++;
+    return <GrandChildComponent ref="grandChild" />;
+  },
+
+  getGrandChildRenderCount() {
+    return this.refs.grandChild.getRenderCount();
+  },
+
+  getRenderCount() {
+    return this.renderCount;
+  },
+
+  updateState(childState) {
+    this.setState({childState});
+  },
+});
+
+const ParentComponent = React.createClass({
+
+  childContextTypes: {
+    testContext: React.PropTypes.object,
+  },
+
+  getChildContext() {
+    return {
+      testContext: {
+        childContextProp: this.state.childContextProp,
+        grandChildContextProp: this.state.grandChildContextProp,
+      },
+    };
+  },
+
+  getInitialState() {
+    return {
+      childProp: 0,
+      childContextProp: 0,
+      grandChildContextProp: 0,
+    };
+  },
+
+  renderCount: 0,
+
+  render() {
+    this.renderCount++;
+    return <ChildComponent ref="child" testProp={this.state.childProp} />;
+  },
+
+  getChildRenderCount() {
+    return this.refs.child.getRenderCount();
+  },
+
+  getGrandChildRenderCount() {
+    return this.refs.child.getGrandChildRenderCount();
+  },
+
+  getRenderCount() {
+    return this.renderCount;
+  },
+
+  updateChildState(childState) {
+    this.refs.child.updateState(childState);
+  },
+
+  updateChildContextProp(childContextProp) {
+    this.setState({childContextProp});
+  },
+
+  updateGrandChildContextProp(grandChildContextProp) {
+    this.setState({grandChildContextProp});
+  },
+
+  updateChildProp(childProp) {
+    this.setState({childProp});
+  },
+});
+
+describe('Mixin-ContextPure', () => {
+  let parentElement;
+
+  beforeEach(() => {
+    parentElement = TestUtils.renderIntoDocument(<ParentComponent />);
+  });
+
+  it('should not render when context is updated but did not change', () => {
+    parentElement.updateChildContextProp(0);
+    parentElement.getRenderCount().should.equal(2);
+    parentElement.getChildRenderCount().should.equal(1);
+    parentElement.getGrandChildRenderCount().should.equal(1);
+  });
+
+  it('should not render when prop is updated but did not change', () => {
+    parentElement.updateChildProp(0);
+    parentElement.getRenderCount().should.equal(2);
+    parentElement.getChildRenderCount().should.equal(1);
+    parentElement.getGrandChildRenderCount().should.equal(1);
+  });
+
+  it('should not render when state is updated but did not change', () => {
+    parentElement.updateChildState(0);
+    parentElement.getRenderCount().should.equal(1);
+    parentElement.getChildRenderCount().should.equal(1);
+    parentElement.getGrandChildRenderCount().should.equal(1);
+  });
+
+  it('should render when context props change', () => {
+    parentElement.updateChildContextProp(1);
+    parentElement.getRenderCount().should.equal(2);
+    parentElement.getChildRenderCount().should.equal(2);
+    parentElement.getGrandChildRenderCount().should.equal(1);
+  });
+
+  it('should render when props change', () => {
+    parentElement.updateChildProp(1);
+    parentElement.getRenderCount().should.equal(2);
+    parentElement.getChildRenderCount().should.equal(2);
+    parentElement.getGrandChildRenderCount().should.equal(1);
+  });
+
+  it('should render when state change', () => {
+    parentElement.updateChildState(1);
+    parentElement.getRenderCount().should.equal(1);
+    parentElement.getChildRenderCount().should.equal(2);
+    parentElement.getGrandChildRenderCount().should.equal(1);
+  });
+
+  it('should render grandchild when grandchild context props change', () => {
+    parentElement.updateGrandChildContextProp(1);
+    parentElement.getRenderCount().should.equal(2);
+    parentElement.getChildRenderCount().should.equal(2);
+    parentElement.getGrandChildRenderCount().should.equal(2);
+  });
+
+});


### PR DESCRIPTION
This mixin checks for context changes in addition to prop and state changes in `shouldComponentUpdate` and is an attempt to address #1176.

The `ContextPure` mixin requires you to declare which context props you care about. To do this, you can add one or both of the following static functions:


#### getContextProps
If the component is dependent on certain context variables, declare them in a static function named getContextProps. This function will take in a context object parameter and return an object containing the context variables needed to render the component. This function is used in `shouldComponentUpdate` to check for context changes. For example:
```javascript
statics: {
  getContextProps(context) {
    return {
      fontFamily: context.muiTheme.contentFontFamily,
    }
  },
```


#### getChildrenClasses
If the component also renders other material-ui components, we'll also need to declare these child components in a static function named getChildrenClasses. This function should return an array of react components that the component renders.  This will allow us to trigger an update in `shouldComponentUpdate` when children context variables change. For example:
```javascript
statics: {
  getChildrenClasses() {
    return [
      EnhancedButton,
      Paper,
    ];
  },
}
```