### PR TITLE
[Overlay] Fix server side rendering

### DIFF
--- a/src/overlay.jsx
+++ b/src/overlay.jsx
@@ -54,7 +54,7 @@ const Overlay = React.createClass({
     };
   },
 
-  componentWillMount() {
+  componentDidMount() {
     this._originalBodyOverflow = document.getElementsByTagName('body')[0].style.overflow;
   },
 


### PR DESCRIPTION
The componentDidMount method is not called when rendering server side.
Aim to fix https://github.com/callemall/material-ui/issues/2013.