### PR TITLE
Fix webpack-example build error.

### DIFF
--- a/examples/webpack-example/.eslintrc
+++ b/examples/webpack-example/.eslintrc
@@ -22,7 +22,8 @@
     "space-unary-ops": 0,
     "space-infix-ops": 0,
     "consistent-return": 0,
-    "strict": 0
+    "strict": 0,
+    "react/require-extension": [1, { "extensions": [".js", ".jsx"] }]
   },
   "parser": "babel-eslint",
   "plugins": [

--- a/examples/webpack-example/.eslintrc
+++ b/examples/webpack-example/.eslintrc
@@ -22,8 +22,7 @@
     "space-unary-ops": 0,
     "space-infix-ops": 0,
     "consistent-return": 0,
-    "strict": 0,
-    "react/require-extension": [1, { "extensions": [".js", ".jsx"] }]
+    "strict": 0
   },
   "parser": "babel-eslint",
   "plugins": [

--- a/examples/webpack-example/src/app/app.jsx
+++ b/examples/webpack-example/src/app/app.jsx
@@ -2,7 +2,7 @@
   let React = require('react');
   let ReactDOM = require('react-dom');
   let injectTapEventPlugin = require('react-tap-event-plugin');
-  let Main = require('./components/main.jsx'); // Our custom react component
+  let Main = require('./components/main'); // Our custom react component
 
   //Needed for React Developer Tools
   window.React = React;

--- a/examples/webpack-example/src/app/app.jsx
+++ b/examples/webpack-example/src/app/app.jsx
@@ -1,4 +1,4 @@
-(function () {
+(function() {
   let React = require('react');
   let ReactDOM = require('react-dom');
   let injectTapEventPlugin = require('react-tap-event-plugin');

--- a/examples/webpack-example/src/app/components/main.jsx
+++ b/examples/webpack-example/src/app/components/main.jsx
@@ -13,7 +13,7 @@ const Main = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  getInitialState () {
+  getInitialState() {
     return {
       muiTheme: ThemeManager.getMuiTheme(LightRawTheme),
     };
@@ -41,7 +41,7 @@ const Main = React.createClass({
     };
 
     let standardActions = [
-      { text: 'Okay' },
+      {text: 'Okay'},
     ];
 
     return (


### PR DESCRIPTION
Fix webpack-example build error.

```
5:14   error  Unable to require module with extension '.jsx'
16:18  error  Unexpected space before function parentheses
44:8   error  There should be no space after '{'
44:22  error  There should be no space before '}'
```