### PR TITLE
Fix a bug in DatePicker when using valueLink

### DIFF
--- a/src/date-picker/date-picker.jsx
+++ b/src/date-picker/date-picker.jsx
@@ -69,11 +69,12 @@ let DatePicker = React.createClass({
       mode,
       onDismiss,
       onFocus,
-      onTouchTap,
       onShow,
+      onTouchTap,
       showYearSelector,
       style,
       textFieldStyle,
+      valueLink,
       ...other,
     } = this.props;
 


### PR DESCRIPTION
This fix will remove valueLink to avoid `Invariant Violation: Cannot provide a valueLink and a value or onChange event. If you want to use value or onChange, you probably don't want to use valueLink.`