### PR TITLE
Recursively extending child in selectable list for nested lists

### DIFF
--- a/docs/src/app/components/pages/components/lists.jsx
+++ b/docs/src/app/components/pages/components/lists.jsx
@@ -753,10 +753,12 @@ import ListItem from 'material-ui/lib/lists/list-item';
               <ListItem
                 value={1}
                 primaryText="Brendan Lim"
-                leftAvatar={<Avatar src="images/ok-128.jpg" />} />
-              <ListItem value={2}
-                primaryText="Grace Ng"
-                leftAvatar={<Avatar src="images/uxceo-128.jpg" />} />
+                leftAvatar={<Avatar src="images/ok-128.jpg" />}
+                nestedItems={[
+                  <ListItem value={2}
+                    primaryText="Grace Ng"
+                    leftAvatar={<Avatar src="images/uxceo-128.jpg" />} />,
+                ]} />
               <ListItem value={3}
                 primaryText="Kerem Suer"
                 leftAvatar={<Avatar src="images/kerem-128.jpg" />} />

--- a/docs/src/app/components/raw-code/lists-code.txt
+++ b/docs/src/app/components/raw-code/lists-code.txt
@@ -105,13 +105,19 @@
   <ListItem
     value={1}
     primaryText="Brendan Lim"
-    leftAvatar={<Avatar src="images/ok-128.jpg" />}/>
-  <ListItem
-    value={2}
-    primaryText="Grace Ng"
-    leftAvatar={<Avatar src="images/uxceo-128.jpg" />} />
-  <ListItem
-    value={3}
+    leftAvatar={<Avatar src="images/ok-128.jpg" />}
+    nestedItems={[
+      <ListItem value={2}
+        primaryText="Grace Ng"
+        leftAvatar={<Avatar src="images/uxceo-128.jpg" />} />
+    ]} />
+  <ListItem value={3}
     primaryText="Kerem Suer"
     leftAvatar={<Avatar src="images/kerem-128.jpg" />} />
+  <ListItem value={4}
+    primaryText="Eric Hoffman"
+    leftAvatar={<Avatar src="images/kolage-128.jpg" />} />
+  <ListItem value={5}
+    primaryText="Raquel Parrado"
+    leftAvatar={<Avatar src="images/raquelromanp-128.jpg" />} />
 </SelectableList>


### PR DESCRIPTION
I'm using the selectable enhancer on a nested list, but for now only top ListItem can be selected.

With this pull request, we recursively modify children and their nestedItems props to make every ListItem selectable.

This is my first pull request so I may be doing this wrong, any advise would be gladly taken.

Thanks !