### PR TITLE
[Doc] Better doc for the onCellClick event (also usable on <TableRow>)

### DIFF
--- a/docs/src/app/components/pages/components/table.jsx
+++ b/docs/src/app/components/pages/components/table.jsx
@@ -221,6 +221,13 @@ export default class TablePage extends React.Component {
         name: 'Table Row Props',
         infoArray: [
           {
+            name: 'onCellClick',
+            type: 'function(rowNumber, columnId)',
+            header: 'optional',
+            desc: 'Called when a row cell is clicked. rowNumber is the row number and columnId is the column number ' +
+              'or the column key. This method can also be set on <Table>, which would catch cell clicks from the table body.',
+          },
+          {
             name: 'displayBorder',
             type: 'boolean',
             header: 'default: true',
@@ -332,7 +339,8 @@ export default class TablePage extends React.Component {
             type: 'function(rowNumber, columnId)',
             header: 'optional',
             desc: 'Called when a row cell is clicked. rowNumber is the row number and columnId is the column number ' +
-              'or the column key.',
+              'or the column key. This method can also be set on <TableRow>, usefull to catch events from ' +
+              'the table header or from specific rows of the table body.',
           },
           {
             name: 'onRowHover',


### PR DESCRIPTION
Small addition to the docs, I had troubles setting an `onClick` event on a `<TableRowColumn>` from the header. Turns out the correct approach was using a `onCellClick` on the `<TableRow>` of my header.
This isn't in the docs.