### PR TITLE
Adding localization to Material-UI

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,8 +15,9 @@
     "codemirror": "^5.5.0"
   },
   "devDependencies": {
+    "json-loader": "^0.5.3",
     "raw-loader": "^0.5.1",
-    "webpack": "^1.11.0",
-    "webpack-dev-server": "^1.10.1"
+    "webpack": "^1.12.2",
+    "webpack-dev-server": "^1.11.0"
   }
 }

--- a/docs/src/app/components/master.jsx
+++ b/docs/src/app/components/master.jsx
@@ -19,7 +19,7 @@ let { AppBar,
 let RouteHandler = Router.RouteHandler;
 let { Colors, Spacing, Typography } = Styles;
 let ThemeManager = new Styles.ThemeManager();
-LocaleManager.setLocale('es');
+LocaleManager.setLocale('en');
 
 class Master extends React.Component {
 

--- a/docs/src/app/components/master.jsx
+++ b/docs/src/app/components/master.jsx
@@ -13,12 +13,13 @@ let { AppBar,
       Styles,
       Tab,
       Tabs,
-      Paper} = require('material-ui');
+      Paper,
+      LocaleManager } = require('material-ui');
 
 let RouteHandler = Router.RouteHandler;
 let { Colors, Spacing, Typography } = Styles;
 let ThemeManager = new Styles.ThemeManager();
-
+LocaleManager.setLocale('es');
 
 class Master extends React.Component {
 
@@ -28,7 +29,8 @@ class Master extends React.Component {
 
   getChildContext() {
     return {
-      muiTheme: ThemeManager.getCurrentTheme()
+      muiTheme: ThemeManager.getCurrentTheme(),
+      muiLocale: LocaleManager.getLocale()
     }
   }
 
@@ -254,7 +256,8 @@ Master.contextTypes = {
 };
 
 Master.childContextTypes = {
-  muiTheme: React.PropTypes.object
+  muiTheme: React.PropTypes.object,
+  muiLocale: React.PropTypes.string
 };
 
 module.exports = Master;

--- a/docs/webpack-dev-server.config.js
+++ b/docs/webpack-dev-server.config.js
@@ -88,6 +88,11 @@ var config = {
             loader:'babel-loader?stage=0', //react-hot is like browser sync and babel loads jsx and es6-7
             include: [__dirname, path.resolve(__dirname, '../src')], //include these files
             exclude: [nodeModulesPath]  //exclude node_modules so that they are not all compiled
+          },
+          {
+            test: /\.json$/,
+            loader: 'json-loader',
+            exclude: [nodeModulesPath]
           }
         ]
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   },
   "homepage": "http://material-ui.com/",
   "dependencies": {
-    "react-draggable2": "^0.5.1"
+    "react-draggable2": "^0.5.1",
+    "react-interpolate-component": "^0.7.1",
+    "react-translate-component": "^0.9.0"
   },
   "peerDependencies": {
     "react": ">=0.13",
@@ -44,6 +46,7 @@
     "babelify": "^6.1.3",
     "browserify-istanbul": "^0.2.1",
     "chai": "^3.2.0",
+    "counterpart": "^0.16.10",
     "eslint": "^1.1.0",
     "eslint-loader": "^1.0.0",
     "eslint-plugin-react": "^3.2.2",

--- a/src/date-picker/calendar.jsx
+++ b/src/date-picker/calendar.jsx
@@ -10,7 +10,8 @@ let CalendarToolbar = require('./calendar-toolbar');
 let DateDisplay = require('./date-display');
 let SlideInTransitionGroup = require('../transition-groups/slide-in');
 let ClearFix = require('../clearfix');
-
+let Counterpart = require('counterpart');
+let Translate   = require('react-translate-component');
 
 let Calendar = React.createClass({
 
@@ -145,13 +146,13 @@ let Calendar = React.createClass({
           <ClearFix
             elementType="ul"
             style={styles.weekTitle}>
-            <li style={styles.weekTitleDay}>S</li>
-            <li style={styles.weekTitleDay}>M</li>
-            <li style={styles.weekTitleDay}>T</li>
-            <li style={styles.weekTitleDay}>W</li>
-            <li style={styles.weekTitleDay}>T</li>
-            <li style={styles.weekTitleDay}>F</li>
-            <li style={styles.weekTitleDay}>S</li>
+            <li style={styles.weekTitleDay}><Translate content="days.sunday.firstLetter"/></li>
+            <li style={styles.weekTitleDay}><Translate content="days.monday.firstLetter"/></li>
+            <li style={styles.weekTitleDay}><Translate content="days.tuesday.firstLetter"/></li>
+            <li style={styles.weekTitleDay}><Translate content="days.wednesday.firstLetter"/></li>
+            <li style={styles.weekTitleDay}><Translate content="days.thursday.firstLetter"/></li>
+            <li style={styles.weekTitleDay}><Translate content="days.friday.firstLetter"/></li>
+            <li style={styles.weekTitleDay}><Translate content="days.saturday.firstLetter"/></li>
           </ClearFix>
 
           <SlideInTransitionGroup

--- a/src/date-picker/date-picker.jsx
+++ b/src/date-picker/date-picker.jsx
@@ -9,7 +9,7 @@ let TextField = require('../text-field');
 let DatePicker = React.createClass({
 
   mixins: [StylePropable, WindowListenable],
-
+  
   propTypes: {
     autoOk: React.PropTypes.bool,
     defaultDate: React.PropTypes.object,

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ module.exports = {
   List: require('./lists/list'),
   ListDivider: require('./lists/list-divider'),
   ListItem: require('./lists/list-item'),
+  LocaleManager: require('./locales/LocaleManager'),
   Menu: require('./menu/menu'),
   MenuItem: require('./menu/menu-item'),
   Mixins: require('./mixins/'),

--- a/src/locales/LocaleManager.jsx
+++ b/src/locales/LocaleManager.jsx
@@ -1,0 +1,17 @@
+let DateTime = require('../utils/date-time');
+
+let LocaleManager = {
+
+    locale: 'en',
+
+    getLocale() {
+      return this.locale;
+    },
+
+    setLocale(l) {
+      DateTime.setLocale(l);
+    },
+
+}
+
+module.exports = LocaleManager

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1,0 +1,62 @@
+module.exports = {
+  'months': {
+    'full': {
+      'january': 'January',
+      'february': 'February',
+      'march' : 'March',
+      'april' : 'April',
+      'may'   : 'May',
+      'june'  : 'June',
+      'july'  : 'July',
+      'august': 'August',
+      'september' : 'September',
+      'october' : 'October',
+      'november'  : 'November',
+      'december' : 'December',
+    },
+    'short': {
+      'jan': 'Jan',
+      'feb': 'Feb',
+      'mar': 'Mar',
+      'apr': 'Apr',
+      'may': 'May',
+      'jun': 'Jun',
+      'jul': 'Jul',
+      'aug': 'Aug',
+      'sep': 'Sep',
+      'oct': 'Oct',
+      'nov': 'Nov',
+      'dec': 'Dec',
+    },
+  },
+  'days': {
+    'sunday': {
+      'short': 'Sun',
+      'firstLetter': 'S',
+    },
+    'monday': {
+      'short': 'Mon',
+      'firstLetter': 'M',
+    },
+    'tuesday': {
+      'short': 'Tue',
+      'firstLetter': 'T',
+    },
+    'wednesday': {
+      'short': 'Wed',
+      'firstLetter': 'W',
+    },
+    'thursday': {
+      'short': 'Thu',
+      'firstLetter': 'T',
+    },
+    'friday': {
+      'short': 'Fri',
+      'firstLetter': 'F',
+    },
+    'saturday': {
+      'short': 'Sat',
+      'firstLetter': 'S',
+    },
+  },
+};

--- a/src/locales/es.js
+++ b/src/locales/es.js
@@ -1,0 +1,62 @@
+module.exports = {
+  'months': {
+    'full': {
+      'january': 'Enero',
+      'february': 'Febrero',
+      'march' : 'Marzo',
+      'april' : 'Abril',
+      'may'   : 'Mayo',
+      'june'  : 'Junio',
+      'july'  : 'Julio',
+      'august': 'Agosto',
+      'september' : 'Septiembre',
+      'october' : 'Octubre',
+      'november'  : 'Noviembre',
+      'december' : 'Diciembre',
+    },
+    'short': {
+      'jan': 'Ene',
+      'feb': 'Feb',
+      'mar': 'Mar',
+      'apr': 'Abr',
+      'may': 'May',
+      'jun': 'Jun',
+      'jul': 'Jul',
+      'aug': 'Ago',
+      'sep': 'Sep',
+      'oct': 'Oct',
+      'nov': 'Nov',
+      'dec': 'Dic',
+    },
+  },
+  'days': {
+    'sunday': {
+      'short': 'Dom',
+      'firstLetter': 'D',
+    },
+    'monday': {
+      'short': 'Lun',
+      'firstLetter': 'L',
+    },
+    'tuesday': {
+      'short': 'Mar',
+      'firstLetter': 'M',
+    },
+    'wednesday': {
+      'short': 'Mie',
+      'firstLetter': 'M',
+    },
+    'thursday': {
+      'short': 'Jue',
+      'firstLetter': 'J',
+    },
+    'friday': {
+      'short': 'Vie',
+      'firstLetter': 'V',
+    },
+    'saturday': {
+      'short': 'Sab',
+      'firstLetter': 'S',
+    },
+  },
+};

--- a/src/utils/date-time.js
+++ b/src/utils/date-time.js
@@ -1,4 +1,13 @@
+let translate = require('counterpart');
+
+translate.registerTranslations('en', require('../locales/en'));
+translate.registerTranslations('es', require('../locales/es'));
+
 module.exports = {
+
+  setLocale(l) {
+    translate.setLocale(l);
+  },
 
   addDays(d, days) {
     let newDate = this.clone(d);
@@ -11,7 +20,7 @@ module.exports = {
     newDate.setMonth(d.getMonth() + months);
     return newDate;
   },
-
+  
   addYears(d, years) {
     let newDate = this.clone(d);
     newDate.setFullYear(d.getFullYear() + years);
@@ -44,49 +53,49 @@ module.exports = {
   getFullMonth(d) {
     let month = d.getMonth();
     switch (month) {
-      case 0: return 'January';
-      case 1: return 'February';
-      case 2: return 'March';
-      case 3: return 'April';
-      case 4: return 'May';
-      case 5: return 'June';
-      case 6: return 'July';
-      case 7: return 'August';
-      case 8: return 'September';
-      case 9: return 'October';
-      case 10: return 'November';
-      case 11: return 'December';
+      case 0: return translate('months.full.january');
+      case 1: return translate('months.full.february');
+      case 2: return translate('months.full.march');
+      case 3: return translate('months.full.april');
+      case 4: return translate('months.full.may');
+      case 5: return translate('months.full.june');
+      case 6: return translate('months.full.july');
+      case 7: return translate('months.full.august');
+      case 8: return translate('months.full.september');
+      case 9: return translate('months.full.october');
+      case 10: return translate('months.full.november');
+      case 11: return translate('months.full.december');
     }
   },
 
   getShortMonth(d) {
     let month = d.getMonth();
     switch (month) {
-      case 0: return 'Jan';
-      case 1: return 'Feb';
-      case 2: return 'Mar';
-      case 3: return 'Apr';
-      case 4: return 'May';
-      case 5: return 'Jun';
-      case 6: return 'Jul';
-      case 7: return 'Aug';
-      case 8: return 'Sep';
-      case 9: return 'Oct';
-      case 10: return 'Nov';
-      case 11: return 'Dec';
+      case 0: return translate('months.short.jan');
+      case 1: return translate('months.short.feb');
+      case 2: return translate('months.short.mar');
+      case 3: return translate('months.short.apr');
+      case 4: return translate('months.short.may');
+      case 5: return translate('months.short.jun');
+      case 6: return translate('months.short.jul');
+      case 7: return translate('months.short.aug');
+      case 8: return translate('months.short.sep');
+      case 9: return translate('months.short.oct');
+      case 10: return translate('months.short.nov');
+      case 11: return translate('months.short.dec');
     }
   },
 
   getDayOfWeek(d) {
     let dow = d.getDay();
     switch (dow) {
-      case 0: return 'Sun';
-      case 1: return 'Mon';
-      case 2: return 'Tue';
-      case 3: return 'Wed';
-      case 4: return 'Thu';
-      case 5: return 'Fri';
-      case 6: return 'Sat';
+      case 0: return translate('days.sunday.short');
+      case 1: return translate('days.monday.short');
+      case 2: return translate('days.tuesday.short');
+      case 3: return translate('days.wednesday.short');
+      case 4: return translate('days.thursday.short');
+      case 5: return translate('days.friday.short');
+      case 6: return translate('days.saturday.short');
     }
   },
 
@@ -112,10 +121,8 @@ module.exports = {
       for (let i = 0; i < emptyDays; i++) {
         week.unshift(null);
       }
-
       weekArray.push(week);
     }
-
     return weekArray;
   },
 


### PR DESCRIPTION
I used react-translate-component and counterpart modules to enable this. If you take a look at master.jsx (from docs module). There are a few simple steps to enable it:

* Add LocaleManager as a dependency
* Add LocaleManager.setLocale('en');
* Add 'muiLocale: LocaleManager.getLocale()' to getChildContext()
* Add 'muiLocale: React.PropTypes.string' to Master.childContextTypes

if you change setLocale to 'es'.. the datepicker will be in spanish (used that for testing)

locales are available in /src/locales/es.js and en.js (file structure needs work)

Let me know if this works for you! 

Material-UI is awesome thanks for the hard work!