### PR TITLE
Fix table row height in Internet Explorer

### DIFF
--- a/src/styles/themes/light-theme.js
+++ b/src/styles/themes/light-theme.js
@@ -163,6 +163,7 @@ let LightTheme = {
         selectedColor: Colors.grey300,
         textColor: Colors.darkBlack,
         borderColor: palette.borderColor,
+        height: 48,
       },
       tableRowColumn: {
         height: 48,

--- a/src/table/table-row.jsx
+++ b/src/table/table-row.jsx
@@ -62,7 +62,7 @@ let TableRow = React.createClass({
 
     let styles = {
       root: {
-        borderBottom: '1px solid ' + this.getTheme().borderColor,
+        borderBottom: '1px solid ' + theme.borderColor,
         color: theme.textColor,
         height: theme.height,
       },

--- a/src/table/table-row.jsx
+++ b/src/table/table-row.jsx
@@ -63,7 +63,8 @@ let TableRow = React.createClass({
     let styles = {
       root: {
         borderBottom: '1px solid ' + this.getTheme().borderColor,
-        color: this.getTheme().textColor,
+        color: theme.textColor,
+        height: theme.height,
       },
       cell: {
         backgroundColor: cellBgColor,


### PR DESCRIPTION
When using the ```Table``` from v0.11 with a fixed height, all rows were stretched to be the full height in Internet Explorer:

![image](https://cloud.githubusercontent.com/assets/1201644/9559417/69625390-4df3-11e5-87ec-92113926db9b.png)

This is because Internet Explorer also needs a ```height``` on the ```tr```.

This PR adds the height in the theme, and utilizes it in the ```table-row.jsx```

End result:

![image](https://cloud.githubusercontent.com/assets/1201644/9559441/d03a0400-4df3-11e5-83ac-ed7f976b3619.png)
