### PR TITLE
Fixed broken tabs on docs site

### DIFF
--- a/docs/src/app/components/master.jsx
+++ b/docs/src/app/components/master.jsx
@@ -95,9 +95,9 @@ const Master = React.createClass({
   render() {
     let styles = this.getStyles();
     let title =
-      this.props.history.isActive('get-started') ? 'Get Started' :
-      this.props.history.isActive('customization') ? 'Customization' :
-      this.props.history.isActive('components') ? 'Components' : '';
+      this.props.history.isActive('/get-started') ? 'Get Started' :
+      this.props.history.isActive('/customization') ? 'Customization' :
+      this.props.history.isActive('/components') ? 'Components' : '';
 
     let githubButton = (
       <IconButton
@@ -223,9 +223,9 @@ const Master = React.createClass({
   },
 
   _getSelectedIndex() {
-    return this.props.history.isActive('get-started') ? '1' :
-      this.props.history.isActive('customization') ? '2' :
-      this.props.history.isActive('components') ? '3' : '0';
+    return this.props.history.isActive('/get-started') ? '1' :
+      this.props.history.isActive('/customization') ? '2' :
+      this.props.history.isActive('/components') ? '3' : '0';
   },
 
   _handleTabChange(value, e, tab) {
@@ -235,9 +235,9 @@ const Master = React.createClass({
 
   _getAppBar() {
     let title =
-      this.props.history.isActive('get-started') ? 'Get Started' :
-      this.props.history.isActive('customization') ? 'Customization' :
-      this.props.history.isActive('components') ? 'Components' : '';
+      this.props.history.isActive('/get-started') ? 'Get Started' :
+      this.props.history.isActive('/customization') ? 'Customization' :
+      this.props.history.isActive('/components') ? 'Components' : '';
 
     let githubButton = (
       <IconButton

--- a/docs/src/app/components/mobile-tear-sheet.jsx
+++ b/docs/src/app/components/mobile-tear-sheet.jsx
@@ -7,7 +7,7 @@ const MobileTearSheet = React.createClass({
   mixins: [StylePropable],
 
   contextTypes : {
-    muiTheme: React.PropTypes.func
+    muiTheme: React.PropTypes.object
   },
 
   propTypes: {

--- a/docs/src/app/components/pages/home.jsx
+++ b/docs/src/app/components/pages/home.jsx
@@ -158,16 +158,16 @@ const HomePage = React.createClass({
       <FullWidthSection useContent={true} contentStyle={styles}>
         <HomeFeature
           heading="Get Started"
-          route="get-started"
+          route="/get-started"
           img="images/get-started.svg"
           firstChild={true}/>
         <HomeFeature
           heading="Customization"
-          route="customization"
+          route="/customization"
           img="images/css-framework.svg" />
         <HomeFeature
           heading="Components"
-          route="components"
+          route="/components"
           img="images/components.svg"
           lastChild={true}/>
       </FullWidthSection>

--- a/test/checkbox-spec.js
+++ b/test/checkbox-spec.js
@@ -19,9 +19,9 @@ describe('Checkbox', () => {
     let render = TestUtils.renderIntoDocument(<ThemedCheckbox defaultChecked={true} />);
     let input = TestUtils.findRenderedDOMComponentWithTag(render, 'input');
     let svgs = TestUtils.scryRenderedDOMComponentsWithTag(render, 'svg');
-    let checkMarkNode = svgs[1].getDOMNode();
+    let checkMarkNode = svgs[1];
 
-    expect(input.getDOMNode().hasAttribute('checked')).to.be.true;
+    expect(input.hasAttribute('checked')).to.be.true;
     expect(checkMarkNode.style.opacity).to.equal('1');
     expect(checkMarkNode.firstChild.getAttribute('d')).to.equal(CHECKMARK_PATH);
   });
@@ -31,9 +31,9 @@ describe('Checkbox', () => {
     let render = TestUtils.renderIntoDocument(<ThemedCheckbox defaultChecked={false} />);
     let input = TestUtils.findRenderedDOMComponentWithTag(render, 'input');
     let svgs = TestUtils.scryRenderedDOMComponentsWithTag(render, 'svg');
-    let checkMarkNode = svgs[1].getDOMNode();
+    let checkMarkNode = svgs[1];
 
-    expect(input.getDOMNode().hasAttribute('checked')).to.be.false;
+    expect(input.hasAttribute('checked')).to.be.false;
     expect(checkMarkNode.style.opacity).to.equal('0');
     expect(checkMarkNode.firstChild.getAttribute('d')).to.equal(CHECKMARK_PATH);
   });
@@ -50,12 +50,12 @@ describe('Checkbox', () => {
 
     it('should display checkmark when clicked once', () => {
       let input = TestUtils.findRenderedDOMComponentWithTag(renderedCheckbox, 'input');
-      let inputNode = input.getDOMNode();
+      let inputNode = input;
       inputNode.checked = !inputNode.checked;
       TestUtils.Simulate.change(input);
 
       let svgs = TestUtils.scryRenderedDOMComponentsWithTag(renderedCheckbox, 'svg');
-      let checkMarkNode = svgs[1].getDOMNode();
+      let checkMarkNode = svgs[1];
       expect(checkMarkNode.style.opacity).to.equal('1');
       expect(checkMarkNode.firstChild.getAttribute('d')).to.equal(CHECKMARK_PATH);
     });
@@ -63,7 +63,7 @@ describe('Checkbox', () => {
 
     it('should NOT display checkmark when clicked twice', () => {
       let input = TestUtils.findRenderedDOMComponentWithTag(renderedCheckbox, 'input');
-      let inputNode = input.getDOMNode();
+      let inputNode = input;
       // Simulate events
       inputNode.checked = !inputNode.checked;
       TestUtils.Simulate.change(input);
@@ -71,7 +71,7 @@ describe('Checkbox', () => {
       TestUtils.Simulate.change(input);
 
       let svgs = TestUtils.scryRenderedDOMComponentsWithTag(renderedCheckbox, 'svg');
-      let checkMarkNode = svgs[1].getDOMNode();
+      let checkMarkNode = svgs[1];
       expect(checkMarkNode.style.opacity).to.equal('0');
       expect(checkMarkNode.firstChild.getAttribute('d')).to.equal(CHECKMARK_PATH);
     });

--- a/test/drop-down-menu-spec.js
+++ b/test/drop-down-menu-spec.js
@@ -36,7 +36,7 @@ describe('DropDownMenu', () => {
                 value={value}/>
         );
         let divWithSelectedText = 
-            TestUtils.scryRenderedDOMComponentsWithTag(render, 'div')[1].getDOMNode();
+            TestUtils.scryRenderedDOMComponentsWithTag(render, 'div')[1];
             
         expect(divWithSelectedText.textContent).to.be.equal(expectedSelectedText);
     });

--- a/test/theming-v12-spec.js
+++ b/test/theming-v12-spec.js
@@ -43,7 +43,7 @@ describe('Theming', () => {
 
 			let renderedAppbar = TestUtils.renderIntoDocument(<AppBar />);
 			let appbarDivs = TestUtils.scryRenderedDOMComponentsWithTag(renderedAppbar, 'div');
-			let firstDiv = appbarDivs[0].getDOMNode();
+			let firstDiv = appbarDivs[0];
 
 			expect(firstDiv.style.backgroundColor).to.equal('rgb(0, 188, 212)');
 		});
@@ -57,7 +57,7 @@ describe('Theming', () => {
 
 				let renderedAppbar = TestUtils.renderIntoDocument(<AppBarDarkUsingContext />);
 				let appbarDivs = TestUtils.scryRenderedDOMComponentsWithTag(renderedAppbar, 'div');
-				let firstDiv = appbarDivs[0].getDOMNode();
+				let firstDiv = appbarDivs[0];
 
 				expect(firstDiv.style.backgroundColor).to.equal('rgb(0, 151, 167)');
 			});
@@ -66,10 +66,10 @@ describe('Theming', () => {
 
 				let renderedAppbar = TestUtils.renderIntoDocument(<AppBarDarkUsingContextWithOverride />);
 				let appbarDivs = TestUtils.scryRenderedDOMComponentsWithTag(renderedAppbar, 'div');
-				let firstDiv = appbarDivs[0].getDOMNode();
+				let firstDiv = appbarDivs[0];
 
 				let appbarH1s = TestUtils.scryRenderedDOMComponentsWithTag(renderedAppbar, 'h1');
-				let firstH1 = appbarH1s[0].getDOMNode();
+				let firstH1 = appbarH1s[0];
 
 				expect(firstDiv.style.backgroundColor).to.equal('rgb(0, 151, 167)');
 				expect(firstH1.style.color).to.equal('rgb(98, 0, 234)');
@@ -83,7 +83,7 @@ describe('Theming', () => {
 
 				let renderedAppbar = TestUtils.renderIntoDocument(<AppBarDarkUsingDecorator />);
 				let appbarDivs = TestUtils.scryRenderedDOMComponentsWithTag(renderedAppbar, 'div');
-				let firstDiv = appbarDivs[0].getDOMNode();
+				let firstDiv = appbarDivs[0];
 
 				expect(firstDiv.style.backgroundColor).to.equal('rgb(0, 151, 167)');
 			});
@@ -92,10 +92,10 @@ describe('Theming', () => {
 
 				let renderedAppbar = TestUtils.renderIntoDocument(<AppBarDarkUsingDecoratorWithOverride />);
 				let appbarDivs = TestUtils.scryRenderedDOMComponentsWithTag(renderedAppbar, 'div');
-				let firstDiv = appbarDivs[0].getDOMNode();
+				let firstDiv = appbarDivs[0];
 
 				let appbarH1s = TestUtils.scryRenderedDOMComponentsWithTag(renderedAppbar, 'h1');
-				let firstH1 = appbarH1s[0].getDOMNode();
+				let firstH1 = appbarH1s[0];
 
 				expect(firstDiv.style.backgroundColor).to.equal('rgb(0, 151, 167)');
 				expect(firstH1.style.color).to.equal('rgb(98, 0, 234)');
@@ -109,11 +109,11 @@ describe('Theming', () => {
 		it('should display with updated theme', () => {
 			let renderedComponent = TestUtils.renderIntoDocument(<ButtonToUpdateThemeWithAppBar />);
 			let componentDivs = TestUtils.scryRenderedDOMComponentsWithTag(renderedComponent, 'div');
-			let appbarDiv = componentDivs[1].getDOMNode();
+			let appbarDiv = componentDivs[1];
 			let buttonNode = (TestUtils.scryRenderedDOMComponentsWithTag(renderedComponent, 'button'))[1];
 
 			let appbarH1s = TestUtils.scryRenderedDOMComponentsWithTag(renderedComponent, 'h1');
-			let firstH1 = appbarH1s[0].getDOMNode();
+			let firstH1 = appbarH1s[0];
 
 			expect(appbarDiv.style.backgroundColor).to.equal('rgb(0, 151, 167)');
 			expect(firstH1.style.color).to.equal('rgb(48, 48, 48)');


### PR DESCRIPTION
The history.isActive function was checking for route paths without the leading "/". Fixing that pretty much clears up all currently known broken things with the docs site