### PR TITLE
[Clock] Fix wrong usage of prepareStyles

### DIFF
--- a/src/time-picker/clock.jsx
+++ b/src/time-picker/clock.jsx
@@ -111,7 +111,7 @@ const Clock = React.createClass({
     }
 
     return (
-      <div style={this.prepareStyles(styles.root)}>
+      <div style={this.mergeStyles(styles.root)}>
         <TimeDisplay
           selectedTime={this.state.selectedTime}
           mode={this.state.mode}
@@ -120,7 +120,7 @@ const Clock = React.createClass({
           onSelectHour={this._setMode.bind(this, 'hour')}
           onSelectMin={this._setMode.bind(this, 'minute')} />
 
-        <div style={this.prepareStyles(styles.container)} >
+        <div style={this.mergeStyles(styles.container)} >
           {clock}
         </div>
 


### PR DESCRIPTION
This is related to https://github.com/callemall/material-ui/issues/1918, pointed out by @shaurya947.
I'm using `mergeStyles` here assuming we don't need RTL support for those two styles.