### PR TITLE
Fix label display with Chrome autocomplete

### DIFF
--- a/src/text-field.jsx
+++ b/src/text-field.jsx
@@ -229,6 +229,7 @@ const TextField = React.createClass({
       top: 38,
       bottom: 'none',
       opacity: 1,
+      zIndex: 1, // Needed to display label above Chrome's autocomplete field background
       transform: 'scale(1) translate3d(0, 0, 0)',
       transformOrigin: 'left top',
     });


### PR DESCRIPTION
This fixes the issue with the floating label being hidden when the field is selected by Chrome to be autocompleted as it was rendered under Chrome's yellow background highlight of the field

Before:
![Before](http://i.imgur.com/cZfG3O6.png)

After:
![After](http://i.imgur.com/fR7gfS0.png)