### PR TITLE
Ability to pass title option to MenuItem

### DIFF
--- a/src/menu/menu-item.jsx
+++ b/src/menu/menu-item.jsx
@@ -34,6 +34,7 @@ let MenuItem = React.createClass({
     onToggle: React.PropTypes.func,
     selected: React.PropTypes.bool,
     active: React.PropTypes.bool,
+    title: React.PropTypes.string,
   },
 
   statics: {
@@ -152,6 +153,7 @@ let MenuItem = React.createClass({
         onTouchTap={this._handleTouchTap}
         onMouseEnter={this._handleMouseEnter}
         onMouseLeave={this._handleMouseLeave}
+        title={this.props.title}
         style={this.mergeAndPrefix(
           styles.root,
           this.props.selected && styles.rootWhenSelected,

--- a/src/menu/menu.jsx
+++ b/src/menu/menu.jsx
@@ -413,6 +413,7 @@ let Menu = React.createClass({
               onTouchTap={this._onItemTap}
               onMouseEnter={this._onItemActivated}
               onMouseLeave={this._onItemDeactivated}
+              title={menuItem.title}
               >
               {menuItem.text}
             </MenuItem>


### PR DESCRIPTION
Just proof of concept/feature request. Let me know if something is missed. Ability to pass title is useful in case of menu items with a lot of text. It also works with DropDownMenu's `menuItems`.