### PR TITLE
per issue 1346, should use lib/menus/menu-item instead of lib/menu/me…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ module.exports = {
   ListDivider: require('./lists/list-divider'),
   ListItem: require('./lists/list-item'),
   Menu: require('./menu/menu'),
-  MenuItem: require('./menu/menu-item'),
+  MenuItem: require('./menus/menu-item'),
   Mixins: require('./mixins/'),
   Overlay: require('./overlay'),
   Paper: require('./paper'),


### PR DESCRIPTION
Per https://github.com/callemall/material-ui/issues/1346 MenuItem component should require ```lib/menus/menu-item```. However, ```index.js``` still shows deprecated ```lib/menu/menu-item```. This pull request is to update ```menu``` to ```menus``` in ```index.js```.