### PR TITLE
Show focus if button gets tabbed INTO

### DIFF
--- a/src/enhanced-button.jsx
+++ b/src/enhanced-button.jsx
@@ -241,10 +241,13 @@ const EnhancedButton = React.createClass({
   },
 
   _handleKeyUp(e) {
-    if (!this.props.disabled &&
-      e.keyCode === KeyCode.SPACE &&
-      this.state.isKeyboardFocused) {
-      this._handleTouchTap(e);
+    if (!this.props.disabled) {
+      if (e.keyCode === KeyCode.SPACE &&
+        this.state.isKeyboardFocused) {
+          this._handleTouchTap(e);
+      } else if (e.keyCode === KeyCode.TAB) {
+        tabPressed = true;
+      }
     }
     this.props.onKeyUp(e);
   },


### PR DESCRIPTION
In a form, if the button gets tabbed into (e.g. from a TextView), the initial focus isn't handled properly (no visible sign that the button now has focus). Added check for tab key in keyUp handler which seems to solve it.