### PR TITLE
[Card] Expand on Click

### DIFF
--- a/docs/src/app/components/pages/components/cards.jsx
+++ b/docs/src/app/components/pages/components/cards.jsx
@@ -54,7 +54,7 @@ class CardPage extends React.Component {
             desc: 'Whether this card component is expandable. Can be set on any child of the Card component.',
           },
           {
-            name: 'expander',
+            name: 'actAsExpander',
             type: 'bool',
             header: 'optional',
             desc: 'Whether a click on this card component expands the card. ' +
@@ -121,7 +121,7 @@ class CardPage extends React.Component {
               title="Title"
               subtitle="Subtitle"
               avatar={<Avatar style={{color:'red'}}>A</Avatar>}
-              expander={true}
+              actAsExpander={true}
               showExpandableButton={true}>
             </CardHeader>
             <CardText expandable={true}>

--- a/docs/src/app/components/pages/components/cards.jsx
+++ b/docs/src/app/components/pages/components/cards.jsx
@@ -54,6 +54,13 @@ class CardPage extends React.Component {
             desc: 'Whether this card component is expandable. Can be set on any child of the Card component.',
           },
           {
+            name: 'expander',
+            type: 'bool',
+            header: 'optional',
+            desc: 'Whether a click on this card component expands the card. ' +
+                   'Can be set on any child of the Card component.',
+          },
+          {
             name: 'showExpandableButton',
             type: 'bool',
             header: 'optional',
@@ -114,6 +121,7 @@ class CardPage extends React.Component {
               title="Title"
               subtitle="Subtitle"
               avatar={<Avatar style={{color:'red'}}>A</Avatar>}
+              expander={true}
               showExpandableButton={true}>
             </CardHeader>
             <CardText expandable={true}>

--- a/docs/src/app/components/raw-code/cards-code.txt
+++ b/docs/src/app/components/raw-code/cards-code.txt
@@ -28,7 +28,7 @@
     title="Title"
     subtitle="Subtitle"
     avatar={<Avatar style={{color:'red'}}>A</Avatar>}
-    expander={true}
+    actAsExpander={true}
     showExpandableButton={true}>
   </CardHeader>
   <CardText expandable={true}>

--- a/docs/src/app/components/raw-code/cards-code.txt
+++ b/docs/src/app/components/raw-code/cards-code.txt
@@ -28,6 +28,7 @@
     title="Title"
     subtitle="Subtitle"
     avatar={<Avatar style={{color:'red'}}>A</Avatar>}
+    expander={true}
     showExpandableButton={true}>
   </CardHeader>
   <CardText expandable={true}>

--- a/src/card/card-actions.jsx
+++ b/src/card/card-actions.jsx
@@ -16,6 +16,7 @@ const CardActions = React.createClass({
 
   propTypes: {
     expandable: React.PropTypes.bool,
+    expander: React.PropTypes.bool,
     showExpandableButton: React.PropTypes.bool,
   },
 

--- a/src/card/card-actions.jsx
+++ b/src/card/card-actions.jsx
@@ -16,7 +16,7 @@ const CardActions = React.createClass({
 
   propTypes: {
     expandable: React.PropTypes.bool,
-    expander: React.PropTypes.bool,
+    actAsExpander: React.PropTypes.bool,
     showExpandableButton: React.PropTypes.bool,
   },
 

--- a/src/card/card-expandable.jsx
+++ b/src/card/card-expandable.jsx
@@ -93,7 +93,7 @@ const CardExpandable = React.createClass({
     let expandableBtn = (
       <IconButton
         style={mergedStyles}
-        onClick={this.props.onExpanding}>
+        onTouchTap={this.props.onExpanding}>
         {expandable}
       </IconButton>
     );

--- a/src/card/card-expandable.jsx
+++ b/src/card/card-expandable.jsx
@@ -79,13 +79,6 @@ const CardExpandable = React.createClass({
     this.setState({muiTheme: newMuiTheme});
   },
 
-  _onExpanding() {
-    if (this.props.expanded === true)
-      this.props.onExpanding(false);
-    else
-      this.props.onExpanding(true);
-  },
-
   render() {
     let styles = this.getStyles();
 
@@ -100,7 +93,7 @@ const CardExpandable = React.createClass({
     let expandableBtn = (
       <IconButton
         style={mergedStyles}
-        onClick={this._onExpanding}>
+        onClick={this.props.onExpanding}>
         {expandable}
       </IconButton>
     );

--- a/src/card/card-header.jsx
+++ b/src/card/card-header.jsx
@@ -17,6 +17,7 @@ const CardHeader = React.createClass({
     subtitleStyle: React.PropTypes.object,
     textStyle: React.PropTypes.object,
     expandable: React.PropTypes.bool,
+    expander: React.PropTypes.bool,
     showExpandableButton: React.PropTypes.bool,
   },
 

--- a/src/card/card-header.jsx
+++ b/src/card/card-header.jsx
@@ -17,7 +17,7 @@ const CardHeader = React.createClass({
     subtitleStyle: React.PropTypes.object,
     textStyle: React.PropTypes.object,
     expandable: React.PropTypes.bool,
-    expander: React.PropTypes.bool,
+    actAsExpander: React.PropTypes.bool,
     showExpandableButton: React.PropTypes.bool,
   },
 

--- a/src/card/card-media.jsx
+++ b/src/card/card-media.jsx
@@ -15,6 +15,7 @@ const CardMedia = React.createClass({
     overlayContentStyle: React.PropTypes.object,
     mediaStyle: React.PropTypes.object,
     expandable: React.PropTypes.bool,
+    expander: React.PropTypes.bool,
   },
 
   getStyles() {

--- a/src/card/card-media.jsx
+++ b/src/card/card-media.jsx
@@ -15,7 +15,7 @@ const CardMedia = React.createClass({
     overlayContentStyle: React.PropTypes.object,
     mediaStyle: React.PropTypes.object,
     expandable: React.PropTypes.bool,
-    expander: React.PropTypes.bool,
+    actAsExpander: React.PropTypes.bool,
   },
 
   getStyles() {

--- a/src/card/card-text.jsx
+++ b/src/card/card-text.jsx
@@ -11,7 +11,7 @@ const CardText = React.createClass({
     color: React.PropTypes.string,
     style: React.PropTypes.object,
     expandable: React.PropTypes.bool,
-    expander: React.PropTypes.bool,
+    actAsExpander: React.PropTypes.bool,
   },
 
   getDefaultProps() {

--- a/src/card/card-text.jsx
+++ b/src/card/card-text.jsx
@@ -11,6 +11,7 @@ const CardText = React.createClass({
     color: React.PropTypes.string,
     style: React.PropTypes.object,
     expandable: React.PropTypes.bool,
+    expander: React.PropTypes.bool,
   },
 
   getDefaultProps() {

--- a/src/card/card-title.jsx
+++ b/src/card/card-title.jsx
@@ -15,6 +15,7 @@ const CardTitle = React.createClass({
     subtitleColor: React.PropTypes.string,
     subtitleStyle: React.PropTypes.object,
     expandable: React.PropTypes.bool,
+    expander: React.PropTypes.bool,
     showExpandableButton: React.PropTypes.bool,
   },
 

--- a/src/card/card-title.jsx
+++ b/src/card/card-title.jsx
@@ -15,7 +15,7 @@ const CardTitle = React.createClass({
     subtitleColor: React.PropTypes.string,
     subtitleStyle: React.PropTypes.object,
     expandable: React.PropTypes.bool,
-    expander: React.PropTypes.bool,
+    actAsExpander: React.PropTypes.bool,
     showExpandableButton: React.PropTypes.bool,
   },
 

--- a/src/card/card.jsx
+++ b/src/card/card.jsx
@@ -17,10 +17,11 @@ const Card = React.createClass({
     onExpandChange: React.PropTypes.func,
   },
 
-  _onExpandable(value) {
-    this.setState({expanded: value});
+  _onExpandable() {
+    let newExpandedState = !(this.state.expanded === true);
+    this.setState({expanded: newExpandedState});
     if (this.props.onExpandChange)
-      this.props.onExpandChange(value);
+      this.props.onExpandChange(newExpandedState);
   },
 
   render() {
@@ -31,6 +32,10 @@ const Card = React.createClass({
       }
       if (this.state.expanded === false && currentChild.props.expandable === true)
         return;
+      if (currentChild.props.expander === true) {
+        currentChild.props.onClick = this._onExpandable;
+        currentChild.props.style = this.mergeStyles({ cursor: 'pointer' }, currentChild.props.style);
+      }
       if (currentChild.props.showExpandableButton === true) {
         lastElement = React.cloneElement(currentChild, {},
           currentChild.props.children,

--- a/src/card/card.jsx
+++ b/src/card/card.jsx
@@ -32,8 +32,8 @@ const Card = React.createClass({
       }
       if (this.state.expanded === false && currentChild.props.expandable === true)
         return;
-      if (currentChild.props.expander === true) {
-        currentChild.props.onClick = this._onExpandable;
+      if (currentChild.props.actAsExpander === true) {
+        currentChild.props.onTouchTap = this._onExpandable;
         currentChild.props.style = this.mergeStyles({ cursor: 'pointer' }, currentChild.props.style);
       }
       if (currentChild.props.showExpandableButton === true) {


### PR DESCRIPTION
This is an implementation proposal for #1354 : To be able to expand card by clicking on an element such as CardHeader, rather than only being able to do it using the CardExpandable button.

This adds a new `expander` prop for Card child components, which triggers the expand on click.

I also updated the card documentation as to provide a demo of the proposed use.