### PR TITLE
AppBar should be positioned 

### DIFF
--- a/src/app-bar.jsx
+++ b/src/app-bar.jsx
@@ -61,6 +61,7 @@ let AppBar = React.createClass({
     let flatButtonSize = 36;
     let styles = {
       root: {
+        position: 'relative',
         zIndex: 5,
         width: '100%',
         display: '-webkit-box; display: -webkit-flex; display: flex',

--- a/src/app-canvas.jsx
+++ b/src/app-canvas.jsx
@@ -24,9 +24,9 @@ let AppCanvas = React.createClass({
       switch (currentChild.type.displayName) {
         case 'AppBar' :
           return React.cloneElement(currentChild, {
-            style: this.mergeStyles({
+            style: this.mergeStyles(currentChild.props.style, {
               position: 'fixed',
-            }, currentChild.props.style),
+            }),
           });
         default:
           return currentChild;


### PR DESCRIPTION
Hi
`z-index` only has an effect if an element is positioned
(https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Understanding_z_index/Adding_z-index)

Though `AppBar` has a `z-index` value as `5`, it isn't positioned.
Look at the following screenshot:
![2015-08-21 9 37 39](https://cloud.githubusercontent.com/assets/3467350/9408425/e92fcbf8-484d-11e5-8bc3-5f51790294ff.png)
As you can see, the half of the shadow of the `AppBar` is hidden by the following element.