### PR TITLE
[theme-manager] fix react addons

### DIFF
--- a/src/styles/theme-manager.js
+++ b/src/styles/theme-manager.js
@@ -1,7 +1,7 @@
 const Colors = require('./colors');
 const ColorManipulator = require('../utils/color-manipulator');
 const Extend = require('../utils/extend');
-const update = require('react').addons.update;
+const update = require('react/lib/update');
 
 module.exports = {
   


### PR DESCRIPTION
`.addons` is not defined when importing only `react`.