### PR TITLE
Fix Slider and Toggle colors

### DIFF
--- a/src/styles/raw-themes/light-raw-theme.js
+++ b/src/styles/raw-themes/light-raw-theme.js
@@ -14,7 +14,7 @@ module.exports = {
   palette: {
     primary1Color: Colors.cyan500,
     primary2Color: Colors.cyan700,
-    primary3Color: Colors.lightBlack,
+    primary3Color: Colors.grey400,
     accent1Color: Colors.pinkA200,
     accent2Color: Colors.grey100,
     accent3Color: Colors.grey500,

--- a/src/styles/theme-manager.js
+++ b/src/styles/theme-manager.js
@@ -118,7 +118,7 @@ module.exports = {
         handleSize: 12,
         handleSizeDisabled: 8,
         handleSizeActive: 18,
-        handleColorZero: rawTheme.palette.borderColor,
+        handleColorZero: rawTheme.palette.primary3Color,
         handleFillColor: rawTheme.palette.alternateTextColor,
         selectionColor: rawTheme.palette.primary1Color,
         rippleColor: rawTheme.palette.primary1Color,
@@ -135,13 +135,13 @@ module.exports = {
         borderColor: rawTheme.palette.borderColor,
       },
       tableHeaderColumn: {
-        textColor: rawTheme.palette.primary3Color,
+        textColor: rawTheme.palette.accent3Color,
         height: 56,
         spacing: 24,
       },
       tableFooter: {
         borderColor: rawTheme.palette.borderColor,
-        textColor: rawTheme.palette.primary3Color,
+        textColor: rawTheme.palette.accent3Color,
       },
       tableRow: {
         hoverColor: rawTheme.palette.accent2Color,
@@ -158,7 +158,7 @@ module.exports = {
         color: rawTheme.palette.alternateTextColor,
         textColor: rawTheme.palette.accent3Color,
         accentColor: rawTheme.palette.primary1Color,
-        clockColor: rawTheme.palette.primary3Color,
+        clockColor: rawTheme.palette.textColor,
         selectColor: rawTheme.palette.primary2Color,
         selectTextColor: rawTheme.palette.alternateTextColor,
       },


### PR DESCRIPTION
This PR fixes background colors of `Slider` and `Toggle` as they were in version 0.11. Now they are extra dark.
But because of very limited amount of colors in new raw themes this will also change colors of `TimePicker` and `Table` header a bit.