### PR TITLE
[ClickAwayable] added event propagation to click-awayable mixin

### DIFF
--- a/src/mixins/click-awayable.js
+++ b/src/mixins/click-awayable.js
@@ -22,7 +22,7 @@ module.exports = {
     if (event.target !== el &&
         !Dom.isDescendant(el, event.target) &&
         document.documentElement.contains(event.target)) {
-      if (this.componentClickAway) this.componentClickAway();
+      if (this.componentClickAway) this.componentClickAway(event);
     }
   },
 


### PR DESCRIPTION
Useful when you need to examine event data in other components.