### PR TITLE
Changed function names in context-pure mixin

### DIFF
--- a/src/buttons/flat-button-label.jsx
+++ b/src/buttons/flat-button-label.jsx
@@ -41,7 +41,7 @@ const FlatButtonLabel = React.createClass({
     this.setState({muiTheme: newMuiTheme});
   },
 
-  getContextProps() {
+  getRelevantContextKeys() {
     const theme = this.state.muiTheme;
 
     return {
@@ -55,11 +55,11 @@ const FlatButtonLabel = React.createClass({
       style,
     } = this.props;
 
-    const contextProps = this.getContextProps();
+    const contextKeys = this.getRelevantContextKeys();
 
     const mergedRootStyles = Styles.mergeAndPrefix({
       position: 'relative',
-      padding: '0 ' + contextProps.spacingDesktopGutterLess + 'px',
+      padding: '0 ' + contextKeys.spacingDesktopGutterLess + 'px',
     }, style);
 
     return (

--- a/src/card/card-expandable.jsx
+++ b/src/card/card-expandable.jsx
@@ -11,9 +11,9 @@ const CardExpandable = React.createClass({
   mixins: [StylePropable],
 
   getStyles() {
-    const contextProps = this.getContextProps();
+    const contextKeys = this.getRelevantContextKeys();
 
-    const directionStyle = contextProps.isRtl ? {
+    const directionStyle = contextKeys.isRtl ? {
       left: 4,
     } : {
       right: 4,
@@ -49,7 +49,7 @@ const CardExpandable = React.createClass({
     };
   },
 
-  getContextProps() {
+  getRelevantContextKeys() {
     const theme = this.state.muiTheme;
 
     return {

--- a/src/flat-button.jsx
+++ b/src/flat-button.jsx
@@ -78,7 +78,7 @@ const FlatButton = React.createClass({
     this.setState({muiTheme: newMuiTheme});
   },
 
-  getContextProps() {
+  getRelevantContextKeys() {
     const theme = this.state.muiTheme;
     const buttonTheme = theme.button;
     const flatButtonTheme = theme.flatButton;
@@ -115,12 +115,12 @@ const FlatButton = React.createClass({
       ...other,
       } = this.props;
 
-    const contextProps = this.getContextProps();
+    const contextKeys = this.getRelevantContextKeys();
 
-    const defaultColor = disabled ? contextProps.disabledTextColor :
-      primary ? contextProps.primaryTextColor :
-      secondary ? contextProps.secondaryTextColor :
-      contextProps.textColor;
+    const defaultColor = disabled ? contextKeys.disabledTextColor :
+      primary ? contextKeys.primaryTextColor :
+      secondary ? contextKeys.secondaryTextColor :
+      contextKeys.textColor;
 
     const defaultHoverColor = ColorManipulator.fade(ColorManipulator.lighten(defaultColor, 0.4), 0.15);
     const defaultRippleColor = ColorManipulator.fade(defaultColor, 0.8);
@@ -133,15 +133,15 @@ const FlatButton = React.createClass({
       transition: Transitions.easeOut(),
       fontSize: Typography.fontStyleButtonFontSize,
       letterSpacing: 0,
-      textTransform: contextProps.textTransform,
+      textTransform: contextKeys.textTransform,
       fontWeight: Typography.fontWeightMedium,
       borderRadius: 2,
       userSelect: 'none',
       position: 'relative',
       overflow: 'hidden',
-      backgroundColor: hovered ? buttonHoverColor : contextProps.buttonColor,
-      lineHeight: contextProps.buttonHeight + 'px',
-      minWidth: contextProps.buttonMinWidth,
+      backgroundColor: hovered ? buttonHoverColor : contextKeys.buttonColor,
+      lineHeight: contextKeys.buttonHeight + 'px',
+      minWidth: contextKeys.buttonMinWidth,
       padding: 0,
       margin: 0,
       //This is need so that ripples do not bleed past border radius.

--- a/src/mixins/context-pure.js
+++ b/src/mixins/context-pure.js
@@ -1,27 +1,28 @@
 const shallowEqual = require('../utils/shallow-equal');
 
-function contextPropsEqual(classObject, currentContext, nextContext) {
+function relevantContextKeysEqual(classObject, currentContext, nextContext) {
 
-  //Check if current object's context props changed
-  if (classObject.getContextProps) {
-    const currentContextProps = classObject.getContextProps(currentContext);
-    const nextContextProps = classObject.getContextProps(nextContext);
-    if (!shallowEqual(currentContextProps, nextContextProps)) {
+  //Get those keys from current object's context that we care
+  //about and check whether those keys have changed or not
+  if (classObject.getRelevantContextKeys) {
+    const currentContextKeys = classObject.getRelevantContextKeys(currentContext);
+    const nextContextKeys = classObject.getRelevantContextKeys(nextContext);
+    if (!shallowEqual(currentContextKeys, nextContextKeys)) {
       return false;
     }
   }
 
-  //Check if children context props changed
+  //Check if children context keys changed
   if (classObject.getChildrenClasses) {
     const childrenArray = classObject.getChildrenClasses();
     for (let i = 0; i < childrenArray.length; i++) {
-      if (!contextPropsEqual(childrenArray[i], currentContext, nextContext)) {
+      if (!relevantContextKeysEqual(childrenArray[i], currentContext, nextContext)) {
         return false;
       }
     }
   }
 
-  //Props are equal
+  //context keys are equal
   return true;
 }
 
@@ -38,7 +39,7 @@ module.exports = {
     return (
       !shallowEqual(this.props, nextProps) ||
       !shallowEqual(this.state, nextState) ||
-      (!staticTheme && !contextPropsEqual(this.constructor, this.context, nextContext))
+      (!staticTheme && !relevantContextKeysEqual(this.constructor, this.context, nextContext))
     );
   },
 

--- a/src/text-field.jsx
+++ b/src/text-field.jsx
@@ -69,7 +69,7 @@ const TextField = React.createClass({
     };
   },
 
-  getContextProps() {
+  getRelevantContextKeys() {
     const theme = this.state.muiTheme;
 
     return {
@@ -125,7 +125,7 @@ const TextField = React.createClass({
   getStyles() {
     let props = this.props;
     let theme = this.getTheme();
-    const contextProps = this.getContextProps();
+    const contextKeys = this.getRelevantContextKeys();
 
     let styles = {
       root: {
@@ -204,7 +204,7 @@ const TextField = React.createClass({
       bottom: 'none',
       opacity: 1,
       transform: 'scale(1) translate3d(0, 0, 0)',
-      transformOrigin: contextProps.isRtl ? 'right top' : 'left top',
+      transformOrigin: contextKeys.isRtl ? 'right top' : 'left top',
     });
 
     styles.textarea = this.mergeStyles(styles.input, {

--- a/test/mixin-context-pure-spec.js
+++ b/test/mixin-context-pure-spec.js
@@ -14,7 +14,7 @@ const GrandChildComponent = React.createClass({
   },
 
   statics: {
-    getContextProps(context) {
+    getRelevantContextKeys(context) {
       return {
         grandChildThemeProp: context.muiTheme.grandChildThemeProp,
       }
@@ -47,7 +47,7 @@ const ChildComponent = React.createClass({
   },
 
   statics: {
-    getContextProps(context) {
+    getRelevantContextKeys(context) {
       return {
         childThemeProp: context.muiTheme.childThemeProp,
       }
@@ -137,14 +137,14 @@ const ParentComponent = React.createClass({
     this.refs.child.updateState(childState);
   },
 
-  updateChildContextProp(childThemeProp) {
+  updateChildContextKey(childThemeProp) {
     this.theme = update(this.theme, {
       childThemeProp: { $set: childThemeProp },
     });
     this.forceUpdate();
   },
 
-  updateGrandChildContextProp(grandChildThemeProp) {
+  updateGrandChildContextKey(grandChildThemeProp) {
     this.theme = update(this.theme, {
       grandChildThemeProp: { $set: grandChildThemeProp },
     });
@@ -170,7 +170,7 @@ describe('Mixin-ContextPure', () => {
     });
 
     it('should not render when context is updated but did not change', () => {
-      parentElement.updateChildContextProp(0);
+      parentElement.updateChildContextKey(0);
       parentElement.getRenderCount().should.equal(2);
       parentElement.getChildRenderCount().should.equal(1);
       parentElement.getGrandChildRenderCount().should.equal(1);
@@ -191,7 +191,7 @@ describe('Mixin-ContextPure', () => {
     });
 
     it('should render when context props change', () => {
-      parentElement.updateChildContextProp(1);
+      parentElement.updateChildContextKey(1);
       parentElement.getRenderCount().should.equal(2);
       parentElement.getChildRenderCount().should.equal(2);
       parentElement.getGrandChildRenderCount().should.equal(1);
@@ -212,7 +212,7 @@ describe('Mixin-ContextPure', () => {
     });
 
     it('should render grandchild when grandchild context props change', () => {
-      parentElement.updateGrandChildContextProp(1);
+      parentElement.updateGrandChildContextKey(1);
       parentElement.getRenderCount().should.equal(2);
       parentElement.getChildRenderCount().should.equal(2);
       parentElement.getGrandChildRenderCount().should.equal(2);
@@ -228,7 +228,7 @@ describe('Mixin-ContextPure', () => {
     });
 
     it('should not render when context is updated but did not change', () => {
-      parentElement.updateChildContextProp(1);
+      parentElement.updateChildContextKey(1);
       parentElement.getRenderCount().should.equal(2);
       parentElement.getChildRenderCount().should.equal(1);
       parentElement.getGrandChildRenderCount().should.equal(1);
@@ -249,14 +249,14 @@ describe('Mixin-ContextPure', () => {
     });
 
     it('should not render when context props change', () => {
-      parentElement.updateChildContextProp(1);
+      parentElement.updateChildContextKey(1);
       parentElement.getRenderCount().should.equal(2);
       parentElement.getChildRenderCount().should.equal(1);
       parentElement.getGrandChildRenderCount().should.equal(1);
     });
 
     it('should not render grandchild when grandchild context props change', () => {
-      parentElement.updateGrandChildContextProp(1);
+      parentElement.updateGrandChildContextKey(1);
       parentElement.getRenderCount().should.equal(2);
       parentElement.getChildRenderCount().should.equal(1);
       parentElement.getGrandChildRenderCount().should.equal(1);


### PR DESCRIPTION
Changed getContextProps() to getRelevantContextKeys()
Changed contextPropsEqual() to relevantContextKeysEqual()

Also updated function calls throughout source code.

Related to callemall/material-ui#1397