### PR TITLE
adding support for mouse events to IconMenu

### DIFF
--- a/src/menus/icon-menu.jsx
+++ b/src/menus/icon-menu.jsx
@@ -124,6 +124,10 @@ const IconMenu = React.createClass({
     let iconButton = React.cloneElement(iconButtonElement, {
       onKeyboardFocus: this.props.onKeyboardFocus,
       iconStyle: this.mergeStyles(iconStyle, iconButtonElement.props.iconStyle),
+      onMouseDown(e): => {
+        this.open(Events.isKeyboard(e));
+        if (iconButtonElement.props.onMouseDown) iconButtonElement.props.onMouseDown(e);
+      },
       onTouchTap: (e) => {
         this.open(Events.isKeyboard(e));
         if (iconButtonElement.props.onTouchTap) iconButtonElement.props.onTouchTap(e);

--- a/src/menus/icon-menu.jsx
+++ b/src/menus/icon-menu.jsx
@@ -124,7 +124,7 @@ const IconMenu = React.createClass({
     let iconButton = React.cloneElement(iconButtonElement, {
       onKeyboardFocus: this.props.onKeyboardFocus,
       iconStyle: this.mergeStyles(iconStyle, iconButtonElement.props.iconStyle),
-      onMouseDown(e): => {
+      onMouseDown: (e) => {
         this.open(Events.isKeyboard(e));
         if (iconButtonElement.props.onMouseDown) iconButtonElement.props.onMouseDown(e);
       },


### PR DESCRIPTION
I believe it was intended for this to work with mouse events as well as
touch events. In my project the mouse events were not working correctly
until I added this bit of code. I tested it when nested in a AppBar’s
iconElementRight and when on it’s own.