### PR TITLE
fixed type problem of variable color

### DIFF
--- a/src/utils/color-manipulator.js
+++ b/src/utils/color-manipulator.js
@@ -79,6 +79,8 @@ module.exports = {
 
   // Returns the type and values of a color of any given type.
   _decomposeColor(color) {
+    color = String(color);
+
     if (color.charAt(0) === '#') {
       return this._decomposeColor(this._convertHexToRGB(color));
     }

--- a/src/utils/color-manipulator.js
+++ b/src/utils/color-manipulator.js
@@ -79,7 +79,7 @@ module.exports = {
 
   // Returns the type and values of a color of any given type.
   _decomposeColor(color) {
-    color = String(color);
+    color = new String(color);
 
     if (color.charAt(0) === '#') {
       return this._decomposeColor(this._convertHexToRGB(color));


### PR DESCRIPTION
I'm doing unit test of our web applications. 
I got error messages as following: color.charAt is not a function

I debug the file:  material-ui/lib/utils/color-manipulator.js
I found that the parameter "color" passed to function _decomposeColor(color) is not always of type String.

This bug may not bother the developer so much, but it bugs the unit testing.
I think this need to be fixed.

Thanks you.

QIu Yun