### PR TITLE
Show IconButton tooltip when disabled

### DIFF
--- a/src/icon-button.jsx
+++ b/src/icon-button.jsx
@@ -204,7 +204,7 @@ const IconButton = React.createClass({
   },
 
   _showTooltip() {
-    if (!this.props.disabled && this.props.tooltip) {
+    if (this.props.tooltip) {
       this.setState({tooltipShown: true});
     }
   },


### PR DESCRIPTION
Fixes #1299.

Simply removes consideration of the disabled state from the tooltip show/hide decision as suggested by @shaurya947.