### PR TITLE
[DatePicker] Fix dialog open then close

### DIFF
--- a/src/date-picker/date-picker.jsx
+++ b/src/date-picker/date-picker.jsx
@@ -151,9 +151,12 @@ const DatePicker = React.createClass({
     if (this.props.onFocus) this.props.onFocus(e);
   },
 
-  _handleInputTouchTap(e) {
-    this.openDialog();
-    if (this.props.onTouchTap) this.props.onTouchTap(e);
+  _handleInputTouchTap: function _handleInputTouchTap(event) {
+    if (this.props.onTouchTap) this.props.onTouchTap(event);
+
+    setTimeout(() => {
+      this.openDialog();
+    }, 0);
   },
 
   _handleWindowKeyUp() {


### PR DESCRIPTION
This happen on a touch device on cordova on android.
The `touchTap` interaction open the dialog, then closed it.
Deferring the display of the modal solve the issue.