### PR TITLE
Depend on official react 0.14.x module releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "react-draggable2": "^0.7.0-alpha1"
   },
   "peerDependencies": {
-    "react": ">=0.14.0-rc1",
-    "react-dom": ">=0.14.0-rc1",
+    "react": ">=0.14.0",
+    "react-dom": ">=0.14.0",
     "react-tap-event-plugin": "^0.2.0",
-    "react-addons-transition-group": "^0.14.0-rc1",
-    "react-addons-update": "^0.14.0-rc1",
-    "react-addons-create-fragment": "^0.14.0-rc1",
-    "react-addons-pure-render-mixin": "^0.14.0-rc1"
+    "react-addons-transition-group": "^0.14.0",
+    "react-addons-update": "^0.14.0",
+    "react-addons-create-fragment": "^0.14.0",
+    "react-addons-pure-render-mixin": "^0.14.0"
   },
   "devDependencies": {
     "babel": "^5.4.3",


### PR DESCRIPTION
Now that React 0.14 has been officially released (and is available on npm), this updates `package.json` to reference the official/non-rc version numbers for impacted modules.

Thanks for all the work you're doing to make material-ui compatible with React 0.14! Can't wait to have a stable release. :)