### PR TITLE
Add width='100%' to mediaChild

### DIFF
--- a/src/card/card-media.jsx
+++ b/src/card/card-media.jsx
@@ -47,6 +47,7 @@ const CardMedia = React.createClass({
         verticalAlign: 'top',
         maxWidth: '100%',
         minWidth: '100%',
+        width:'100%',
       },
     };
   },


### PR DESCRIPTION
Add width='100%' to mediaChild for Firefox. 
In Firefox, the IMG tag children pop out of their containers if the width isn't set.