### PR TITLE
[LeftNav] Declarative API

### DIFF
--- a/docs/src/app/components/app-left-nav.jsx
+++ b/docs/src/app/components/app-left-nav.jsx
@@ -22,6 +22,12 @@ const AppLeftNav = React.createClass({
     muiTheme: React.PropTypes.object,
     router: React.PropTypes.func,
   },
+  
+  getInitialState () {
+    return {
+      leftNavOpen: false,
+    };
+  },
 
   getStyles() {
     return {
@@ -49,7 +55,8 @@ const AppLeftNav = React.createClass({
       <LeftNav
         ref="leftNav"
         docked={false}
-        isInitiallyOpen={false}
+        open={this.state.leftNavOpen}
+        onChangeRequest={this._onLeftNavChangeRequest}
         header={header}
         menuItems={menuItems}
         selectedIndex={this._getSelectedIndex()}
@@ -58,7 +65,7 @@ const AppLeftNav = React.createClass({
   },
 
   toggle() {
-    this.refs.leftNav.toggle();
+    this.setState({leftNavOpen: !this.state.leftNavOpen});
   },
 
   _getSelectedIndex() {
@@ -70,13 +77,17 @@ const AppLeftNav = React.createClass({
     }
   },
 
+  _onLeftNavChangeRequest(open) {
+    this.setState({leftNavOpen: open});
+  },
+
   _onLeftNavChange(e, key, payload) {
     this.props.history.pushState(null, payload.route);
   },
 
   _onHeaderClick() {
     this.props.history.pushState(null, '/');
-    this.refs.leftNav.close();
+    this.setState({leftNavOpen: false});
   },
 
 });

--- a/docs/src/app/components/pages/components/left-nav.jsx
+++ b/docs/src/app/components/pages/components/left-nav.jsx
@@ -9,11 +9,14 @@ export default class LeftNavPage extends React.Component {
 
   constructor() {
     super();
-    this._showLeftNavClick = this._showLeftNavClick.bind(this);
-    this._toggleDockedLeftNavClick = this._toggleDockedLeftNavClick.bind(this);
-    this._showLeftNavChildrenClick = this._showLeftNavChildrenClick.bind(this);
+    this._toggleLeftNavChildrenClick = this._toggleLeftNavChildrenClick.bind(this);
+    this._toggleLeftNavControlledClick = this._toggleLeftNavControlledClick.bind(this);
+    this._showLeftNavUndockedControlledClick = this._showLeftNavUndockedControlledClick.bind(this);
+    this._changeLeftNavUndockedControlledClick = this._changeLeftNavUndockedControlledClick.bind(this);
     this.state = {
-      isDocked: false,
+      navOpen: false,
+      navWithChildrenOpen: false,
+      undockedNavOpen: false,
     };
   }
 
@@ -27,6 +30,14 @@ export default class LeftNavPage extends React.Component {
       { text: 'Disabled', disabled: true },
       { type: MenuItem.Types.LINK, payload: 'https://www.google.com', text: 'Disabled Link', disabled: true },
     ];
+    
+    this.desc = 'The api of Left Nav has been changed to be declarative. ' + 
+                'The methods close, open and toggle have been deprecated. ' +
+                'In order to control the Left Nav use the open property and handle ' +
+                'the onChangeRequest event. Also, as you have noticed there are no examples ' +
+                'for uncontrolled mode. That is because uncontrolled Left Nav can only be open ' +
+                'with swipe. The doc site has an uncontrolled Left Nav, swipe left with a touch ' +
+                'device to see it.';
 
     let componentInfo = [
       {
@@ -45,6 +56,13 @@ export default class LeftNavPage extends React.Component {
             header: 'default: true',
             desc: 'Indicates that the left nav should be docked. In this state, the ' +
               'overlay won\'t show and clicking on a menu item will not close the left nav.',
+          },
+          {
+            name: 'open',
+            type: 'bool',
+            header: 'default: null',
+            desc: 'Indicates that the left nav should be opened, closed or uncontrolled. Providing a boolean ' +
+              'will turn the left nav into a controlled component.',
           },
           {
             name: 'header',
@@ -102,14 +120,25 @@ export default class LeftNavPage extends React.Component {
         name: 'Methods',
         infoArray: [
           {
-            name: 'close',
-            header: 'LeftNav.close()',
-            desc: 'Closes the component, hiding it from view.',
+            name: 'Deprecated: open',
+            header: 'LeftNav.open()',
+            desc: 'Opens the component. ' +
+              'Using this method is deprecated, use the ' +
+              'open property and handle onChangeRequest to control the left nav.',
           },
           {
-            name: 'toggle',
+            name: 'Deprecated: close',
+            header: 'LeftNav.close()',
+            desc: 'Closes the component, hiding it from view. ' +
+              'Using this method is deprecated, use the ' +
+              'open property and handle onChangeRequest to control the left nav.',
+          },
+          {
+            name: 'Deprecated: toggle',
             header: 'LeftNav.toggle()',
-            desc: 'Toggles between the open and closed states.',
+            desc: 'Toggles between the open and closed states. ' +
+              'Using this method is deprecated, use the ' +
+              'open property and handle onChangeRequest to control the left nav.',
           },
         ],
       },
@@ -124,14 +153,29 @@ export default class LeftNavPage extends React.Component {
               'See the "Get Started" section for more detail.',
           },
           {
-            name: 'onNavOpen',
+            name: 'Deprecated: onNavOpen',
             header: 'function()',
-            desc: 'Fired when the component is opened',
+            desc: 'Fired when the component is opened. ' +
+              'Using this method is deprecated, use the ' +
+              'open property and handle onChangeRequest to control the left nav.',
           },
           {
-            name: 'onNavClose',
+            name: 'Deprecated: onNavClose',
             header: 'function()',
-            desc: 'Fired when the component is closed',
+            desc: 'Fired when the component is closed. ' +
+              'Using this method is deprecated, use the ' +
+              'open property and handle onChangeRequest to control the left nav.',
+          },
+          {
+            name: 'onChangeRequest',
+            header: 'function(open, reason)',
+            desc: 'Callback function that is fired when the ' + 
+              'open state of the left nav is requested to be changed. ' + 
+              'The provided open argument determines whether the left nav is ' +
+              'requested to be opened or closed. Also, the reason argument states why the ' +
+              'left nav got closed or opend. It can be either \'clickaway\' for menuItem and ' +
+              'overlay clicks, \'escape\' for pressing the escape key and \'swipe\' for swiping. ' +
+              'For opening the reason is always \'swipe\'.',
           },
         ],
       },
@@ -140,6 +184,7 @@ export default class LeftNavPage extends React.Component {
     return (
       <ComponentDoc
         name="Left Nav"
+        desc={this.desc}
         componentInfo={componentInfo}>
 
         <Paper style = {{marginBottom: '22px'}}>
@@ -157,33 +202,48 @@ import LeftNav from 'material-ui/lib/left-nav/';
         <CodeExample code={Code}>
           <div>
             <div>
-              <RaisedButton label="Toggle Docked Left Nav" onTouchTap={this._toggleDockedLeftNavClick} /><br/><br/>
-              <RaisedButton label="Show Hideable Left Nav" onTouchTap={this._showLeftNavClick} /><br/><br/>
-              <RaisedButton label="Show Hideable Children Left Nav" onTouchTap={this._showLeftNavChildrenClick} /><br/><br/>
+              <RaisedButton label="Toggle Docked Controlled Left Nav" onTouchTap={this._toggleLeftNavControlledClick} /><br/><br/>
+              <RaisedButton label="Toggle Docked Controlled Left Nav With Children" onTouchTap={this._toggleLeftNavChildrenClick} /><br/><br/>
+              <RaisedButton label="Show Undocked Controlled Left Nav" onTouchTap={this._showLeftNavUndockedControlledClick} /><br/><br/>
             </div>
 
-            <LeftNav ref="dockedLeftNav" docked={this.state.isDocked} menuItems={menuItems} />
-            <LeftNav ref="leftNav" docked={false} menuItems={menuItems} />
-            <LeftNav ref="leftNavChildren" docked={false}>
+            <LeftNav ref="leftNavChildren" open={this.state.navWithChildrenOpen}>
               <MenuItem index={0}>Menu Item</MenuItem>
               <MenuItem index={1}><a href="/link">Link</a></MenuItem>
             </LeftNav>
+            <LeftNav open={this.state.navOpen} menuItems={menuItems} />
+            <LeftNav 
+              open={this.state.undockedNavOpen} 
+              onChangeRequest={this._changeLeftNavUndockedControlledClick}
+              docked={false} 
+              menuItems={menuItems} />
           </div>
         </CodeExample>
       </ComponentDoc>
     );
   }
 
-  _showLeftNavClick() {
-    this.refs.leftNav.toggle();
-  }
-  _showLeftNavChildrenClick() {
-    this.refs.leftNavChildren.toggle();
-  }
-  _toggleDockedLeftNavClick() {
-    this.refs.dockedLeftNav.toggle();
+  _toggleLeftNavChildrenClick() {
     this.setState({
-      isDocked: !this.state.isDocked,
+      navWithChildrenOpen: !this.state.navWithChildrenOpen,
+    });
+  }
+  
+  _toggleLeftNavControlledClick() {
+    this.setState({
+      navOpen: !this.state.navOpen,
+    });
+  }
+  
+  _showLeftNavUndockedControlledClick() {
+    this.setState({
+      undockedNavOpen: true,
+    });
+  }
+  
+  _changeLeftNavUndockedControlledClick(open) {
+    this.setState({
+      undockedNavOpen: open,
     });
   }
 

--- a/docs/src/app/components/raw-code/left-nav-code.txt
+++ b/docs/src/app/components/raw-code/left-nav-code.txt
@@ -20,17 +20,21 @@ menuItems = [
   },
 ];
 
-//Toggle the LeftNav
-this.refs.leftNav.toggle();
-
 //Docked Left Nav
 <LeftNav ref="leftNav" menuItems={menuItems} />
 
-//Hideable Left Nav
-<LeftNav ref="leftNav" docked={false} menuItems={menuItems} />
+//Controlled and docked Left Nav. Can only be opened and close by changing the open prop.
+<LeftNav open={this.state.navOpen} menuItems={menuItems} />
 
-//Hideable Left Nav with Nested Children
-<LeftNav ref="leftNavChildren" docked={false}>
+//Controlled and docked Left Nav with nested children
+<LeftNav ref="leftNavChildren" open={this.state.navWithChildrenOpen} docked={false}>
   <MenuItem index={0}>Menu Item</MenuItem>
   <MenuItem index={1}><a href="/link">Link</a></MenuItem>
 </LeftNav>
+
+//Controlled and undocked Left Nav.
+<LeftNav 
+  open={this.state.undockedNavOpen} 
+  onChangeRequest={this._handleLeftNavChanged}
+  docked={false} 
+  menuItems={menuItems} />


### PR DESCRIPTION
addressing #2117, `LeftNav` can now be controlled with `open` prop and `onNavOpen` and `onNavClose`.

## Questions:
- [x] ~~`open` or `show`?~~ `open` is preferred.
- [x] ~~Should we follow the convention of `onChangeRequest` but with a mouthful name like: `onOpenStateChangeRequest`? Or is this good enough?~~ `onChangeRequest` is more convenient.
- [x] ~~Should we still support menu items although they can be nested and composed easily?~~ too many changes, must be a separate PR.

P.S. I also made a tiny style change so that when `LeftNav` is closing the user can click on the page. It was annoying that you had to wait until the nav completely closed before you could do anything else.