### PR TITLE
[TimePicker] autoOk prop to automatically close the dialog

### DIFF
--- a/docs/src/app/components/pages/components/time-picker.jsx
+++ b/docs/src/app/components/pages/components/time-picker.jsx
@@ -14,6 +14,12 @@ let TimePickerPage = React.createClass({
         name: 'Props',
         infoArray: [
           {
+            name: 'autoOk',
+            type: 'boolean',
+            header: 'default: false',
+            desc: 'If true, automatically accept and close the picker on set minutes.',
+          },
+          {
             name: 'defaultTime',
             type: 'date object',
             header: 'optional',
@@ -113,6 +119,12 @@ let TimePickerPage = React.createClass({
             format="24hr"
             hintText="24hr Format"
             onChange={this._changeTimePicker12}  />
+
+          <TimePicker
+            ref="pickerAutoOk"
+            format="24hr"
+            hintText="AutoOk"
+            autoOk={true} />
         </CodeExample>
       </ComponentDoc>
     );

--- a/docs/src/app/components/raw-code/time-picker-code.txt
+++ b/docs/src/app/components/raw-code/time-picker-code.txt
@@ -7,3 +7,8 @@
 <TimePicker
   format="24hr"
   hintText="24hr Format" />
+
+//Auto OK
+<TimePicker
+  hintText="AutoOk"
+  autoOk={true} />

--- a/src/time-picker/clock.jsx
+++ b/src/time-picker/clock.jsx
@@ -174,7 +174,7 @@ const Clock = React.createClass({
 
     const { onChangeMinutes } = this.props;
     if (typeof(onChangeMinutes) === 'function') {
-        onChangeMinutes(time);
+        setTimeout(() => { onChangeMinutes(time); }, 0);
       }
   },
 

--- a/src/time-picker/clock.jsx
+++ b/src/time-picker/clock.jsx
@@ -11,6 +11,8 @@ const Clock = React.createClass({
   mixins: [StylePropable],
 
   propTypes: {
+    onChangeMinutes: React.PropTypes.func,
+    onChangeHours: React.PropTypes.func,
     initialTime: React.PropTypes.object,
     mode: React.PropTypes.oneOf(['hour', 'minute']),
     format: React.PropTypes.oneOf(['ampm', '24hr']),
@@ -148,12 +150,17 @@ const Clock = React.createClass({
     this.setState({
       selectedTime: time,
     });
-
+    
+    let { onChangeHours } = this.props;
+    
     if (finished) {
       setTimeout(() => {
         this.setState({
           mode: 'minute',
         });
+        if (typeof(onChangeHours === 'function')) {
+          onChangeHours(time);
+        }
       }, 100);
     }
   },
@@ -164,6 +171,11 @@ const Clock = React.createClass({
     this.setState({
       selectedTime: time,
     });
+
+    let { onChangeMinutes } = this.props;
+    if (typeof(onChangeMinutes === 'function')) {
+        onChangeMinutes(time);
+      }
   },
 
   getSelectedTime() {

--- a/src/time-picker/clock.jsx
+++ b/src/time-picker/clock.jsx
@@ -151,14 +151,14 @@ const Clock = React.createClass({
       selectedTime: time,
     });
     
-    let { onChangeHours } = this.props;
+    const { onChangeHours } = this.props;
     
     if (finished) {
       setTimeout(() => {
         this.setState({
           mode: 'minute',
         });
-        if (typeof(onChangeHours === 'function')) {
+        if (typeof(onChangeHours) === 'function') {
           onChangeHours(time);
         }
       }, 100);
@@ -172,8 +172,8 @@ const Clock = React.createClass({
       selectedTime: time,
     });
 
-    let { onChangeMinutes } = this.props;
-    if (typeof(onChangeMinutes === 'function')) {
+    const { onChangeMinutes } = this.props;
+    if (typeof(onChangeMinutes) === 'function') {
         onChangeMinutes(time);
       }
   },

--- a/src/time-picker/time-picker-dialog.jsx
+++ b/src/time-picker/time-picker-dialog.jsx
@@ -92,7 +92,7 @@ const TimePickerDialog = React.createClass({
         onTouchTap={this._handleOKTouchTap} />,
     ];
     
-    let onClockChangeMinutes = (autoOk === true ? this._handleOKTouchTap : undefined);
+    const onClockChangeMinutes = (autoOk === true ? this._handleOKTouchTap : undefined);
     
     return (
       <Dialog {...other}

--- a/src/time-picker/time-picker-dialog.jsx
+++ b/src/time-picker/time-picker-dialog.jsx
@@ -17,6 +17,7 @@ const TimePickerDialog = React.createClass({
   },
 
   propTypes: {
+    autoOk: React.PropTypes.bool,
     initialTime: React.PropTypes.object,
     onAccept: React.PropTypes.func,
     onShow: React.PropTypes.func,
@@ -61,6 +62,7 @@ const TimePickerDialog = React.createClass({
       initialTime,
       onAccept,
       format,
+      autoOk,
       ...other,
     } = this.props;
 
@@ -89,7 +91,9 @@ const TimePickerDialog = React.createClass({
         secondary={true}
         onTouchTap={this._handleOKTouchTap} />,
     ];
-
+    
+    let onClockChangeMinutes = (autoOk === true ? this._handleOKTouchTap : undefined);
+    
     return (
       <Dialog {...other}
         ref="dialogWindow"
@@ -103,7 +107,8 @@ const TimePickerDialog = React.createClass({
         <Clock
           ref="clock"
           format={format}
-          initialTime={initialTime} />
+          initialTime={initialTime}
+          onChangeMinutes={onClockChangeMinutes} />
       </Dialog>
     );
   },

--- a/src/time-picker/time-picker.jsx
+++ b/src/time-picker/time-picker.jsx
@@ -35,6 +35,7 @@ const TimePicker = React.createClass({
       defaultTime: null,
       format: 'ampm',
       pedantic: false,
+      autoOk: false,
     };
   },
 

--- a/src/time-picker/time-picker.jsx
+++ b/src/time-picker/time-picker.jsx
@@ -15,6 +15,7 @@ const TimePicker = React.createClass({
   mixins: [StylePropable, WindowListenable],
 
   propTypes: {
+    autoOk: React.PropTypes.bool,
     defaultTime: React.PropTypes.object,
     format: React.PropTypes.oneOf(['ampm', '24hr']),
     pedantic: React.PropTypes.bool,
@@ -76,6 +77,7 @@ const TimePicker = React.createClass({
 
   render() {
     let {
+      autoOk,
       format,
       onFocus,
       onTouchTap,
@@ -104,7 +106,8 @@ const TimePicker = React.createClass({
           onAccept={this._handleDialogAccept}
           onShow={onShow}
           onDismiss={onDismiss}
-          format={format} />
+          format={format}
+          autoOk={autoOk} />
       </div>
     );
   },


### PR DESCRIPTION
Similar to DatePicker, but used after user sets the minutes.

Flow:
1. User taps/clicks TimePicker field
2. Dialog opens
3. User sets Hour
4. User sets Minutes -
- if autoOk `_handleOKTouchTap` is triggered to dismiss the dialog is Ok was tapped/clicked.