### PR TITLE
Make TimePicker more like android's

### DIFF
--- a/src/time-picker/clock-hours.jsx
+++ b/src/time-picker/clock-hours.jsx
@@ -149,7 +149,7 @@ const ClockHours = React.createClass({
 
     value = value || 12;
     if (this.props.format === "24hr"){
-      if (distance < 90){
+      if (distance >= 90){
         value += 12;
         value %= 24;
       }
@@ -185,8 +185,8 @@ const ClockHours = React.createClass({
 
     return hours.map((hour) => {
       let isSelected = this._getSelected() === hour;
-      return <ClockNumber key={hour} style={style} isSelected={isSelected} type="hour"
-        value={hour} />;
+      return <ClockNumber key={hour} style={style} isSelected={isSelected}
+        type="hour" hourFormat={this.props.format} value={hour} />;
     });
   },
 
@@ -213,7 +213,7 @@ const ClockHours = React.createClass({
 
     return (
       <div ref="clock" style={this.prepareStyles(styles.root)} >
-        <ClockPointer hasSelected={true} value={hours} type="hour" />
+        <ClockPointer hasSelected={true} value={hours} type="hour" hourFormat={this.props.format} />
         {numbers}
         <div ref="mask" style={this.prepareStyles(styles.hitMask)} onTouchMove={this.handleTouchMove}
           onTouchEnd={this.handleTouchEnd} onMouseUp={this.handleUp} onMouseMove={this.handleMove}/>

--- a/src/time-picker/clock-number.jsx
+++ b/src/time-picker/clock-number.jsx
@@ -14,6 +14,7 @@ const ClockNumber = React.createClass({
   propTypes: {
     value: React.PropTypes.number,
     type: React.PropTypes.oneOf(['hour', 'minute']),
+    hourFormat: React.PropTypes.oneOf(['ampm', '24hr']),
     onSelected: React.PropTypes.func,
     isSelected: React.PropTypes.bool,
   },
@@ -46,6 +47,7 @@ const ClockNumber = React.createClass({
     return {
       value: 0,
       type: 'minute',
+      hourFormat: 'ampm',
       isSelected: false,
     };
   },
@@ -58,12 +60,11 @@ const ClockNumber = React.createClass({
     let pos = this.props.value;
     let inner = false;
 
-    if (this.props.type === "hour") {
-      inner = pos < 1 || pos > 12;
-      pos %= 12;
-    }
-    else {
+    if (this.props.type === "minute") {
       pos = pos / 5;
+    } else if (this.props.type === "hour") {
+      inner = this.props.hourFormat === "24hr" && pos >= 1 && pos <= 12;
+      pos %= 12;
     }
 
     let positions = [
@@ -132,8 +133,13 @@ const ClockNumber = React.createClass({
 
     styles.root.transform = "translate(" + x + "px, " + y + "px)";
 
+    let text = this.props.value;
+    if (this.props.type === "minute" || this.props.value < 1 || this.props.value > 12) {
+      text = ("0" + this.props.value).slice(-2);
+    }
+
     return (
-        <span style={this.prepareStyles(styles.root)}>{this.props.value}</span>
+        <span style={this.prepareStyles(styles.root)}>{text}</span>
     );
   },
 });

--- a/src/time-picker/clock-pointer.jsx
+++ b/src/time-picker/clock-pointer.jsx
@@ -14,6 +14,7 @@ const ClockPointer = React.createClass({
   propTypes: {
     value: React.PropTypes.number,
     type: React.PropTypes.oneOf(['hour', 'minute']),
+    hourFormat: React.PropTypes.oneOf(['ampm', '24hr']),
   },
 
   //for passing default theme context to children
@@ -38,6 +39,7 @@ const ClockPointer = React.createClass({
     return {
       value: null,
       type: 'minute',
+      hourFormat: 'ampm',
       hasSelected: false,
     };
   },
@@ -51,10 +53,10 @@ const ClockPointer = React.createClass({
   },
 
   isInner(value) {
-    if (this.props.type !== "hour" ) {
+    if (this.props.type !== "hour") {
       return false;
     }
-    return value < 1 || value > 12 ;
+    return this.props.hourFormat === "24hr" && value >= 1 && value <= 12;
   },
 
   getAngle() {


### PR DESCRIPTION
Hello, it's my first PR

What do you think of swapping TimePicker's 24hr inner and outer hour circles (to make it like Android's) ?

![clock_kit_kat](https://cloud.githubusercontent.com/assets/732231/11294551/71f5fd7c-8f75-11e5-9b4a-f43525890539.png)