### PR TITLE
issue/1870: Fix if newHeight is 0, use rowsHeight instead

### DIFF
--- a/src/enhanced-textarea.jsx
+++ b/src/enhanced-textarea.jsx
@@ -120,6 +120,8 @@ const EnhancedTextarea = React.createClass({
       newHeight = Math.min(this.props.rowsMax * rowsHeight, newHeight);
     }
 
+    newHeight = Math.max(newHeight, rowsHeight);
+
     if (this.state.height !== newHeight) {
       this.setState({
         height: newHeight,


### PR DESCRIPTION
Please review solution to issue 1870
Issue reference: https://github.com/callemall/material-ui/issues/1870

The problem:
newHeight was being set to 0 on componentDidMount.

Solution:
Use the max value between newheight and rowsHeight for height consistency.