### PR TITLE
[strict] Enforce no-dup-keys

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@ rules:
   # Errors
   comma-dangle: [2, always-multiline]
   no-var: 2
+  no-dupe-keys: 2
   eqeqeq: [2, allow-null]
   eol-last: 2
   yoda: 2


### PR DESCRIPTION
Using duplicate keys fails in strict mode.
Prevent issues like https://github.com/callemall/material-ui/issues/1918 to happen again. 