### PR TITLE
dialog render-to-layer version

### DIFF
--- a/docs/src/app/components/pages/components/dialog.jsx
+++ b/docs/src/app/components/pages/components/dialog.jsx
@@ -212,6 +212,7 @@ export default class DialogPage extends React.Component {
             title="Dialog With Standard Actions"
             actions={standardActions}
             actionFocus="submit"
+            modal={this.state.modal}
             open={this.state.openDialogStandardActions}
             onRequestClose={this._handleRequestClose}>
             The actions in this window are created from the json that&#39;s passed in.
@@ -221,6 +222,7 @@ export default class DialogPage extends React.Component {
             ref="customDialog"
             title="Dialog With Custom Actions"
             actions={customActions}
+            modal={this.state.modal}
             open={this.state.openDialogCustomActions}
             onRequestClose={this._handleRequestClose}>
             The actions in this window were passed in as an array of react objects.
@@ -235,6 +237,7 @@ export default class DialogPage extends React.Component {
             ref="scrollableContentDialog"
             title="Dialog With Scrollable Content"
             actions={scrollableCustomActions}
+            modal={this.state.modal}
             autoDetectWindowHeight={true}
             autoScrollBodyContent={true}
             open={this.state.openDialogScrollable}

--- a/src/dialog.jsx
+++ b/src/dialog.jsx
@@ -47,6 +47,10 @@ const TransitionItem = React.createClass({
     this.setState({muiTheme: newMuiTheme});
   },
 
+  componentWillEnter(callback) {
+    this.componentWillAppear(callback);
+  },
+
   componentWillAppear(callback) {
     let spacing = this.state.muiTheme.rawTheme.spacing;
 
@@ -111,10 +115,10 @@ const DialogInline = React.createClass({
     bodyStyle: React.PropTypes.object,
     contentClassName: React.PropTypes.string,
     contentStyle: React.PropTypes.object,
+    open: React.PropTypes.bool.isRequired,
     repositionOnUpdate: React.PropTypes.bool,
     style: React.PropTypes.object,
     title: React.PropTypes.node,
-    open: React.PropTypes.bool.isRequired,
   },
 
   windowListeners: {
@@ -221,7 +225,9 @@ const DialogInline = React.createClass({
 
     return (
       <div ref="container" style={this.prepareStyles(styles.main)}>
-        <ReactTransitionGroup component="div" ref="dialogWindow" transitionAppear={true} transitionAppearTimeout={450}>
+        <ReactTransitionGroup component="div" ref="dialogWindow" 
+          transitionAppear={true} transitionAppearTimeout={450}
+          transitionEnter={true} transitionEnterTimeout={450}>
           {this.props.open &&
             <TransitionItem
               className={this.props.contentClassName}
@@ -348,7 +354,8 @@ const DialogInline = React.createClass({
   },
 
   _requestClose(buttonClicked) {
-    if (!buttonClicked || this.props.modal) {
+    
+    if (!buttonClicked && this.props.modal) {
       return;
     }
 
@@ -386,13 +393,14 @@ const Dialog = React.createClass({
     bodyStyle: React.PropTypes.object,
     contentClassName: React.PropTypes.string,
     contentStyle: React.PropTypes.object,
+    defaultOpen: React.PropTypes.bool,
+    modal: React.PropTypes.bool,
+    onRequestClose: React.PropTypes.func,
+    open: React.PropTypes.bool,
     openImmediately: React.PropTypes.bool,
-    onClickAway: React.PropTypes.func,
     repositionOnUpdate: React.PropTypes.bool,
     style: React.PropTypes.object,
     title: React.PropTypes.node,
-    defaultOpen: React.PropTypes.bool,
-    open: React.PropTypes.bool,
   },
 
   getInitialState() {
@@ -416,6 +424,7 @@ const Dialog = React.createClass({
     return {
       open:null,
       defaultOpen:false,
+      modal:false,
     }
   },
 
@@ -446,7 +455,7 @@ const Dialog = React.createClass({
   renderLayer() {
     return (
       <div style={wrapperStyle}>
-          <DialogInline {...this.props} onRequestClose={this.props.onRequestClose} open={this.props.open} />
+        <DialogInline {...this.props} onRequestClose={this.props.onRequestClose} open={this.state.open} />
       </div>
     );
   },

--- a/src/dialog.jsx
+++ b/src/dialog.jsx
@@ -387,6 +387,7 @@ const wrapperStyle = {position:'fixed', top:0, left:0, zIndex:20};
 const Dialog = React.createClass({
 
   propTypes: {
+    actionFocus: React.PropTypes.string, 
     actions: React.PropTypes.array,
     autoDetectWindowHeight: React.PropTypes.bool,
     autoScrollBodyContent: React.PropTypes.bool,
@@ -395,12 +396,15 @@ const Dialog = React.createClass({
     contentStyle: React.PropTypes.object,
     defaultOpen: React.PropTypes.bool,
     modal: React.PropTypes.bool,
+    onDismiss: React.PropTypes.func,
     onRequestClose: React.PropTypes.func,
+    onShow: React.PropTypes.func,
     open: React.PropTypes.bool,
     openImmediately: React.PropTypes.bool,
     repositionOnUpdate: React.PropTypes.bool,
     style: React.PropTypes.object,
     title: React.PropTypes.node,
+    titleStyle: React.PropTypes.object,
   },
 
   getInitialState() {

--- a/src/overlay.jsx
+++ b/src/overlay.jsx
@@ -39,33 +39,30 @@ const Overlay = React.createClass({
   componentWillReceiveProps (nextProps, nextContext) {
     let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
     this.setState({muiTheme: newMuiTheme});
+    if (this.props.show !== nextProps.show) {
+      this._applyAutoLockScrolling();
+    }
   },
 
   propTypes: {
     autoLockScrolling: React.PropTypes.bool,
-    show: React.PropTypes.bool,
-    transitionEnabled: React.PropTypes.bool,
+    show: React.PropTypes.bool.isRequired,
     style: React.PropTypes.object,
+    transitionEnabled: React.PropTypes.bool,
   },
 
   getDefaultProps() {
     return {
       autoLockScrolling: true,
       transitionEnabled: true,
+      style:{},
     };
   },
 
   componentDidMount() {
     this._originalBodyOverflow = document.getElementsByTagName('body')[0].style.overflow;
-  },
-
-  componentDidUpdate() {
-    if (this.props.autoLockScrolling) {
-      if (this.props.show) {
-        this._preventScrolling();
-      } else {
-        this._allowScrolling();
-      }
+    if (this.props.show) {
+      this._applyAutoLockScrolling();
     }
   },
 
@@ -126,12 +123,14 @@ const Overlay = React.createClass({
     );
   },
 
-  preventScrolling() {
-    if (!this.props.autoLockScrolling) this._preventScrolling();
-  },
-
-  allowScrolling() {
-    if (!this.props.autoLockScrolling) this._allowScrolling();
+  _applyAutoLockScrolling() {
+    if (this.props.autoLockScrolling) {
+      if (this.props.show) {
+        this._preventScrolling();
+      } else {
+        this._allowScrolling();
+      }
+    }
   },
 
   _preventScrolling() {

--- a/src/overlay.jsx
+++ b/src/overlay.jsx
@@ -40,7 +40,7 @@ const Overlay = React.createClass({
     let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
     this.setState({muiTheme: newMuiTheme});
     if (this.props.show !== nextProps.show) {
-      this._applyAutoLockScrolling();
+      this._applyAutoLockScrolling(nextProps);
     }
   },
 
@@ -62,7 +62,7 @@ const Overlay = React.createClass({
   componentDidMount() {
     this._originalBodyOverflow = document.getElementsByTagName('body')[0].style.overflow;
     if (this.props.show) {
-      this._applyAutoLockScrolling();
+      this._applyAutoLockScrolling(this.props);
     }
   },
 
@@ -123,9 +123,9 @@ const Overlay = React.createClass({
     );
   },
 
-  _applyAutoLockScrolling() {
-    if (this.props.autoLockScrolling) {
-      if (this.props.show) {
+  _applyAutoLockScrolling(props) {
+    if (props.autoLockScrolling) {
+      if (props.show) {
         this._preventScrolling();
       } else {
         this._allowScrolling();


### PR DESCRIPTION
This PR created a wrapped dialog component that uses the render to layer component to put the dialog in a separate dom tree.

The reason for the wrapping is so that refs can continue to be used as normal within the dialog component for animation.

(This doesn't depend on the #2043 branch)