### PR TITLE
[SelectField] Fix the positionning of the text

### DIFF
--- a/src/select-field.jsx
+++ b/src/select-field.jsx
@@ -109,16 +109,15 @@ const SelectField = React.createClass({
     };
 
     if (!this.props.floatingLabelText) {
+      styles.label.top = -6;
+      styles.icon.top = 11;
+
       if(this.props.hintText) {
         styles.root.top = -5;
-        styles.label.top = 1;
-        styles.icon.top = 17;
-      }
-      else {
+      } else {
         styles.root.top = -8;
       }
-    }
-    else {
+    } else {
       styles.error.bottom = -15;
     }
 


### PR DESCRIPTION
Follow more closely the material spec
https://www.google.com/design/spec/components/text-fields.html#text-fields-floating-labels
There is still stuff to fix and they have added the dense option.
That's for later.

Before:
![screen shot 2015-11-12 at 20 51 26](https://cloud.githubusercontent.com/assets/3165635/11129405/61419078-897f-11e5-9793-68e379c94ba0.png)

After:
![screen shot 2015-11-12 at 20 50 59](https://cloud.githubusercontent.com/assets/3165635/11129401/5abd1ede-897f-11e5-8454-eaf0b8c9ccb9.png)
