### PR TITLE
[bugfix] moves key prop to TableHeaderColumn

### DIFF
--- a/src/table/table-header.jsx
+++ b/src/table/table-header.jsx
@@ -127,11 +127,10 @@ let TableHeader = React.createClass({
   },
 
   _getSelectAllCheckboxColumn(props) {
-  if (!this.props.displaySelectAll) return this._getCheckboxPlaceholder(props);
+    if (!this.props.displaySelectAll) return this._getCheckboxPlaceholder(props); 
 
     const checkbox =
       <Checkbox
-        key="selectallcb"
         name="selectallcb"
         value="selected"
         disabled={!this.props.enableSelectAll}
@@ -139,7 +138,8 @@ let TableHeader = React.createClass({
         onCheck={this._onSelectAll} />;
 
     return (
-      <TableHeaderColumn style={{width: 24}}>
+      <TableHeaderColumn style={{width: 24}}
+        key="selectallcb">
         {checkbox}
       </TableHeaderColumn>
     );


### PR DESCRIPTION
- Key property was defined on the Checkbox element, causing React
to throw a warning when enumerating any TableHeaderColumns
- Fixes #1583