### PR TITLE
Prevent CardActions from overriding child.style

### DIFF
--- a/src/card/card-actions.jsx
+++ b/src/card/card-actions.jsx
@@ -56,7 +56,7 @@ const CardActions = React.createClass({
 
     let children = React.Children.map(this.props.children, (child) => {
       return React.cloneElement(child, {
-        style: {marginRight: 8},
+        style: this.mergeStyles({marginRight: 8}, child.props.style),
       });
     });
 


### PR DESCRIPTION
Suppose we have the following JSX:

```
<CardActions>
  <IconButton style={{ margin: '0 auto', display: 'inherit' }} ... />
</CardActions>
```

The current `CardActions` component's `React.cloneElement(child, { style: {marginRight: 8} })`
will return a list of children whose `style` property gets overridden by the `React.cloneElement`
calls. The end result is an JSX in the following way:

```
<CardActions>
  <IconButton style={{ marginRight: 8 }} ... />
</CardActions>
```

This commit will change CardActions' behaviour to always return the list of children as-is
if some of them have already specified the property `style`.