### PR TITLE
Alias onClick to onTouchTap for ListItem right button/icon.

### DIFF
--- a/src/lists/list-item.jsx
+++ b/src/lists/list-item.jsx
@@ -291,6 +291,7 @@ const ListItem = React.createClass({
         onMouseEnter: this._handleRightIconButtonMouseEnter,
         onMouseLeave: this._handleRightIconButtonMouseLeave,
         onTouchTap: this._handleRightIconButtonTouchTap,
+        onClick: this._handleRightIconButtonTouchTap,
         onMouseDown: this._handleRightIconButtonMouseUp,
         onMouseUp: this._handleRightIconButtonMouseUp,
       };


### PR DESCRIPTION
We have had a lot of issues with initializeTapEventsPlugin when trying to build a Material-UI project with Webpack using React as an external.  The way the tap event plugin is injected just does not work with an external React.  This may be more widespread (in other components) but our biggest pain point right now is not being able to expand nested list items.  Is there a problem with aliasing onClick to onTouchTap for those who might not be able to handle touch events or those that have an issue with the initializeTapEvents plugin and Webpack externals?