### PR TITLE
[Documentation] Comma clean up, add export default on es6 classes.

### DIFF
--- a/docs/src/app/components/app-left-nav.jsx
+++ b/docs/src/app/components/app-left-nav.jsx
@@ -14,7 +14,11 @@ let menuItems = [
   ];
 
 
-class AppLeftNav extends React.Component {
+export default class AppLeftNav extends React.Component {
+
+  static contextTypes = {
+    router: React.PropTypes.func
+  };
 
   constructor() {
     super();
@@ -81,9 +85,3 @@ class AppLeftNav extends React.Component {
   }
 
 }
-
-AppLeftNav.contextTypes = {
-  router: React.PropTypes.func
-};
-
-module.exports = AppLeftNav;

--- a/docs/src/app/components/code-example/code-block.jsx
+++ b/docs/src/app/components/code-example/code-block.jsx
@@ -11,18 +11,18 @@ const CodeBlock = React.createClass({
 
   //for passing default theme context to children
   childContextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object
   },
 
   getChildContext () {
     return {
-      muiTheme: this.state.muiTheme,
+      muiTheme: this.state.muiTheme
     };
   },
 
   getInitialState () {
     return {
-      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
+      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme)
     };
   },
 
@@ -35,11 +35,11 @@ const CodeBlock = React.createClass({
     var code = React.findDOMNode(this.refs.code);
     require([
       "codemirror/lib/codemirror.js",
-      "codemirror/mode/htmlmixed/htmlmixed.js",
+      "codemirror/mode/htmlmixed/htmlmixed.js"
     ], function(Codemirror){
       Codemirror.fromTextArea(code, {
         mode: "htmlmixed",
-        readOnly: true,
+        readOnly: true
       });
     });
   },
@@ -52,7 +52,7 @@ const CodeBlock = React.createClass({
     return (
       <textarea ref="code" value={this.props.children} readOnly={true}/>
     );
-  },
+  }
 });
 
 module.exports = CodeBlock;

--- a/docs/src/app/components/code-example/code-example.jsx
+++ b/docs/src/app/components/code-example/code-example.jsx
@@ -19,7 +19,7 @@ const CodeExample = React.createClass({
 
   propTypes : {
     code: React.PropTypes.string.isRequired,
-    layoutSideBySide: React.PropTypes.bool,
+    layoutSideBySide: React.PropTypes.bool
   },
 
   contextTypes : {
@@ -28,18 +28,18 @@ const CodeExample = React.createClass({
 
   //for passing default theme context to children
   childContextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object
   },
 
   getChildContext () {
     return {
-      muiTheme: this.state.muiTheme,
+      muiTheme: this.state.muiTheme
     };
   },
 
   getInitialState () {
     return {
-      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
+      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme)
     };
   },
 
@@ -74,14 +74,14 @@ const CodeExample = React.createClass({
         lineHeight: '20px',
         letterSpacing: 0,
         textTransform: 'uppercase',
-        fontWeight: Typography.fontWeightMedium,
+        fontWeight: Typography.fontWeightMedium
       },
       exampleBlock: {
         borderRadius: '0 0 2px 0',
         padding: Spacing.desktopGutter,
         margin: 0,
         width: layoutSideBySide ? '45%' : null,
-        float: layoutSideBySide ? 'right' : null,
+        float: layoutSideBySide ? 'right' : null
       }
     };
 

--- a/docs/src/app/components/component-doc.jsx
+++ b/docs/src/app/components/component-doc.jsx
@@ -26,18 +26,18 @@ const ComponentDoc = React.createClass({
 
   //for passing default theme context to children
   childContextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object
   },
 
   getChildContext () {
     return {
-      muiTheme: this.state.muiTheme,
+      muiTheme: this.state.muiTheme
     };
   },
 
   getInitialState () {
     return {
-      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
+      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme)
     };
   },
 

--- a/docs/src/app/components/component-info.jsx
+++ b/docs/src/app/components/component-info.jsx
@@ -21,18 +21,18 @@ const ComponentInfo = React.createClass({
 
   //for passing default theme context to children
   childContextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object
   },
 
   getChildContext () {
     return {
-      muiTheme: this.state.muiTheme,
+      muiTheme: this.state.muiTheme
     };
   },
 
   getInitialState () {
     return {
-      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
+      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme)
     };
   },
 

--- a/docs/src/app/components/pages/components.jsx
+++ b/docs/src/app/components/pages/components.jsx
@@ -28,7 +28,7 @@ class Components extends React.Component {
       { route: 'tabs', text: 'Tabs'},
       { route: 'text-fields', text: 'Text Fields'},
       { route: 'time-picker', text: 'Time Picker'},
-      { route: 'toolbars', text: 'Toolbars'},
+      { route: 'toolbars', text: 'Toolbars'}
     ];
 
     return (

--- a/docs/src/app/components/pages/components/app-bar.jsx
+++ b/docs/src/app/components/pages/components/app-bar.jsx
@@ -10,7 +10,7 @@ const IconMenu = require('menus/icon-menu');
 const MenuItem = require('menus/menu-item');
 const MoreVertIcon = require('svg-icons/navigation/more-vert');
 
-class AppBarPage extends React.Component {
+export default class AppBarPage extends React.Component {
 
   constructor(props) {
     super(props);
@@ -141,5 +141,3 @@ class AppBarPage extends React.Component {
   }
 
 }
-
-module.exports = AppBarPage;

--- a/docs/src/app/components/pages/components/avatars.jsx
+++ b/docs/src/app/components/pages/components/avatars.jsx
@@ -7,7 +7,7 @@ let Code = require('avatars-code');
 let CodeExample = require('../../code-example/code-example');
 
 
-class AvatarsPage extends React.Component {
+export default class AvatarsPage extends React.Component {
 
   render() {
 
@@ -52,7 +52,7 @@ class AvatarsPage extends React.Component {
             type: 'object',
             header: 'optional',
             desc: 'Override the inline-styles of the root element.'
-          },
+          }
         ]
       }
     ];
@@ -87,5 +87,3 @@ class AvatarsPage extends React.Component {
   }
 
 }
-
-module.exports = AvatarsPage;

--- a/docs/src/app/components/pages/components/buttons.jsx
+++ b/docs/src/app/components/pages/components/buttons.jsx
@@ -22,7 +22,7 @@ let FlatButtonCode = require('flat-button-code');
 let CodeExample = require('../../code-example/code-example');
 
 
-class ButtonPage extends React.Component {
+export default class ButtonPage extends React.Component {
 
   constructor(props) {
     super(props);
@@ -463,5 +463,3 @@ class ButtonPage extends React.Component {
   }
 
 }
-
-module.exports = ButtonPage;

--- a/docs/src/app/components/pages/components/cards.jsx
+++ b/docs/src/app/components/pages/components/cards.jsx
@@ -16,7 +16,7 @@ let {
 } = mui;
 let Code = require('cards-code');
 
-class CardPage extends React.Component {
+export default class CardPage extends React.Component {
 
   constructor(props) {
     super(props);
@@ -40,9 +40,9 @@ class CardPage extends React.Component {
             name: 'initiallyExpanded',
             type: 'bool',
             header: 'optional',
-            desc: 'Whether this card is initially expanded.',
-          },
-        ],
+            desc: 'Whether this card is initially expanded.'
+          }
+        ]
       },
       {
         name: 'Props',
@@ -51,7 +51,7 @@ class CardPage extends React.Component {
             name: 'expandable',
             type: 'bool',
             header: 'optional',
-            desc: 'Whether this card component is expandable. Can be set on any child of the Card component.',
+            desc: 'Whether this card component is expandable. Can be set on any child of the Card component.'
           },
           {
             name: 'showExpandableButton',
@@ -59,9 +59,9 @@ class CardPage extends React.Component {
             header: 'optional',
             desc: 'Whether this card component include a button to expand the card. CardTitle, CardHeader ' +
                   'and CardActions implement showExpandableButton. Any child component of Card can implements ' +
-                  'showExpandableButton or forwards the property to a child component supporting it.',
-          },
-        ],
+                  'showExpandableButton or forwards the property to a child component supporting it.'
+          }
+        ]
       },
       {
         name: 'Card.Events',
@@ -71,9 +71,9 @@ class CardPage extends React.Component {
             type: 'function(isExpanded)',
             header: 'optional',
             desc: 'Fired when the expandable state changes.'
-          },
-        ],
-      },
+          }
+        ]
+      }
     ];
   }
 
