### PR TITLE
[For Review] Menu/Popover/IconMenu/Dialog Portal updates

### DIFF
--- a/docs/src/app/app-routes.jsx
+++ b/docs/src/app/app-routes.jsx
@@ -36,6 +36,7 @@ const Lists = require('./components/pages/components/lists');
 const Menus = require('./components/pages/components/menus');
 const Paper = require('./components/pages/components/paper');
 const Progress = require('./components/pages/components/progress');
+const Popover = require('./components/pages/components/popover');
 const RefreshIndicator = require('./components/pages/components/refresh-indicator');
 const Sliders = require('./components/pages/components/sliders');
 const Snackbar = require('./components/pages/components/snackbar');
@@ -90,6 +91,7 @@ const AppRoutes = (
       <Route path="lists" component={Lists} />
       <Route path="menus" component={Menus} />
       <Route path="paper" component={Paper} />
+      <Route path="popover" component={Popover} />
       <Route path="progress" component={Progress} />
       <Route path="refresh-indicator" component={RefreshIndicator} />
       <Route path="sliders" component={Sliders} />

--- a/docs/src/app/components/pages/components.jsx
+++ b/docs/src/app/components/pages/components.jsx
@@ -22,6 +22,7 @@ export default class Components extends React.Component {
       { route: '/components/paper', text: 'Paper'},
       { route: '/components/progress', text: 'Progress'},
       { route: '/components/refresh-indicator', text: 'Refresh Indicator'},
+      { route: '/components/popover', text: 'Popover'},
       { route: '/components/sliders', text: 'Sliders'},
       { route: '/components/switches', text: 'Switches'},
       { route: '/components/snackbar', text: 'Snackbar'},

--- a/docs/src/app/components/pages/components/dialog.jsx
+++ b/docs/src/app/components/pages/components/dialog.jsx
@@ -175,6 +175,7 @@ export default class DialogPage extends React.Component {
             title="Dialog With Standard Actions"
             actions={standardActions}
             actionFocus="submit"
+            open={false}
             modal={this.state.modal}>
             The actions in this window are created from the json that&#39;s passed in.
           </Dialog>
@@ -183,6 +184,7 @@ export default class DialogPage extends React.Component {
             ref="customDialog"
             title="Dialog With Custom Actions"
             actions={customActions}
+            open={false}
             modal={this.state.modal}>
             The actions in this window were passed in as an array of react objects.
           </Dialog>
@@ -197,6 +199,7 @@ export default class DialogPage extends React.Component {
             title="Dialog With Scrollable Content"
             actions={scrollableCustomActions}
             modal={this.state.modal}
+            open={false}
             autoDetectWindowHeight={true}
             autoScrollBodyContent={true}>
             <div style={{height: '1000px'}}>

--- a/docs/src/app/components/pages/components/icon-menus.jsx
+++ b/docs/src/app/components/pages/components/icon-menus.jsx
@@ -151,7 +151,10 @@ export default class IconMenus extends React.Component {
 
           <p>Menu with various open directions</p>
           <div>
-            <IconMenu iconButtonElement={iconButtonElement}>
+            <IconMenu iconButtonElement={iconButtonElement}
+              anchorOrigin={{horizontal:'right', vertical:'top'}}
+              targetOrigin={{horizontal:'right', vertical:'top'}}
+              >
               <MenuItem primaryText="Refresh" />
               <MenuItem primaryText="Send feedback" />
               <MenuItem primaryText="Settings" />
@@ -161,7 +164,8 @@ export default class IconMenus extends React.Component {
 
             <IconMenu
               iconButtonElement={iconButtonElement}
-              openDirection="bottom-right">
+              anchorOrigin={{horizontal:'left', vertical:'top'}}
+              targetOrigin={{horizontal:'left', vertical:'top'}}>
               <MenuItem primaryText="Refresh" />
               <MenuItem primaryText="Send feedback" />
               <MenuItem primaryText="Settings" />
@@ -171,7 +175,8 @@ export default class IconMenus extends React.Component {
 
             <IconMenu
               iconButtonElement={iconButtonElement}
-              openDirection="top-left">
+              anchorOrigin={{horizontal:'right', vertical:'bottom'}}
+              targetOrigin={{horizontal:'right', vertical:'bottom'}}>
               <MenuItem primaryText="Refresh" />
               <MenuItem primaryText="Send feedback" />
               <MenuItem primaryText="Settings" />
@@ -181,7 +186,9 @@ export default class IconMenus extends React.Component {
 
             <IconMenu
               iconButtonElement={iconButtonElement}
-              openDirection="top-right">
+              anchorOrigin={{horizontal:'left', vertical:'bottom'}}
+              targetOrigin={{horizontal:'left', vertical:'bottom'}}
+              >
               <MenuItem primaryText="Refresh" />
               <MenuItem primaryText="Send feedback" />
               <MenuItem primaryText="Settings" />
@@ -195,7 +202,6 @@ export default class IconMenus extends React.Component {
             <IconMenu
               iconButtonElement={iconButtonElement}
               onChange={this._handleIconMenuChange}
-              openDirection="bottom-right"
               value={this.state.iconMenuValue}>
               <MenuItem value="1" primaryText="Refresh" />
               <MenuItem value="2" primaryText="Send feedback" />
@@ -219,7 +225,6 @@ export default class IconMenus extends React.Component {
               iconButtonElement={filterButtonElement}
               multiple={true}
               onChange={this._handleIconMenuMultiChange}
-              openDirection="bottom-right"
               value={this.state.iconMenuMultiValue}>
               <MenuItem value="1" primaryText="Blu-ray" />
               <MenuItem value="2" primaryText="Cassette" />
@@ -233,8 +238,7 @@ export default class IconMenus extends React.Component {
           <p>Menu Item variations</p>
           <div>
             <IconMenu
-              iconButtonElement={iconButtonElement}
-              openDirection="bottom-right">
+              iconButtonElement={iconButtonElement}>
               <MenuItem primaryText="Home" />
               <MenuItem primaryText="Back" />
               <MenuItem primaryText="Forward" disabled={true} />
@@ -245,8 +249,7 @@ export default class IconMenus extends React.Component {
             </IconMenu>
 
             <IconMenu
-              iconButtonElement={iconButtonElement}
-              openDirection="bottom-right">
+              iconButtonElement={iconButtonElement}>
               <MenuItem primaryText="Preview" leftIcon={<RemoveRedEye />} />
               <MenuItem primaryText="Share" leftIcon={<PersonAdd />} />
               <MenuItem primaryText="Get link" leftIcon={<ContentLink />} />
@@ -263,7 +266,6 @@ export default class IconMenus extends React.Component {
             <IconMenu
               iconButtonElement={mapsButtonElement}
               maxHeight={272}
-              openDirection="bottom-right"
               valueLink={usStateValueLink}>
               <MenuItem value="AL" primaryText="Alabama" />
               <MenuItem value="AK" primaryText="Alaska" />
@@ -321,7 +323,6 @@ export default class IconMenus extends React.Component {
             <IconMenu
               iconButtonElement={mapsButtonElement}
               maxHeight={272}
-              openDirection="bottom-left"
               valueLink={usStateValueLink}>
               <MenuItem value="AL" primaryText="Alabama" />
               <MenuItem value="AK" primaryText="Alaska" />
@@ -379,7 +380,8 @@ export default class IconMenus extends React.Component {
             <IconMenu
               iconButtonElement={mapsButtonElement}
               maxHeight={272}
-              openDirection="top-right"
+              anchorOrigin={{horizontal:'left', vertical:'bottom'}}
+              targetOrigin={{horizontal:'left', vertical:'top'}}
               valueLink={usStateValueLink}>
               <MenuItem value="AL" primaryText="Alabama" />
               <MenuItem value="AK" primaryText="Alaska" />
@@ -437,7 +439,173 @@ export default class IconMenus extends React.Component {
             <IconMenu
               iconButtonElement={mapsButtonElement}
               maxHeight={272}
-              openDirection="top-left"
+              valueLink={usStateValueLink}>
+              <MenuItem value="AL" primaryText="Alabama" />
+              <MenuItem value="AK" primaryText="Alaska" />
+              <MenuItem value="AZ" primaryText="Arizona" />
+              <MenuItem value="AR" primaryText="Arkansas" />
+              <MenuItem value="CA" primaryText="California" />
+              <MenuItem value="CO" primaryText="Colorado" />
+              <MenuItem value="CT" primaryText="Connecticut" />
+              <MenuItem value="DE" primaryText="Delaware" />
+              <MenuItem value="DC" primaryText="District Of Columbia" />
+              <MenuItem value="FL" primaryText="Florida" />
+              <MenuItem value="GA" primaryText="Georgia" />
+              <MenuItem value="HI" primaryText="Hawaii" />
+              <MenuItem value="ID" primaryText="Idaho" />
+              <MenuItem value="IL" primaryText="Illinois" />
+              <MenuItem value="IN" primaryText="Indiana" />
+              <MenuItem value="IA" primaryText="Iowa" />
+              <MenuItem value="KS" primaryText="Kansas" />
+              <MenuItem value="KY" primaryText="Kentucky" />
+              <MenuItem value="LA" primaryText="Louisiana" />
+              <MenuItem value="ME" primaryText="Maine" />
+              <MenuItem value="MD" primaryText="Maryland" />
+              <MenuItem value="MA" primaryText="Massachusetts" />
+              <MenuItem value="MI" primaryText="Michigan" />
+              <MenuItem value="MN" primaryText="Minnesota" />
+              <MenuItem value="MS" primaryText="Mississippi" />
+              <MenuItem value="MO" primaryText="Missouri" />
+              <MenuItem value="MT" primaryText="Montana" />
+              <MenuItem value="NE" primaryText="Nebraska" />
+              <MenuItem value="NV" primaryText="Nevada" />
+              <MenuItem value="NH" primaryText="New Hampshire" />
+              <MenuItem value="NJ" primaryText="New Jersey" />
+              <MenuItem value="NM" primaryText="New Mexico" />
+              <MenuItem value="NY" primaryText="New York" />
+              <MenuItem value="NC" primaryText="North Carolina" />
+              <MenuItem value="ND" primaryText="North Dakota" />
+              <MenuItem value="OH" primaryText="Ohio" />
+              <MenuItem value="OK" primaryText="Oklahoma" />
+              <MenuItem value="OR" primaryText="Oregon" />
+              <MenuItem value="PA" primaryText="Pennsylvania" />
+              <MenuItem value="RI" primaryText="Rhode Island" />
+              <MenuItem value="SC" primaryText="South Carolina" />
+              <MenuItem value="SD" primaryText="South Dakota" />
+              <MenuItem value="TN" primaryText="Tennessee" />
+              <MenuItem value="TX" primaryText="Texas" />
+              <MenuItem value="UT" primaryText="Utah" />
+              <MenuItem value="VT" primaryText="Vermont" />
+              <MenuItem value="VA" primaryText="Virginia" />
+              <MenuItem value="WA" primaryText="Washington" />
+              <MenuItem value="WV" primaryText="West Virginia" />
+              <MenuItem value="WI" primaryText="Wisconsin" />
+              <MenuItem value="WY" primaryText="Wyoming" />
+            </IconMenu>
+            <IconMenu
+              iconButtonElement={mapsButtonElement}
+              maxHeight={500}
+              valueLink={usStateValueLink}>
+              <MenuItem value="AL" primaryText="Alabama" />
+              <MenuItem value="AK" primaryText="Alaska" />
+              <MenuItem value="AZ" primaryText="Arizona" />
+              <MenuItem value="AR" primaryText="Arkansas" />
+              <MenuItem value="CA" primaryText="California" />
+              <MenuItem value="CO" primaryText="Colorado" />
+              <MenuItem value="CT" primaryText="Connecticut" />
+              <MenuItem value="DE" primaryText="Delaware" />
+              <MenuItem value="DC" primaryText="District Of Columbia" />
+              <MenuItem value="FL" primaryText="Florida" />
+              <MenuItem value="GA" primaryText="Georgia" />
+              <MenuItem value="HI" primaryText="Hawaii" />
+              <MenuItem value="ID" primaryText="Idaho" />
+              <MenuItem value="IL" primaryText="Illinois" />
+              <MenuItem value="IN" primaryText="Indiana" />
+              <MenuItem value="IA" primaryText="Iowa" />
+              <MenuItem value="KS" primaryText="Kansas" />
+              <MenuItem value="KY" primaryText="Kentucky" />
+              <MenuItem value="LA" primaryText="Louisiana" />
+              <MenuItem value="ME" primaryText="Maine" />
+              <MenuItem value="MD" primaryText="Maryland" />
+              <MenuItem value="MA" primaryText="Massachusetts" />
+              <MenuItem value="MI" primaryText="Michigan" />
+              <MenuItem value="MN" primaryText="Minnesota" />
+              <MenuItem value="MS" primaryText="Mississippi" />
+              <MenuItem value="MO" primaryText="Missouri" />
+              <MenuItem value="MT" primaryText="Montana" />
+              <MenuItem value="NE" primaryText="Nebraska" />
+              <MenuItem value="NV" primaryText="Nevada" />
+              <MenuItem value="NH" primaryText="New Hampshire" />
+              <MenuItem value="NJ" primaryText="New Jersey" />
+              <MenuItem value="NM" primaryText="New Mexico" />
+              <MenuItem value="NY" primaryText="New York" />
+              <MenuItem value="NC" primaryText="North Carolina" />
+              <MenuItem value="ND" primaryText="North Dakota" />
+              <MenuItem value="OH" primaryText="Ohio" />
+              <MenuItem value="OK" primaryText="Oklahoma" />
+              <MenuItem value="OR" primaryText="Oregon" />
+              <MenuItem value="PA" primaryText="Pennsylvania" />
+              <MenuItem value="RI" primaryText="Rhode Island" />
+              <MenuItem value="SC" primaryText="South Carolina" />
+              <MenuItem value="SD" primaryText="South Dakota" />
+              <MenuItem value="TN" primaryText="Tennessee" />
+              <MenuItem value="TX" primaryText="Texas" />
+              <MenuItem value="UT" primaryText="Utah" />
+              <MenuItem value="VT" primaryText="Vermont" />
+              <MenuItem value="VA" primaryText="Virginia" />
+              <MenuItem value="WA" primaryText="Washington" />
+              <MenuItem value="WV" primaryText="West Virginia" />
+              <MenuItem value="WI" primaryText="Wisconsin" />
+              <MenuItem value="WY" primaryText="Wyoming" />
+            </IconMenu>
+            <IconMenu
+              iconButtonElement={mapsButtonElement}
+              maxHeight={272}
+              valueLink={usStateValueLink}>
+              <MenuItem value="AL" primaryText="Alabama" />
+              <MenuItem value="AK" primaryText="Alaska" />
+              <MenuItem value="AZ" primaryText="Arizona" />
+              <MenuItem value="AR" primaryText="Arkansas" />
+              <MenuItem value="CA" primaryText="California" />
+              <MenuItem value="CO" primaryText="Colorado" />
+              <MenuItem value="CT" primaryText="Connecticut" />
+              <MenuItem value="DE" primaryText="Delaware" />
+              <MenuItem value="DC" primaryText="District Of Columbia" />
+              <MenuItem value="FL" primaryText="Florida" />
+              <MenuItem value="GA" primaryText="Georgia" />
+              <MenuItem value="HI" primaryText="Hawaii" />
+              <MenuItem value="ID" primaryText="Idaho" />
+              <MenuItem value="IL" primaryText="Illinois" />
+              <MenuItem value="IN" primaryText="Indiana" />
+              <MenuItem value="IA" primaryText="Iowa" />
+              <MenuItem value="KS" primaryText="Kansas" />
+              <MenuItem value="KY" primaryText="Kentucky" />
+              <MenuItem value="LA" primaryText="Louisiana" />
+              <MenuItem value="ME" primaryText="Maine" />
+              <MenuItem value="MD" primaryText="Maryland" />
+              <MenuItem value="MA" primaryText="Massachusetts" />
+              <MenuItem value="MI" primaryText="Michigan" />
+              <MenuItem value="MN" primaryText="Minnesota" />
+              <MenuItem value="MS" primaryText="Mississippi" />
+              <MenuItem value="MO" primaryText="Missouri" />
+              <MenuItem value="MT" primaryText="Montana" />
+              <MenuItem value="NE" primaryText="Nebraska" />
+              <MenuItem value="NV" primaryText="Nevada" />
+              <MenuItem value="NH" primaryText="New Hampshire" />
+              <MenuItem value="NJ" primaryText="New Jersey" />
+              <MenuItem value="NM" primaryText="New Mexico" />
+              <MenuItem value="NY" primaryText="New York" />
+              <MenuItem value="NC" primaryText="North Carolina" />
+              <MenuItem value="ND" primaryText="North Dakota" />
+              <MenuItem value="OH" primaryText="Ohio" />
+              <MenuItem value="OK" primaryText="Oklahoma" />
+              <MenuItem value="OR" primaryText="Oregon" />
+              <MenuItem value="PA" primaryText="Pennsylvania" />
+              <MenuItem value="RI" primaryText="Rhode Island" />
+              <MenuItem value="SC" primaryText="South Carolina" />
+              <MenuItem value="SD" primaryText="South Dakota" />
+              <MenuItem value="TN" primaryText="Tennessee" />
+              <MenuItem value="TX" primaryText="Texas" />
+              <MenuItem value="UT" primaryText="Utah" />
+              <MenuItem value="VT" primaryText="Vermont" />
+              <MenuItem value="VA" primaryText="Virginia" />
+              <MenuItem value="WA" primaryText="Washington" />
+              <MenuItem value="WV" primaryText="West Virginia" />
+              <MenuItem value="WI" primaryText="Wisconsin" />
+              <MenuItem value="WY" primaryText="Wyoming" />
+            </IconMenu>
+            <IconMenu
+              iconButtonElement={mapsButtonElement}
               valueLink={usStateValueLink}>
               <MenuItem value="AL" primaryText="Alabama" />
               <MenuItem value="AK" primaryText="Alaska" />

--- a/docs/src/app/components/pages/components/menus.jsx
+++ b/docs/src/app/components/pages/components/menus.jsx
@@ -292,7 +292,18 @@ export default class MenusPage extends React.Component {
             <MenuItem primaryText="Single" insetChildren={true} />
             <MenuItem primaryText="1.15" insetChildren={true} />
             <MenuItem primaryText="Double" insetChildren={true} />
-            <MenuItem primaryText="Custom: 1.2" checked={true} rightIcon={<ArrowDropRight />} />
+            <MenuItem primaryText="Custom: 1.2" checked={true} rightIcon={<ArrowDropRight />} menuItems={[
+                <MenuItem primaryText="Show" rightIcon={<ArrowDropRight />} menuItems={[
+                  <MenuItem primaryText="Show" />,
+                  <MenuItem primaryText="Grid lines" checked={true} />,
+                  <MenuItem primaryText="Page breaks" insetChildren={true} />,
+                  <MenuItem primaryText="Rules" checked={true} />,
+                  ]}/>,
+                <MenuItem primaryText="Grid lines" checked={true} />,
+                <MenuItem primaryText="Page breaks" insetChildren={true} />,
+                <MenuItem primaryText="Rules" checked={true} />,
+              ]}>
+            </MenuItem>
             <MenuDivider />
             <MenuItem primaryText="Add space before paragraph" />
             <MenuItem primaryText="Add space after paragraph" />

--- a/docs/src/app/components/pages/components/popover.jsx
+++ b/docs/src/app/components/pages/components/popover.jsx
@@ -1,0 +1,157 @@
+let React = require('react');
+let { Popover, RaisedButton, SelectField, TextField } = require('material-ui');
+let ComponentDoc = require('../../component-doc');
+let Code = require('popover-code');
+let CodeExample = require('../../code-example/code-example');
+
+
+let PopoverPage = React.createClass({
+  getInitialState() {
+    return {
+      selectValue:'1',
+      textValue:'here is a value',
+    }
+  },
+
+  render() {
+
+    let componentInfo = [
+      {
+        name: 'Props',
+        infoArray: [
+          {
+            name: 'anchorOrigin',
+            type: 'origin object',
+            header: 'optional',
+            desc:
+              'This is the point on the anchor where the popover targetOrigin will stick to.\n' +
+              'Options:\n'+
+              'vertical: [top, middle, bottom]\n' +
+              'horizontal: [left, center, right]\n',
+          },
+          {
+            name: 'targetOrigin',
+            type: 'origin object',
+            header: 'optional',
+            desc:
+              'This is the point on the popover which will stick to the anchors origin.' +
+              'Options:'+
+              'vertical: [top, middle, bottom]' +
+              'horizontal: [left, center, right]',
+          },
+          {
+            name: 'animated',
+            type: 'bool',
+            header: 'default: false',
+            desc: 'If true, the popover will apply transitions when added it gets added to the DOM. In order for transitions ' +
+              'to work, wrap the popover inside a ReactTransitionGroup.',
+          },
+          {
+            name: 'autoCloseWhenOffScreen',
+            type: 'bool',
+            header: 'default: true',
+            desc: 'If true, the popover will hide when the anchor scrolls off the screen',
+          },
+          {
+            name: 'canAutoPosition',
+            type: 'bool',
+            header: 'default: true',
+            desc: 'If true, the popover (potentially) ignore targetOrigin and anchorOrigin to make itself fit on screen,' +
+            'which is useful for mobile devices.',
+          },
+          {
+            name: 'childContextTypes',
+            type: 'object',
+            header: 'default: true',
+            desc: 'React 0.13 hack to allow contexts to be passed through to the popover.  This is necessary because it' +
+            'renders outside the owner in the DOM.',
+          },
+          {
+            name: 'zDepth',
+            type: 'number (0-5)',
+            header: 'default: 1',
+            desc: 'This number represents the zDepth of the paper shadow.',
+          },
+        ],
+      },
+      {
+        name: 'Methods',
+        infoArray: [
+          {
+            name: 'show',
+            header: 'Popover.show(anchor)',
+            desc: 'Show the popover adjacent or over the anchor.',
+          },
+          {
+            name: 'hide',
+            header: 'Popover.hide()',
+            desc: 'Hide the popover.',
+          },
+          {
+            name: 'toggle',
+            header: 'Popover.toggle(anchor)',
+            desc: 'Show or hide the popover adjacent or over the anchor.',
+          },
+        ],
+      },
+    ];
+
+    let menuItems = [
+      { payload: '1', text: 'Never' },
+      { payload: '2', text: 'Every Night' },
+      { payload: '3', text: 'Weeknights' },
+      { payload: '4', text: 'Weekends' },
+      { payload: '5', text: 'Weekly' },
+    ];
+
+    return (
+      <ComponentDoc
+        name="Popover"
+        componentInfo={componentInfo}>
+        <CodeExample code={Code}>
+          <a onClick={this.show.bind(this, "pop")}>
+            Click on me to show a popover
+          </a>
+          <br/>
+
+          <a onClick={this.show.bind(this, "pop2")}>
+            Click on me to show a with a nested popover (SelectField)
+          </a>
+
+          <Popover ref="pop"
+            anchorEl={this.anchorEl}>
+            <div style={{padding:20}}>
+              <h2>Here is an arbitrary popover</h2>
+              <p>Hi - here is some content</p>
+              <RaisedButton primary={true} label="Here is a button"/>
+            </div>
+          </Popover>
+          <Popover ref="pop2"
+            anchorEl={this.anchorEl}>
+            <div style={{padding:20}}>
+              <h2>Here is an arbitrary popover</h2>
+              <p>Hi - here is some content</p>
+              <SelectField menuItems={menuItems} onChange={this.onChangeSelect} value={this.state.selectValue} />
+              <TextField onChange={this.onChangeText} value={this.state.textValue} />
+            </div>
+          </Popover>
+        </CodeExample>
+      </ComponentDoc>
+    );
+  },
+
+  show(ref, e) {
+    this.refs[ref].show(e.currentTarget);
+  },
+
+  onChangeSelect(e) {
+    this.setState({selectValue:e.target.value});
+  },
+  onChangeText(e) {
+    this.setState({textValue:e.target.value});
+  },
+
+
+});
+
+module.exports = PopoverPage;

--- a/docs/src/app/components/raw-code/popover-code.txt
+++ b/docs/src/app/components/raw-code/popover-code.txt
@@ -1,0 +1,16 @@
+<span style={{cursor:'pointer'}} onClick={this.show}>
+  Click on me to show a popover
+</span>
+
+<Popover ref="pop" 
+  show={true} 
+  anchorEl={this.anchorEl}>
+  <div style={{padding:20}}>
+    <h2>Here is an arbitrary popover</h2>
+    <p>Hi - here is some content</p>
+  </div>
+</Popover>
+
+show(e) {
+  this.refs.pop.show(e.currentTarget)
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
     "url": "https://github.com/callemall/material-ui/issues"
   },
   "homepage": "http://material-ui.com/",
+  "dependencies": {
+    "lodash.throttle": "~3.0.4",
+    "lodash.debounce": "~3.1.1"
+  },
   "peerDependencies": {
     "inline-style-prefixer": "^0.3.3",
     "react": "^0.14.0",

--- a/src/date-picker/date-picker-dialog.jsx
+++ b/src/date-picker/date-picker-dialog.jsx
@@ -50,6 +50,7 @@ const DatePickerDialog = React.createClass({
     onClickAway: React.PropTypes.func,
     onDismiss: React.PropTypes.func,
     onShow: React.PropTypes.func,
+    open:React.PropTypes.bool,
     shouldDisableDate: React.PropTypes.func,
     showYearSelector: React.PropTypes.bool,
   },
@@ -69,6 +70,7 @@ const DatePickerDialog = React.createClass({
     return {
       DateTimeFormat: DateTime.DateTimeFormat,
       locale: 'en-US',
+      open:false,
       wordings: {
         ok: 'OK',
         cancel: 'Cancel',
@@ -83,6 +85,7 @@ const DatePickerDialog = React.createClass({
   getInitialState() {
     return {
       isCalendarActive: false,
+      open:this.props.open,
       muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
     };
   },
@@ -159,6 +162,7 @@ const DatePickerDialog = React.createClass({
         onDismiss={this._handleDialogDismiss}
         onShow={this._handleDialogShow}
         onClickAway={this._handleDialogClickAway}
+        open={this.state.open}
         repositionOnUpdate={false}>
         <Calendar
           DateTimeFormat={DateTimeFormat}
@@ -177,11 +181,11 @@ const DatePickerDialog = React.createClass({
   },
 
   show() {
-    this.refs.dialog.show();
+    this.setState({open:true});
   },
 
   dismiss() {
-    this.refs.dialog.dismiss();
+    this.setState({open:false});
   },
 
   _onDayTouchTap() {
@@ -211,20 +215,17 @@ const DatePickerDialog = React.createClass({
   },
 
   _handleDialogDismiss() {
-    CssEvent.onTransitionEnd(ReactDOM.findDOMNode(this.refs.dialog), () => {
-      this.setState({
-        isCalendarActive: false,
-      });
+    this.setState({
+      isCalendarActive: false,
+      open:false,
     });
-
     if (this.props.onDismiss) this.props.onDismiss();
   },
 
   _handleDialogClickAway() {
-    CssEvent.onTransitionEnd(ReactDOM.findDOMNode(this.refs.dialog), () => {
-      this.setState({
-        isCalendarActive: false,
-      });
+    this.setState({
+      isCalendarActive: false,
+      open:false,
     });
 
     if (this.props.onClickAway) this.props.onClickAway();

--- a/src/drop-down-menu.jsx
+++ b/src/drop-down-menu.jsx
@@ -127,7 +127,7 @@ const DropDownMenu = React.createClass({
         lineHeight: spacing.desktopToolbarHeight + 'px',
         position: 'relative',
         paddingLeft: spacing.desktopGutter,
-        paddingRight: spacing.desktopGutter * 2,
+        paddingRight: spacing.desktopGutter,
         opacity: 1,
         width:'auto',
         color: disabled ? this.state.muiTheme.rawTheme.palette.disabledColor : this.state.muiTheme.rawTheme.palette.textColor,
@@ -211,10 +211,10 @@ const DropDownMenu = React.createClass({
     }
 
     let menuItems = this.props.menuItems.map((item, idx) => {
-      return <MenuItem 
-        key={idx} 
-        primaryText={item[displayMember]} 
-        value={item[valueMember]} 
+      return <MenuItem
+        key={idx}
+        primaryText={item[displayMember]}
+        value={item[valueMember]}
         onClick={this._onMenuItemClick.bind(this, idx, item[valueMember])} />
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ module.exports = {
   Mixins: require('./mixins/'),
   Overlay: require('./overlay'),
   Paper: require('./paper'),
+  Popover:require('./popover/popover'),
   RadioButton: require('./radio-button'),
   RadioButtonGroup: require('./radio-button-group'),
   RaisedButton: require('./raised-button'),

--- a/src/left-nav.jsx
+++ b/src/left-nav.jsx
@@ -11,7 +11,8 @@ const Transitions = require('./styles/transitions');
 const WindowListenable = require('./mixins/window-listenable');
 const Overlay = require('./overlay');
 const Paper = require('./paper');
-const Menu = require('./menu/menu');
+const Menu = require('./menus/menu');
+const MenuItem = require('./menus/menu-item');
 const DefaultRawTheme = require('./styles/raw-themes/light-raw-theme');
 const ThemeManager = require('./styles/theme-manager');
 

--- a/src/lists/list-item.jsx
+++ b/src/lists/list-item.jsx
@@ -339,7 +339,7 @@ const ListItem = React.createClass({
 
     const nestedList = nestedItems.length ? (
       <NestedList nestedLevel={nestedLevel + 1} open={this.state.open}>
-        {nestedItems}
+        {React.Children.toArray(nestedItems)}
       </NestedList>
     ) : undefined;
 

--- a/src/menu/menu.jsx
+++ b/src/menu/menu.jsx
@@ -498,7 +498,7 @@ const Menu = React.createClass({
       CssEvent.onTransitionEnd(el, () => {
         //Make sure the menu is open before setting the overflow.
         //This is to accout for fast clicks
-        if (this.props.visible) container.style.overflow = 'visible';
+        if (this.props.visible) container.style.overflow = 'auto';
         el.style.transition = null;
         el.focus();
       });

--- a/src/menus/menu.jsx
+++ b/src/menus/menu.jsx
@@ -45,7 +45,7 @@ const Menu = React.createClass({
       onEscKeyDown: () => {},
       onItemTouchTap: () => {},
       onKeyDown: () => {},
-      openDirection: 'bottom-left',
+      openDirection: 'top-left',
       zDepth: 1,
     };
   },
@@ -184,7 +184,7 @@ const Menu = React.createClass({
     let menuItemIndex = 0;
     let newChildren = React.Children.map(children, (child) => {
 
-      let childIsADivider = child.type.displayName === 'MenuDivider';
+      let childIsADivider = child.type && child.type.displayName === 'MenuDivider';
       let childIsDisabled = child.props.disabled;
       let childrenContainerStyles = {};
 
@@ -321,7 +321,7 @@ const Menu = React.createClass({
     //max menu height
     React.Children.forEach(children, (child) => {
       if (currentHeight < maxHeight) {
-        let childIsADivider = child.type.displayName === 'MenuDivider';
+        let childIsADivider = child.type && child.type.displayName === 'MenuDivider';
 
         currentHeight += childIsADivider ? 16 : menuItemHeight;
         count++;
@@ -335,7 +335,7 @@ const Menu = React.createClass({
   _getMenuItemCount() {
     let menuItemCount = 0;
     React.Children.forEach(this.props.children, (child) => {
-      let childIsADivider = child.type.displayName === 'MenuDivider';
+      let childIsADivider = child.type && child.type.displayName === 'MenuDivider';
       let childIsDisabled = child.props.disabled;
       if (!childIsADivider && !childIsDisabled) menuItemCount++;
     });
@@ -350,7 +350,7 @@ const Menu = React.createClass({
     let menuItemIndex = 0;
 
     React.Children.forEach(children, (child) => {
-      let childIsADivider = child.type.displayName === 'MenuDivider';
+      let childIsADivider = child.type && child.type.displayName === 'MenuDivider';
 
       if (this._isChildSelected(child, props)) selectedIndex = menuItemIndex;
       if (!childIsADivider) menuItemIndex++;

--- a/src/mixins/render-to-layer.js
+++ b/src/mixins/render-to-layer.js
@@ -102,14 +102,14 @@ const LayerMixin = {
 
   _bindClickAway() {
     this.canClickAway = true;
-    Events.on(document, 'mouseup', this._checkClickAway);
+    Events.on(document, 'mousedown', this._checkClickAway);
     Events.on(document, 'touchend', this._checkClickAway);
     Events.on(document, 'popOverOnShow', this._preventClickAway);
     Events.on(document, 'popOverOnHide', this._allowClickAway);
   },
 
   _unbindClickAway() {
-    Events.off(document, 'mouseup', this._checkClickAway);
+    Events.off(document, 'mousedown', this._checkClickAway);
     Events.off(document, 'touchend', this._checkClickAway);
     Events.off(document, 'popOverOnShow', this._preventClickAway);
     Events.off(document, 'popOverOnHide', this._allowClickAway);

--- a/src/mixins/render-to-layer.js
+++ b/src/mixins/render-to-layer.js
@@ -1,0 +1,119 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Events from '../utils/events';
+import Dom from '../utils/dom';
+import debounce from 'lodash.debounce';
+
+// heavily inspired by https://github.com/Khan/react-components/blob/master/js/layered-component-mixin.jsx
+const LayerMixin = {
+
+  componentDidMount() {
+    this._renderLayer();
+  },
+
+  componentDidUpdate() {
+    this._renderLayer();
+  },
+
+  componentWillUnmount() {
+    this._unbindClickAway();
+    if (this._layer) {
+      this._unrenderLayer();
+    }
+  },
+
+  _checkClickAway(e) {
+    if (!this.canClickAway) {
+      return;
+    }
+    const el = this._layer;
+    if (e.target !== el &&
+        !Dom.isDescendant(el, e.target) &&
+        document.documentElement.contains(e.target)) {
+      if (this.componentClickAway) {
+        this.componentClickAway(e);
+      }
+    }
+  },
+
+  _preventClickAway(e) {
+    if (e.detail === this) {
+      return;
+    }
+    this.canClickAway = false;
+  },
+
+  _allowClickAway() {
+    this.canClickAway = true;
+  },
+
+  _renderLayer: function() {
+    if (this.state.open || this.props.open) {
+      if (!this._layer) {
+        this._layer = document.createElement('div');
+        document.body.appendChild(this._layer);
+      }
+      this._bindClickAway();
+      if (this.reactUnmount) {
+        this.reactUnmount.cancel();
+      }
+    } else if (this._layer) {
+      this._unbindClickAway();
+      this._unrenderLayer();
+    } else {
+      return;
+    }
+
+    // By calling this method in componentDidMount() and
+    // componentDidUpdate(), you're effectively creating a "wormhole" that
+    // funnels React's hierarchical updates through to a DOM node on an
+    // entirely different part of the page.
+
+    const layerElement = this.renderLayer();
+    // Renders can return null, but React.render() doesn't like being asked
+    // to render null. If we get null back from renderLayer(), just render
+    // a noscript element, like React does when an element's render returns
+    // null.
+    if (layerElement === null) {
+        this.layerElement = ReactDOM.unstable_renderSubtreeIntoContainer (this, <noscript />, this._layer);
+    } else {
+        this.layerElement = ReactDOM.unstable_renderSubtreeIntoContainer(this, layerElement, this._layer);
+    }
+
+    if (this.layerDidMount) {
+        this.layerDidMount(this._layer);
+    }
+  },
+
+  _unrenderLayer: function() {
+    if (this.layerWillUnmount) {
+        this.layerWillUnmount(this._layer);
+    }
+    if (!this.reactUnmount)
+      this.reactUnmount = debounce(function() {
+        if (this._layer) {
+          ReactDOM.unmountComponentAtNode(this._layer);
+          document.body.removeChild(this._layer);
+          delete this._layer;
+        }
+      }.bind(this), 1000);
+    this.reactUnmount();
+  },
+
+  _bindClickAway() {
+    this.canClickAway = true;
+    Events.on(document, 'mouseup', this._checkClickAway);
+    Events.on(document, 'touchend', this._checkClickAway);
+    Events.on(document, 'popOverOnShow', this._preventClickAway);
+    Events.on(document, 'popOverOnHide', this._allowClickAway);
+  },
+
+  _unbindClickAway() {
+    Events.off(document, 'mouseup', this._checkClickAway);
+    Events.off(document, 'touchend', this._checkClickAway);
+    Events.off(document, 'popOverOnShow', this._preventClickAway);
+    Events.off(document, 'popOverOnHide', this._allowClickAway);
+  },
+};
+
+export default LayerMixin;

--- a/src/overlay.jsx
+++ b/src/overlay.jsx
@@ -31,6 +31,7 @@ const Overlay = React.createClass({
   getInitialState () {
     return {
       muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
+      show:false,
     };
   },
 
@@ -51,20 +52,20 @@ const Overlay = React.createClass({
     return {
       autoLockScrolling: true,
       transitionEnabled: true,
+      style:{},
     };
   },
 
   componentDidMount() {
     this._originalBodyOverflow = document.getElementsByTagName('body')[0].style.overflow;
+    if (this.state.show !== this.props.show) {
+      this.setState({show:this.props.show}, this._applyAutoLockScrolling);
+    }
   },
 
   componentDidUpdate() {
-    if (this.props.autoLockScrolling) {
-      if (this.props.show) {
-        this._preventScrolling();
-      } else {
-        this._allowScrolling();
-      }
+    if (this.state.show !== this.props.show) {
+      this.setState({show:this.props.show}, this._applyAutoLockScrolling);
     }
   },
 
@@ -131,6 +132,16 @@ const Overlay = React.createClass({
 
   allowScrolling() {
     if (!this.props.autoLockScrolling) this._allowScrolling();
+  },
+
+  _applyAutoLockScrolling() {
+    if (this.props.autoLockScrolling) {
+      if (this.state.show) {
+        this._preventScrolling();
+      } else {
+        this._allowScrolling();
+      }
+    }
   },
 
   _preventScrolling() {

--- a/src/popover/popover.jsx
+++ b/src/popover/popover.jsx
@@ -1,0 +1,346 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import WindowListenable from '../mixins/window-listenable';
+import RenderToLayer from '../mixins/render-to-layer';
+import StylePropable from '../mixins/style-propable';
+import Extend from '../utils/extend';
+import CssEvent from '../utils/css-event';
+import Dom from '../utils/dom';
+import PropTypes from '../utils/prop-types';
+import Transitions from '../styles/transitions';
+import Paper from '../paper';
+import throttle from 'lodash.throttle';
+import AutoPrefix from '../styles/auto-prefix';
+import ContextPure from '../mixins/context-pure';
+
+export default React.createClass({
+  mixins: [
+    ContextPure,
+    RenderToLayer,
+    StylePropable,
+    WindowListenable,
+  ],
+
+  propTypes: {
+    anchorEl: React.PropTypes.object,
+    anchorOrigin: PropTypes.origin,
+    animated: React.PropTypes.bool,
+    autoCloseWhenOffScreen: React.PropTypes.bool,
+    canAutoPosition: React.PropTypes.bool,
+    children: React.PropTypes.object,
+    className: React.PropTypes.string,
+    onRequestClose: React.PropTypes.func,
+    style: React.PropTypes.object,
+    targetOrigin: PropTypes.origin,
+    zDepth: PropTypes.zDepth,
+  },
+
+  getDefaultProps() {
+    return {
+      anchorOrigin: {
+        vertical:'bottom',
+        horizontal:'left',
+      },
+      animated:true,
+      autoCloseWhenOffScreen:true,
+      canAutoPosition:true,
+      onRequestClose: () => {},
+      open:false,
+      style: {},
+      targetOrigin: {
+        vertical:'top',
+        horizontal:'left',
+      },
+      zDepth: 1,
+    };
+  },
+
+  getInitialState() {
+    this.setPlacementThrottled = throttle(this.setPlacement, 100);
+    return {
+      open: false,
+    };
+  },
+
+  contextTypes: {
+    muiTheme: React.PropTypes.object,
+  },
+
+  windowListeners: {
+    resize: 'setPlacementThrottled',
+    scroll: 'setPlacementThrottled',
+  },
+
+  componentWillReceiveProps(nextProps) {
+    if (this.state.openedManually)
+      return;
+
+    if (nextProps.open !== this.state.open) {
+      if (nextProps.open)
+        this._showInternal(nextProps.anchorEl);
+      else
+        this.hide();
+    }
+  },
+
+  componentDidUpdate() {
+    this.setPlacement();
+  },
+
+  render() {
+    return null;
+  },
+
+  renderLayer() {
+    let {
+      animated,
+      targetOrigin,
+      className,
+      zDepth,
+    } = this.props;
+
+    const anchorEl = this.props.anchorEl || this.anchorEl;
+    let anchor = this.getAnchorPosition(anchorEl);
+    let horizontal = targetOrigin.horizontal.replace("middle", "vertical");
+
+    let wrapperStyle = {
+      position: 'fixed',
+      top: anchor.top, left:
+      anchor.left,
+      zIndex: 20,
+      opacity:1,
+      overflow:'auto',
+      maxHeight:'100%',
+      transform:'scale(0,0)',
+      transformOrigin: `${horizontal} ${targetOrigin.vertical}`,
+      transition: animated ? Transitions.easeOut('500ms', ['transform', 'opacity']) : null,
+    };
+    wrapperStyle = this.mergeAndPrefix(wrapperStyle, this.props.style);
+
+    let horizontalAnimation = {
+      maxHeight:'100%',
+      overflowY:'auto',
+      transform:'scaleX(0)',
+      opacity:1,
+      transition: animated ? Transitions.easeOut('250ms', ['transform', 'opacity']): null,
+      transformOrigin: `${horizontal} ${targetOrigin.vertical}`,
+    };
+
+    let verticalAnimation = {
+      opacity:1,
+      transform:'scaleY(0)',
+      transformOrigin: `${horizontal} ${targetOrigin.vertical}`,
+      transition: animated ? Transitions.easeOut('500ms', ['transform', 'opacity']) : null,
+    }
+
+    const open = this.state.open;
+
+    return (
+      <Paper style={wrapperStyle} zDepth={zDepth} className={className} >
+        <div>
+          <div style={horizontalAnimation}>
+            <div style={verticalAnimation}>
+                {this.props.children}
+           </div>
+          </div>
+        </div>
+      </Paper>
+    );
+  },
+
+  requestClose() {
+    if (this.props.onRequestClose)
+      this.props.onRequestClose();
+  },
+
+  componentClickAway(e) {
+    if (e.defaultPrevented) {
+      return;
+    }
+    this.hide();
+  },
+
+  _resizeAutoPosition() {
+    this.setPlacement();
+  },
+
+  _showInternal(anchorEl) {
+    this.anchorEl = anchorEl || this.props.anchorEl;
+    this.setState({open: true});
+    const popOverShowEvent = new CustomEvent('popOverOnShow', {detail: this});
+    process.nextTick(() => { document.dispatchEvent(popOverShowEvent) });
+
+  },
+
+  show(anchorEl) {
+    this._showInternal(anchorEl);
+    this.setState({openedManually: true});
+  },
+
+  hide() {
+    if (!this.state.open) {
+      return;
+    }
+    this.setState({
+      open: false,
+      openedManually: false,
+    }, () => {
+      this._animateClose();
+      const popOverHideEvent = new CustomEvent('popOverOnHide');
+      process.nextTick(() => { document.dispatchEvent(popOverHideEvent) });
+    });
+  },
+
+  toggle(anchorEl) {
+    if (this.anchorEl) {
+      this.hide();
+    } else {
+      this.show(anchorEl);
+    }
+  },
+
+  _animateClose() {
+    if (!this._layer){
+      return;
+    }
+    let el = this._layer.children[0];
+    this._animate(el, false);
+  },
+
+  _animateOpen(el) {
+    this._animate(el, true);
+  },
+
+  _animate(el) {
+    let value = '0';
+    const inner = el.children[0];
+    const innerInner = inner.children[0];
+    const innerInnerInner = innerInner.children[0];
+    const rootStyle = inner.style;
+    const innerStyle = innerInner.style;
+
+    if (this.state.open) {
+      value = '1';
+    }
+    else {
+      CssEvent.onTransitionEnd(inner, () => {
+        if (!this.state.open)
+          this.requestClose();
+      });
+    }
+
+    AutoPrefix.set(el.style, 'transform', `scale(${value},${value})`);
+    AutoPrefix.set(innerInner.style, 'transform', `scaleX(${value})`);
+    AutoPrefix.set(innerInnerInner.style, 'transform', `scaleY(${value})`);
+    AutoPrefix.set(rootStyle, 'opacity', value);
+    AutoPrefix.set(innerStyle, 'opacity', value);
+    AutoPrefix.set(innerInnerInner, 'opacity', value);
+    AutoPrefix.set(el.style, 'opacity', value);
+  },
+
+  getAnchorPosition(el) {
+    if (!el)
+      el = ReactDOM.findDOMNode(this);
+
+    const rect = el.getBoundingClientRect();
+    const a = {
+      top: rect.top,
+      left: rect.left,
+      width: el.offsetWidth,
+      height: el.offsetHeight,
+    };
+
+    a.right = a.left + a.width;
+    a.bottom = a.top + a.height;
+    a.middle = a.left + a.width / 2;
+    a.center = a.top + a.height / 2;
+    return a;
+  },
+
+  getTargetPosition(targetEl) {
+    return {
+      top:0,
+      center: targetEl.offsetHeight / 2,
+      bottom: targetEl.offsetHeight,
+      left:0,
+      middle:targetEl.offsetWidth / 2,
+      right:targetEl.offsetWidth,
+    }
+  },
+
+  setPlacement(el) {
+    if (!this.state.open)
+      return;
+    const anchorEl = this.props.anchorEl || this.anchorEl;
+
+    const targetEl = this._layer.children[0];
+    if (!targetEl) {
+      return {};
+    }
+
+    let {targetOrigin, anchorOrigin} = this.props;
+
+    let anchor = this.getAnchorPosition(anchorEl);
+    let target = this.getTargetPosition(targetEl);
+
+    let targetPosition = {
+      top: anchor[anchorOrigin.vertical] - target[targetOrigin.vertical],
+      left: anchor[anchorOrigin.horizontal] - target[targetOrigin.horizontal],
+    }
+
+    if (this.props.autoCloseWhenOffScreen)
+      this.autoCloseWhenOffScreen(anchor);
+
+    if (this.props.canAutoPosition) {
+      target = this.getTargetPosition(targetEl); // update as height may have changed
+      targetPosition = this.applyAutoPositionIfNeeded(anchor, target, targetOrigin, anchorOrigin, targetPosition);
+    }
+
+
+    targetEl.style.top = targetPosition.top + 'px';
+    targetEl.style.left = targetPosition.left + 'px';
+    this._animateOpen(targetEl)
+  },
+
+  autoCloseWhenOffScreen(anchorPosition) {
+    if (!this.props.autoCloseWhenOffScreen)
+      return;
+    if (anchorPosition.top < 0
+        || anchorPosition.top > window.innerHeight
+        || anchorPosition.left < 0
+        || anchorPosition.left > window.innerWith
+        )
+      this.hide();
+  },
+
+  applyAutoPositionIfNeeded(anchor, target, targetOrigin, anchorOrigin, targetPosition) {
+    if (targetPosition.top + target.bottom > window.innerHeight) {
+      let positions = ["top", "center", "bottom"]
+        .filter((position) => position !== targetOrigin.vertical);
+
+      let newTop = anchor[anchorOrigin.vertical] - target[positions[0]];
+      if (newTop + target.bottom  <= window.innerHeight)
+        targetPosition.top = Math.max(0, newTop);
+      else {
+        newTop = anchor[anchorOrigin.vertical] - target[positions[1]];
+        if (newTop + target.bottom <= window.innerHeight)
+          targetPosition.top = Math.max(0, newTop);
+      }
+    }
+    if (targetPosition.left + target.right > window.innerWidth) {
+      let positions = ["left", "middle", "right"]
+        .filter((position) => position !== targetOrigin.horizontal);
+
+      let newLeft = anchor[anchorOrigin.horizontal] - target[positions[0]];
+      if (newLeft + target.right  <= window.innerWidth)
+        targetPosition.left = Math.max(0, newLeft);
+      else {
+        newLeft = anchor[anchorOrigin.horizontal] - target[positions[1]];
+        if (newLeft + target.right <= window.innerWidth)
+          targetPosition.left = Math.max(0, newLeft);
+      }
+    }
+    return targetPosition;
+  },
+
+});

--- a/src/select-field.jsx
+++ b/src/select-field.jsx
@@ -83,21 +83,24 @@ const SelectField = React.createClass({
   },
 
   getStyles() {
+    let spacing = this.state.muiTheme.rawTheme.spacing;
     let styles = {
       root: {
-        height: 46,
+        height: spacing.desktopSubheaderHeight,
         position: 'relative',
         width: '100%',
         top: 16,
         fontSize: 16,
+        overflow:'hidden',
       },
       label: {
         paddingLeft: 0,
-        top: 4,
+        top: 0,
         width: '100%',
+        lineHeight: spacing.desktopSubheaderHeight + 'px',
       },
       icon: {
-        top: 20,
+        top: 12,
         right: 0,
       },
       underline: {
@@ -107,18 +110,9 @@ const SelectField = React.createClass({
       error: {},
     };
 
-    if (!this.props.floatingLabelText) {
-      if(this.props.hintText) {
-        styles.root.top = -5;
-        styles.label.top = 1;
-        styles.icon.top = 17;
-      }
-      else {
-        styles.root.top = -8;
-      }
-    }
-    else {
-      styles.error.bottom = -15;
+    if (this.props.floatingLabelText) {
+      styles.label.top = 10;
+      styles.icon.top = 22;
     }
 
     return styles;

--- a/src/table/table-body.jsx
+++ b/src/table/table-body.jsx
@@ -15,21 +15,11 @@ const TableBody = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  //for passing default theme context to children
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getChildContext () {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  propTypes: {
+  propTypes:{
     allRowsSelected: React.PropTypes.bool,
     deselectOnClickaway: React.PropTypes.bool,
     displayRowCheckbox: React.PropTypes.bool,
+    label: React.PropTypes.node,
     multiSelectable: React.PropTypes.bool,
     onCellClick: React.PropTypes.func,
     onCellHover: React.PropTypes.func,
@@ -42,6 +32,17 @@ const TableBody = React.createClass({
     showRowHover: React.PropTypes.bool,
     stripedRows: React.PropTypes.bool,
     style: React.PropTypes.object,
+  },
+
+  //for passing default theme context to children
+  childContextTypes: {
+    muiTheme: React.PropTypes.object,
+  },
+
+  getChildContext() {
+    return {
+      muiTheme: this.state.muiTheme,
+    };
   },
 
   getDefaultProps() {

--- a/src/time-picker/clock-hours.jsx
+++ b/src/time-picker/clock-hours.jsx
@@ -32,6 +32,9 @@ const ClockHours = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
+    format: React.PropTypes.oneOf(['ampm', '24hr']),
+    initialHours: React.PropTypes.number,
+    onChange: React.PropTypes.func,
   //for passing default theme context to children
   childContextTypes: {
     muiTheme: React.PropTypes.object,
@@ -54,12 +57,6 @@ const ClockHours = React.createClass({
   componentWillReceiveProps (nextProps, nextContext) {
     let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
     this.setState({muiTheme: newMuiTheme});
-  },
-
-  propTypes: {
-    initialHours: React.PropTypes.number,
-    onChange: React.PropTypes.func,
-    format: React.PropTypes.oneOf(['ampm', '24hr']),
   },
 
   center: {x: 0, y: 0},

--- a/src/time-picker/time-picker-dialog.jsx
+++ b/src/time-picker/time-picker-dialog.jsx
@@ -7,10 +7,16 @@ const Dialog = require('../dialog');
 const FlatButton = require('../flat-button');
 const DefaultRawTheme = require('../styles/raw-themes/light-raw-theme');
 const ThemeManager = require('../styles/theme-manager');
+const ContextPure = require('../mixins/context-pure');
+
 
 const TimePickerDialog = React.createClass({
 
-  mixins: [StylePropable, WindowListenable],
+  mixins: [
+    StylePropable, 
+    WindowListenable, 
+    ContextPure,
+  ],
 
   contextTypes: {
     muiTheme: React.PropTypes.object,
@@ -22,6 +28,8 @@ const TimePickerDialog = React.createClass({
     onAccept: React.PropTypes.func,
     onShow: React.PropTypes.func,
     onDismiss: React.PropTypes.func,
+    onRequestClose: React.PropTypes.func,
+    open: React.PropTypes.bool,
   },
 
   //for passing default theme context to children
@@ -38,6 +46,14 @@ const TimePickerDialog = React.createClass({
   getInitialState () {
     return {
       muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
+    };
+  },
+
+  getDefaultProps() {
+    return {
+      onRequestClose: () => {},
+      onShow: () => {},
+      onDismiss: () => {},
     };
   },
 
@@ -93,16 +109,15 @@ const TimePickerDialog = React.createClass({
     ];
     
     const onClockChangeMinutes = (autoOk === true ? this._handleOKTouchTap : undefined);
-    
     return (
       <Dialog {...other}
-        ref="dialogWindow"
         style={this.mergeAndPrefix(styles.root)}
         bodyStyle={this.mergeAndPrefix(styles.body)}
         actions={actions}
         contentStyle={styles.dialogContent}
+        open={this.props.open}
         onDismiss={this._handleDialogDismiss}
-        onShow={this._handleDialogShow}
+        onShow={this.props.onShow}
         repositionOnUpdate={false}>
         <Clock
           ref="clock"
@@ -113,39 +128,25 @@ const TimePickerDialog = React.createClass({
     );
   },
 
-  show() {
-    this.refs.dialogWindow.show();
-  },
-
-  dismiss() {
-    this.refs.dialogWindow.dismiss();
-  },
-
   _handleCancelTouchTap() {
-    this.dismiss();
+    this.props.onRequestClose();
   },
 
   _handleOKTouchTap() {
-    this.dismiss();
+    this.props.onRequestClose();
     if (this.props.onAccept) {
       this.props.onAccept(this.refs.clock.getSelectedTime());
     }
   },
 
-  _handleDialogShow() {
-    if (this.props.onShow) {
-      this.props.onShow();
-    }
-  },
-
   _handleDialogDismiss() {
-    if (this.props.onDismiss) {
-      this.props.onDismiss();
-    }
+    this.setState({open:false});  
+    this.props.onRequestClose();
+    this.props.onDismiss();
   },
 
   _handleWindowKeyUp(e) {
-    if (this.refs.dialogWindow.isOpen()) {
+    if (this.props.open) {
       switch (e.keyCode) {
         case KeyCode.ENTER:
           this._handleOKTouchTap();

--- a/src/time-picker/time-picker.jsx
+++ b/src/time-picker/time-picker.jsx
@@ -3,6 +3,7 @@ const StylePropable = require('../mixins/style-propable');
 const WindowListenable = require('../mixins/window-listenable');
 const TimePickerDialog = require('./time-picker-dialog');
 const TextField = require('../text-field');
+const ContextPure = require('../mixins/context-pure');
 
 
 let emptyTime = new Date();
@@ -12,7 +13,11 @@ emptyTime.setMinutes(0);
 
 const TimePicker = React.createClass({
 
-  mixins: [StylePropable, WindowListenable],
+  mixins: [
+    StylePropable, 
+    WindowListenable,
+    ContextPure,
+  ],
 
   propTypes: {
     autoOk: React.PropTypes.bool,
@@ -50,6 +55,7 @@ const TimePicker = React.createClass({
     return {
       time: this.props.defaultTime || emptyTime,
       dialogTime: new Date(),
+      dialogOpen:false,
     };
   },
 
@@ -112,11 +118,12 @@ const TimePicker = React.createClass({
           onFocus={this._handleInputFocus}
           onTouchTap={this._handleInputTouchTap} />
         <TimePickerDialog
-          ref="dialogWindow"
+          open={this.state.dialogOpen}
           initialTime={this.state.dialogTime}
           onAccept={this._handleDialogAccept}
           onShow={onShow}
           onDismiss={onDismiss}
+          onRequestClose={this._handleDialogClose}
           format={format}
           autoOk={autoOk} />
       </div>
@@ -144,14 +151,18 @@ const TimePicker = React.createClass({
   openDialog() {
     this.setState({
       dialogTime: this.getTime(),
+      dialogOpen:true,
     });
-
-    this.refs.dialogWindow.show();
   },
 
   _handleDialogAccept(t) {
+    this.setState({dialogOpen:false});
     this.setTime(t);
     if (this.props.onChange) this.props.onChange(null, t);
+  },
+
+  _handleDialogClose() {
+    this.setState({dialogOpen:false});
   },
 
   _handleInputFocus(e) {
@@ -161,9 +172,7 @@ const TimePicker = React.createClass({
 
   _handleInputTouchTap(e) {
     e.preventDefault();
-
     this.openDialog();
-
     if (this.props.onTouchTap) this.props.onTouchTap(e);
   },
 });

--- a/src/utils/prop-types.js
+++ b/src/utils/prop-types.js
@@ -1,5 +1,8 @@
 let React = require('react');
 
+const horizontal = React.PropTypes.oneOf(['left', 'middle', 'right']);
+const vertical = React.PropTypes.oneOf(['top', 'center', 'bottom']);
+
 module.exports = {
 
   corners: React.PropTypes.oneOf([
@@ -8,6 +11,21 @@ module.exports = {
     'top-left',
     'top-right',
   ]),
+  popOverPositions: React.PropTypes.oneOf([
+    'bottom-left',
+    'bottom-right',
+    'top-left',
+    'top-right',
+    'above',
+    'below',
+  ]),
+  horizontal:horizontal,
+  vertical:vertical,
+
+  origin: React.PropTypes.shape({
+      horizontal: horizontal,
+      vertical:vertical,
+  }),
 
   cornersAndCenter: React.PropTypes.oneOf([
     'bottom-center',


### PR DESCRIPTION
This PR 
a) currently breaks dialogs
b) introduces a component `Popover` which is an arbitrary control that shows a popup menu, either `onClick` or on `props.open = true`.
c) Popover component wraps menu in IconMenu - nearly transparently.
d) Popover renders to a new DOM Tree, and in theory context should transfer for React@0.13
e) Dialog renders into new tree, but has issues that I'll sort shortly...