### PR TITLE
[CardHeader] title and subtitle can be any node, not only strings

### DIFF
--- a/src/card/card-header.jsx
+++ b/src/card/card-header.jsx
@@ -39,10 +39,10 @@ const CardHeader = React.createClass({
   },
 
   propTypes: {
-    title: React.PropTypes.string,
+    title: React.PropTypes.node,
     titleColor: React.PropTypes.string,
     titleStyle: React.PropTypes.object,
-    subtitle: React.PropTypes.string,
+    subtitle: React.PropTypes.node,
     subtitleColor: React.PropTypes.string,
     subtitleStyle: React.PropTypes.object,
     textStyle: React.PropTypes.object,


### PR DESCRIPTION
For example, when card title is a name that should be linked to the user's profile.

When subtitle is a location that can be linked to location-based search page

And so on. Not sure if other components could need this kind of patch.

PR does not interfere with current text-only usage, but removes warning when using sub components instead
