### PR TITLE
Adds onTitleTouchTap to AppBar

### DIFF
--- a/docs/src/app/components/pages/components/app-bar.jsx
+++ b/docs/src/app/components/pages/components/app-bar.jsx
@@ -103,6 +103,12 @@ export default class AppBarPage extends React.Component {
             desc: 'Callback function for when the right icon is selected via ' +
                   'a touch tap.',
           },
+          {
+            name: 'onTitleTouchTap',
+            header: 'AppBar.onTitleTouchTap(e)',
+            desc: 'Callback function for when the title text is selected via ' +
+                  'a touch tap.',
+          },
         ],
       },
     ];

--- a/src/app-bar.jsx
+++ b/src/app-bar.jsx
@@ -30,6 +30,7 @@ const AppBar = React.createClass({
   propTypes: {
     onLeftIconButtonTouchTap: React.PropTypes.func,
     onRightIconButtonTouchTap: React.PropTypes.func,
+    onTitleTouchTap: React.PropTypes.func,
     showMenuIconButton: React.PropTypes.bool,
     style: React.PropTypes.object,
     iconClassNameLeft: React.PropTypes.string,
@@ -162,8 +163,8 @@ const AppBar = React.createClass({
       // If the title is a string, wrap in an h1 tag.
       // If not, just use it as a node.
       titleElement = typeof title === 'string' || title instanceof String ?
-        <h1 style={this.prepareStyles(styles.title, styles.mainElement)}>{title}</h1> :
-        <div style={this.prepareStyles(styles.mainElement)}>{title}</div>;
+        <h1 onTouchTap={this._onTitleTouchTap} style={this.prepareStyles(styles.title, styles.mainElement)}>{title}</h1> :
+        <div onTouchTap={this._onTitleTouchTap} style={this.prepareStyles(styles.mainElement)}>{title}</div>;
     }
 
     if (showMenuIconButton) {
@@ -251,6 +252,12 @@ const AppBar = React.createClass({
   _onRightIconButtonTouchTap(event) {
     if (this.props.onRightIconButtonTouchTap) {
       this.props.onRightIconButtonTouchTap(event);
+    }
+  },
+
+  _onTitleTouchTap(event) {
+    if (this.props.onTitleTouchTap) {
+      this.props.onTitleTouchTap(event);
     }
   },
 


### PR DESCRIPTION
There is no current mechanism for attaching an event hook to clicking an AppBar title.  This seems contrary to typical web design, and was a problem for my project.  Please consider this change.  :smile: 