### PR TITLE
[Table] Added key to selectall column in TableHeader. Addresses #2028

### DIFF
--- a/src/table/table-header.jsx
+++ b/src/table/table-header.jsx
@@ -120,6 +120,7 @@ const TableHeader = React.createClass({
       children.push(child);
     });
 
+    console.log('key is ', props.key)
     return React.cloneElement(child, props, children);
   },
 
@@ -152,8 +153,8 @@ const TableHeader = React.createClass({
   },
 
   _getSelectAllCheckboxColumn(props) {
-  if (!this.props.displaySelectAll) return this._getCheckboxPlaceholder(props);
-
+    if (!this.props.displaySelectAll) return this._getCheckboxPlaceholder(props);
+    
     const checkbox =
       <Checkbox
         key="selectallcb"
@@ -163,8 +164,9 @@ const TableHeader = React.createClass({
         checked={this.props.selectAllSelected}
         onCheck={this._onSelectAll} />;
 
+    const key = 'hpcb' + props.rowNumber;
     return (
-      <TableHeaderColumn style={{width: 24}}>
+      <TableHeaderColumn key={key} style={{width: 24}}>
         {checkbox}
       </TableHeaderColumn>
     );

--- a/src/table/table-header.jsx
+++ b/src/table/table-header.jsx
@@ -120,7 +120,6 @@ const TableHeader = React.createClass({
       children.push(child);
     });
 
-    console.log('key is ', props.key)
     return React.cloneElement(child, props, children);
   },
 
@@ -154,7 +153,7 @@ const TableHeader = React.createClass({
 
   _getSelectAllCheckboxColumn(props) {
     if (!this.props.displaySelectAll) return this._getCheckboxPlaceholder(props);
-    
+
     const checkbox =
       <Checkbox
         key="selectallcb"


### PR DESCRIPTION
Just adds the same key as the one added to the placeholder when displaySelectAll is set to false. Gets rid of the warning that shows on the docs site. Fixes issue #2028