### PR TITLE
Add property to override underline styles of a focussed textfield

### DIFF
--- a/docs/src/app/components/pages/components/text-fields.jsx
+++ b/docs/src/app/components/pages/components/text-fields.jsx
@@ -108,6 +108,12 @@ let TextFieldsPage = React.createClass({
             desc: 'Override the inline-styles of the TextField\'s underline element.'
           },
           {
+            name: 'underlineFocusStyle',
+            type: 'object',
+            header: 'optional',
+            desc: 'Override the inline-styles of the TextField\'s underline element when focussed.'
+          },
+          {
             name: 'type',
             type: 'string',
             header: 'optional',
@@ -213,6 +219,10 @@ let TextFieldsPage = React.createClass({
               value={this.state.propValue}
               underlineStyle={{borderColor:Colors.green500}}
               onChange={this._handleInputChange} /><br/>
+            <TextField
+              style={styles.textfield}
+              hintText="Custom Underline Focus Color"
+              underlineFocusStyle={{borderColor: Colors.amber900}} /><br />
             <TextField
               style={styles.textfield}
               hintText="Hint Text"

--- a/docs/src/app/components/raw-code/text-fields-code.txt
+++ b/docs/src/app/components/raw-code/text-fields-code.txt
@@ -10,6 +10,9 @@
   underlineStyle={{borderColor:Colors.green500}}
   onChange={this._handleInputChange} />
 <TextField
+  hintText="Custom Underline Focus Color"
+  underlineFocusStyle={{borderColor: Colors.amber900}} />
+<TextField
   hintText="Hint Text"
   valueLink={this.linkState('valueLinkValue')} />
 <TextField

--- a/src/text-field.jsx
+++ b/src/text-field.jsx
@@ -41,6 +41,7 @@ let TextField = React.createClass({
     rows: React.PropTypes.number,
     type: React.PropTypes.string,
     underlineStyle: React.PropTypes.object,
+    underlineFocusStyle: React.PropTypes.object,
   },
 
   getDefaultProps() {
@@ -157,6 +158,12 @@ let TextField = React.createClass({
         bottom: 8,
         borderBottom: 'dotted 2px ' + theme.disabledTextColor,
       },
+      underlineFocus: {
+        borderBottom: 'solid 2px',
+        borderColor: theme.focusColor,
+        transform: 'scaleX(0)',
+        transition: Transitions.easeOut(),
+      },
     };
 
     styles.error = this.mergeAndPrefix(styles.error, props.errorStyle);
@@ -178,12 +185,7 @@ let TextField = React.createClass({
       font: 'inherit',
     });
 
-    styles.focusUnderline= this.mergeStyles(styles.underline, {
-      borderBottom: 'solid 2px',
-      borderColor: theme.focusColor,
-      transform: 'scaleX(0)',
-      transition: Transitions.easeOut(),
-    });
+    styles.focusUnderline = this.mergeStyles(styles.underline, styles.underlineFocus, props.underlineFocusStyle);
 
     if (this.state.isFocused) {
       styles.floatingLabel.color = theme.focusColor;


### PR DESCRIPTION
I feel like this is valuable as it is consistent with `underlineStyle`.
Thoughts on this feature?

Suggested by: https://github.com/callemall/material-ui/issues/1419