### PR TITLE
Add linting to test files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,7 @@ var gulp = require('gulp');
 var eslint = require('gulp-eslint');
 
 gulp.task('eslint', function () {
-  return gulp.src(['src/**', 'docs/src/**/*.{js,jsx}'])
+  return gulp.src(['src/**', 'docs/src/**/*.{js,jsx}', 'test/**/*.{js,jsx}'])
     // eslint() attaches the lint output to the eslint property
     // of the file object so it can be used by other modules.
     .pipe(eslint())

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "env": {
+    "mocha": true,
+  },
+  "rules": {
+    "no-unused-expressions": 0,
+    "no-undef": 0
+  }
+}

--- a/test/drop-down-menu-spec.js
+++ b/test/drop-down-menu-spec.js
@@ -15,16 +15,16 @@ describe('DropDownMenu', () => {
         let menuItems = [
             {
                 text: 'Text1',
-                payload: 0
+                payload: 0,
             },
             {
                 text: 'Text2',
-                payload: 1
+                payload: 1,
             },
             {
                 text: 'Text3',
-                payload: 2
-            }
+                payload: 2,
+            },
         ];
 
         let value = 0;

--- a/test/react-stub-context.js
+++ b/test/react-stub-context.js
@@ -1,11 +1,11 @@
 // "react-stub-context": "^0.3.0",
 
-var React = require('react');
+const React = require('react');
 
 function stubContext(BaseComponent, context) {
   if(typeof context === 'undefined' || context === null) context = {};
 
-  var _contextTypes = {}, _context = context;
+  let _contextTypes = {}, _context = context;
 
   try {
     Object.keys(_context).forEach(function(key) {
@@ -15,7 +15,7 @@ function stubContext(BaseComponent, context) {
     throw new TypeError('createdStubbedContextComponent requires an object');
   }
 
-  var StubbedContextParent = React.createClass({
+  let StubbedContextParent = React.createClass({
     displayName: 'StubbedContextParent',
     childContextTypes: _contextTypes,
     getChildContext() { return _context; },
@@ -23,10 +23,10 @@ function stubContext(BaseComponent, context) {
 
     render() {
       return React.Children.only(this.props.children);
-    }
+    },
   });
 
-  var StubbedContextHandler = React.createClass({
+  let StubbedContextHandler = React.createClass({
     displayName: 'StubbedContextHandler',
     childContextTypes: _contextTypes,
     getChildContext() { return _context; },
@@ -39,7 +39,7 @@ function stubContext(BaseComponent, context) {
       this._wrappedParentElement = <StubbedContextParent>{this._wrappedElement}</StubbedContextParent>;
 
       return this._wrappedParentElement;
-    }
+    },
   });
 
   BaseComponent.contextTypes = Object.assign({}, BaseComponent.contextTypes, _contextTypes);

--- a/test/theming-v12-spec.js
+++ b/test/theming-v12-spec.js
@@ -137,7 +137,7 @@ const AppBarDarkUsingContext = React.createClass({
 
 	getChildContext() {
 		return {
-			muiTheme: ThemeManager.getMuiTheme(DarkRawTheme)
+			muiTheme: ThemeManager.getMuiTheme(DarkRawTheme),
 		};
 	},
 


### PR DESCRIPTION
Create separate .eslintrc under test/ to set mocha environment and ignore errors relating to "expect," "it," and "describe" not being defined.