### PR TITLE
Include 'import' code block for Popovers, per convention.

### DIFF
--- a/docs/src/app/components/pages/components/popover.jsx
+++ b/docs/src/app/components/pages/components/popover.jsx
@@ -87,7 +87,7 @@ let PopoverPage = React.createClass({
       <ComponentDoc
         name="Popover"
         componentInfo={componentInfo}>
-        
+  
         <Paper style = {{marginBottom: '22px'}}>
           <CodeBlock>
           {
@@ -96,7 +96,7 @@ let PopoverPage = React.createClass({
           }
           </CodeBlock>
         </Paper>
-        
+
         <CodeExample code={Code}>
           <RaisedButton onClick={this.show.bind(this, 'pop')} label="Click on me to show a popover" />
           <br/>

--- a/docs/src/app/components/pages/components/popover.jsx
+++ b/docs/src/app/components/pages/components/popover.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Popover, RadioButton, RaisedButton} from 'material-ui';
+import {Paper, Popover, RadioButton, RaisedButton} from 'material-ui';
 import ComponentDoc from '../../component-doc';
 import Code from 'popover-code';
 import CodeExample from '../../code-example/code-example';

--- a/docs/src/app/components/pages/components/popover.jsx
+++ b/docs/src/app/components/pages/components/popover.jsx
@@ -87,6 +87,16 @@ let PopoverPage = React.createClass({
       <ComponentDoc
         name="Popover"
         componentInfo={componentInfo}>
+        
+        <Paper style = {{marginBottom: '22px'}}>
+          <CodeBlock>
+          {
+            '//Import statement:\nimport Popover from \'material-ui/lib/popover\';\n\n' +
+            '//See material-ui/lib/index.js for more\n'
+          }
+          </CodeBlock>
+        </Paper>
+        
         <CodeExample code={Code}>
           <RaisedButton onClick={this.show.bind(this, 'pop')} label="Click on me to show a popover" />
           <br/>

--- a/docs/src/app/components/pages/components/popover.jsx
+++ b/docs/src/app/components/pages/components/popover.jsx
@@ -87,7 +87,6 @@ let PopoverPage = React.createClass({
       <ComponentDoc
         name="Popover"
         componentInfo={componentInfo}>
-  
         <Paper style = {{marginBottom: '22px'}}>
           <CodeBlock>
           {


### PR DESCRIPTION
Adds `<Popover/>` import code to component documentation.