### PR TITLE
Remove warning when using a Component as a text field hint

### DIFF
--- a/src/text-field.jsx
+++ b/src/text-field.jsx
@@ -29,7 +29,10 @@ let TextField = React.createClass({
     floatingLabelStyle: React.PropTypes.object,
     floatingLabelText: React.PropTypes.string,
     fullWidth: React.PropTypes.bool,
-    hintText: React.PropTypes.string,
+    hintText: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.element,
+    ]),
     id: React.PropTypes.string,
     inputStyle: React.PropTypes.object,
     multiLine: React.PropTypes.bool,


### PR DESCRIPTION
It allows the hintText proptype to be either a string or an element.

Enhancement requested by https://github.com/callemall/material-ui/issues/1202