### PR TITLE
[LeftNav] Open or close if docked prop changes when window resizes

### DIFF
--- a/src/left-nav.jsx
+++ b/src/left-nav.jsx
@@ -82,7 +82,10 @@ const LeftNav = React.createClass({
   //from the parent / owner using context
   componentWillReceiveProps (nextProps, nextContext) {
     let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
+    this.setState({
+      muiTheme: newMuiTheme,
+      open: (this.props.docked !== nextProps.docked) ? nextProps.docked : this.state.open,
+    });
   },
 
   componentDidMount() {


### PR DESCRIPTION
If docked prop changes when window resizes, LeftNav will display properly when the window changes instead of having to refresh.