@@ -139,5 +139,3 @@ class CardPage extends React.Component {
   }
 
 }
-
-module.exports = CardPage;

--- a/docs/src/app/components/pages/components/date-picker.jsx
+++ b/docs/src/app/components/pages/components/date-picker.jsx
@@ -5,7 +5,8 @@ let Code = require('date-picker-code');
 let CodeExample = require('../../code-example/code-example');
 
 
-class DatePickerPage extends React.Component {
+export default class DatePickerPage extends React.Component {
+
   constructor(props) {
     super(props);
 
@@ -133,7 +134,7 @@ class DatePickerPage extends React.Component {
             'changes. Since there is no particular event associated with ' +
             'the change the first argument will always be null and the second ' +
             'argument will be the new Date instance.'
-          },
+          }
         ]
       }
     ];
@@ -196,7 +197,6 @@ class DatePickerPage extends React.Component {
       </ComponentDoc>
     );
   }
-
   _updateMinDate(e) {
     this.setState({
       minDate: new Date(e.target.value)
@@ -219,5 +219,3 @@ class DatePickerPage extends React.Component {
     this.setState({controlledDate: date});
   }
 }
-
-module.exports = DatePickerPage;

--- a/docs/src/app/components/pages/components/dialog.jsx
+++ b/docs/src/app/components/pages/components/dialog.jsx
@@ -5,7 +5,7 @@ let Code = require('dialog-code');
 let CodeExample = require('../../code-example/code-example');
 
 
-class DialogPage extends React.Component {
+export default class DialogPage extends React.Component {
 
   constructor() {
     super();
@@ -246,5 +246,3 @@ class DialogPage extends React.Component {
   }
 
 }
-
-module.exports = DialogPage;

--- a/docs/src/app/components/pages/components/drop-down-menu.jsx
+++ b/docs/src/app/components/pages/components/drop-down-menu.jsx
@@ -5,7 +5,7 @@ let Code = require('drop-down-menu-code');
 let CodeExample = require('../../code-example/code-example');
 
 
-class DropDownMenuPage extends React.Component {
+export default class DropDownMenuPage extends React.Component {
 
   render() {
 
@@ -14,7 +14,7 @@ class DropDownMenuPage extends React.Component {
       { payload: '2', text: 'Every Night' },
       { payload: '3', text: 'Weeknights' },
       { payload: '4', text: 'Weekends' },
-      { payload: '5', text: 'Weekly' },
+      { payload: '5', text: 'Weekly' }
     ];
 
     let componentInfo = [
@@ -119,5 +119,3 @@ class DropDownMenuPage extends React.Component {
   }
 
 }
-
-module.exports = DropDownMenuPage;

--- a/docs/src/app/components/pages/components/icon-buttons.jsx
+++ b/docs/src/app/components/pages/components/icon-buttons.jsx
@@ -7,7 +7,7 @@ let Code = require('icon-buttons-code');
 let CodeExample = require('../../code-example/code-example');
 
 
-class IconButtonsPage extends React.Component {
+export default class IconButtonsPage extends React.Component {
 
   render() {
 
@@ -167,5 +167,3 @@ class IconButtonsPage extends React.Component {
   }
 
 }
-
-module.exports = IconButtonsPage;

--- a/docs/src/app/components/pages/components/icon-menus.jsx
+++ b/docs/src/app/components/pages/components/icon-menus.jsx
@@ -18,7 +18,7 @@ let Code = require('icon-menus-code');
 let CodeExample = require('../../code-example/code-example');
 
 
-class IconMenus extends React.Component {
+export default class IconMenus extends React.Component {
 
   constructor(props) {
     super(props);
@@ -106,7 +106,7 @@ class IconMenus extends React.Component {
             type: 'number',
             header: 'default: 200',
             desc: 'Sets the delay in milliseconds before closing the menu when an item is clicked.'
-          },
+          }
         ]
       },
       {
@@ -523,5 +523,3 @@ class IconMenus extends React.Component {
   }
 
 }
-
-module.exports = IconMenus;

--- a/docs/src/app/components/pages/components/icons.jsx
+++ b/docs/src/app/components/pages/components/icons.jsx
@@ -10,7 +10,7 @@ let SvgIconsCode = require('svg-icons-code');
 let CodeExample = require('../../code-example/code-example');
 
 
-class FontIconPage extends React.Component {
+export default class FontIconPage extends React.Component {
 
   getStyles() {
     return {
@@ -93,7 +93,7 @@ class FontIconPage extends React.Component {
             header: 'optional',
             desc: 'This is the icon color when the mouse hovers over the icon.'
           }
-        ],
+        ]
       }
     ];
 
@@ -145,5 +145,3 @@ class FontIconPage extends React.Component {
   }
 
 }
-
-module.exports = FontIconPage;

--- a/docs/src/app/components/pages/components/left-nav.jsx
+++ b/docs/src/app/components/pages/components/left-nav.jsx
@@ -5,7 +5,7 @@ let Code = require('left-nav-code');
 let CodeExample = require('../../code-example/code-example');
 
 
-class LeftNavPage extends React.Component {
+export default class LeftNavPage extends React.Component {
 
   constructor() {
     super();
@@ -165,5 +165,3 @@ class LeftNavPage extends React.Component {
   }
 
 }
-
-module.exports = LeftNavPage;

--- a/docs/src/app/components/pages/components/lists.jsx
+++ b/docs/src/app/components/pages/components/lists.jsx
@@ -35,7 +35,7 @@ let CodeExample = require('../../code-example/code-example');
 
 
 
-class ListsPage extends React.Component {
+export default class ListsPage extends React.Component {
 
   constructor() {
     super();
@@ -210,7 +210,7 @@ class ListsPage extends React.Component {
             type: 'function(event)',
             header: 'optional',
             desc: 'Called when a touch tap event occures on the component.'
-          },
+          }
         ]
       }
     ];
@@ -374,9 +374,9 @@ class ListsPage extends React.Component {
                     primaryText="Sent Mail"
                     leftIcon={<ContentSend />}
                     nestedItems={[
-                      <ListItem primaryText="Drafts" leftIcon={<ContentDrafts />} />,
+                      <ListItem primaryText="Drafts" leftIcon={<ContentDrafts />} />
                     ]}
-                  />,
+                  />
                 ]}
               />
             </List>
@@ -648,5 +648,3 @@ class ListsPage extends React.Component {
   }
 
 }
-
-module.exports = ListsPage;

--- a/docs/src/app/components/pages/components/menus.jsx
+++ b/docs/src/app/components/pages/components/menus.jsx
@@ -16,7 +16,7 @@ let Code = require('menus-code');
 let CodeExample = require('../../code-example/code-example');
 
 
-class MenusPage extends React.Component {
+export default class MenusPage extends React.Component {
 
   render() {
 
@@ -313,5 +313,3 @@ class MenusPage extends React.Component {
   }
 
 }
-
-module.exports = MenusPage;

--- a/docs/src/app/components/pages/components/progress.jsx
+++ b/docs/src/app/components/pages/components/progress.jsx
@@ -67,7 +67,7 @@ let ProgressPage = React.createClass({
             desc: 'The size of the progress.'
           }
         ]
-      },
+      }
     ];
 
 

--- a/docs/src/app/components/pages/components/refresh-indicator.jsx
+++ b/docs/src/app/components/pages/components/refresh-indicator.jsx
@@ -48,9 +48,9 @@ let RefreshIndicatorPage = React.createClass({
             type: 'number',
             header: 'required',
             desc: 'The absolute right position of the indicator in pixels.'
-          },
+          }
         ]
-      },
+      }
     ];
 
 

--- a/docs/src/app/components/pages/components/sliders.jsx
+++ b/docs/src/app/components/pages/components/sliders.jsx
@@ -5,7 +5,7 @@ let Code = require('sliders-code');
 let CodeExample = require('../../code-example/code-example');
 
 
-class SlidersPage extends React.Component {
+export default class SlidersPage extends React.Component {
 
   handleMouseDown(e) {
     console.log('hmd', e);
@@ -84,7 +84,7 @@ class SlidersPage extends React.Component {
             type: 'number',
             header: 'optional',
             desc: 'The value of the slider.'
-          },
+          }
         ]
       },
       {
@@ -120,9 +120,9 @@ class SlidersPage extends React.Component {
             type: 'function(e)',
             header: 'optional',
             desc: 'Callback fired when the user has focused on the slider.'
-          },
+          }
         ]
-      },
+      }
     ];
 
     return (
@@ -142,5 +142,3 @@ class SlidersPage extends React.Component {
   }
 
 }
