### PR TITLE
Don't animate multiLine TextField height while mounting.

### DIFF
--- a/src/text-field.jsx
+++ b/src/text-field.jsx
@@ -109,6 +109,11 @@ const TextField = React.createClass({
 
   componentDidMount() {
     this._uniqueId = UniqueId.generate();
+    this._mounted = true;
+  },
+
+  componentWillUnmount() {
+    this._mounted = false;
   },
 
   componentWillReceiveProps(nextProps, nextContext) {
@@ -160,7 +165,7 @@ const TextField = React.createClass({
         display: 'inline-block',
         position: 'relative',
         fontFamily: this.state.muiTheme.rawTheme.fontFamily,
-        transition: this.isMounted() ? Transitions.easeOut('200ms', 'height') : '',
+        transition: this._mounted ? Transitions.easeOut('200ms', 'height') : '',
       },
       error: {
         position: 'relative',

--- a/src/text-field.jsx
+++ b/src/text-field.jsx
@@ -160,7 +160,7 @@ const TextField = React.createClass({
         display: 'inline-block',
         position: 'relative',
         fontFamily: this.state.muiTheme.rawTheme.fontFamily,
-        transition: Transitions.easeOut('200ms', 'height'),
+        transition: this.isMounted() ? Transitions.easeOut('200ms', 'height') : '',
       },
       error: {
         position: 'relative',


### PR DESCRIPTION
When a `multiLine` `TextField` has an initial value longer than a single line the element mounts as a single line and then animates the change in height to the full text height as it's matched to the shadow text area. 

For one it looks a bit weird, but it also causes problems when reading the container's height immediately after a mount since that uses the incorrect height of the text field at the start of said animation. My solution is to only enable the `transition` style once the component has mounted.