### PR TITLE
Fixed GridList style broken in Safari

### DIFF
--- a/src/grid-list/grid-list.jsx
+++ b/src/grid-list/grid-list.jsx
@@ -53,7 +53,7 @@ const GridList = React.createClass({
   {
     return {
       root: {
-        display: 'flex',
+        display: '-webkit-box; display: -moz-box; display: -ms-flexbox; display: -webkit-flex; display: flex',
         flexWrap: 'wrap',
         margin: `-${this.props.padding/2}px`,
       },
@@ -84,7 +84,7 @@ const GridList = React.createClass({
       const childRows = currentChild.props.rows || 1;
       const itemStyle = this.mergeStyles(styles.item, {
         width: (100 / cols * childCols) + '%',
-        height: cellHeight * childRows + padding,
+        height: parseInt(cellHeight) * childRows + padding,
       });
 
       return <div style={this.prepareStyles(itemStyle)}>{currentChild}</div>;

--- a/src/grid-list/grid-list.jsx
+++ b/src/grid-list/grid-list.jsx
@@ -32,7 +32,7 @@ const GridList = React.createClass({
     return {
       cols: 2,
       padding: 4,
-      cellHeight: '180px',
+      cellHeight: 180,
     };
   },
 
@@ -84,7 +84,7 @@ const GridList = React.createClass({
       const childRows = currentChild.props.rows || 1;
       const itemStyle = this.mergeStyles(styles.item, {
         width: (100 / cols * childCols) + '%',
-        height: parseInt(cellHeight) * childRows + padding,
+        height: cellHeight * childRows + padding,
       });
 
       return <div style={this.prepareStyles(itemStyle)}>{currentChild}</div>;

--- a/src/grid-list/grid-tile.jsx
+++ b/src/grid-list/grid-tile.jsx
@@ -83,7 +83,7 @@ const GridTile = React.createClass({
         [this.props.titlePosition]: 0,
         height: this.props.subtitle ? 68 : 48,
         background: this.props.titleBackground,
-        display: 'flex',
+        display: '-webkit-box; display: -moz-box; display: -ms-flexbox; display: -webkit-flex; display: flex',
         alignItems: 'center',
       },
       titleWrap: {


### PR DESCRIPTION
Flex require `-webkit-` prefix to work in Safari.
Fixed GridTile height: it was `NaN` if you set `cellHeight` using a 'px' value.

