### PR TITLE
fixed actions check

### DIFF
--- a/src/dialog.jsx
+++ b/src/dialog.jsx
@@ -328,7 +328,7 @@ let Dialog = React.createClass({
         let maxDialogContentHeight = clientHeight - 2 * (styles.body.padding + 64);
 
         if (this.props.title) maxDialogContentHeight -= dialogContent.previousSibling.offsetHeight;
-        if (this.props.actions) maxDialogContentHeight -= dialogContent.nextSibling.offsetHeight;
+        if (this.props.actions.length) maxDialogContentHeight -= dialogContent.nextSibling.offsetHeight;
 
         dialogContent.style.maxHeight = maxDialogContentHeight + 'px';
       }


### PR DESCRIPTION
The Dialog component does an erroneous check for whether actions exist. The empty array is truthy and will be evaluated as true. I changed the check to a length check so that empty arrays are false. 

The previous version gives a `Uncaught TypeError: Cannot read property 'offsetHeight' of null` error when setting `autoScrollBodyContent={true}` of a Dialog box. 

Addresses issue #1567