-
-module.exports = SlidersPage;

--- a/docs/src/app/components/pages/components/snackbar.jsx
+++ b/docs/src/app/components/pages/components/snackbar.jsx
@@ -5,7 +5,7 @@ let Code = require('snackbars-code');
 let CodeExample = require('../../code-example/code-example');
 
 
-class SnackbarPage extends React.Component {
+export default class SnackbarPage extends React.Component {
 
   constructor() {
     super();
@@ -136,5 +136,3 @@ class SnackbarPage extends React.Component {
   }
 
 }
-
-module.exports = SnackbarPage;

--- a/docs/src/app/components/pages/components/switches.jsx
+++ b/docs/src/app/components/pages/components/switches.jsx
@@ -22,7 +22,7 @@ let RadioButtonCode = require('radio-buttons-code');
 let ToggleCode = require('toggle-code');
 
 
-class SwitchesPage extends React.Component {
+export default class SwitchesPage extends React.Component {
 
   constructor(props) {
     super(props);
@@ -315,7 +315,7 @@ class SwitchesPage extends React.Component {
           desc: 'Callback function that is fired when the toggle switch is toggled.'
         }
       ]
-    },
+    }
     ];
   }
 
@@ -497,5 +497,3 @@ class SwitchesPage extends React.Component {
     console.log('Selected: ', selected);
   }
 }
