### PR TITLE
Stacked event listeners

### DIFF
--- a/src/dialog.jsx
+++ b/src/dialog.jsx
@@ -86,8 +86,11 @@ let Dialog = React.createClass({
   },
 
   windowListeners: {
-    keyup: '_handleWindowKeyUp',
     resize: '_positionDialog',
+  },
+
+  stackWindowListeners: {
+    keyup: '_handleWindowKeyUp',
   },
 
   getDefaultProps() {

--- a/src/mixins/window-listenable.js
+++ b/src/mixins/window-listenable.js
@@ -5,19 +5,31 @@ module.exports = {
 
   componentDidMount() {
     let listeners = this.windowListeners;
+    var stackListeners = this.stackWindowListeners;
 
     for (let eventName in listeners) {
        let callbackName = listeners[eventName];
        Events.on(window, eventName, this[callbackName]);
     }
+
+    for (var eventName in stackListeners) {
+      var callbackName = stackListeners[eventName];
+      Events.onstack(window, eventName, this[callbackName]);
+    }
   },
 
   componentWillUnmount() {
     let listeners = this.windowListeners;
+    var stackListeners = this.stackWindowListeners;
 
     for (let eventName in listeners) {
        let callbackName = listeners[eventName];
        Events.off(window, eventName, this[callbackName]);
+    }
+
+    for (var eventName in stackListeners) {
+      var callbackName = stackListeners[eventName];
+      Events.offstack(window, eventName, this[callbackName]);
     }
   },
 

--- a/src/mixins/window-listenable.js
+++ b/src/mixins/window-listenable.js
@@ -5,30 +5,30 @@ module.exports = {
 
   componentDidMount() {
     let listeners = this.windowListeners;
-    var stackListeners = this.stackWindowListeners;
+    let stackListeners = this.stackWindowListeners;
 
     for (let eventName in listeners) {
        let callbackName = listeners[eventName];
        Events.on(window, eventName, this[callbackName]);
     }
 
-    for (var eventName in stackListeners) {
-      var callbackName = stackListeners[eventName];
+    for (let eventName in stackListeners) {
+      let callbackName = stackListeners[eventName];
       Events.onstack(window, eventName, this[callbackName]);
     }
   },
 
   componentWillUnmount() {
     let listeners = this.windowListeners;
-    var stackListeners = this.stackWindowListeners;
+    let stackListeners = this.stackWindowListeners;
 
     for (let eventName in listeners) {
        let callbackName = listeners[eventName];
        Events.off(window, eventName, this[callbackName]);
     }
 
-    for (var eventName in stackListeners) {
-      var callbackName = stackListeners[eventName];
+    for (let eventName in stackListeners) {
+      let callbackName = stackListeners[eventName];
       Events.offstack(window, eventName, this[callbackName]);
     }
   },

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -1,4 +1,4 @@
-var storedEvents = {};
+let storedEvents = {};
 
 module.exports = {
 
@@ -29,7 +29,7 @@ module.exports = {
     if (storedEvents[el] === undefined) return;
     if (!storedEvents[el][type] === undefined) return;
 
-    var idx = storedEvents[el][type].indexOf(callback);
+    let idx = storedEvents[el][type].indexOf(callback);
 
     if (idx >= 0) {
       storedEvents[el][type].splice(idx, 1);

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -1,3 +1,5 @@
+var storedEvents = {};
+
 module.exports = {
 
   once(el, type, callback) {
@@ -10,6 +12,37 @@ module.exports = {
     for (let i = typeArray.length - 1; i >= 0; i--) {
       this.on(el, typeArray[i], recursiveFunction);
     }
+  },
+
+  // Only fire the last callback added to the stack
+  onstack: function(el, type, callback) {
+    if (storedEvents[el] === undefined) storedEvents[el] = {};
+    if (storedEvents[el][type] === undefined) storedEvents[el][type] = [];
+    if (storedEvents[el][type].length) this.off(el, type, storedEvents[el][type][0]);
+
+    this.on(el, type, callback);
+    storedEvents[el][type] = [callback].concat(storedEvents[el][type]);
+  },
+
+  // Remove a callback from the stack and reassign if callback was current
+  offstack: function (el, type, callback) {
+    if (storedEvents[el] === undefined) return;
+    if (!storedEvents[el][type] === undefined) return;
+
+    var idx = storedEvents[el][type].indexOf(callback);
+
+    if (idx >= 0) {
+      storedEvents[el][type].splice(idx, 1);
+      if (idx === 0) {
+        this.off(el, type, callback);
+        if (storedEvents[el][type].length) {
+          this.on(el, type, storedEvents[el][type][0]);
+        }
+      }
+    }
+
+    if (storedEvents[el][type].length === 0) delete(storedEvents[el][type]);
+    if (storedEvents[el].length === 0) delete(storedEvents[el]);
   },
 
   on(el, type, callback) {


### PR DESCRIPTION
When multiple Dialogs are open, hitting ESC will close all dialogs. This creates an event callback stack so the last in callback is the only one to fire.