### PR TITLE
Made color a prop for LinearProgress and RefreshIndicator

### DIFF
--- a/docs/src/app/components/pages/components/progress.jsx
+++ b/docs/src/app/components/pages/components/progress.jsx
@@ -72,6 +72,12 @@ const ProgressPage = React.createClass({
             header: 'optional',
             desc: 'Override the inline-styles of the progress\'s root element.',
           },
+          {
+            name: 'color',
+            type: 'string',
+            header: 'optional',
+            desc: 'Override the progress\'s color.',
+          },
         ],
       },
     ];
@@ -102,7 +108,10 @@ const ProgressPage = React.createClass({
             Indeterminate
           </p>
           <LinearProgress mode="indeterminate"  />
-
+          <p>
+            Overriding the theme's color
+          </p>
+          <LinearProgress mode="determinate" color={"#4CAF50"} value={this.state.completed} />
           <br/><br/>
           <h2>Circular Progress</h2>
           <p>
@@ -116,7 +125,7 @@ const ProgressPage = React.createClass({
           </p>
           <CircularProgress mode="indeterminate"  />
           <CircularProgress mode="indeterminate" size={1.5} />
-          <CircularProgress mode="indeterminate" size={2} />
+          <CircularProgress mode="indeterminate" color={"red"} size={2} />
         </CodeExample>
       </ComponentDoc>
     );

--- a/docs/src/app/components/pages/components/refresh-indicator.jsx
+++ b/docs/src/app/components/pages/components/refresh-indicator.jsx
@@ -14,12 +14,6 @@ let RefreshIndicatorPage = React.createClass({
         name: 'Props',
         infoArray: [
           {
-            name: 'left',
-            type: 'number',
-            header: 'required',
-            desc: 'The absolute left position of the indicator in pixels.',
-          },
-          {
             name: 'percentage',
             type: 'number',
             header: 'default: 0',
@@ -44,10 +38,28 @@ let RefreshIndicatorPage = React.createClass({
             desc: 'Override the inline-styles of the indicator\'s root element.',
           },
           {
+            name: 'color',
+            type: 'string',
+            header: 'optional',
+            desc: 'Override the theme\'s color of the indicator while it\'s status is \"ready\" or it\'s percentage is less than 100.',
+          },
+          {
+            name: 'loadingColor',
+            type: 'string',
+            header: 'optional',
+            desc: 'Override the theme\'s color of the indicator while it\'s status is \"loading\" or it\'s percentage is 100.',
+          },
+          {
             name: 'top',
             type: 'number',
             header: 'required',
             desc: 'The absolute right position of the indicator in pixels.',
+          },
+          {
+            name: 'left',
+            type: 'number',
+            header: 'required',
+            desc: 'The absolute left position of the indicator in pixels.',
           },
         ],
       },
@@ -90,6 +102,7 @@ let RefreshIndicatorPage = React.createClass({
               size={40}
               left={120}
               top={30}
+              color={"red"}
               status="ready" />
             <RefreshIndicator
               percentage={100}
@@ -101,6 +114,8 @@ let RefreshIndicatorPage = React.createClass({
               Loading status
             </p>
             <RefreshIndicator size={40} left={10} top={130} status="loading" />
+            <RefreshIndicator size={40} left={70} top={130} loadingColor={"#FF9800"}
+                              status="loading" />
           </div>
         </CodeExample>
       </ComponentDoc>

--- a/docs/src/app/components/raw-code/progress-code.txt
+++ b/docs/src/app/components/raw-code/progress-code.txt
@@ -1,10 +1,12 @@
 //Linear
 <LinearProgress mode="determinate" value={60} />
 <LinearProgress mode="indeterminate"  />
+<LinearProgress mode="determinate" color={"#4CAF50"} value={60} />
+
 //Circular
 <CircularProgress mode="determinate" value={60} />
 <CircularProgress mode="determinate" value={60} size={1.5} />
 <CircularProgress mode="determinate" value={60} size={2} />
 <CircularProgress mode="indeterminate" />
 <CircularProgress mode="indeterminate" size={1.5} />
-<CircularProgress mode="indeterminate" size={2} />
+<CircularProgress mode="indeterminate" color={"red"} size={2} />

--- a/docs/src/app/components/raw-code/refresh-indicator-code.txt
+++ b/docs/src/app/components/raw-code/refresh-indicator-code.txt
@@ -1,7 +1,9 @@
 // Ready status
 <RefreshIndicator percentage={30} size={40} left={10} top={5} status="ready" />
 <RefreshIndicator percentage={60} size={40} left={10} top={5} status="ready" />
-<RefreshIndicator percentage={80} size={40} left={10} top={5} status="ready" />
+<RefreshIndicator percentage={80} size={40} left={10} top={5}
+    color={"red"} status="ready" />
 <RefreshIndicator percentage={100} size={40} left={10} top={5} status="ready" />
 // Loading status
 <RefreshIndicator size={40} left={80} top={5} status="loading" />
+<RefreshIndicator size={40} left={80} top={5} loadingColor={"#FF9800"} status="loading" />

--- a/src/linear-progress.jsx
+++ b/src/linear-progress.jsx
@@ -15,6 +15,7 @@ const LinearProgress = React.createClass({
     min:  React.PropTypes.number,
     max:  React.PropTypes.number,
     style: React.PropTypes.object,
+    color: React.PropTypes.string,
   },
 
   contextTypes: {
@@ -134,7 +135,7 @@ const LinearProgress = React.createClass({
     if (this.props.mode === "indeterminate") {
       styles.barFragment1 = {
         position: "absolute",
-        backgroundColor: this.getTheme().primary1Color,
+        backgroundColor: this.props.color || this.getTheme().primary1Color,
         top: 0,
         left: 0,
         bottom: 0,
@@ -143,7 +144,7 @@ const LinearProgress = React.createClass({
 
       styles.barFragment2 = {
         position: "absolute",
-        backgroundColor: this.getTheme().primary1Color,
+        backgroundColor: this.props.color || this.getTheme().primary1Color,
         top: 0,
         left: 0,
         bottom: 0,
@@ -151,7 +152,7 @@ const LinearProgress = React.createClass({
       };
     }
     else {
-      styles.bar.backgroundColor= this.getTheme().primary1Color;
+      styles.bar.backgroundColor= this.props.color || this.getTheme().primary1Color;
       styles.bar.transition = Transitions.create("width", ".3s", null, "linear");
       styles.bar.width = this._getRelativeValue() + "%";
     }

--- a/src/refresh-indicator.jsx
+++ b/src/refresh-indicator.jsx
@@ -22,6 +22,8 @@ const RefreshIndicator = React.createClass({
     status: React.PropTypes.oneOf(['ready', 'loading', 'hide']),
     style: React.PropTypes.object,
     top: React.PropTypes.number.isRequired,
+    color: React.PropTypes.string,
+    loadingColor: React.PropTypes.string,
   },
 
   getDefaultProps() {
@@ -199,7 +201,7 @@ const RefreshIndicator = React.createClass({
       style: {
         strokeDasharray: arcLen + ', ' + (perimeter - arcLen),
         strokeDashoffset: dashOffset,
-        stroke: (isLoading || this.props.percentage === 100) ? theme.loadingStrokeColor : theme.strokeColor,
+        stroke: (isLoading || this.props.percentage === 100) ? (this.props.loadingColor || theme.loadingStrokeColor) : (this.props.color || theme.strokeColor),
         strokeLinecap: 'round',
         opacity: p1,
         strokeWidth: circle.strokeWidth * p1,
@@ -227,7 +229,7 @@ const RefreshIndicator = React.createClass({
     const theme = this._getTheme();
     return {
       style: {
-        fill: this.props.percentage === 100 ? theme.loadingStrokeColor : theme.strokeColor,
+        fill: this.props.percentage === 100 ? (this.props.loadingColor || theme.loadingStrokeColor) : (this.props.color || theme.strokeColor),
         transform: `rotate(${endDeg}deg)`,
         transformOrigin: `${circle.originX}px ${circle.originY}px`,
         opacity: p1,


### PR DESCRIPTION
Added a color prop to LinearProgress to override the theme's color (CircularProgress already has this)
Added a color prop and loadingColor prop to RefreshIndicator to override the theme's color
Updated the docs to reflect these changes.