-
-module.exports = SwitchesPage;

--- a/docs/src/app/components/pages/components/table.jsx
+++ b/docs/src/app/components/pages/components/table.jsx
@@ -17,7 +17,7 @@ let {
 let Code = require('table-code');
 
 
-class TablePage extends React.Component {
+export default class TablePage extends React.Component {
 
   constructor(props) {
     super(props);
@@ -86,7 +86,7 @@ class TablePage extends React.Component {
             header: 'optional',
             desc: 'If true, table rows can be selected. If multiple row selection is desired, enable multiSelectable. ' +
               'The default value is true.'
-          },
+          }
         ]
       },
       {
@@ -119,7 +119,7 @@ class TablePage extends React.Component {
             header: 'default: true',
             desc: 'If set to true the select all checkbox will be programmatically checked and will not trigger the select ' +
               'all event.'
-          },
+          }
         ]
       },
       {
@@ -176,7 +176,7 @@ class TablePage extends React.Component {
             type: 'boolean',
             header: 'optional',
             desc: 'If true, every other table row starting with the first row will be striped. The default value is false.'
-          },
+          }
         ]
       },
       {
@@ -189,7 +189,7 @@ class TablePage extends React.Component {
             desc: 'Controls whether or not header rows should be adjusted for a checkbox column. If the select all checkbox ' +
               'is true, this property will not influence the number of columns. This is mainly useful for "super header" ' +
               'rows so that the checkbox column does not create an offset that needs to be accounted for manually.'
-          },
+          }
         ]
       },
       {
@@ -231,7 +231,7 @@ class TablePage extends React.Component {
             type: 'boolean',
             header: 'default: false',
             desc: 'Indicates whether or not the row is striped.'
-          },
+          }
         ]
       },
       {
@@ -271,7 +271,7 @@ class TablePage extends React.Component {
             type: 'boolean',
             header: 'default: false',
             desc: 'If true, this column responds to hover events.'
-          },
+          }
         ]
       },
       {
@@ -327,10 +327,10 @@ class TablePage extends React.Component {
             name: 'onSelectAll',
             type: 'function(checked)',
             header: 'optional',
-            desc: 'Called when the select all checkbox has been toggled.',
-          },
+            desc: 'Called when the select all checkbox has been toggled.'
+          }
         ]
