### PR TITLE
Making card-text pull its text color from the theme

### DIFF
--- a/src/card/card-text.jsx
+++ b/src/card/card-text.jsx
@@ -44,18 +44,13 @@ const CardText = React.createClass({
     actAsExpander: React.PropTypes.bool,
   },
 
-  getDefaultProps() {
-    return {
-      color: Styles.Colors.ck,
-    };
-  },
-
   getStyles() {
+    let themeVariables = this.state.muiTheme.cardText;
     return {
       root: {
         padding: 16,
         fontSize: '14px',
-        color: this.props.color,
+        color: this.props.color ? this.props.color : themeVariables.textColor,
       },
     };
   },

--- a/src/card/card-text.jsx
+++ b/src/card/card-text.jsx
@@ -25,7 +25,7 @@ const CardText = React.createClass({
   },
 
   getInitialState() {
-    return { 
+    return {
       muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
     };
   },
@@ -45,7 +45,7 @@ const CardText = React.createClass({
   },
 
   getStyles() {
-    let themeVariables = this.state.muiTheme.cardText;
+    const themeVariables = this.state.muiTheme.cardText;
     return {
       root: {
         padding: 16,

--- a/src/styles/theme-manager.js
+++ b/src/styles/theme-manager.js
@@ -21,6 +21,9 @@ module.exports = {
         minWidth: 88,
         iconButtonSize: rawTheme.spacing.iconSize * 2,
       },
+      cardText: {
+        textColor: rawTheme.palette.textColor,
+      },
       checkbox: {
         boxColor: rawTheme.palette.textColor,
         checkedColor: rawTheme.palette.primary1Color,

--- a/src/styles/theme-manager.js
+++ b/src/styles/theme-manager.js
@@ -183,6 +183,8 @@ module.exports = {
       },
       tabs: {
         backgroundColor: rawTheme.palette.primary1Color,
+        textColor: ColorManipulator.fade(rawTheme.palette.alternateTextColor, 0.6),
+        selectedTextColor: rawTheme.palette.alternateTextColor,
       },
       textField: {
         textColor: rawTheme.palette.textColor,

--- a/src/tabs/tab.jsx
+++ b/src/tabs/tab.jsx
@@ -68,7 +68,7 @@ const Tab = React.createClass({
       textAlign: 'center',
       verticalAlign: 'middle',
       height: 48,
-      color: selected ? 'rgba(255,255,255,1)' : 'rgba(255,255,255,0.6)',
+      color: selected ? this.state.muiTheme.tabs.selectedTextColor : this.state.muiTheme.tabs.textColor,
       outline: 'none',
       fontSize: 14,
       fontWeight: 500,


### PR DESCRIPTION
Hi guys, I'm using your library at work and we noticed the `<CardText/>` component was not pulling the text color from the theme we're using. This pull request fixes it.

There are some other components that have similar issues; for example, tabs are hardcoded so their text color is always white.

This pull request is just a proof of concept of how I think this can be fixed, please look over it and tell me if it's the right way to go.