### PR TITLE
Allow overriding background color of tabs

### DIFF
--- a/src/tabs/tab.jsx
+++ b/src/tabs/tab.jsx
@@ -70,6 +70,7 @@ const Tab = React.createClass({
       verticalAlign: 'middle',
       height: 48,
       color: selected ? this.state.muiTheme.tabs.selectedTextColor : this.state.muiTheme.tabs.textColor,
+      backgroundColor: selected ? this.state.muiTheme.tabs.selectedBGColor : this.state.muiTheme.tabs.bgColor,
       outline: 'none',
       fontSize: 14,
       fontWeight: 500,


### PR DESCRIPTION
I needed to be able to override the background color of tabs that were selected, this small change adds the ability to specify two options in your theme file:

tabs.selectedBGColor
tabs.bgColor