-      },
+      }
     ];
 
     let propContainerStyle = {
@@ -495,5 +495,3 @@ class TablePage extends React.Component {
     console.log(rows);
   }
 }
-
-module.exports = TablePage;

--- a/docs/src/app/components/pages/components/tabs.jsx
+++ b/docs/src/app/components/pages/components/tabs.jsx
@@ -6,10 +6,14 @@ let { Colors, Typography } = Styles;
 let Code = require('tabs-code');
 
 
-class TabsPage extends React.Component {
+export default class TabsPage extends React.Component {
 
-  constructor() {
-    super();
+  static contextTypes = {
+    router: React.PropTypes.func
+  };
+
+  constructor(props) {
+    super(props);
     this._handleTabActive = this._handleTabActive.bind(this);
     this.state = {tabsValue: 'a'};
   }
@@ -60,7 +64,7 @@ class TabsPage extends React.Component {
             type: 'string or number',
             header: 'optional',
             desc: 'Makes Tabs controllable and selects the tab whose value prop matches this prop.'
-          },
+          }
         ]
       },
       {
@@ -109,14 +113,14 @@ class TabsPage extends React.Component {
 
     let styles = {
       contentContainerStyle: {
-        marginLeft: -padding,
+        marginLeft: -padding
       },
       div: {
         position: 'absolute',
         left: 48,
         backgroundColor: Colors.cyan500,
         width: padding,
-        height: 48,
+        height: 48
       },
       headline: {
         fontSize: 24,
@@ -125,25 +129,25 @@ class TabsPage extends React.Component {
         marginBottom: 12,
         letterSpacing: 0,
         fontWeight: Typography.fontWeightNormal,
-        color: Typography.textDarkBlack,
+        color: Typography.textDarkBlack
       },
       iconButton: {
         position: 'absolute',
         left: 0,
         backgroundColor: Colors.cyan500,
         color: 'white',
-        marginRight: padding,
+        marginRight: padding
       },
       iconStyle: {
-        color: Colors.white,
+        color: Colors.white
       },
       tabs: {
-        position: 'relative',
+        position: 'relative'
       },
       tabsContainer: {
         position: 'relative',
-        paddingLeft: padding,
-      },
+        paddingLeft: padding
+      }
     };
 
     return (
@@ -234,13 +238,7 @@ class TabsPage extends React.Component {
     this.context.router.transitionTo(tab.props.route);
   }
 
-  _handleTabsChange(value, e, tab){
+  _handleTabsChange(value, tab){
     this.setState({tabsValue: value});
   }
 }
-
-TabsPage.contextTypes = {
-  router: React.PropTypes.func
-};
-
-module.exports = TabsPage;

--- a/docs/src/app/components/pages/components/text-fields.jsx
+++ b/docs/src/app/components/pages/components/text-fields.jsx
@@ -202,7 +202,7 @@ let TextFieldsPage = React.createClass({
             header: 'function(e)',
             desc: 'Callback function that is fired when the textfield gains ' +
                   'focus.'
-          },
+          }
         ]
       }
     ];
