### PR TITLE
[TimePicker] allow set time to null

### DIFF
--- a/src/time-picker/time-picker.jsx
+++ b/src/time-picker/time-picker.jsx
@@ -8,6 +8,8 @@ const TextField = require('../text-field');
 let emptyTime = new Date();
 emptyTime.setHours(0);
 emptyTime.setMinutes(0);
+emptyTime.setSeconds(0);
+emptyTime.setMilliseconds(0);
 
 
 const TimePicker = React.createClass({
@@ -128,10 +130,19 @@ const TimePicker = React.createClass({
   },
 
   setTime(t) {
-    this.setState({
-      time: t,
-    });
-    this.refs.input.setValue(this.formatTime(t));
+    if (t){
+      this.setState({
+        time: t,
+      });
+      
+      this.refs.input.setValue(this.formatTime(t));
+    }else{
+      this.setState({
+        time: emptyTime,
+      });
+      
+      this.refs.input.setValue(null);
+    }
   },
 
   /**


### PR DESCRIPTION
When i try to set time picker back to `null` it raises error `getHours undefined in null` so now i need to make custom hack:

```
  resetTime(){
    const emptyTime = new Date();
    emptyTime.setHours(0);
    emptyTime.setMinutes(0);
    emptyTime.setSeconds(0);
    emptyTime.setMilliseconds(0);

    this.refs.time.setState({
      time: emptyTime
    });
    this.refs.time.refs.input.setValue(null);
  }
```