### PR TITLE
disable lint as part of build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test-base": "./node_modules/.bin/karma start",
     "prebuild": "rm -rf lib",
     "eslint": "gulp eslint",
-    "build": "npm run eslint && babel --stage 1 ./src --out-dir ./lib",
+    "build": "babel --stage 1 ./src --out-dir ./lib",
     "prepublish": "npm run build"
   },
   "keywords": [


### PR DESCRIPTION
there are a bunch of linting errors that break `npm run build` right now