### PR TITLE
[RenderToLayout] Remove the debounce

### DIFF
--- a/src/dialog.jsx
+++ b/src/dialog.jsx
@@ -462,7 +462,7 @@ const Dialog = React.createClass({
 
   render() {
     return (
-      <RenderToLayer render={this.renderLayer} open={this.state.open} />
+      <RenderToLayer render={this.renderLayer} open={true} useLayerForClickAway={false} />
     );
   },
 
@@ -521,10 +521,6 @@ const Dialog = React.createClass({
     this.setState({
       open: false,
     }, this._onDismiss);
-  },
-
-  layerWillUnmount() {
-    if (this.props.onDismiss) this.props.onDismiss();
   },
 
   isOpen() {


### PR DESCRIPTION
@chrismcv My goal here is to remove the debounce of the render-to-layout component.
This is what was causing me issues when I was unmounting an open Popover.
Feedbacks are welcomed.