### PR TITLE
[React-v14] Use findDOMNode where needed and fix package

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,17 +15,17 @@
   "dependencies": {
     "codemirror": "^5.5.0",
     "history": "^1.11.1",
-    "react-addons-create-fragment": "^0.14.0-rc1",
-    "react-addons-pure-render-mixin": "^0.14.0-rc1",
-    "react-addons-transition-group": "^0.14.0-rc1",
-    "react-addons-update": "^0.14.0-rc1",
-    "react-dom": "^0.14.0-rc1",
+    "react-addons-create-fragment": "^0.14.0",
+    "react-addons-pure-render-mixin": "^0.14.0",
+    "react-addons-transition-group": "^0.14.0",
+    "react-addons-update": "^0.14.0",
+    "react-dom": "^0.14.0",
     "react-tap-event-plugin": "^0.2.0"
   },
   "devDependencies": {
     "raw-loader": "^0.5.1",
-    "react": "^0.14.0-rc1",
-    "react-addons-linked-state-mixin": "^0.14.0-rc1",
+    "react": "^0.14.0",
+    "react-addons-linked-state-mixin": "^0.14.0",
     "webpack": "^1.11.0",
     "webpack-dev-server": "^1.10.1"
   }

--- a/docs/webpack-dev-server.config.js
+++ b/docs/webpack-dev-server.config.js
@@ -23,7 +23,7 @@ var config = {
     },
     //Modules will be searched for in these directories
     modulesDirectories: [
-      "web_modules",
+      "node_modules",
       path.resolve(__dirname, "node_modules"),
       path.resolve(__dirname, '../src'),
       path.resolve(__dirname, '../node_modules'),

--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "react-draggable2": "^0.7.0-alpha1"
   },
   "peerDependencies": {
-    "react": ">=0.14.0-rc1",
-    "react-dom": ">=0.14.0-rc1",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
     "react-tap-event-plugin": "^0.2.0",
-    "react-addons-transition-group": "^0.14.0-rc1",
-    "react-addons-update": "^0.14.0-rc1",
-    "react-addons-create-fragment": "^0.14.0-rc1",
-    "react-addons-pure-render-mixin": "^0.14.0-rc1"
+    "react-addons-transition-group": "^0.14.0",
+    "react-addons-update": "^0.14.0",
+    "react-addons-create-fragment": "^0.14.0",
+    "react-addons-pure-render-mixin": "^0.14.0"
   },
   "devDependencies": {
     "babel": "^5.4.3",
@@ -53,6 +53,7 @@
     "eslint": "^1.1.0",
     "eslint-loader": "^1.0.0",
     "eslint-plugin-react": "^3.2.2",
+    "fbjs": "^0.2.1",
     "gulp": "^3.9.0",
     "gulp-eslint": "^1.0.0",
     "html-webpack-plugin": "^1.6.1",
@@ -66,19 +67,19 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.2.5",
     "phantomjs": "^1.9.17",
+    "react": "^0.14.0",
+    "react-addons-create-fragment": "^0.14.0",
+    "react-addons-pure-render-mixin": "^0.14.0",
+    "react-addons-transition-group": "^0.14.0",
+    "react-addons-update": "^0.14.0",
+    "react-dom": "^0.14.0",
     "react-hot-loader": "^1.2.8",
     "react-router": "^1.0.0-rc1",
+    "react-tap-event-plugin": "^0.2.0",
     "rimraf": "^2.4.3",
     "sinon": "^1.15.4",
     "sinon-chai": "^2.8.0",
     "transfer-webpack-plugin": "^0.1.4",
-    "webpack": "^1.11.0",
-    "react": ">=0.14.0-rc1",
-    "react-dom": ">=0.14.0-rc1",
-    "react-tap-event-plugin": "^0.2.0",
-    "react-addons-transition-group": "^0.14.0-rc1",
-    "react-addons-update": "^0.14.0-rc1",
-    "react-addons-create-fragment": "^0.14.0-rc1",
-    "react-addons-pure-render-mixin": "^0.14.0-rc1"
+    "webpack": "^1.11.0"
   }
 }