@@ -213,7 +213,7 @@ let TextFieldsPage = React.createClass({
       { payload: '2', text: 'Every Night' },
       { payload: '3', text: 'Weeknights' },
       { payload: '4', text: 'Weekends' },
-      { payload: '5', text: 'Weekly' },
+      { payload: '5', text: 'Weekly' }
     ];
     let arbitraryArrayMenuItems = [
       {id:1, name:'Never'},

--- a/docs/src/app/components/pages/components/toolbars.jsx
+++ b/docs/src/app/components/pages/components/toolbars.jsx
@@ -16,7 +16,7 @@ let Code = require('toolbars-code');
 let CodeExample = require('../../code-example/code-example');
 
 
-class ToolbarPage extends React.Component {
+export default class ToolbarPage extends React.Component {
 
   render() {
 
@@ -25,7 +25,7 @@ class ToolbarPage extends React.Component {
                'appBars. AppBars are a subset of toolbars. The following ' +
                'toolbar components can help organize your layout. Note that ' +
                'every component listed here (including Toolbar) have a style ' +
-               'prop which overrides the inline-styles of their root element.'
+               'prop which overrides the inline-styles of their root element.';
 
     let componentInfo = [
       {
@@ -69,7 +69,7 @@ class ToolbarPage extends React.Component {
               desc: 'The text to be displayed for the element.'
             }
           ]
-      },
+      }
     ];
 
     let filterOptions = [
@@ -79,7 +79,7 @@ class ToolbarPage extends React.Component {
       { payload: '4', text: 'Complete Voice' },
       { payload: '5', text: 'Complete Text' },
       { payload: '6', text: 'Active Voice' },
-      { payload: '7', text: 'Active Text' },
+      { payload: '7', text: 'Active Text' }
     ];
     let iconMenuItems = [
       { payload: '1', text: 'Download' },
@@ -110,5 +110,3 @@ class ToolbarPage extends React.Component {
   }
 
 }
-
-module.exports = ToolbarPage;

--- a/docs/src/app/components/pages/customization/inline-styles.jsx
+++ b/docs/src/app/components/pages/customization/inline-styles.jsx
@@ -125,7 +125,7 @@ const InlineStyles = React.createClass({
 
       </div>
     );
-  },
+  }
 
 });
 

--- a/docs/src/app/components/pages/customization/themes.jsx
+++ b/docs/src/app/components/pages/customization/themes.jsx
@@ -45,12 +45,12 @@ const ThemesPage = React.createClass({
 
   //for passing default theme context to children
   childContextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object
   },
 
   getChildContext () {
     return {
-      muiTheme: this.state.muiTheme,
+      muiTheme: this.state.muiTheme
     };
   },
 
@@ -125,7 +125,7 @@ const ThemesPage = React.createClass({
       liveExampleBlock: {
         borderRadius: '0 0 2px 0',
         padding: this.state.muiTheme.rawTheme.spacing.desktopGutter,
-        margin: 0,
+        margin: 0
       },
       headline: {
         fontSize: '24px',
@@ -138,7 +138,7 @@ const ThemesPage = React.createClass({
       },
       bottomBorderWrapper: {
         borderBottom: 'solid 1px ' + borderColor,
-        paddingBottom: '10px',
+        paddingBottom: '10px'
       },
       inlineCode: {
         backgroundColor: '#F8F8F8'
@@ -309,7 +309,7 @@ const ThemesPage = React.createClass({
             desc: 'Accepts two arguments: the current mui theme object and the new font family to be applied. ' +
                   'This function creates a new raw theme by overriding the font family of the existing raw theme, ' +
                   'and returns a new mui theme object calculated from the new raw theme'
-          },
+          }
         ]
       }
     ];
@@ -639,19 +639,19 @@ const ThemesPage = React.createClass({
       isThemeDark: isDark});
   },
 
-  handleAction(e) {
+  handleAction() {
     this.refs.snackbar.dismiss();
   },
 
-  handleClickNav(e) {
+  handleClickNav() {
     this.refs.leftNav.toggle();
   },
 
-  handleClickSnackbar(e) {
+  handleClickSnackbar() {
     this.refs.snackbar.show();
   },
 
-  handleTouchTapDialog(e) {
+  handleTouchTapDialog() {
     this.refs.dialog.show();
   },
 

--- a/docs/src/app/components/pages/get-started/examples.jsx
+++ b/docs/src/app/components/pages/get-started/examples.jsx
@@ -13,18 +13,18 @@ const Examples = React.createClass({
 
   //for passing default theme context to children
   childContextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object
   },
 
   getChildContext () {
     return {
-      muiTheme: this.state.muiTheme,
+      muiTheme: this.state.muiTheme
     };
   },
 
   getInitialState () {
     return {
-      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
+      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme)
     };
   },
 
@@ -45,7 +45,7 @@ const Examples = React.createClass({
         letterSpacing: '0',
         fontWeight: Typography.fontWeightNormal,
         color: Typography.textDarkBlack
-      },
+      }
     };
   },
 
@@ -74,7 +74,7 @@ const Examples = React.createClass({
 
     </div>
     );
-  },
+  }
 
 });
 

--- a/docs/src/app/components/pages/get-started/installation.jsx
+++ b/docs/src/app/components/pages/get-started/installation.jsx
@@ -14,18 +14,18 @@ const Installation = React.createClass({
 
   //for passing default theme context to children
   childContextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object
   },
 
   getChildContext () {
     return {
-      muiTheme: this.state.muiTheme,
+      muiTheme: this.state.muiTheme
     };
   },
 
   getInitialState () {
     return {
-      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
+      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme)
     };
   },
 
@@ -62,7 +62,7 @@ const Installation = React.createClass({
       },
       inlineCode: {
         backgroundColor: '#F8F8F8'
-      },
+      }
     };
   },
 
@@ -164,7 +164,7 @@ const Installation = React.createClass({
 
       </div>
     );
-  },
+  }
 
 });
 

