### PR TITLE
Fix Slider issue #1448

### DIFF
--- a/src/ripples/focus-ripple.jsx
+++ b/src/ripples/focus-ripple.jsx
@@ -113,8 +113,12 @@ const FocusRipple = React.createClass({
     const width = el.offsetWidth;
     const size = Math.max(height, width);
 
+    let oldTop = 0;
+    if (el.style.top.endsWith('px')) {
+      oldTop = parseInt(el.style.top);
+    } 
     el.style.height = size + 'px';
-    el.style.top = (size / 2 * -1) + (height / 2) + 'px';
+    el.style.top = (height / 2) - (size / 2 ) + oldTop + 'px';
   },
 
 });

--- a/src/ripples/focus-ripple.jsx
+++ b/src/ripples/focus-ripple.jsx
@@ -114,7 +114,8 @@ const FocusRipple = React.createClass({
     const size = Math.max(height, width);
 
     let oldTop = 0;
-    if (el.style.top.endsWith('px')) {
+    // For browsers that don't support endsWith()
+    if (el.style.top.indexOf('px', el.style.top.length - 2) !== -1) {
       oldTop = parseInt(el.style.top);
     } 
     el.style.height = size + 'px';

--- a/src/slider.jsx
+++ b/src/slider.jsx
@@ -246,7 +246,7 @@ let Slider = React.createClass({
       this.props.disabled && styles.handleWhenDisabled
     );
 
-    let rippleStyle = {height: '12px', width: '12px'};
+    let rippleStyle = {height: '12px', width: '12px', overflow: 'visible'};
 
     if ((this.state.hovered || this.state.focused) && !this.props.disabled) {
       remainingStyles.backgroundColor = this.getTheme().trackColorSelected;


### PR DESCRIPTION
There are two issues which cause #1448:
1. overflow is hidden in FocusRipple by default
2. _setRippleSize() ignores existing el.top value
This fixes both.