### PR TITLE
[TextField] Added placeholder prop for better ie10 compatibility

### DIFF
--- a/src/text-field.jsx
+++ b/src/text-field.jsx
@@ -33,6 +33,7 @@ let TextField = React.createClass({
       React.PropTypes.string,
       React.PropTypes.element,
     ]),
+    placeholder: React.PropTypes.string,
     id: React.PropTypes.string,
     inputStyle: React.PropTypes.object,
     multiLine: React.PropTypes.bool,
@@ -242,6 +243,7 @@ let TextField = React.createClass({
       floatingLabelText,
       fullWidth,
       hintText,
+      placeholder,
       id,
       multiLine,
       onBlur,
@@ -285,6 +287,9 @@ let TextField = React.createClass({
       onKeyDown: this._handleInputKeyDown,
     };
 
+    if (placeholder) {
+      inputProps.placeholder = placeholder;
+    }
     if (!this.props.hasOwnProperty('valueLink')) {
       inputProps.onChange = this._handleInputChange;
     }


### PR DESCRIPTION
When experiencing issues with the ability to focus on the input element, use placeholder prop instead of hintText. The placeholder is not animated as the hintText is, but it works on ie10.

closes #1191