### PR TITLE
[Dialog] Add style to Dialog's propTypes

### DIFF
--- a/src/dialog.jsx
+++ b/src/dialog.jsx
@@ -114,6 +114,7 @@ let Dialog = React.createClass({
     onDismiss: React.PropTypes.func,
     onShow: React.PropTypes.func,
     repositionOnUpdate: React.PropTypes.bool,
+    style: React.PropTypes.object,
     title: React.PropTypes.node,
   },
 


### PR DESCRIPTION
The style props is used to override the main style, it's useful to have. might as well document it in a way.