### PR TITLE
Rename "Item Three" to be more obvious

### DIFF
--- a/docs/src/app/components/pages/components/tabs.jsx
+++ b/docs/src/app/components/pages/components/tabs.jsx
@@ -177,7 +177,7 @@ class TabsPage extends React.Component {
               </div>
             </Tab>
             <Tab
-              label="Item Three"
+              label="Home (non-content example)"
               route="home"
               onActive={this._handleTabActive} />
           </Tabs>


### PR DESCRIPTION
Now it indicates what it is meant to do, so it doesn't look like a bug.