--- a/docs/src/app/components/pages/get-started/prerequisites.jsx
+++ b/docs/src/app/components/pages/get-started/prerequisites.jsx
@@ -14,18 +14,18 @@ const Prerequisites = React.createClass({
 
   //for passing default theme context to children
   childContextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object
   },
 
   getChildContext () {
     return {
-      muiTheme: this.state.muiTheme,
+      muiTheme: this.state.muiTheme
     };
   },
 
   getInitialState () {
     return {
-      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
+      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme)
     };
   },
 
@@ -152,7 +152,7 @@ const Prerequisites = React.createClass({
 
       </div>
     );
-  },
+  }
 
 });
 

--- a/docs/src/app/components/pages/home-feature.jsx
+++ b/docs/src/app/components/pages/home-feature.jsx
@@ -50,7 +50,7 @@ let HomeFeature = React.createClass({
       image: {
         //Not sure why this is needed but it fixes a display
         //issue in chrome
-        marginBottom: -6,
+        marginBottom: -6
       },
       heading: {
         fontSize: '20px',

--- a/docs/src/app/components/pages/home.jsx
+++ b/docs/src/app/components/pages/home.jsx
@@ -37,19 +37,19 @@ const HomePage = React.createClass({
     let styles = {
       root: {
         backgroundColor: Colors.cyan500,
-        overflow: 'hidden',
+        overflow: 'hidden'
       },
       svgLogo: {
         marginLeft: (window.innerWidth * 0.5) - 130 + 'px',
-        width: 420,
+        width: 420
       },
       tagline: {
         margin: '16px auto 0 auto',
         textAlign: 'center',
-        maxWidth: 575,
+        maxWidth: 575
       },
       label: {
-        color: DefaultRawTheme.palette.primary1Color,
+        color: DefaultRawTheme.palette.primary1Color
       },
       githubStyle: {
         margin: '16px 32px 0px 8px'
@@ -59,14 +59,14 @@ const HomePage = React.createClass({
       },
       h1: {
         color: Colors.darkWhite,
-        fontWeight: Typography.fontWeightLight,
+        fontWeight: Typography.fontWeightLight
       },
       h2: {
         fontSize: 20,
         lineHeight: '28px',
         paddingTop: 19,
         marginBottom: 13,
-        letterSpacing: 0,
+        letterSpacing: 0
       },
       nowrap: {
         whiteSpace: 'nowrap'
@@ -81,7 +81,7 @@ const HomePage = React.createClass({
         fontSize: 24,
         lineHeight: '32px',
         paddingTop: 16,
-        marginBottom: 12,
+        marginBottom: 12
       }
     };
 
@@ -130,7 +130,7 @@ const HomePage = React.createClass({
         paddingTop: 19,
         marginBottom: 13,
         letterSpacing: 0,
-        color: Typography.textDarkBlack,
+        color: Typography.textDarkBlack
       }
     };
 
@@ -178,13 +178,13 @@ const HomePage = React.createClass({
     let styles = {
       root: {
         backgroundColor: Colors.grey200,
-        textAlign: 'center',
+        textAlign: 'center'
       },
       h3: {
         margin: 0,
         padding: 0,
         fontWeight: Typography.fontWeightLight,
-        fontSize: 22,
+        fontSize: 22
       },
       button: {
         marginTop: 32


### PR DESCRIPTION
* Cleaning up trailing commas
* Removing ```module.export``` in favor for ```export default``` when using es6 classes.
* Moving contextTypes to a static inside classes when applicable