### PR TITLE
#1207 - Prevent disabled dates from being selectable with arrow keys

### DIFF
--- a/docs/src/app/components/pages/components/date-picker.jsx
+++ b/docs/src/app/components/pages/components/date-picker.jsx
@@ -172,7 +172,7 @@ class DatePickerPage extends React.Component {
 
           <DatePicker
             hintText="With Disabled Dates"
-            shouldDisableDate={date => date.getTime() > Date.now()}
+            maxDate={new Date()}
             onChange={this._handleChange.bind(this)} />
 
           <DatePicker

--- a/docs/src/app/components/pages/components/date-picker.jsx
+++ b/docs/src/app/components/pages/components/date-picker.jsx
@@ -171,6 +171,11 @@ class DatePickerPage extends React.Component {
             onChange={this._handleChange.bind(this)} />
 
           <DatePicker
+            hintText="With Disabled Dates"
+            shouldDisableDate={date => date.getTime() > Date.now()}
+            onChange={this._handleChange.bind(this)} />
+
+          <DatePicker
             hintText="Ranged Date Picker"
             autoOk={this.state.autoOk}
             minDate={this.state.minDate}

--- a/docs/src/app/components/raw-code/date-picker-code.txt
+++ b/docs/src/app/components/raw-code/date-picker-code.txt
@@ -9,6 +9,9 @@
   hintText="Controlled Date Input"
   value={this.state.controlledDate}
   onChange={this._handleChange} />
+<DatePicker
+  hintText="With Disabled Dates"
+  shouldDisableDate={date => date.getTime() > Date.now()} />
 //Ranged Date Picker
 <DatePicker
   hintText="Ranged Date Picker"

--- a/docs/src/app/components/raw-code/date-picker-code.txt
+++ b/docs/src/app/components/raw-code/date-picker-code.txt
@@ -1,17 +1,21 @@
 //Portrait Dialog
 <DatePicker hintText="Portrait Dialog" />
+
 //Landscape Dialog
 <DatePicker
   hintText="Landscape Dialog"
   mode="landscape"/>
+
 //Controlled Input
 <DatePicker
   hintText="Controlled Date Input"
   value={this.state.controlledDate}
   onChange={this._handleChange} />
+
 <DatePicker
   hintText="With Disabled Dates"
-  shouldDisableDate={date => date.getTime() > Date.now()} />
+  maxDate={new Date()} />
+
 //Ranged Date Picker
 <DatePicker
   hintText="Ranged Date Picker"

--- a/docs/src/app/components/raw-code/date-picker-code.txt
+++ b/docs/src/app/components/raw-code/date-picker-code.txt
@@ -12,6 +12,7 @@
   value={this.state.controlledDate}
   onChange={this._handleChange} />
 
+//With Disabled Dates
 <DatePicker
   hintText="With Disabled Dates"
   maxDate={new Date()} />

--- a/src/date-picker/calendar-month.jsx
+++ b/src/date-picker/calendar-month.jsx
@@ -34,6 +34,14 @@ let CalendarMonth = React.createClass({
     return this._selectedDateDisabled;
   },
 
+  isDateDisabled(day) {
+    if (day === null) return false;
+    let disabled = !DateTime.isBetweenDates(day, this.props.minDate, this.props.maxDate);
+    if (!disabled && this.props.shouldDisableDate) disabled = this.props.shouldDisableDate(day);
+
+    return disabled;
+  },
+
   _getWeekElements() {
     let weekArray = DateTime.getWeekArray(this.props.displayDate);
 
@@ -49,7 +57,7 @@ let CalendarMonth = React.createClass({
   _getDayElements(week, i) {
     return week.map((day, j) => {
       let isSameDate = DateTime.isEqualDate(this.props.selectedDate, day);
-      let disabled = this._shouldDisableDate(day);
+      let disabled = this.isDateDisabled(day);
       let selected = !disabled && isSameDate;
 
       if (isSameDate) {
@@ -74,14 +82,6 @@ let CalendarMonth = React.createClass({
 
   _handleDayTouchTap(e, date) {
     if (this.props.onDayTouchTap) this.props.onDayTouchTap(e, date);
-  },
-
-  _shouldDisableDate(day) {
-    if (day === null) return false;
-    let disabled = !DateTime.isBetweenDates(day, this.props.minDate, this.props.maxDate);
-    if (!disabled && this.props.shouldDisableDate) disabled = this.props.shouldDisableDate(day);
-
-    return disabled;
   },
 
 });

--- a/src/date-picker/calendar-month.jsx
+++ b/src/date-picker/calendar-month.jsx
@@ -61,12 +61,7 @@ let CalendarMonth = React.createClass({
       let selected = !disabled && isSameDate;
 
       if (isSameDate) {
-        if (disabled) {
-          this._selectedDateDisabled = true;
-        }
-        else {
-          this._selectedDateDisabled = false;
-        }
+        this._selectedDateDisabled = disabled;
       }
 
       return (

--- a/src/date-picker/calendar.jsx
+++ b/src/date-picker/calendar.jsx
@@ -205,6 +205,10 @@ let Calendar = React.createClass({
     return this.refs.calendar.isSelectedDateDisabled();
   },
 
+  isDateDisabled(day) {
+    return this.refs.calendar.isDateDisabled(day);
+  },
+
   _addSelectedDays(days) {
     this._setSelectedDate(DateTime.addDays(this.state.selectedDate, days));
   },
@@ -231,22 +235,24 @@ let Calendar = React.createClass({
   },
 
   _setSelectedDate(date) {
-    let adjustedDate = date;
-    if (DateTime.isBeforeDate(date, this.props.minDate)) {
-      adjustedDate = this.props.minDate;
-    }
-    else if (DateTime.isAfterDate(date, this.props.maxDate)) {
-      adjustedDate = this.props.maxDate;
-    }
+    if (!this.isDateDisabled(date)) {
+      let adjustedDate = date;
+      if (DateTime.isBeforeDate(date, this.props.minDate)) {
+        adjustedDate = this.props.minDate;
+      }
+      else if (DateTime.isAfterDate(date, this.props.maxDate)) {
+        adjustedDate = this.props.maxDate;
+      }
 
-    let newDisplayDate = DateTime.getFirstDayOfMonth(adjustedDate);
-    if (newDisplayDate !== this.state.displayDate) {
-      this._setDisplayDate(newDisplayDate, adjustedDate);
-    }
-    else {
-      this.setState({
-        selectedDate: adjustedDate,
-      });
+      let newDisplayDate = DateTime.getFirstDayOfMonth(adjustedDate);
+      if (newDisplayDate !== this.state.displayDate) {
+        this._setDisplayDate(newDisplayDate, adjustedDate);
+      }
+      else {
+        this.setState({
+          selectedDate: adjustedDate,
+        });
+      }
     }
   },
 


### PR DESCRIPTION
Currently if a date-picker has disabled dates, they can still be selected with arrow keys, although without a display effect. This adds a guard to prevent the date from being changed if it would be 'disabled'.

I renamed `_shouldDisableDate` to `isDateDisabled` in 'calendar-month', as I feel this is a useful public method and is consistent with `isSelectedDateDisabled`.

Reported by https://github.com/callemall/material-ui/issues/1207