### PR TITLE
[DropDownMenu] menuStyle prop

### DIFF
--- a/docs/src/app/components/pages/components/drop-down-menu.jsx
+++ b/docs/src/app/components/pages/components/drop-down-menu.jsx
@@ -64,6 +64,13 @@ export default class DropDownMenuPage extends React.Component {
                   'DropDownMenu is expanded.',
           },
           {
+            name: 'menuStyle',
+            type: 'object',
+            header: 'optional',
+            desc: 'Overrides the inline-styles of the Menu when the ' +
+                  'DropDownMenu is expanded.',
+          },
+          {
             name: 'selectedIndex',
             type: 'number',
             header: 'default: 0',

--- a/src/drop-down-menu.jsx
+++ b/src/drop-down-menu.jsx
@@ -43,6 +43,7 @@ const DropDownMenu = React.createClass({
     labelStyle:React.PropTypes.object,
     menuItemStyle: React.PropTypes.object,
     menuItems: React.PropTypes.array.isRequired,
+    menuStyle: React.PropTypes.object,
     onChange: React.PropTypes.func,
     openImmediately: React.PropTypes.bool,
     selectedIndex: React.PropTypes.number,
@@ -190,6 +191,7 @@ const DropDownMenu = React.createClass({
       iconStyle,
       underlineStyle,
       menuItemStyle,
+      menuStyle,
       labelMember,
       ...other,
     } = this.props;
@@ -248,7 +250,7 @@ const DropDownMenu = React.createClass({
             autoWidth={autoWidth}
             selectedIndex={selectedIndex}
             menuItems={menuItems}
-            style={styles.menu}
+            style={this.mergeStyles(styles.menu, menuStyle)}
             menuItemStyle={this.mergeStyles(styles.menuItem, menuItemStyle)}
             hideable={true}
             visible={this.state.open}


### PR DESCRIPTION
This will allow customizing `DropDownMenu`'s `Menu` component. Although this is temporary (Implementation will be switched with `Popover`) but it doesn't hurt.

@oliviertassinari Please review this too, thanks :grin: 