### PR TITLE
Fix body overflow style reset in overlay.jsx

### DIFF
--- a/src/overlay.jsx
+++ b/src/overlay.jsx
@@ -54,8 +54,8 @@ const Overlay = React.createClass({
     };
   },
 
-  componentDidMount() {
-    this._originalBodyOverflow = document.getElementsByTagName('body')[0].style.oveflow;
+  componentWillMount() {
+    this._originalBodyOverflow = document.getElementsByTagName('body')[0].style.overflow;
   },
 
   componentDidUpdate() {


### PR DESCRIPTION
* Fixes a typo in the `body` style selector.
* Moves the function to `componentWillMount` to ensure the `this._originalBodyOverflow` will be set before the `overflow: hidden` style is applied.