### PR TITLE
Fix for issue #1722. Fix for time picker display covering the entire display and not showing the clock.

### DIFF
--- a/src/date-picker/calendar.jsx
+++ b/src/date-picker/calendar.jsx
@@ -95,7 +95,7 @@ const Calendar = React.createClass({
         height: isLandscape ?
           weekCount === 5 ? 238 :
           weekCount === 6 ? 278 :
-          198 : '100%',
+          198 : 64,
         float: isLandscape ? 'left' : 'none',
       },
       weekTitle: {

--- a/src/time-picker/time-display.jsx
+++ b/src/time-picker/time-display.jsx
@@ -89,7 +89,7 @@ const TimeDisplay = React.createClass({
         textAlign: "center",
         position: "relative",
         width: 280,
-        height: "100%",
+        height: 102,
       },
 
       time: {


### PR DESCRIPTION
Time Picker issue screenshot:
<img width="1269" alt="screen shot 2015-09-25 at 4 08 23 pm" src="https://cloud.githubusercontent.com/assets/5900191/10111133/cfb9488a-639f-11e5-822b-fab2da590421.png">

Date picker issue screenshot:
<img width="1268" alt="screen shot 2015-09-25 at 4 09 17 pm" src="https://cloud.githubusercontent.com/assets/5900191/10111139/dc9de6fa-639f-11e5-9382-5017680e57e1.png">

