### PR TITLE
ipad enhanced textarea fix

### DIFF
--- a/src/enhanced-textarea.jsx
+++ b/src/enhanced-textarea.jsx
@@ -19,10 +19,11 @@ const styles = {
     // Overflow also needed to here to remove the extra row
     // added to textareas in Firefox.
     overflow: 'hidden',
+    // Visibility needed to hide the extra text area on ipads
+    visibility: 'hidden',
     font: 'inherit',
     padding: 0,
     position: 'absolute',
-    opacity: 0,
   },
 };
 


### PR DESCRIPTION
We noticed a bug were the shadow text area was appearing as selectable on the ipad. Fixed by changing the top properity of the shadow text area.