### PR TITLE
[npm] Add missing peerDependency for npm@3

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -27,6 +27,7 @@
     "raw-loader": "^0.5.1",
     "react": "^0.14.0",
     "react-addons-linked-state-mixin": "^0.14.0",
+    "react-addons-pure-render-mixin": "^0.14.3",
     "webpack": "^1.11.0",
     "webpack-dev-server": "^1.10.1"
   }


### PR DESCRIPTION
This is just for the doc and `react-swipeable-view`.