### PR TITLE
Remove emptyTime to support hintText

### DIFF
--- a/src/time-picker/time-picker.jsx
+++ b/src/time-picker/time-picker.jsx
@@ -31,7 +31,7 @@ let TimePicker = React.createClass({
 
   getDefaultProps() {
     return {
-      defaultTime: emptyTime,
+      defaultTime: null,
       format: 'ampm',
       pedantic: false,
     };
@@ -39,7 +39,7 @@ let TimePicker = React.createClass({
 
   getInitialState() {
     return {
-      time: this.props.defaultTime,
+      time: this.props.defaultTime || emptyTime,
       dialogTime: new Date(),
     };
   },


### PR DESCRIPTION
Since defaultTime is always defined because it has a default prop, defaultValue is always true, so hintText can't work.