### PR TITLE
[TimePicker] openDialog() method similar to DatePicker

### DIFF
--- a/docs/src/app/components/pages/components/time-picker.jsx
+++ b/docs/src/app/components/pages/components/time-picker.jsx
@@ -63,6 +63,18 @@ let TimePickerPage = React.createClass({
             header: 'TimePicker.formatTime(time)',
             desc: 'Formats the Date object to a current component\'s time format.',
           },
+          {
+            name: 'openDialog',
+            header: 'TimePicker.openDialog()',
+            desc: 'Opens the time-picker dialog programmatically. Use this if you want to open the ' +
+            'dialog in response to some event other than focus/tap on the input field, such as an ' +
+            'external button click.',
+          },
+          {
+            name: 'focus',
+            header: 'TimePicker.focus()',
+            desc: 'An alias for the `openDialog()` method to allow more generic use alongside `TextField`.',
+          },
         ],
       },
       {

--- a/src/time-picker/time-picker.jsx
+++ b/src/time-picker/time-picker.jsx
@@ -120,6 +120,13 @@ const TimePicker = React.createClass({
     this.refs.input.setValue(this.formatTime(t));
   },
 
+  /**
+   * Alias for `openDialog()` for an api consistent with TextField.
+   */
+  focus() {
+    this.openDialog();
+  },
+
   openDialog() {
     this.setState({
       dialogTime: this.getTime(),

--- a/src/time-picker/time-picker.jsx
+++ b/src/time-picker/time-picker.jsx
@@ -120,6 +120,14 @@ const TimePicker = React.createClass({
     this.refs.input.setValue(this.formatTime(t));
   },
 
+  openDialog() {
+    this.setState({
+      dialogTime: this.getTime(),
+    });
+
+    this.refs.dialogWindow.show();
+  },
+
   _handleDialogAccept(t) {
     this.setTime(t);
     if (this.props.onChange) this.props.onChange(null, t);
@@ -133,11 +141,8 @@ const TimePicker = React.createClass({
   _handleInputTouchTap(e) {
     e.preventDefault();
 
-    this.setState({
-      dialogTime: this.getTime(),
-    });
+    this.openDialog();
 
-    this.refs.dialogWindow.show();
     if (this.props.onTouchTap) this.props.onTouchTap(e);
   },
 });


### PR DESCRIPTION
added openDialog() to TimePicker.

Possible use case - a date and time picker:
```
<div>
<TimePicker ref="time" onChange={(e, value) => this.props.setTime(value); } />
<DatePicker ref="date" onChange={(e, value) => { this.props.setDate(value); this.refs.time.openDialog(); }} />
</div>
````

onChange of DatePicker will be called when the DatePicker dialog has been dismissed and the user selected a date, which will then automatically open the TimePicker dialog allowing the user to set the time.