### PR TITLE
Allow programmatic opening and closing DropDownMenu

### DIFF
--- a/docs/src/app/components/pages/components/drop-down-menu.jsx
+++ b/docs/src/app/components/pages/components/drop-down-menu.jsx
@@ -92,6 +92,12 @@ export default class DropDownMenuPage extends React.Component {
             header: 'default: false',
             desc: 'Disables the menu.',
           },
+          {
+            name: 'openImmediately',
+            type: 'bool',
+            header: 'default: false',
+            desc: 'Set to true to have the DropDownMenu automatically open on mount.',
+          },
         ],
       },
       {

--- a/src/drop-down-menu.jsx
+++ b/src/drop-down-menu.jsx
@@ -46,6 +46,7 @@ const DropDownMenu = React.createClass({
     iconStyle:React.PropTypes.object,
     labelStyle:React.PropTypes.object,
     selectedIndex: React.PropTypes.number,
+    openImmediately: React.PropTypes.bool,
   },
 
   getDefaultProps() {
@@ -54,12 +55,13 @@ const DropDownMenu = React.createClass({
       disabled: false,
       valueMember: 'payload',
       displayMember: 'text',
+      openImmediately: false,
     };
   },
 
   getInitialState() {
     return {
-      open: false,
+      open: this.props.openImmediately,
       selectedIndex: this._isControlled() ? null : (this.props.selectedIndex || 0),
       muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
     };


### PR DESCRIPTION
I found that I couldn't mount a DropDownMenu and have it automatically be open, or programmatically open it myself, so I propose the following additions to DropDownMenu:

- ~~Adds `isOpen()`, `open()`, and `close()` methods.~~
- Adds `openImmediately` boolean property.