### PR TITLE
Snackbar style

### DIFF
--- a/docs/src/app/components/pages/components/snackbar.jsx
+++ b/docs/src/app/components/pages/components/snackbar.jsx
@@ -55,6 +55,12 @@ export default class SnackbarPage extends React.Component {
             header: 'optional',
             desc: 'Override the inline-styles of the Snackbar\'s root element.',
           },
+          {
+            name: 'bodyStyle',
+            type: 'object',
+            header: 'optional',
+            desc: 'Override the inline-styles of the Snackbar\'s body element.',
+          },
         ],
       },
       {

--- a/src/snackbar.jsx
+++ b/src/snackbar.jsx
@@ -63,6 +63,7 @@ const Snackbar = React.createClass({
     onDismiss: React.PropTypes.func,
     openOnMount: React.PropTypes.bool,
     style: React.PropTypes.object,
+    bodyStyle: React.PropTypes.object
   },
 
   //for passing default theme context to children
@@ -215,6 +216,7 @@ const Snackbar = React.createClass({
     const {
       onActionTouchTap,
       style,
+      bodyStyle,
       ...others,
     } = this.props;
     const styles = this.getStyles();
@@ -239,11 +241,13 @@ const Snackbar = React.createClass({
       );
     }
 
+    const mergedBodyStyle = this.mergeStyles(styles.body, bodyStyle);
+
     const contentStyle = open ? this.mergeStyles(styles.content, styles.contentWhenOpen) : styles.content;
 
     return (
       <div {...others} style={rootStyles}>
-        <div style={styles.body}>
+        <div style={mergedBodyStyle}>
           <div style={contentStyle}>
             <span>{message}</span>
             {actionButton}

--- a/src/snackbar.jsx
+++ b/src/snackbar.jsx
@@ -63,7 +63,7 @@ const Snackbar = React.createClass({
     onDismiss: React.PropTypes.func,
     openOnMount: React.PropTypes.bool,
     style: React.PropTypes.object,
-    bodyStyle: React.PropTypes.object
+    bodyStyle: React.PropTypes.object,
   },
 
   //for passing default theme context to children


### PR DESCRIPTION
With the old snackbar version I could easily change the background color of the snackbar.

```
<Snackbar
          openOnMount={true}
          style={{backgroundColor: Colors.red400}}
          autoHideDuration={3000}
          message="Bla bla bla" />
```

But with the new implementation the background color is set to a children div (because the responsive feature).
So the code above doesn't work anymore.

![](http://s16.postimg.org/vvq62zwgl/Schermata_da_2015_11_09_18_16_10.png)


I have to add different classes to the snackbars with different colors and match the children div with this css:
```
.snackbar-red {
  & > div {
    background-color: $red-color;
  }
}
```

I don't like it.
Using the syntax `style={{backgroundColor: Colors.red400}}` was much more easy to read.
Also I could use directly the `Colors` object from `Material.Styles.Colors`.