### PR TITLE
[Docs] Reset the scroll at the top when routing

### DIFF
--- a/docs/src/app/app.jsx
+++ b/docs/src/app/app.jsx
@@ -18,6 +18,11 @@ injectTapEventPlugin();
  * Render the main app component. You can read more about the react-router here:
  * https://github.com/rackt/react-router/blob/master/docs/guides/overview.md
  */
-ReactDOM.render(<Router history={createHistory({queryKey: false})}>
-  {AppRoutes}
-</Router>, document.getElementById('app'));
+ReactDOM.render(
+  <Router
+    history={createHistory({queryKey: false})}
+    onUpdate={() => window.scrollTo(0, 0)}
+  >
+    {AppRoutes}
+  </Router>
+, document.getElementById('app'));


### PR DESCRIPTION
When changing route, we set the scroll at the top of the page. This was the default behavior before react-router v1.0.0.

See the react-router doc:
> In 0.13.x we had a couple of implementations to restore scroll position,
we've realized that we can build a better implementation on top of the router
and will be doing that very soon, before the 1.0 final release,
but it doesn't need to be baked into routing like it was before