### PR TITLE
Allow css-file overrides

### DIFF
--- a/src/left-nav.jsx
+++ b/src/left-nav.jsx
@@ -32,357 +32,391 @@ const LeftNav = React.createClass({
   },
 
   getChildContext () {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
+  return {
+    muiTheme: this.state.muiTheme,
+  };
+},
 
-  propTypes: {
-    className: React.PropTypes.string,
-    disableSwipeToOpen: React.PropTypes.bool,
-    docked: React.PropTypes.bool,
-    header: React.PropTypes.element,
-    menuItems: React.PropTypes.array,
-    onChange: React.PropTypes.func,
-    onNavOpen: React.PropTypes.func,
-    onNavClose: React.PropTypes.func,
-    openRight: React.PropTypes.bool,
-    selectedIndex: React.PropTypes.number,
-    menuItemClassName: React.PropTypes.string,
-    menuItemClassNameSubheader: React.PropTypes.string,
-    menuItemClassNameLink: React.PropTypes.string,
-  },
+propTypes: {
+  className: React.PropTypes.string,
+      disableSwipeToOpen: React.PropTypes.bool,
+      docked: React.PropTypes.bool,
+      header: React.PropTypes.element,
+      menuItems: React.PropTypes.array,
+      onChange: React.PropTypes.func,
+      onNavOpen: React.PropTypes.func,
+      onNavClose: React.PropTypes.func,
+      openRight: React.PropTypes.bool,
+      selectedIndex: React.PropTypes.number,
+      menuItemClassName: React.PropTypes.string,
+      menuItemClassNameSubheader: React.PropTypes.string,
+      menuItemClassNameLink: React.PropTypes.string,
+},
 
-  windowListeners: {
-    'keyup': '_onWindowKeyUp',
-    'resize': '_onWindowResize',
-  },
+windowListeners: {
+  'keyup': '_onWindowKeyUp',
+      'resize': '_onWindowResize',
+},
 
-  getDefaultProps() {
-    return {
-      disableSwipeToOpen: false,
-      docked: true,
-    };
-  },
+getDefaultProps() {
+  return {
+    disableSwipeToOpen: false,
+    docked: true,
+  };
+},
 
-  getInitialState() {
-    this._maybeSwiping = false;
-    this._touchStartX = null;
-    this._touchStartY = null;
-    this._swipeStartX = null;
+getInitialState() {
+  this._maybeSwiping = false;
+  this._touchStartX = null;
+  this._touchStartY = null;
+  this._swipeStartX = null;
 
-    return {
-      open: this.props.docked,
-      swiping: null,
-      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
-    };
-  },
+  return {
+    open: this.props.docked,
+    swiping: null,
+    muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
+  };
+},
 
-  //to update theme inside state whenever a new theme is passed down
-  //from the parent / owner using context
-  componentWillReceiveProps (nextProps, nextContext) {
-    let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
-  },
+//to update theme inside state whenever a new theme is passed down
+//from the parent / owner using context
+componentWillReceiveProps (nextProps, nextContext) {
+  let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
+  this.setState({muiTheme: newMuiTheme});
+},
 
-  componentDidMount() {
-    this._updateMenuHeight();
-    this._enableSwipeHandling();
-  },
+componentDidMount() {
+  this._updateMenuHeight();
+  this._enableSwipeHandling();
+},
 
-  componentDidUpdate() {
-    this._updateMenuHeight();
-    this._enableSwipeHandling();
-  },
+componentDidUpdate() {
+  this._updateMenuHeight();
+  this._enableSwipeHandling();
+},
 
-  componentWillUnmount() {
-    this._disableSwipeHandling();
-  },
+componentWillUnmount() {
+  this._disableSwipeHandling();
+},
 
-  toggle() {
-    this.setState({ open: !this.state.open });
-    return this;
-  },
+toggle() {
+  this.setState({ open: !this.state.open });
+  return this;
+},
 
-  close() {
-    this.setState({ open: false });
-    if (this.props.onNavClose) this.props.onNavClose();
-    return this;
-  },
+close() {
+  this.setState({ open: false });
+  if (this.props.onNavClose) this.props.onNavClose();
+  return this;
+},
 
-  open() {
-    this.setState({ open: true });
-    if (this.props.onNavOpen) this.props.onNavOpen();
-    return this;
-  },
+open() {
+  this.setState({ open: true });
+  if (this.props.onNavOpen) this.props.onNavOpen();
+  return this;
+},
 
-  getThemePalette() {
-    return this.state.muiTheme.rawTheme.palette;
-  },
+getThemePalette() {
+  return this.state.muiTheme.rawTheme.palette;
+},
 
-  getTheme() {
-    return this.state.muiTheme.leftNav;
-  },
+getTheme() {
+  let initState = this.state.muiTheme.leftNav;
+  if (this.props.className) {
+    //prepare for css-file override
+    let initStateProps = Object.keys(initState);
+    let classes = this.props.className.split(' ');
+    for (let c = 0; c < classes.length; c++) {
+      let curClass = '.' + classes[c];
+      for (let s = 0; s < document.styleSheets.length; s++) {
+        let curStyleSheetRules = document.styleSheets[s].rules || document.styleSheets[s].cssRules;
+        for (let r = 0; r < curStyleSheetRules.length; r++) {
+          var curRule = curStyleSheetRules[r];
+          if (curRule.selectorText !== curClass) continue;
+          for (let p = 0; p < initStateProps.length; p++) {
+            let defaultProp = initStateProps[p]; //OK if undefined
+            if (!curRule.style.getPropertyValue(defaultProp)) continue;
+            initState = this.objWithoutProp(initState, defaultProp);
+          }
+        }
+      }
+    }
+  }
+  return initState;
+},
 
-  getStyles() {
-    let x = this._getTranslateMultiplier() * (this.state.open ? 0 : this._getMaxTranslateX());
-    let styles = {
-      root: {
-        height: '100%',
-        width: this.getTheme().width,
-        position: 'fixed',
-        zIndex: 10,
-        left: isBrowser && Modernizr.csstransforms3d ? 0 : x,
-        top: 0,
-        transform: 'translate3d(' + x + 'px, 0, 0)',
-        transition: !this.state.swiping && Transitions.easeOut(),
-        backgroundColor: this.getTheme().color,
-        overflow: 'hidden',
-      },
-      menu: {
-        overflowY: 'auto',
-        overflowX: 'hidden',
-        height: '100%',
-        borderRadius: '0',
-      },
-      menuItem: {
-        height: this.state.muiTheme.rawTheme.spacing.desktopLeftNavMenuItemHeight,
-        lineHeight: this.state.muiTheme.rawTheme.spacing.desktopLeftNavMenuItemHeight + 'px',
-      },
-      rootWhenOpenRight: {
-        left: 'auto',
-        right: 0,
-      },
-    };
+objWithoutProp(obj, excludeProp)
+{
+  let keys = Object.keys(obj);
+  let newObj = {};
+  for (let i = 0; i < keys.length; i++) {
+    let curKey = keys[i];
+    if (curKey === excludeProp) continue;
+    newObj[curKey] = obj[curKey];
+  }
+  return newObj;
+},
 
-    styles.menuItemLink = this.mergeStyles(styles.menuItem, {
-      display: 'block',
-      textDecoration: 'none',
-      color: this.getThemePalette().textColor,
-    });
-    styles.menuItemSubheader = this.mergeStyles(styles.menuItem, {
+getStyles() {
+  let x = this._getTranslateMultiplier() * (this.state.open ? 0 : this._getMaxTranslateX());
+  let {width, color} = this.getTheme();
+  let styles = {
+    root: {
+      height: '100%',
+      width: width.width,
+      position: 'fixed',
+      zIndex: 10,
+      left: isBrowser && Modernizr.csstransforms3d ? 0 : x,
+      top: 0,
+      transform: 'translate3d(' + x + 'px, 0, 0)',
+      transition: !this.state.swiping && Transitions.easeOut(),
+      backgroundColor: color.color,
       overflow: 'hidden',
-    });
+    },
+    menu: {
+      overflowY: 'auto',
+      overflowX: 'hidden',
+      height: '100%',
+      borderRadius: '0',
+    },
+    menuItem: {
+      height: this.state.muiTheme.rawTheme.spacing.desktopLeftNavMenuItemHeight,
+      lineHeight: this.state.muiTheme.rawTheme.spacing.desktopLeftNavMenuItemHeight + 'px',
+    },
+    rootWhenOpenRight: {
+      left: 'auto',
+      right: 0,
+    },
+  };
 
-    return styles;
-  },
+  styles.menuItemLink = this.mergeStyles(styles.menuItem, {
+    display: 'block',
+    textDecoration: 'none',
+    color: this.getThemePalette().textColor,
+  });
+  styles.menuItemSubheader = this.mergeStyles(styles.menuItem, {
+    overflow: 'hidden',
+  });
 
-  render() {
-    let selectedIndex = this.props.selectedIndex;
-    let overlay;
+  return styles;
+},
 
-    let styles = this.getStyles();
-    if (!this.props.docked) {
-      overlay = (
+render() {
+  let selectedIndex = this.props.selectedIndex;
+  let overlay;
+
+  let styles = this.getStyles();
+  if (!this.props.docked) {
+    overlay = (
         <Overlay
-          ref="overlay"
-          show={this.state.open || !!this.state.swiping}
-          transitionEnabled={!this.state.swiping}
-          onTouchTap={this._onOverlayTouchTap} />
-      );
-    }
-    let children;
-    if (this.props.menuItems === undefined) {
-      children = this.props.children;
-    }
-    else {
-       children = (
+            ref="overlay"
+            show={this.state.open || !!this.state.swiping}
+            transitionEnabled={!this.state.swiping}
+            onTouchTap={this._onOverlayTouchTap} />
+    );
+  }
+  let children;
+  if (this.props.menuItems === undefined) {
+    children = this.props.children;
+  }
+  else {
+    children = (
         <Menu
-          ref="menuItems"
-          style={this.mergeStyles(styles.menu)}
-          zDepth={0}
-          menuItems={this.props.menuItems}
-          menuItemStyle={this.mergeStyles(styles.menuItem)}
-          menuItemStyleLink={this.mergeStyles(styles.menuItemLink)}
-          menuItemStyleSubheader={this.mergeStyles(styles.menuItemSubheader)}
-          menuItemClassName={this.props.menuItemClassName}
-          menuItemClassNameSubheader={this.props.menuItemClassNameSubheader}
-          menuItemClassNameLink={this.props.menuItemClassNameLink}
-          selectedIndex={selectedIndex}
-          onItemTap={this._onMenuItemClick} />
-        );
-    }
-    return (
+            ref="menuItems"
+            style={this.mergeStyles(styles.menu)}
+            zDepth={0}
+            menuItems={this.props.menuItems}
+            menuItemStyle={this.mergeStyles(styles.menuItem)}
+            menuItemStyleLink={this.mergeStyles(styles.menuItemLink)}
+            menuItemStyleSubheader={this.mergeStyles(styles.menuItemSubheader)}
+            menuItemClassName={this.props.menuItemClassName}
+            menuItemClassNameSubheader={this.props.menuItemClassNameSubheader}
+            menuItemClassNameLink={this.props.menuItemClassNameLink}
+            selectedIndex={selectedIndex}
+            onItemTap={this._onMenuItemClick} />
+    );
+  }
+  return (
       <div className={this.props.className}>
         {overlay}
         <Paper
-          ref="clickAwayableElement"
-          zDepth={2}
-          rounded={false}
-          transitionEnabled={!this.state.swiping}
-          style={this.mergeStyles(
+            ref="clickAwayableElement"
+            zDepth={2}
+            rounded={false}
+            transitionEnabled={!this.state.swiping}
+            style={this.mergeStyles(
             styles.root,
             this.props.openRight && styles.rootWhenOpenRight,
             this.props.style)}>
-            {this.props.header}
-            {children}
+          {this.props.header}
+          {children}
         </Paper>
       </div>
-    );
-  },
+  );
+},
 
-  _updateMenuHeight() {
-    if (this.props.header) {
-      let container = ReactDOM.findDOMNode(this.refs.clickAwayableElement);
-      let menu = ReactDOM.findDOMNode(this.refs.menuItems);
-      let menuHeight = container.clientHeight - menu.offsetTop;
-      menu.style.height = menuHeight + 'px';
-    }
-  },
+_updateMenuHeight() {
+  if (this.props.header) {
+    let container = ReactDOM.findDOMNode(this.refs.clickAwayableElement);
+    let menu = ReactDOM.findDOMNode(this.refs.menuItems);
+    let menuHeight = container.clientHeight - menu.offsetTop;
+    menu.style.height = menuHeight + 'px';
+  }
+},
 
-  _onMenuItemClick(e, key, payload) {
-    if (this.props.onChange && this.props.selectedIndex !== key) {
-      this.props.onChange(e, key, payload);
-    }
-    if (!this.props.docked) this.close();
-  },
+_onMenuItemClick(e, key, payload) {
+  if (this.props.onChange && this.props.selectedIndex !== key) {
+    this.props.onChange(e, key, payload);
+  }
+  if (!this.props.docked) this.close();
+},
 
-  _onOverlayTouchTap() {
+_onOverlayTouchTap() {
+  this.close();
+},
+
+_onWindowKeyUp(e) {
+  if (e.keyCode === KeyCode.ESC &&
+      !this.props.docked &&
+      this.state.open) {
     this.close();
-  },
+  }
+},
 
-  _onWindowKeyUp(e) {
-    if (e.keyCode === KeyCode.ESC &&
-        !this.props.docked &&
-        this.state.open) {
-      this.close();
+_onWindowResize() {
+  this._updateMenuHeight();
+},
+
+_getMaxTranslateX() {
+  return this.getTheme().width + 10;
+},
+
+_getTranslateMultiplier() {
+  return this.props.openRight ? 1 : -1;
+},
+
+_enableSwipeHandling() {
+  if (!this.props.docked) {
+    document.body.addEventListener('touchstart', this._onBodyTouchStart);
+    if (!openNavEventHandler) {
+      openNavEventHandler = this._onBodyTouchStart;
     }
-  },
+  } else {
+    this._disableSwipeHandling();
+  }
+},
 
-  _onWindowResize() {
-    this._updateMenuHeight();
-  },
+_disableSwipeHandling() {
+  document.body.removeEventListener('touchstart', this._onBodyTouchStart);
+  if (openNavEventHandler === this._onBodyTouchStart) {
+    openNavEventHandler = null;
+  }
+},
 
-  _getMaxTranslateX() {
-    return this.getTheme().width + 10;
-  },
+_onBodyTouchStart(e) {
+  if (!this.state.open &&
+      (openNavEventHandler !== this._onBodyTouchStart ||
+      this.props.disableSwipeToOpen)
+  ) {
+    return;
+  }
 
-  _getTranslateMultiplier() {
-    return this.props.openRight ? 1 : -1;
-  },
+  let touchStartX = e.touches[0].pageX;
+  let touchStartY = e.touches[0].pageY;
 
-  _enableSwipeHandling() {
-    if (!this.props.docked) {
-      document.body.addEventListener('touchstart', this._onBodyTouchStart);
-      if (!openNavEventHandler) {
-        openNavEventHandler = this._onBodyTouchStart;
-      }
-    } else {
-      this._disableSwipeHandling();
-    }
-  },
+  this._maybeSwiping = true;
+  this._touchStartX = touchStartX;
+  this._touchStartY = touchStartY;
 
-  _disableSwipeHandling() {
-    document.body.removeEventListener('touchstart', this._onBodyTouchStart);
-    if (openNavEventHandler === this._onBodyTouchStart) {
-      openNavEventHandler = null;
-    }
-  },
+  document.body.addEventListener('touchmove', this._onBodyTouchMove);
+  document.body.addEventListener('touchend', this._onBodyTouchEnd);
+  document.body.addEventListener('touchcancel', this._onBodyTouchEnd);
+},
 
-  _onBodyTouchStart(e) {
-    if (!this.state.open &&
-         (openNavEventHandler !== this._onBodyTouchStart ||
-          this.props.disableSwipeToOpen)
-       ) {
-      return;
-    }
-
-    let touchStartX = e.touches[0].pageX;
-    let touchStartY = e.touches[0].pageY;
-
-    this._maybeSwiping = true;
-    this._touchStartX = touchStartX;
-    this._touchStartY = touchStartY;
-
-    document.body.addEventListener('touchmove', this._onBodyTouchMove);
-    document.body.addEventListener('touchend', this._onBodyTouchEnd);
-    document.body.addEventListener('touchcancel', this._onBodyTouchEnd);
-  },
-
-  _setPosition(translateX) {
-    let leftNav = ReactDOM.findDOMNode(this.refs.clickAwayableElement);
-    leftNav.style[AutoPrefix.single('transform')] =
+_setPosition(translateX) {
+  let leftNav = ReactDOM.findDOMNode(this.refs.clickAwayableElement);
+  leftNav.style[AutoPrefix.single('transform')] =
       'translate3d(' + (this._getTranslateMultiplier() * translateX) + 'px, 0, 0)';
-    this.refs.overlay.setOpacity(1 - translateX / this._getMaxTranslateX());
-  },
+  this.refs.overlay.setOpacity(1 - translateX / this._getMaxTranslateX());
+},
 
-  _getTranslateX(currentX) {
-    return Math.min(
-             Math.max(
-               this.state.swiping === 'closing' ?
-                 this._getTranslateMultiplier() * (currentX - this._swipeStartX) :
-                 this._getMaxTranslateX() - this._getTranslateMultiplier() * (this._swipeStartX - currentX),
-               0
-             ),
-             this._getMaxTranslateX()
-           );
-  },
+_getTranslateX(currentX) {
+  return Math.min(
+      Math.max(
+          this.state.swiping === 'closing' ?
+          this._getTranslateMultiplier() * (currentX - this._swipeStartX) :
+          this._getMaxTranslateX() - this._getTranslateMultiplier() * (this._swipeStartX - currentX),
+          0
+      ),
+      this._getMaxTranslateX()
+  );
+},
 
-  _onBodyTouchMove(e) {
-    let currentX = e.touches[0].pageX;
-    let currentY = e.touches[0].pageY;
+_onBodyTouchMove(e) {
+  let currentX = e.touches[0].pageX;
+  let currentY = e.touches[0].pageY;
 
-    if (this.state.swiping) {
-      e.preventDefault();
+  if (this.state.swiping) {
+    e.preventDefault();
+    this._setPosition(this._getTranslateX(currentX));
+  }
+  else if (this._maybeSwiping) {
+    let dXAbs = Math.abs(currentX - this._touchStartX);
+    let dYAbs = Math.abs(currentY - this._touchStartY);
+    // If the user has moved his thumb ten pixels in either direction,
+    // we can safely make an assumption about whether he was intending
+    // to swipe or scroll.
+    let threshold = 10;
+
+    if (dXAbs > threshold && dYAbs <= threshold) {
+      this._swipeStartX = currentX;
+      this.setState({
+        swiping: this.state.open ? 'closing' : 'opening',
+      });
       this._setPosition(this._getTranslateX(currentX));
     }
-    else if (this._maybeSwiping) {
-      let dXAbs = Math.abs(currentX - this._touchStartX);
-      let dYAbs = Math.abs(currentY - this._touchStartY);
-      // If the user has moved his thumb ten pixels in either direction,
-      // we can safely make an assumption about whether he was intending
-      // to swipe or scroll.
-      let threshold = 10;
-
-      if (dXAbs > threshold && dYAbs <= threshold) {
-        this._swipeStartX = currentX;
-        this.setState({
-          swiping: this.state.open ? 'closing' : 'opening',
-        });
-        this._setPosition(this._getTranslateX(currentX));
-      }
-      else if (dXAbs <= threshold && dYAbs > threshold) {
-        this._onBodyTouchEnd();
-      }
+    else if (dXAbs <= threshold && dYAbs > threshold) {
+      this._onBodyTouchEnd();
     }
-  },
+  }
+},
 
-  _onBodyTouchEnd(e) {
-    if (this.state.swiping) {
-      let currentX = e.changedTouches[0].pageX;
-      let translateRatio = this._getTranslateX(currentX) / this._getMaxTranslateX();
+_onBodyTouchEnd(e) {
+  if (this.state.swiping) {
+    let currentX = e.changedTouches[0].pageX;
+    let translateRatio = this._getTranslateX(currentX) / this._getMaxTranslateX();
 
-      this._maybeSwiping = false;
-      let swiping = this.state.swiping;
-      this.setState({
-        swiping: null,
-      });
+    this._maybeSwiping = false;
+    let swiping = this.state.swiping;
+    this.setState({
+      swiping: null,
+    });
 
-      // We have to open or close after setting swiping to null,
-      // because only then CSS transition is enabled.
-      if (translateRatio > 0.5) {
-        if (swiping === 'opening') {
-          this._setPosition(this._getMaxTranslateX());
-        } else {
-          this.close();
-        }
-      }
-      else {
-        if (swiping === 'opening') {
-          this.open();
-        } else {
-          this._setPosition(0);
-        }
+    // We have to open or close after setting swiping to null,
+    // because only then CSS transition is enabled.
+    if (translateRatio > 0.5) {
+      if (swiping === 'opening') {
+        this._setPosition(this._getMaxTranslateX());
+      } else {
+        this.close();
       }
     }
     else {
-      this._maybeSwiping = false;
+      if (swiping === 'opening') {
+        this.open();
+      } else {
+        this._setPosition(0);
+      }
     }
+  }
+  else {
+    this._maybeSwiping = false;
+  }
 
-    document.body.removeEventListener('touchmove', this._onBodyTouchMove);
-    document.body.removeEventListener('touchend', this._onBodyTouchEnd);
-    document.body.removeEventListener('touchcancel', this._onBodyTouchEnd);
-  },
+  document.body.removeEventListener('touchmove', this._onBodyTouchMove);
+  document.body.removeEventListener('touchend', this._onBodyTouchEnd);
+  document.body.removeEventListener('touchcancel', this._onBodyTouchEnd);
+},
 
 });
 


### PR DESCRIPTION
Currently, default styles override css file rules. This reverses it.

If a component is given a className, we know the user wants to customize the component’s style. So, we compare the css files to the default rules. If a default rule would override the css-file rule, we remove it. This is just a proof of concept using the LeftNav. You can test it by adding a rule to your css (eg `.wide {width:300px;}`) and then passing that className to the component (eg `<LeftNav className=‘wide’…/>`). Note that the other default props (color) are left untouched. 

Since we’re only reading the css & we’re not mutating the theme state, the changes are on a per-render basis. 

Looks like my editor went crazy on the diff, check out the `getTheme` method & the `objWithoutProp` helper method below it (probably can be moved into your immutable helpers util). 