--- a/src/date-picker/calendar-year.jsx
+++ b/src/date-picker/calendar-year.jsx
@@ -1,4 +1,5 @@
 const React = require('react');
+const ReactDOM = require('react-dom');
 const StylePropable = require('../mixins/style-propable');
 const Colors = require('../styles/colors');
 const DateTime = require('../utils/date-time');
@@ -78,8 +79,8 @@ const CalendarYear = React.createClass({
   _scrollToSelectedYear() {
     if (this.refs.selectedYearButton === undefined) return;
 
-    let container = this.getDOMNode();
-    let yearButtonNode = this.refs.selectedYearButton.getDOMNode();
+    let container = this.findDOMNode();
+    let yearButtonNode = ReactDOM.findDOMNode(this.refs.selectedYearButton);
 
     let containerHeight = container.clientHeight;
     let yearButtonNodeHeight = yearButtonNode.clientHeight || 32;

--- a/src/date-picker/date-picker-dialog.jsx
+++ b/src/date-picker/date-picker-dialog.jsx
@@ -1,4 +1,5 @@
 const React = require('react');
+const ReactDOM = require('react-dom');
 const StylePropable = require('../mixins/style-propable');
 const WindowListenable = require('../mixins/window-listenable');
 const CssEvent = require('../utils/css-event');
@@ -169,7 +170,7 @@ const DatePickerDialog = React.createClass({
   },
 
   _handleDialogDismiss() {
-    CssEvent.onTransitionEnd(this.refs.dialog.getDOMNode(), () => {
+    CssEvent.onTransitionEnd(ReactDOM.findDOMNode(this.refs.dialog), () => {
       this.setState({
         isCalendarActive: false,
         showMonthDayPicker: true,
@@ -180,7 +181,7 @@ const DatePickerDialog = React.createClass({
   },
 
   _handleDialogClickAway() {
-    CssEvent.onTransitionEnd(this.refs.dialog.getDOMNode(), () => {
+    CssEvent.onTransitionEnd(ReactDOM.findDOMNode(this.refs.dialog), () => {
       this.setState({
         isCalendarActive: false,
         showMonthDayPicker: true,

--- a/src/dialog.jsx
+++ b/src/dialog.jsx
@@ -1,4 +1,5 @@
 const React = require('react');
+const ReactDOM = require('react-dom');
 const WindowListenable = require('./mixins/window-listenable');
 const CssEvent = require('./utils/css-event');
 const KeyCode = require('./utils/key-code');
@@ -265,7 +266,7 @@ let Dialog = React.createClass({
   },
 
   dismiss() {
-    CssEvent.onTransitionEnd(this.getDOMNode(), () => {
+    CssEvent.onTransitionEnd(this.findDOMNode(), () => {
       this.refs.dialogOverlay.allowScrolling();
     });
 
@@ -346,9 +347,9 @@ let Dialog = React.createClass({
   _positionDialog() {
     if (this.state.open) {
       let clientHeight = window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight;
-      let container = this.getDOMNode();
-      let dialogWindow = this.refs.dialogWindow.getDOMNode();
-      let dialogContent = this.refs.dialogContent.getDOMNode();
+      let container = this.findDOMNode();
+      let dialogWindow = ReactDOM.findDOMNode(this.refs.dialogWindow);
+      let dialogContent = ReactDOM.findDOMNode(this.refs.dialogContent);
       let minPaddingTop = 16;
 
       //Reset the height in case the window was resized.

--- a/src/menu/menu.jsx
+++ b/src/menu/menu.jsx
@@ -66,8 +66,7 @@ const NestedMenuItem = React.createClass({
 
   componentDidMount() {
     this._positionNestedMenu();
-    let el = this.getDOMNode();
-    el.focus();
+    this.findDOMNode().focus();
   },
 
   componentDidUpdate() {


### PR DESCRIPTION
- Remove `-rc1` with the offical release.
- Use `^` instead of `>=` to prevent future breaking changes with react v0.15.
- Remove deprecated `getDOMNode`.
- Fix docs webpack-dev-server.