### PR TITLE
Fix examples peerinvalid

### DIFF
--- a/examples/browserify-gulp-example/package.json
+++ b/examples/browserify-gulp-example/package.json
@@ -23,8 +23,8 @@
     "watchify": "^2.2.1"
   },
   "dependencies": {
-    "material-ui": ">=0.8",
-    "react": ">=0.13",
-    "react-tap-event-plugin": "^0.1.3"
+    "material-ui": "^0.13.0",
+    "react": "^0.14.0",
+    "react-tap-event-plugin": "^0.2.1"
   }
 }

--- a/examples/webpack-example/package.json
+++ b/examples/webpack-example/package.json
@@ -25,8 +25,8 @@
     "webpack-dev-server": "^1.10.1"
   },
   "dependencies": {
-    "material-ui": ">=0.8",
-    "react": "0.13",
-    "react-tap-event-plugin": "^0.1.3"
+    "material-ui": "^0.13.0",
+    "react": "^0.14.0",
+    "react-tap-event-plugin": "^0.2.1"
   }
 }


### PR DESCRIPTION
```
    error peerinvalid The package react-tap-event-plugin does not satisfy its siblings' peerDependencies requirements!
```