### PR TITLE
fix for IE9 when closing dialog

### DIFF
--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -1,7 +1,7 @@
 module.exports = {
 
   once(el, type, callback) {
-    let typeArray = type.split(' ');
+    let typeArray = type ? type.split(' ') : [];
     let recursiveFunction = (e) => {
       e.target.removeEventListener(e.type, recursiveFunction);
       return callback(e);


### PR DESCRIPTION
I have found an issue, when user is closing the dialog in IE9. IE9 is throwing:

> Unable to get value of the property 'split': object is null or undefined

I have made a simple check fix and it should not break anything. 