### PR TITLE
[EnhancedSwitch] added inputStyle prop to enhanced switch

### DIFF
--- a/src/checkbox.jsx
+++ b/src/checkbox.jsx
@@ -36,6 +36,11 @@ const Checkbox = React.createClass({
     iconStyle: React.PropTypes.object,
 
     /**
+     * Overrides the inline-styles of the input element.
+     */
+    inputStyle: React.PropTypes.object,
+
+    /**
      * Where the label will be placed next to the checkbox.
      */
     labelPosition: React.PropTypes.oneOf(['left', 'right']),

--- a/src/enhanced-switch.jsx
+++ b/src/enhanced-switch.jsx
@@ -27,6 +27,7 @@ const EnhancedSwitch = React.createClass({
     disabled: React.PropTypes.bool,
     iconStyle: React.PropTypes.object,
     id: React.PropTypes.string,
+    inputStyle: React.PropTypes.object,
     inputType: React.PropTypes.string.isRequired,
     label: React.PropTypes.node,
     labelPosition: React.PropTypes.oneOf(['left', 'right']),
@@ -361,7 +362,7 @@ const EnhancedSwitch = React.createClass({
     const inputProps = {
       ref: 'checkbox',
       type: this.props.inputType,
-      style: this.prepareStyles(styles.input),
+      style: this.prepareStyles(styles.input, this.props.inputStyle),
       name: this.props.name,
       value: this.props.value,
       defaultChecked: this.props.defaultSwitched,

--- a/src/radio-button.jsx
+++ b/src/radio-button.jsx
@@ -26,6 +26,11 @@ const RadioButton = React.createClass({
     iconStyle: React.PropTypes.object,
 
     /**
+    * Overrides the inline-styles of the input element.
+    */
+    inputStyle: React.PropTypes.object,
+
+    /**
      * Used internally by `RadioButtonGroup`. Use the `labelPosition` property of `RadioButtonGroup` instead.
      */
     /* Where the label will be placed next to the radio button. */

--- a/src/toggle.jsx
+++ b/src/toggle.jsx
@@ -29,6 +29,11 @@ const Toggle = React.createClass({
     iconStyle: React.PropTypes.object,
 
     /**
+     * Overrides the inline-styles of the input element.
+     */
+    inputStyle: React.PropTypes.object,
+
+    /**
      * Where the label will be placed next to the toggle.
      */
     labelPosition: React.PropTypes.oneOf(['left', 'right']),


### PR DESCRIPTION
Allows overriding styles of backing input element. Having `position: absolute` by default doesn't always play nicely with surrounding elements.