### PR TITLE
Prevent clicking the track from changing a disabled sliders value

### DIFF
--- a/src/slider.jsx
+++ b/src/slider.jsx
@@ -388,7 +388,7 @@ let Slider = React.createClass({
   },
 
   _onMouseDown(e) {
-    this._pos = e.clientX;
+    if (!this.props.disabled) this._pos = e.clientX;
   },
 
   _onMouseEnter() {


### PR DESCRIPTION
This issue can be seen here - http://material-ui.com/#/components/sliders
When clicking on the track of a disabled slider, its value still changes.

Reported by: https://github.com/callemall/material-ui/issues/1215

