### PR TITLE
[npm] Separate the lint and the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 node_js:
   - "stable"
 sudo: false
+script:
+  - npm run lint
+  - npm test

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "test-watch": "npm run test-base -- --auto-watch",
     "test-base": "./node_modules/.bin/karma start",
     "prebuild": "rimraf lib",
-    "eslint": "gulp eslint",
-    "build": "npm run eslint && babel --stage 1 ./src --out-dir ./lib",
+    "lint": "gulp eslint",
+    "build": "babel --stage 1 ./src --out-dir ./lib",
     "prepublish": "npm run build"
   },
   "keywords": [
@@ -53,7 +53,7 @@
     "babelify": "^6.1.3",
     "browserify-istanbul": "^0.2.1",
     "chai": "^3.2.0",
-    "eslint": "^1.1.0",
+    "eslint": "~1.8.0",
     "eslint-loader": "^1.0.0",
     "eslint-plugin-react": "^3.2.2",
     "fbjs": "^0.2.1",


### PR DESCRIPTION
Will help to fix the travis fail.
Also had to fallback to eslint v1.8.0 to make the build pass (https://github.com/eslint/eslint/issues/4356)