### PR TITLE
[TextField] Fix for floating label element not allowing focus

### DIFF
--- a/src/text-field.jsx
+++ b/src/text-field.jsx
@@ -228,6 +228,7 @@ const TextField = React.createClass({
       bottom: 'none',
       opacity: 1,
       zIndex: 1, // Needed to display label above Chrome's autocomplete field background
+      cursor: 'text',
       transform: 'scale(1) translate3d(0, 0, 0)',
       transformOrigin: 'left top',
     });
@@ -309,7 +310,8 @@ const TextField = React.createClass({
     let floatingLabelTextElement = floatingLabelText ? (
       <label
         style={this.prepareStyles(styles.floatingLabel, this.props.floatingLabelStyle)}
-        htmlFor={inputId}>
+        htmlFor={inputId}
+        onTouchTap={this.focus}>
         {floatingLabelText}
       </label>
     ) : null;


### PR DESCRIPTION
This is a regression bug from #2078. The floating label was set with a zIndex of 1, which moves it on top of the input element. The click events on the floating label do not reach input element, hence not allowing focus.

Also, the cursor became an arrow instead of `text`, because the floating label `div` is on top, which is an unexpected visual feedback on a text field.

OSX El Capitan, Chrome Version 46.0.2490.86 (64-bit)