### PR TITLE
Provide isScrollbarVisible for table

### DIFF
--- a/src/table/table.jsx
+++ b/src/table/table.jsx
@@ -136,8 +136,8 @@ let Table = React.createClass({
     return (
       <div className="mui-table-wrapper" style={styles.tableWrapper}>
         {headerTable}
-        <div className="mui-body-table" style={styles.bodyTable}>
-          <table className={classes} style={mergedTableStyle}>
+        <div className="mui-body-table" style={styles.bodyTable} ref="tableDiv">
+          <table className={classes} style={mergedTableStyle} ref="tableBody">
             {inlineHeader}
             {inlineFooter}
             {tBody}
@@ -146,6 +146,13 @@ let Table = React.createClass({
         {footerTable}
       </div>
     );
+  },
+
+  isScrollbarVisible() {
+    const tableDivHeight = React.findDOMNode(this.refs.tableDiv).clientHeight;
+    const tableBodyHeight = React.findDOMNode(this.refs.tableBody).clientHeight;
+
+    return tableBodyHeight > tableDivHeight;
   },
 
   _createTableHeader(base) {


### PR DESCRIPTION
Right now, when the ```Table``` has enough elements in the body, it will gain a scrollbar.

Since this scrollbar is applied to the main rows, the header actually has no clue about it. In some cases, this might break positioning of header elements (because the main rows suddenly get a little bit smaller width due to a visible scrollbar).

By providing a ```isScrollbarVisible()``` on ```Table``` the caller can determine if a scrollbar is visible, and take it into account in his styles to possibly offset this.