### PR TITLE
[ListItem] render children if there is

### DIFF
--- a/src/lists/list-item.jsx
+++ b/src/lists/list-item.jsx
@@ -215,7 +215,7 @@ const ListItem = React.createClass({
       },
     };
 
-    let contentChildren = [];
+    let contentChildren = [children];
 
     if (leftIcon) {
       this._pushElement(


### PR DESCRIPTION
Was first using the `primaryText` prop with a custom component. But, my component is cloned with a new style. This new style is preventing the PureRender of my component to stop the rendering (because the property style change every time).
Now, I can pass my custom component as a children and performance are great
