### PR TITLE
[Tabs] Added tabTemplate property in Tabs component for custom tab templates.

### DIFF
--- a/docs/src/app/components/pages/components/tabs.jsx
+++ b/docs/src/app/components/pages/components/tabs.jsx
@@ -56,6 +56,12 @@ export default class TabsPage extends React.Component {
             desc: 'Override the inline-styles of the tab-labels container.',
           },
           {
+            name: 'tabTemplate',
+            type: 'ReactClass',
+            header: 'optional',
+            desc: 'Override the default tab template used to wrap the content of each tab element.',
+          },
+          {
             name: 'value',
             type: 'string or number',
             header: 'optional',

--- a/src/tabs/tabs.jsx
+++ b/src/tabs/tabs.jsx
@@ -20,6 +20,7 @@ const Tabs = React.createClass({
     initialSelectedIndex: React.PropTypes.number,
     inkBarStyle: React.PropTypes.object,
     tabItemContainerStyle: React.PropTypes.object,
+    tabTemplate: React.PropTypes.func,
   },
 
   //for passing default theme context to children
@@ -36,6 +37,7 @@ const Tabs = React.createClass({
   getDefaultProps() {
     return {
       initialSelectedIndex : 0,
+      tabTemplate: TabTemplate,
     };
   },
 
@@ -85,6 +87,7 @@ const Tabs = React.createClass({
       style,
       tabWidth,
       tabItemContainerStyle,
+      tabTemplate,
       ...other,
     } = this.props;
 
@@ -118,7 +121,7 @@ const Tabs = React.createClass({
         }
 
         tabContent.push(tab.props.children ?
-          React.createElement(TabTemplate, {
+          React.createElement(tabTemplate, {
             key: index,
             selected: this._getSelected(tab, index),
           }, tab.props.children) : undefined);


### PR DESCRIPTION
Not always we want to use the default tab template. Sometimes, it is simply not compatible with our page structure. Now, the developer can provide a custom tab template with its own structure, style or state management.