### PR TITLE
Update inline-style-prefixer to 0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "http://material-ui.com/",
   "dependencies": {
-    "inline-style-prefixer": "^0.5.1",
+    "inline-style-prefixer": "^0.5.2",
     "lodash.throttle": "~3.0.4",
     "lodash.debounce": "~3.1.1",
     "react-addons-transition-group": "^0.14.0",


### PR DESCRIPTION
Fixes rofrischmann/inline-style-prefixer#26 issues with material-ui components not functioning properly on Android 4.* browsers.