### PR TITLE
[theme] fix theme light

### DIFF
--- a/src/styles/themes/light-theme.js
+++ b/src/styles/themes/light-theme.js
@@ -75,7 +75,7 @@ let LightTheme = {
         secondaryIconColor: Colors.white,
       },
       inkBar: {
-        backgroundColor: Colors.yellow200,
+        backgroundColor: palette.accent1Color,
       },
       leftNav: {
         width: spacing.desktopKeylineIncrement * 4,


### PR DESCRIPTION
Was change accidentally by 4c13c4d84f346b5633f274e4865b29f0fa3118a9 `Upgraded Docs site to use Tabs instead of Left Nav`.