### PR TITLE
Fix Date Picker docs crash in Safari

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -19,6 +19,7 @@
     "react-addons-perf": "^0.14.0",
     "react-dom": "^0.14.0",
     "react-motion": "^0.3.1",
+    "react-router": "^1.0.0-rc1",
     "react-swipeable-views": "^0.3.0"
   },
   "devDependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "codemirror": "^5.5.0",
     "history": "^1.11.1",
+    "intl": "^1.0.1",
     "react-addons-perf": "^0.14.0",
     "react-dom": "^0.14.0",
     "react-motion": "^0.3.1",

--- a/docs/src/app/components/pages/components/date-picker.jsx
+++ b/docs/src/app/components/pages/components/date-picker.jsx
@@ -5,6 +5,11 @@ const Code = require('date-picker-code');
 const CodeExample = require('../../code-example/code-example');
 const CodeBlock = require('../../code-example/code-block');
 
+if (!window.Intl) {
+  require('intl');
+  require('intl/locale-data/jsonp/fr');
+}
+
 export default class DatePickerPage extends React.Component {
   constructor(props) {
     super(props);
@@ -247,7 +252,8 @@ export default class DatePickerPage extends React.Component {
           <DatePicker
             hintText="fr version"
             DateTimeFormat={Intl.DateTimeFormat}
-            // Intl is defined by the browser see http://caniuse.com/#search=intl
+            // Intl is supported by most modern browsers, see http://caniuse.com/#search=intl
+            // for browsers that don't support it use this polyfill https://github.com/andyearnshaw/Intl.js
             wordings={{ok: 'OK', cancel: 'Annuler'}}
             locale="fr" />
 

--- a/docs/src/app/components/raw-code/date-picker-code.txt
+++ b/docs/src/app/components/raw-code/date-picker-code.txt
@@ -19,7 +19,8 @@
 
 <DatePicker
   hintText="fr version"
-  // Intl is defined by the browser see http://caniuse.com/#search=intl
+  // Intl is supported by most modern browsers, see http://caniuse.com/#search=intl
+  // for browsers that don't support it use this polyfill https://github.com/andyearnshaw/Intl.js
   DateTimeFormat={Intl.DateTimeFormat}
   wordings={{ok: 'OK', cancel: 'Annuler'}}
   locale="fr" />

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "react-dom": "^0.14.0",
     "react-tap-event-plugin": "^0.2.0",
     "react-hot-loader": "^1.2.8",
-    "react-router": "^1.0.0-rc1",
     "recursive-readdir-sync": "^1.0.6",
     "rimraf": "^2.4.3",
     "sinon": "^1.15.4",


### PR DESCRIPTION
Safari [doesn't support Intl](http://caniuse.com/#search=intl), so I'm using the [polyfill](https://github.com/andyearnshaw/Intl.js). Otherwise the Date Picker page wouldn't start at all in Safari, it caused a fatal error which made the rest of the docs stop working as well.