### PR TITLE
check muiTheme is defined

### DIFF
--- a/src/utils/styles.js
+++ b/src/utils/styles.js
@@ -93,7 +93,7 @@ module.exports = {
 
   prepareStyles(muiTheme, ...styles) {
     styles = styles.length > 1 ? ImmutabilityHelper.merge.apply(this, styles) : (styles[0] || {});
-    const flipped = this.ensureDirection(muiTheme, styles);
+    const flipped = muiTheme ? this.ensureDirection(muiTheme, styles) : styles;
     return AutoPrefix.all(flipped);
   },
 };

--- a/src/utils/styles.js
+++ b/src/utils/styles.js
@@ -25,7 +25,7 @@ module.exports = {
     }
 
     // Left to right is the default. No need to flip anything.
-    if (!muiTheme.isRtl) return style; 
+    if (!muiTheme || muiTheme.isRtl) return style; 
 
     const flippedAttributes = {
       // Keys and their replacements.

--- a/src/utils/styles.js
+++ b/src/utils/styles.js
@@ -25,7 +25,7 @@ module.exports = {
     }
 
     // Left to right is the default. No need to flip anything.
-    if (!muiTheme || muiTheme.isRtl) return style; 
+    if (!muiTheme || !muiTheme.isRtl) return style; 
 
     const flippedAttributes = {
       // Keys and their replacements.


### PR DESCRIPTION
TimePicker dialog wont open when muiTheme is null/undefined. Steps to reproduce:
1. Browse to http://material-ui.com/#/components/time-picker
2. Open the console on browser
3. Click on any of the TimePicker input fields.
- Uncaught TypeError: Cannot read property 'isRtl' of undefined

Source: `/src/time-picker/clock.jsx` line 118 ```<div style={this.prepareStyles(styles.root)}>```, styles.root is ```{}```.

Fix: added a double check to `ensureDirection` to check `muiTheme` is not `null` or `undefined` before checking its `isRtl` property.