### PR TITLE
Fix a potential error in <Card>

### DIFF
--- a/src/card/card.jsx
+++ b/src/card/card.jsx
@@ -31,7 +31,7 @@ const Card = React.createClass({
       let newChild = undefined;
       let newProps = {};
       let element = currentChild;
-      if (!currentChild) {
+      if (!currentChild || !currentChild.props) {
         return null;
       }
       if (this.state.expanded === false && currentChild.props.expandable === true)


### PR DESCRIPTION
An unrecognisable error will occur if you pass a text node as a child to `<Card>` element.

For example:

    <Card>
      <CardTitle />
      Test
    <Card>

I was thinking about adding a warning as well. Should I use `console.warn`?