### PR TITLE
Fix rendering to body warning in example projects.

### DIFF
--- a/examples/browserify-gulp-example/src/app/app.jsx
+++ b/examples/browserify-gulp-example/src/app/app.jsx
@@ -1,5 +1,6 @@
 (function () {
   let React = require('react');
+  let ReactDOM = require('react-dom');
   let injectTapEventPlugin = require('react-tap-event-plugin');
   let Main = require('./components/main.jsx'); // Our custom react component
 
@@ -14,6 +15,6 @@
 
   // Render the main app react component into the app div.
   // For more details see: https://facebook.github.io/react/docs/top-level-api.html#react.render
-  React.render(<Main />, document.getElementById('app'));
+  ReactDOM.render(<Main />, document.getElementById('app'));
 
 })();

--- a/examples/browserify-gulp-example/src/app/app.jsx
+++ b/examples/browserify-gulp-example/src/app/app.jsx
@@ -12,8 +12,8 @@
   //https://github.com/zilverline/react-tap-event-plugin
   injectTapEventPlugin();
 
-  // Render the main app react component into the document body.
+  // Render the main app react component into the app div.
   // For more details see: https://facebook.github.io/react/docs/top-level-api.html#react.render
-  React.render(<Main />, document.body);
+  React.render(<Main />, document.getElementById('app'));
 
 })();

--- a/examples/browserify-gulp-example/src/www/index.html
+++ b/examples/browserify-gulp-example/src/www/index.html
@@ -11,6 +11,8 @@
 </head>
 
 <body>
+  <div id="app"></div>
+  
   <!-- This script adds the Roboto font to our project. For more detail go to this site:  http://www.google.com/fonts#UsePlace:use/Collection:Roboto:400,300,500 -->
   <script>
     var WebFontConfig = {

--- a/examples/webpack-example/src/app/app.jsx
+++ b/examples/webpack-example/src/app/app.jsx
@@ -1,5 +1,6 @@
 (function () {
   let React = require('react');
+  let ReactDOM = require('react-dom');
   let injectTapEventPlugin = require('react-tap-event-plugin');
   let Main = require('./components/main.jsx'); // Our custom react component
 
@@ -14,6 +15,6 @@
 
   // Render the main app react component into the app div.
   // For more details see: https://facebook.github.io/react/docs/top-level-api.html#react.render
-  React.render(<Main />, document.getElementById('app'));
+  ReactDOM.render(<Main />, document.getElementById('app'));
 
 })();

--- a/examples/webpack-example/src/app/app.jsx
+++ b/examples/webpack-example/src/app/app.jsx
@@ -12,8 +12,8 @@
   //https://github.com/zilverline/react-tap-event-plugin
   injectTapEventPlugin();
 
-  // Render the main app react component into the document body.
+  // Render the main app react component into the app div.
   // For more details see: https://facebook.github.io/react/docs/top-level-api.html#react.render
-  React.render(<Main />, document.body);
+  React.render(<Main />, document.getElementById('app'));
 
 })();

--- a/examples/webpack-example/src/www/index.html
+++ b/examples/webpack-example/src/www/index.html
@@ -11,6 +11,8 @@
 </head>
 
 <body>
+  <div id="app"></div>
+
   <!-- This script adds the Roboto font to our project. For more detail go to this site:  http://www.google.com/fonts#UsePlace:use/Collection:Roboto:400,300,500 -->
   <script>
     var WebFontConfig = {


### PR DESCRIPTION
After the React 14 update, the example projects give the warnings:

> Warning: render(): Rendering components directly into document.body is discouraged, since its children are often manipulated by third-party scripts and browser extensions. This may lead to subtle reconciliation issues. Try rendering into a container element created for your app.

and

> Warning: React.render is deprecated.  Please use ReactDOM.render from require('react-dom') instead.