### PR TITLE
Changing propType from string to node on components

### DIFF
--- a/docs/src/app/components/pages/components/grid-list.jsx
+++ b/docs/src/app/components/pages/components/grid-list.jsx
@@ -50,7 +50,7 @@ class GridListPage extends React.Component {
         infoArray: [
           {
             name: 'title',
-            type: 'string',
+            type: 'node',
             header: 'optional',
             desc: 'Title to be displayed on tile.',
           },

--- a/docs/src/app/components/pages/components/lists.jsx
+++ b/docs/src/app/components/pages/components/lists.jsx
@@ -55,7 +55,7 @@ export default class ListsPage extends React.Component {
           },
           {
             name: 'subheader',
-            type: 'string',
+            type: 'node',
             header: 'optional',
             desc: 'The subheader string that will be displayed at the top of the list.',
           },

--- a/docs/src/app/components/pages/components/switches.jsx
+++ b/docs/src/app/components/pages/components/switches.jsx
@@ -55,7 +55,7 @@ export default class SwitchesPage extends React.Component {
         },
         {
           name: 'label',
-          type: 'string',
+          type: 'node',
           header: 'optional',
           desc: 'The text that is displayed beside the checkbox.',
         },
@@ -130,7 +130,7 @@ export default class SwitchesPage extends React.Component {
         },
         {
           name: 'label',
-          type: 'string',
+          type: 'node',
           header: 'optional',
           desc: 'The text that is displayed beside the radio button.',
         },
@@ -252,7 +252,7 @@ export default class SwitchesPage extends React.Component {
         },
         {
           name: 'label',
-          type: 'string',
+          type: 'node',
           header: 'optional',
           desc: 'The text that is displayed beside the toggle switch.',
         },

--- a/src/card/card-title.jsx
+++ b/src/card/card-title.jsx
@@ -38,10 +38,10 @@ const CardTitle = React.createClass({
   },
 
   propTypes: {
-    title: React.PropTypes.string,
+    title: React.PropTypes.node,
     titleColor: React.PropTypes.string,
     titleStyle: React.PropTypes.object,
-    subtitle: React.PropTypes.string,
+    subtitle: React.PropTypes.node,
     subtitleColor: React.PropTypes.string,
     subtitleStyle: React.PropTypes.object,
     expandable: React.PropTypes.bool,

--- a/src/enhanced-switch.jsx
+++ b/src/enhanced-switch.jsx
@@ -45,7 +45,7 @@ const EnhancedSwitch = React.createClass({
       labelStyle: React.PropTypes.object,
       name: React.PropTypes.string,
       value: React.PropTypes.string,
-      label: React.PropTypes.string,
+      label: React.PropTypes.node,
       onSwitch: React.PropTypes.func,
       required: React.PropTypes.bool,
       disabled: React.PropTypes.bool,

--- a/src/grid-list/grid-tile.jsx
+++ b/src/grid-list/grid-tile.jsx
@@ -13,7 +13,7 @@ const GridTile = React.createClass({
   },
 
   propTypes: {
-    title: React.PropTypes.string,
+    title: React.PropTypes.node,
     subtitle: React.PropTypes.node,
     titlePosition: React.PropTypes.oneOf(['top', 'bottom']),
     titleBackground: React.PropTypes.string,

--- a/src/lists/list.jsx
+++ b/src/lists/list.jsx
@@ -17,7 +17,7 @@ const List = React.createClass({
 
   propTypes: {
     insetSubheader: React.PropTypes.bool,
-    subheader: React.PropTypes.string,
+    subheader: React.PropTypes.node,
     subheaderStyle: React.PropTypes.object,
     zDepth: PropTypes.zDepth,
   },


### PR DESCRIPTION
Following PR #1950  and as proposed in issue #1961 , here is a patch to update PropTypes of some components for which `node` seems more flexible than `string`, without breaking current usage

Components / propsTypes modified :

 - CardTitle `title` and `subtitle`
 - GridTile `title`
 - Checkbox `label`  (example use case: `<span>Check to accept our <Link>TOS</Link></span>`)
 - List `subHeader`

If you think other components should be change as well (from the "not sure" list in #1961 ), let me know.

Thanks