### PR TITLE
[React] Only use 0.13.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-draggable2": "^0.5.1"
   },
   "peerDependencies": {
-    "react": ">=0.13",
+    "react": "^0.13",
     "react-tap-event-plugin": "^0.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This is a hot fix. Should probably be pushed to npm quickly