### PR TITLE
[MenuItem] Fix issue when using number and data

### DIFF
--- a/src/menu/menu-item.jsx
+++ b/src/menu/menu-item.jsx
@@ -161,9 +161,9 @@ let MenuItem = React.createClass({
 
         {icon}
         {this.props.children}
-        {data}
-        {attribute}
         {number}
+        {attribute}
+        {data}
         {toggleElement}
         {iconRight}
 


### PR DESCRIPTION
When number is added after data, it is shoved below MenuItem because data is display:block