### PR TITLE
[babel] Do not use experimental ES7 features

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test-base": "./node_modules/.bin/karma start",
     "prebuild": "rm -rf lib",
     "eslint": "gulp eslint",
-    "build": "npm run eslint && babel --stage 1 ./src --out-dir ./lib",
+    "build": "npm run eslint && babel ./src --out-dir ./lib",
     "prepublish": "npm run build"
   },
   "keywords": [


### PR DESCRIPTION
I think that it's safer like this. Beside, as far as I have see, we are not using stage 1 features. 