### PR TITLE
Update package.json

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "https://github.com/callemall/material-ui.git"
   },
+  "private": true,
   "scripts": {
     "prestart": "webpack-dev-server --config webpack-dev-server.config.js --progress --colors --inline",
     "start": "open http://localhost:3000",


### PR DESCRIPTION
Add private to the docs package.json.
Will prevent this warning to be displayed `npm WARN package.json material-ui-docs@0.13.1 No license field.`
and accidental publish.