### PR TITLE
Added Typescript Material-UI Basic Example Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ We have implemented a default theme to render all Material-UI components. Stylin
 
 ## Examples
 
-There are 2 projects that you can look at to get started. They can be found in the [examples folder](https://github.com/callemall/material-ui/tree/master/examples). These projects are basic examples that show how to consume material-ui components in your own project. The first project uses [browserify](http://browserify.org/) for module bundling and [gulp](http://gulpjs.com/) for JS task automation, while the second project uses [webpack](http://webpack.github.io/) for module bundling and building.
+There are 3 projects that you can look at to get started. They can be found in the [examples folder](https://github.com/callemall/material-ui/tree/master/examples). These projects are basic examples that show how to consume material-ui components in your own project. The first and second projects both use [browserify](http://browserify.org/) for module bundling and [gulp](http://gulpjs.com/) for JS task automation. The second project, in addition, demonstrates how React components can be written using [typescript](http://www.typescriptlang.org/). Finally, the third project uses [webpack](http://webpack.github.io/) for module bundling and building. 
 
 The source code for this documentation site is also included in the repository. This is a slightly more complex project that also uses webpack, and contains examples of every material-ui component. Check out the [docs folder](https://github.com/callemall/material-ui/tree/master/docs) for build instructions.
 

--- a/examples/browserify-typescript-gulp-example/.gitignore
+++ b/examples/browserify-typescript-gulp-example/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+build

--- a/examples/browserify-typescript-gulp-example/README.md
+++ b/examples/browserify-typescript-gulp-example/README.md
@@ -1,0 +1,29 @@
+# [Material-UI](http://callemall.github.io/material-ui/) - Example Project
+
+This is an example project that uses [Material-UI](http://callemall.github.io/material-ui/).
+
+## Installation
+After cloning the repository, install dependencies:
+```
+cd <project folder>/material-ui/examples/browserify-typescript-gulp-example
+npm install
+```
+
+Now you can run your local server:
+```
+npm start
+```
+#Description of [Gulp](https://github.com/gulpjs/gulp) Plugins
+
+
+##[browserify](https://github.com/substack/node-browserify)
+Browsers do not allow us to use the require method from Node.js. With browserify, we can implement dependency management on the browser. It also will bundle the code into one file in an efficient way to not repeat dependiencies that are used more than once.
+
+##[browserSync](http://www.browsersync.io/)
+When developing and testing the website, browserSync is a powerful tool that will rebuild and refresh the webpage so you can see the changes you make as you are working.
+
+##markup
+Copies all of the files from /src/www to the build folder.
+
+##[gulp_starter](https://github.com/greypants/gulp-starter)
+A useful repository that explains how many of gulp's features work and contains an example project to get familiar with it. We use this example to construct our own project.

--- a/examples/browserify-typescript-gulp-example/gulp/config.js
+++ b/examples/browserify-typescript-gulp-example/gulp/config.js
@@ -1,0 +1,32 @@
+var dest = './build',
+  src = './src',
+  mui = './node_modules/material-ui/src';
+
+module.exports = {
+  browserSync: {
+    server: {
+      // We're serving the src folder as well
+      // for sass sourcemap linking
+      baseDir: [dest, src]
+    },
+    files: [
+      dest + '/**'
+    ]
+  },
+  markup: {
+    src: src + "/www/**",
+    dest: dest
+  },
+  browserify: {
+    // Enable source maps
+    debug: true,
+    // A separate bundle will be generated for each
+    // bundle config in the list below
+    bundleConfigs: [{
+      entries: [src + '/typings/tsd.d.ts', src + '/app/app.tsx'],
+      dest: dest,
+      outputName: 'app.js'
+    }],
+    extensions: ['.tsx'],
+  }
+};

--- a/examples/browserify-typescript-gulp-example/gulp/tasks/browserSync.js
+++ b/examples/browserify-typescript-gulp-example/gulp/tasks/browserSync.js
@@ -1,0 +1,7 @@
+var browserSync = require('browser-sync');
+var gulp        = require('gulp');
+var config      = require('../config').browserSync;
+
+gulp.task('browserSync', ['build'], function() {
+  browserSync(config);
+});

--- a/examples/browserify-typescript-gulp-example/gulp/tasks/browserify.js
+++ b/examples/browserify-typescript-gulp-example/gulp/tasks/browserify.js
@@ -1,0 +1,80 @@
+/* browserify task
+   ---------------
+   Bundle javascripty things with browserify!
+   This task is set up to generate multiple separate bundles, from
+   different sources, and to use Watchify when run from the default task.
+   See browserify.bundleConfigs in gulp/config.js
+*/
+
+var browserify   = require('browserify');
+var watchify     = require('watchify');
+var bundleLogger = require('../util/bundleLogger');
+var gulp         = require('gulp');
+var handleErrors = require('../util/handleErrors');
+var source       = require('vinyl-source-stream');
+var config       = require('../config').browserify;
+var tsify        = require('tsify');
+
+gulp.task('browserify', function(callback) {
+
+  var bundleQueue = config.bundleConfigs.length;
+
+  var browserifyThis = function(bundleConfig) {
+
+    var bundler = browserify({
+      // Required watchify args
+      cache: {}, packageCache: {}, fullPaths: false,
+      // Specify the entry point of your app
+      entries: bundleConfig.entries,
+      // Add file extentions to make optional in your requires
+      extensions: config.extensions,
+      // Enable source maps!
+      debug: config.debug
+    });
+
+    bundler.plugin(tsify);
+
+    var bundle = function() {
+      // Log when bundling starts
+      bundleLogger.start(bundleConfig.outputName);
+
+      return bundler
+        .bundle()
+        // Report compile errors
+        .on('error', handleErrors)
+        // Use vinyl-source-stream to make the
+        // stream gulp compatible. Specifiy the
+        // desired output filename here.
+        .pipe(source(bundleConfig.outputName))
+        // Specify the output destination
+        .pipe(gulp.dest(bundleConfig.dest))
+        .on('end', reportFinished);
+    };
+
+    if (global.isWatching) {
+      // Wrap with watchify and rebundle on changes
+      bundler = watchify(bundler);
+      // Rebundle on update
+      bundler.on('update', bundle);
+    }
+
+    var reportFinished = function() {
+      // Log when bundling completes
+      bundleLogger.end(bundleConfig.outputName);
+
+      if (bundleQueue) {
+        bundleQueue--;
+        if (bundleQueue === 0) {
+          // If queue is empty, tell gulp the task is complete.
+          // https://github.com/gulpjs/gulp/blob/master/docs/API.md#accept-a-callback
+          callback();
+        }
+      }
+    };
+
+    return bundle();
+  };
+
+  // Start bundling with Browserify for each bundleConfig specified
+  config.bundleConfigs.forEach(browserifyThis);
+});

--- a/examples/browserify-typescript-gulp-example/gulp/tasks/build.js
+++ b/examples/browserify-typescript-gulp-example/gulp/tasks/build.js
@@ -1,0 +1,3 @@
+var gulp = require('gulp');
+
+gulp.task('build', ['browserify', 'markup']);

--- a/examples/browserify-typescript-gulp-example/gulp/tasks/default.js
+++ b/examples/browserify-typescript-gulp-example/gulp/tasks/default.js
@@ -1,0 +1,3 @@
+var gulp = require('gulp');
+
+gulp.task('default', ['watch']);

--- a/examples/browserify-typescript-gulp-example/gulp/tasks/markup.js
+++ b/examples/browserify-typescript-gulp-example/gulp/tasks/markup.js
@@ -1,0 +1,7 @@
+var gulp = require('gulp');
+var config = require('../config').markup;
+
+gulp.task('markup', function() {
+  return gulp.src(config.src)
+    .pipe(gulp.dest(config.dest));
+});

--- a/examples/browserify-typescript-gulp-example/gulp/tasks/setWatch.js
+++ b/examples/browserify-typescript-gulp-example/gulp/tasks/setWatch.js
@@ -1,0 +1,5 @@
+var gulp = require('gulp');
+
+gulp.task('setWatch', function() {
+  global.isWatching = true;
+});

--- a/examples/browserify-typescript-gulp-example/gulp/tasks/watch.js
+++ b/examples/browserify-typescript-gulp-example/gulp/tasks/watch.js
@@ -1,0 +1,12 @@
+
+/* Notes:
+   - gulp/tasks/browserify.js handles js recompiling with watchify
+   - gulp/tasks/browserSync.js watches and reloads compiled files
+*/
+
+var gulp   = require('gulp');
+var config = require('../config');
+
+gulp.task('watch', ['setWatch', 'browserSync'], function() {
+  gulp.watch(config.markup.src, ['markup']);
+});

--- a/examples/browserify-typescript-gulp-example/gulp/util/bundleLogger.js
+++ b/examples/browserify-typescript-gulp-example/gulp/util/bundleLogger.js
@@ -1,0 +1,21 @@
+/* bundleLogger
+   ------------
+   Provides gulp style logs to the bundle method in browserify.js
+*/
+
+var gutil        = require('gulp-util');
+var prettyHrtime = require('pretty-hrtime');
+var startTime;
+
+module.exports = {
+  start: function(filepath) {
+    startTime = process.hrtime();
+    gutil.log('Bundling', gutil.colors.green(filepath) + '...');
+  },
+
+  end: function(filepath) {
+    var taskTime = process.hrtime(startTime);
+    var prettyTime = prettyHrtime(taskTime);
+    gutil.log('Bundled', gutil.colors.green(filepath), 'in', gutil.colors.magenta(prettyTime));
+  }
+};

--- a/examples/browserify-typescript-gulp-example/gulp/util/handleErrors.js
+++ b/examples/browserify-typescript-gulp-example/gulp/util/handleErrors.js
@@ -1,0 +1,15 @@
+var notify = require("gulp-notify");
+
+module.exports = function() {
+
+  var args = Array.prototype.slice.call(arguments);
+
+  // Send error to notification center with gulp-notify
+  notify.onError({
+    title: "Compile Error",
+    message: "<%= error.message %>"
+  }).apply(this, args);
+
+  // Keep gulp from hanging on this task
+  this.emit('end');
+};

--- a/examples/browserify-typescript-gulp-example/gulpfile.js
+++ b/examples/browserify-typescript-gulp-example/gulpfile.js
@@ -1,0 +1,16 @@
+/*
+  gulpfile.js
+  ===========
+  Rather than manage one giant configuration file responsible
+  for creating multiple tasks, each task has been broken out into
+  its own file in gulp/tasks. Any files in that directory get
+  automatically required below.
+  To add a new task, simply add a new task file that directory.
+  gulp/tasks/default.js specifies the default set of tasks to run
+  when you run `gulp`.
+*/
+
+var requireDir = require('require-dir');
+
+// Require all tasks in gulp/tasks, including subfolders
+requireDir('./gulp/tasks', { recurse: true });

--- a/examples/browserify-typescript-gulp-example/package.json
+++ b/examples/browserify-typescript-gulp-example/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "material-ui-example",
+  "version": "0.13.2",
+  "description": "Sample project that uses material-ui",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/callemall/material-ui.git"
+  },
+  "scripts": {
+    "start": "gulp"
+  },
+  "private": true,
+  "devDependencies": {
+    "browser-sync": "^1.8.1",
+    "browserify": "^12.0.1",
+    "gulp": "^3.8.10",
+    "gulp-notify": "^2.1.0",
+    "gulp-util": "^3.0.1",
+    "pretty-hrtime": "^0.2.2",
+    "require-dir": "^0.1.0",
+    "tsify": "^0.13.1",
+    "underscore": "^1.7.0",
+    "vinyl-source-stream": "^1.0.0",
+    "watchify": "^2.2.1"
+  },
+  "dependencies": {
+    "core-js": "^1.2.6",
+    "material-ui": "^0.13.0",
+    "pure-render-decorator": "^0.2.0",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
+    "react-tap-event-plugin": "^0.2.1"
+  }
+}

--- a/examples/browserify-typescript-gulp-example/src/app/app.tsx
+++ b/examples/browserify-typescript-gulp-example/src/app/app.tsx
@@ -1,5 +1,7 @@
 /// <reference path="../typings/tsd.d.ts"/>
 
+import 'core-js'; // Support for older browsers
+
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import Main from './components/main'; // Our custom react component

--- a/examples/browserify-typescript-gulp-example/src/app/app.tsx
+++ b/examples/browserify-typescript-gulp-example/src/app/app.tsx
@@ -1,0 +1,16 @@
+/// <reference path="../typings/tsd.d.ts"/>
+
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import Main from './components/main'; // Our custom react component
+
+//Needed for onTouchTap
+//Can go away when react 1.0 release
+//Check this repo:
+//https://github.com/zilverline/react-tap-event-plugin
+declare function require(p: string): any;
+require("react-tap-event-plugin")();
+
+// Render the main app react component into the app div.
+// For more details see: https://facebook.github.io/react/docs/top-level-api.html#react.render
+ReactDOM.render(<Main />, document.getElementById('app'));

--- a/examples/browserify-typescript-gulp-example/src/app/components/main.tsx
+++ b/examples/browserify-typescript-gulp-example/src/app/components/main.tsx
@@ -1,0 +1,73 @@
+/** In this file, we create a React component which incorporates components provided by material-ui */
+
+import * as React from 'react';
+import * as Mui from 'material-ui';
+import pureRender from "pure-render-decorator";
+
+const containerStyle = {
+  textAlign: 'center',
+  paddingTop: 200,
+};
+
+const standardActions = [
+  {
+    text: 'Okay',
+  },
+];
+
+interface MainProps {
+  // define 'Main' component's properties here
+}
+
+interface MainState {
+  // define 'Main' component's state here
+}
+
+@pureRender // apply pure render mixin
+class Main extends React.Component<MainProps, MainState>
+                                  implements React.ChildContextProvider<any> {
+
+  static childContextTypes: React.ValidationMap<any> = {
+      muiTheme: React.PropTypes.object
+  };
+
+  getChildContext(): any {
+      return {
+          muiTheme: Mui.Styles.ThemeManager.getMuiTheme(Mui.Styles.LightRawTheme)
+      };
+  };
+
+  constructor(props: MainProps) {
+      super(props);
+  }
+
+  private handleTouchTap() {
+    (this.refs["dlg1"] as Mui.Dialog).show();
+  }
+
+  render() {
+    return (
+      <div style={containerStyle}>
+        <Mui.Dialog
+          key={0}
+          ref="dlg1"
+          openImmediately={false}
+          title="Super Secret Password"
+          actions={standardActions}
+        >
+          1-2-3-4-5
+        </Mui.Dialog>
+        <h1>material-ui</h1>
+        <h2>example project</h2>
+        <Mui.RaisedButton
+          key={1}
+          ref="btn1"
+          label="Super Secret Password"
+          primary={true}
+          onTouchTap={() => this.handleTouchTap()} />
+      </div>
+    );
+  }
+}
+
+export default Main;

--- a/examples/browserify-typescript-gulp-example/src/typings/core-js/core-js.d.ts
+++ b/examples/browserify-typescript-gulp-example/src/typings/core-js/core-js.d.ts
@@ -1,0 +1,3032 @@
+﻿// Type definitions for core-js v0.9.7
+// Project: https://github.com/zloirock/core-js/
+// Definitions by: Ron Buckton <http://github.com/rbuckton>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/* *****************************************************************************
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+
+THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+MERCHANTABLITY OR NON-INFRINGEMENT.
+
+See the Apache Version 2.0 License for specific language governing permissions
+and limitations under the License.
+***************************************************************************** */
+
+declare type PropertyKey = string | number | symbol;
+
+// #############################################################################################
+// ECMAScript 6: Object & Function
+// Modules: es6.object.assign, es6.object.is, es6.object.set-prototype-of,
+//          es6.object.to-string, es6.function.name and es6.function.has-instance.
+// #############################################################################################
+
+interface ObjectConstructor {
+    /**
+      * Copy the values of all of the enumerable own properties from one or more source objects to a
+      * target object. Returns the target object.
+      * @param target The target object to copy to.
+      * @param sources One or more source objects to copy properties from.
+      */
+    assign(target: any, ...sources: any[]): any;
+
+    /**
+      * Returns true if the values are the same value, false otherwise.
+      * @param value1 The first value.
+      * @param value2 The second value.
+      */
+    is(value1: any, value2: any): boolean;
+
+    /**
+      * Sets the prototype of a specified object o to  object proto or null. Returns the object o.
+      * @param o The object to change its prototype.
+      * @param proto The value of the new prototype or null.
+      * @remarks Requires `__proto__` support.
+      */
+    setPrototypeOf(o: any, proto: any): any;
+}
+
+interface Function {
+    /**
+      * Returns the name of the function. Function names are read-only and can not be changed.
+      */
+    name: string;
+
+    /**
+      * Determines if a constructor object recognizes an object as one of the
+      * constructor’s instances.
+      * @param value The object to test.
+      */
+    [Symbol.hasInstance](value: any): boolean;
+}
+
+// #############################################################################################
+// ECMAScript 6: Array
+// Modules: es6.array.from, es6.array.of, es6.array.copy-within, es6.array.fill, es6.array.find,
+//          and es6.array.find-index
+// #############################################################################################
+
+interface Array<T> {
+    /**
+      * Returns the value of the first element in the array where predicate is true, and undefined
+      * otherwise.
+      * @param predicate find calls predicate once for each element of the array, in ascending
+      * order, until it finds one where predicate returns true. If such an element is found, find
+      * immediately returns that element value. Otherwise, find returns undefined.
+      * @param thisArg If provided, it will be used as the this value for each invocation of
+      * predicate. If it is not provided, undefined is used instead.
+      */
+    find(predicate: (value: T, index: number, obj: Array<T>) => boolean, thisArg?: any): T;
+
+    /**
+      * Returns the index of the first element in the array where predicate is true, and undefined
+      * otherwise.
+      * @param predicate find calls predicate once for each element of the array, in ascending
+      * order, until it finds one where predicate returns true. If such an element is found, find
+      * immediately returns that element value. Otherwise, find returns undefined.
+      * @param thisArg If provided, it will be used as the this value for each invocation of
+      * predicate. If it is not provided, undefined is used instead.
+      */
+    findIndex(predicate: (value: T) => boolean, thisArg?: any): number;
+
+    /**
+      * Returns the this object after filling the section identified by start and end with value
+      * @param value value to fill array section with
+      * @param start index to start filling the array at. If start is negative, it is treated as
+      * length+start where length is the length of the array.
+      * @param end index to stop filling the array at. If end is negative, it is treated as
+      * length+end.
+      */
+    fill(value: T, start?: number, end?: number): T[];
+
+    /**
+      * Returns the this object after copying a section of the array identified by start and end
+      * to the same array starting at position target
+      * @param target If target is negative, it is treated as length+target where length is the
+      * length of the array.
+      * @param start If start is negative, it is treated as length+start. If end is negative, it
+      * is treated as length+end.
+      * @param end If not specified, length of the this object is used as its default value.
+      */
+    copyWithin(target: number, start: number, end?: number): T[];
+
+    [Symbol.unscopables]: any;
+}
+
+interface ArrayConstructor {
+    /**
+      * Creates an array from an array-like object.
+      * @param arrayLike An array-like object to convert to an array.
+      * @param mapfn A mapping function to call on every element of the array.
+      * @param thisArg Value of 'this' used to invoke the mapfn.
+      */
+    from<T, U>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => U, thisArg?: any): Array<U>;
+
+    /**
+      * Creates an array from an iterable object.
+      * @param iterable An iterable object to convert to an array.
+      * @param mapfn A mapping function to call on every element of the array.
+      * @param thisArg Value of 'this' used to invoke the mapfn.
+      */
+    from<T, U>(iterable: Iterable<T>, mapfn: (v: T, k: number) => U, thisArg?: any): Array<U>;
+
+    /**
+      * Creates an array from an array-like object.
+      * @param arrayLike An array-like object to convert to an array.
+      */
+    from<T>(arrayLike: ArrayLike<T>): Array<T>;
+
+    /**
+      * Creates an array from an iterable object.
+      * @param iterable An iterable object to convert to an array.
+      */
+    from<T>(iterable: Iterable<T>): Array<T>;
+
+    /**
+      * Returns a new array from a set of elements.
+      * @param items A set of elements to include in the new array object.
+      */
+    of<T>(...items: T[]): Array<T>;
+}
+
+// #############################################################################################
+// ECMAScript 6: String & RegExp
+// Modules: es6.string.from-code-point, es6.string.raw, es6.string.code-point-at,
+//          es6.string.ends-with, es6.string.includes, es6.string.repeat,
+//          es6.string.starts-with, and es6.regexp
+// #############################################################################################
+
+interface String {
+    /**
+      * Returns a nonnegative integer Number less than 1114112 (0x110000) that is the code point
+      * value of the UTF-16 encoded code point starting at the string element at position pos in
+      * the String resulting from converting this object to a String.
+      * If there is no element at that position, the result is undefined.
+      * If a valid UTF-16 surrogate pair does not begin at pos, the result is the code unit at pos.
+      */
+    codePointAt(pos: number): number;
+
+    /**
+      * Returns true if searchString appears as a substring of the result of converting this
+      * object to a String, at one or more positions that are
+      * greater than or equal to position; otherwise, returns false.
+      * @param searchString search string
+      * @param position If position is undefined, 0 is assumed, so as to search all of the String.
+      */
+    includes(searchString: string, position?: number): boolean;
+
+    /**
+      * Returns true if the sequence of elements of searchString converted to a String is the
+      * same as the corresponding elements of this object (converted to a String) starting at
+      * endPosition – length(this). Otherwise returns false.
+      */
+    endsWith(searchString: string, endPosition?: number): boolean;
+
+    /**
+      * Returns a String value that is made from count copies appended together. If count is 0,
+      * T is the empty String is returned.
+      * @param count number of copies to append
+      */
+    repeat(count: number): string;
+
+    /**
+      * Returns true if the sequence of elements of searchString converted to a String is the
+      * same as the corresponding elements of this object (converted to a String) starting at
+      * position. Otherwise returns false.
+      */
+    startsWith(searchString: string, position?: number): boolean;
+}
+
+interface StringConstructor {
+    /**
+      * Return the String value whose elements are, in order, the elements in the List elements.
+      * If length is 0, the empty string is returned.
+      */
+    fromCodePoint(...codePoints: number[]): string;
+
+    /**
+      * String.raw is intended for use as a tag function of a Tagged Template String. When called
+      * as such the first argument will be a well formed template call site object and the rest
+      * parameter will contain the substitution values.
+      * @param template A well-formed template string call site representation.
+      * @param substitutions A set of substitution values.
+      */
+    raw(template: TemplateStringsArray, ...substitutions: any[]): string;
+}
+
+interface RegExp {
+    /**
+      * Returns a string indicating the flags of the regular expression in question. This field is read-only.
+      * The characters in this string are sequenced and concatenated in the following order:
+      *
+      *    - "g" for global
+      *    - "i" for ignoreCase
+      *    - "m" for multiline
+      *    - "u" for unicode
+      *    - "y" for sticky
+      *
+      * If no flags are set, the value is the empty string.
+      */
+    flags: string;
+}
+
+// #############################################################################################
+// ECMAScript 6: Number & Math
+// Modules: es6.number.constructor, es6.number.statics, and es6.math
+// #############################################################################################
+
+interface NumberConstructor {
+    /**
+      * The value of Number.EPSILON is the difference between 1 and the smallest value greater than 1
+      * that is representable as a Number value, which is approximately:
+      * 2.2204460492503130808472633361816 x 10‍−‍16.
+      */
+    EPSILON: number;
+
+    /**
+      * Returns true if passed value is finite.
+      * Unlike the global isFininte, Number.isFinite doesn't forcibly convert the parameter to a
+      * number. Only finite values of the type number, result in true.
+      * @param number A numeric value.
+      */
+    isFinite(number: number): boolean;
+
+    /**
+      * Returns true if the value passed is an integer, false otherwise.
+      * @param number A numeric value.
+      */
+    isInteger(number: number): boolean;
+
+    /**
+      * Returns a Boolean value that indicates whether a value is the reserved value NaN (not a
+      * number). Unlike the global isNaN(), Number.isNaN() doesn't forcefully convert the parameter
+      * to a number. Only values of the type number, that are also NaN, result in true.
+      * @param number A numeric value.
+      */
+    isNaN(number: number): boolean;
+
+    /**
+      * Returns true if the value passed is a safe integer.
+      * @param number A numeric value.
+      */
+    isSafeInteger(number: number): boolean;
+
+    /**
+      * The value of the largest integer n such that n and n + 1 are both exactly representable as
+      * a Number value.
+      * The value of Number.MIN_SAFE_INTEGER is 9007199254740991 2^53 − 1.
+      */
+    MAX_SAFE_INTEGER: number;
+
+    /**
+      * The value of the smallest integer n such that n and n − 1 are both exactly representable as
+      * a Number value.
+      * The value of Number.MIN_SAFE_INTEGER is −9007199254740991 (−(2^53 − 1)).
+      */
+    MIN_SAFE_INTEGER: number;
+
+    /**
+      * Converts a string to a floating-point number.
+      * @param string A string that contains a floating-point number.
+      */
+    parseFloat(string: string): number;
+
+    /**
+      * Converts A string to an integer.
+      * @param s A string to convert into a number.
+      * @param radix A value between 2 and 36 that specifies the base of the number in numString.
+      * If this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.
+      * All other strings are considered decimal.
+      */
+    parseInt(string: string, radix?: number): number;
+}
+
+interface Math {
+    /**
+      * Returns the number of leading zero bits in the 32-bit binary representation of a number.
+      * @param x A numeric expression.
+      */
+    clz32(x: number): number;
+
+    /**
+      * Returns the result of 32-bit multiplication of two numbers.
+      * @param x First number
+      * @param y Second number
+      */
+    imul(x: number, y: number): number;
+
+    /**
+      * Returns the sign of the x, indicating whether x is positive, negative or zero.
+      * @param x The numeric expression to test
+      */
+    sign(x: number): number;
+
+    /**
+      * Returns the base 10 logarithm of a number.
+      * @param x A numeric expression.
+      */
+    log10(x: number): number;
+
+    /**
+      * Returns the base 2 logarithm of a number.
+      * @param x A numeric expression.
+      */
+    log2(x: number): number;
+
+    /**
+      * Returns the natural logarithm of 1 + x.
+      * @param x A numeric expression.
+      */
+    log1p(x: number): number;
+
+    /**
+      * Returns the result of (e^x - 1) of x (e raised to the power of x, where e is the base of
+      * the natural logarithms).
+      * @param x A numeric expression.
+      */
+    expm1(x: number): number;
+
+    /**
+      * Returns the hyperbolic cosine of a number.
+      * @param x A numeric expression that contains an angle measured in radians.
+      */
+    cosh(x: number): number;
+
+    /**
+      * Returns the hyperbolic sine of a number.
+      * @param x A numeric expression that contains an angle measured in radians.
+      */
+    sinh(x: number): number;
+
+    /**
+      * Returns the hyperbolic tangent of a number.
+      * @param x A numeric expression that contains an angle measured in radians.
+      */
+    tanh(x: number): number;
+
+    /**
+      * Returns the inverse hyperbolic cosine of a number.
+      * @param x A numeric expression that contains an angle measured in radians.
+      */
+    acosh(x: number): number;
+
+    /**
+      * Returns the inverse hyperbolic sine of a number.
+      * @param x A numeric expression that contains an angle measured in radians.
+      */
+    asinh(x: number): number;
+
+    /**
+      * Returns the inverse hyperbolic tangent of a number.
+      * @param x A numeric expression that contains an angle measured in radians.
+      */
+    atanh(x: number): number;
+
+    /**
+      * Returns the square root of the sum of squares of its arguments.
+      * @param values Values to compute the square root for.
+      *     If no arguments are passed, the result is +0.
+      *     If there is only one argument, the result is the absolute value.
+      *     If any argument is +Infinity or -Infinity, the result is +Infinity.
+      *     If any argument is NaN, the result is NaN.
+      *     If all arguments are either +0 or −0, the result is +0.
+      */
+    hypot(...values: number[]): number;
+
+    /**
+      * Returns the integral part of the a numeric expression, x, removing any fractional digits.
+      * If x is already an integer, the result is x.
+      * @param x A numeric expression.
+      */
+    trunc(x: number): number;
+
+    /**
+      * Returns the nearest single precision float representation of a number.
+      * @param x A numeric expression.
+      */
+    fround(x: number): number;
+
+    /**
+      * Returns an implementation-dependent approximation to the cube root of number.
+      * @param x A numeric expression.
+      */
+    cbrt(x: number): number;
+}
+
+// #############################################################################################
+// ECMAScript 6: Symbols
+// Modules: es6.symbol
+// #############################################################################################
+
+interface Symbol {
+    /** Returns a string representation of an object. */
+    toString(): string;
+
+    [Symbol.toStringTag]: string;
+}
+
+interface SymbolConstructor {
+    /**
+      * A reference to the prototype.
+      */
+    prototype: Symbol;
+
+    /**
+      * Returns a new unique Symbol value.
+      * @param  description Description of the new Symbol object.
+      */
+    (description?: string|number): symbol;
+
+    /**
+      * Returns a Symbol object from the global symbol registry matching the given key if found.
+      * Otherwise, returns a new symbol with this key.
+      * @param key key to search for.
+      */
+    for(key: string): symbol;
+
+    /**
+      * Returns a key from the global symbol registry matching the given Symbol if found.
+      * Otherwise, returns a undefined.
+      * @param sym Symbol to find the key for.
+      */
+    keyFor(sym: symbol): string;
+
+    // Well-known Symbols
+
+    /**
+      * A method that determines if a constructor object recognizes an object as one of the
+      * constructor’s instances. Called by the semantics of the instanceof operator.
+      */
+    hasInstance: symbol;
+
+    /**
+      * A Boolean value that if true indicates that an object should flatten to its array elements
+      * by Array.prototype.concat.
+      */
+    isConcatSpreadable: symbol;
+
+    /**
+      * A method that returns the default iterator for an object. Called by the semantics of the
+      * for-of statement.
+      */
+    iterator: symbol;
+
+    /**
+      * A regular expression method that matches the regular expression against a string. Called
+      * by the String.prototype.match method.
+      */
+    match: symbol;
+
+    /**
+      * A regular expression method that replaces matched substrings of a string. Called by the
+      * String.prototype.replace method.
+      */
+    replace: symbol;
+
+    /**
+      * A regular expression method that returns the index within a string that matches the
+      * regular expression. Called by the String.prototype.search method.
+      */
+    search: symbol;
+
+    /**
+      * A function valued property that is the constructor function that is used to create
+      * derived objects.
+      */
+    species: symbol;
+
+    /**
+      * A regular expression method that splits a string at the indices that match the regular
+      * expression. Called by the String.prototype.split method.
+      */
+    split: symbol;
+
+    /**
+      * A method that converts an object to a corresponding primitive value.Called by the ToPrimitive
+      * abstract operation.
+      */
+    toPrimitive: symbol;
+
+    /**
+      * A String value that is used in the creation of the default string description of an object.
+      * Called by the built-in method Object.prototype.toString.
+      */
+    toStringTag: symbol;
+
+    /**
+      * An Object whose own property names are property names that are excluded from the with
+      * environment bindings of the associated objects.
+      */
+    unscopables: symbol;
+
+    /**
+      * Non-standard. Use simple mode for core-js symbols. See https://github.com/zloirock/core-js/#caveats-when-using-symbol-polyfill
+      */
+    useSimple(): void;
+
+    /**
+      * Non-standard. Use setter mode for core-js symbols. See https://github.com/zloirock/core-js/#caveats-when-using-symbol-polyfill
+      */
+    userSetter(): void;
+}
+
+declare var Symbol: SymbolConstructor;
+
+interface Object {
+    /**
+      * Determines whether an object has a property with the specified name.
+      * @param v A property name.
+      */
+    hasOwnProperty(v: PropertyKey): boolean;
+
+    /**
+      * Determines whether a specified property is enumerable.
+      * @param v A property name.
+      */
+    propertyIsEnumerable(v: PropertyKey): boolean;
+}
+
+interface ObjectConstructor {
+    /**
+      * Returns an array of all symbol properties found directly on object o.
+      * @param o Object to retrieve the symbols from.
+      */
+    getOwnPropertySymbols(o: any): symbol[];
+
+    /**
+      * Gets the own property descriptor of the specified object.
+      * An own property descriptor is one that is defined directly on the object and is not
+      * inherited from the object's prototype.
+      * @param o Object that contains the property.
+      * @param p Name of the property.
+    */
+    getOwnPropertyDescriptor(o: any, propertyKey: PropertyKey): PropertyDescriptor;
+
+    /**
+      * Adds a property to an object, or modifies attributes of an existing property.
+      * @param o Object on which to add or modify the property. This can be a native JavaScript
+      * object (that is, a user-defined object or a built in object) or a DOM object.
+      * @param p The property name.
+      * @param attributes Descriptor for the property. It can be for a data property or an accessor
+      *  property.
+      */
+    defineProperty(o: any, propertyKey: PropertyKey, attributes: PropertyDescriptor): any;
+}
+
+interface Math {
+    [Symbol.toStringTag]: string;
+}
+
+interface JSON {
+    [Symbol.toStringTag]: string;
+}
+
+// #############################################################################################
+// ECMAScript 6: Collections
+// Modules: es6.map, es6.set, es6.weak-map, and es6.weak-set
+// #############################################################################################
+
+interface Map<K, V> {
+    clear(): void;
+    delete(key: K): boolean;
+    forEach(callbackfn: (value: V, index: K, map: Map<K, V>) => void, thisArg?: any): void;
+    get(key: K): V;
+    has(key: K): boolean;
+    set(key: K, value?: V): Map<K, V>;
+    size: number;
+}
+
+interface MapConstructor {
+    new <K, V>(): Map<K, V>;
+    new <K, V>(iterable: Iterable<[K, V]>): Map<K, V>;
+    prototype: Map<any, any>;
+}
+
+declare var Map: MapConstructor;
+
+interface Set<T> {
+    add(value: T): Set<T>;
+    clear(): void;
+    delete(value: T): boolean;
+    forEach(callbackfn: (value: T, index: T, set: Set<T>) => void, thisArg?: any): void;
+    has(value: T): boolean;
+    size: number;
+}
+
+interface SetConstructor {
+    new <T>(): Set<T>;
+    new <T>(iterable: Iterable<T>): Set<T>;
+    prototype: Set<any>;
+}
+
+declare var Set: SetConstructor;
+
+interface WeakMap<K, V> {
+    delete(key: K): boolean;
+    get(key: K): V;
+    has(key: K): boolean;
+    set(key: K, value?: V): WeakMap<K, V>;
+}
+
+interface WeakMapConstructor {
+    new <K, V>(): WeakMap<K, V>;
+    new <K, V>(iterable: Iterable<[K, V]>): WeakMap<K, V>;
+    prototype: WeakMap<any, any>;
+}
+
+declare var WeakMap: WeakMapConstructor;
+
+interface WeakSet<T> {
+    add(value: T): WeakSet<T>;
+    delete(value: T): boolean;
+    has(value: T): boolean;
+}
+
+interface WeakSetConstructor {
+    new <T>(): WeakSet<T>;
+    new <T>(iterable: Iterable<T>): WeakSet<T>;
+    prototype: WeakSet<any>;
+}
+
+declare var WeakSet: WeakSetConstructor;
+
+// #############################################################################################
+// ECMAScript 6: Iterators
+// Modules: es6.string.iterator, es6.array.iterator, es6.map, es6.set, web.dom.iterable
+// #############################################################################################
+
+interface IteratorResult<T> {
+    done: boolean;
+    value?: T;
+}
+
+interface Iterator<T> {
+    next(value?: any): IteratorResult<T>;
+    return?(value?: any): IteratorResult<T>;
+    throw?(e?: any): IteratorResult<T>;
+}
+
+interface Iterable<T> {
+    [Symbol.iterator](): Iterator<T>;
+}
+
+interface IterableIterator<T> extends Iterator<T> {
+    [Symbol.iterator](): IterableIterator<T>;
+}
+
+interface String {
+    /** Iterator */
+    [Symbol.iterator](): IterableIterator<string>;
+}
+
+interface Array<T> {
+    /** Iterator */
+    [Symbol.iterator](): IterableIterator<T>;
+
+    /**
+      * Returns an array of key, value pairs for every entry in the array
+      */
+    entries(): IterableIterator<[number, T]>;
+
+    /**
+      * Returns an list of keys in the array
+      */
+    keys(): IterableIterator<number>;
+
+    /**
+      * Returns an list of values in the array
+      */
+    values(): IterableIterator<T>;
+}
+
+interface Map<K, V> {
+    entries(): IterableIterator<[K, V]>;
+    keys(): IterableIterator<K>;
+    values(): IterableIterator<V>;
+    [Symbol.iterator](): IterableIterator<[K, V]>;
+}
+
+interface Set<T> {
+    entries(): IterableIterator<[T, T]>;
+    keys(): IterableIterator<T>;
+    values(): IterableIterator<T>;
+    [Symbol.iterator](): IterableIterator<T>;
+}
+
+interface NodeList {
+    [Symbol.iterator](): IterableIterator<Node>;
+}
+
+interface $for<T> extends IterableIterator<T> {
+    of(callbackfn: (value: T, key: any) => void, thisArg?: any): void;
+    array(): T[];
+    array<U>(callbackfn: (value: T, key: any) => U, thisArg?: any): U[];
+    filter(callbackfn: (value: T, key: any) => boolean, thisArg?: any): $for<T>;
+    map<U>(callbackfn: (value: T, key: any) => U, thisArg?: any): $for<U>;
+}
+
+declare function $for<T>(iterable: Iterable<T>): $for<T>;
+
+// #############################################################################################
+// ECMAScript 6: Promises
+// Modules: es6.promise
+// #############################################################################################
+
+interface PromiseLike<T> {
+    /**
+    * Attaches callbacks for the resolution and/or rejection of the Promise.
+    * @param onfulfilled The callback to execute when the Promise is resolved.
+    * @param onrejected The callback to execute when the Promise is rejected.
+    * @returns A Promise for the completion of which ever callback is executed.
+    */
+    then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): PromiseLike<TResult>;
+    then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): PromiseLike<TResult>;
+}
+
+/**
+ * Represents the completion of an asynchronous operation
+ */
+interface Promise<T> {
+    /**
+    * Attaches callbacks for the resolution and/or rejection of the Promise.
+    * @param onfulfilled The callback to execute when the Promise is resolved.
+    * @param onrejected The callback to execute when the Promise is rejected.
+    * @returns A Promise for the completion of which ever callback is executed.
+    */
+    then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): Promise<TResult>;
+    then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): Promise<TResult>;
+
+    /**
+     * Attaches a callback for only the rejection of the Promise.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of the callback.
+     */
+    catch(onrejected?: (reason: any) => T | PromiseLike<T>): Promise<T>;
+    catch(onrejected?: (reason: any) => void): Promise<T>;
+}
+
+interface PromiseConstructor {
+    /**
+      * A reference to the prototype.
+      */
+    prototype: Promise<any>;
+
+    /**
+     * Creates a new Promise.
+     * @param executor A callback used to initialize the promise. This callback is passed two arguments:
+     * a resolve callback used resolve the promise with a value or the result of another promise,
+     * and a reject callback used to reject the promise with a provided reason or error.
+     */
+    new <T>(executor: (resolve: (value?: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
+
+    /**
+     * Creates a Promise that is resolved with an array of results when all of the provided Promises
+     * resolve, or rejected when any Promise is rejected.
+     * @param values An array of Promises.
+     * @returns A new Promise.
+     */
+    all<T>(values: Iterable<T | PromiseLike<T>>): Promise<T[]>;
+
+    /**
+     * Creates a Promise that is resolved or rejected when any of the provided Promises are resolved
+     * or rejected.
+     * @param values An array of Promises.
+     * @returns A new Promise.
+     */
+    race<T>(values: Iterable<T | PromiseLike<T>>): Promise<T>;
+
+    /**
+     * Creates a new rejected promise for the provided reason.
+     * @param reason The reason the promise was rejected.
+     * @returns A new rejected Promise.
+     */
+    reject(reason: any): Promise<void>;
+
+    /**
+     * Creates a new rejected promise for the provided reason.
+     * @param reason The reason the promise was rejected.
+     * @returns A new rejected Promise.
+     */
+    reject<T>(reason: any): Promise<T>;
+
+    /**
+      * Creates a new resolved promise for the provided value.
+      * @param value A promise.
+      * @returns A promise whose internal state matches the provided promise.
+      */
+    resolve<T>(value: T | PromiseLike<T>): Promise<T>;
+
+    /**
+     * Creates a new resolved promise .
+     * @returns A resolved promise.
+     */
+    resolve(): Promise<void>;
+}
+
+declare var Promise: PromiseConstructor;
+
+// #############################################################################################
+// ECMAScript 6: Reflect
+// Modules: es6.reflect
+// #############################################################################################
+
+declare module Reflect {
+    function apply(target: Function, thisArgument: any, argumentsList: ArrayLike<any>): any;
+    function construct(target: Function, argumentsList: ArrayLike<any>, newTarget?: any): any;
+    function defineProperty(target: any, propertyKey: PropertyKey, attributes: PropertyDescriptor): boolean;
+    function deleteProperty(target: any, propertyKey: PropertyKey): boolean;
+    function enumerate(target: any): IterableIterator<any>;
+    function get(target: any, propertyKey: PropertyKey, receiver?: any): any;
+    function getOwnPropertyDescriptor(target: any, propertyKey: PropertyKey): PropertyDescriptor;
+    function getPrototypeOf(target: any): any;
+    function has(target: any, propertyKey: PropertyKey): boolean;
+    function isExtensible(target: any): boolean;
+    function ownKeys(target: any): Array<PropertyKey>;
+    function preventExtensions(target: any): boolean;
+    function set(target: any, propertyKey: PropertyKey, value: any, receiver?: any): boolean;
+    function setPrototypeOf(target: any, proto: any): boolean;
+}
+
+// #############################################################################################
+// ECMAScript 7
+// Modules: es7.array.includes, es7.string.at, es7.string.lpad, es7.string.rpad,
+//          es7.object.to-array, es7.object.get-own-property-descriptors, es7.regexp.escape,
+//          es7.map.to-json, and es7.set.to-json
+// #############################################################################################
+
+interface Array<T> {
+    includes(value: T, fromIndex?: number): boolean;
+}
+
+interface String {
+    at(index: number): string;
+    lpad(length: number, fillStr?: string): string;
+    rpad(length: number, fillStr?: string): string;
+}
+
+interface ObjectConstructor {
+    values(object: any): any[];
+    entries(object: any): [string, any][];
+    getOwnPropertyDescriptors(object: any): PropertyDescriptorMap;
+}
+
+interface RegExpConstructor {
+    escape(str: string): string;
+}
+
+interface Map<K, V> {
+    toJSON(): any;
+}
+
+interface Set<T> {
+    toJSON(): any;
+}
+
+// #############################################################################################
+// Mozilla JavaScript: Array generics
+// Modules: js.array.statics
+// #############################################################################################
+
+interface ArrayConstructor {
+    /**
+      * Appends new elements to an array, and returns the new length of the array.
+      * @param items New elements of the Array.
+      */
+    push<T>(array: ArrayLike<T>, ...items: T[]): number;
+    /**
+      * Removes the last element from an array and returns it.
+      */
+    pop<T>(array: ArrayLike<T>): T;
+    /**
+      * Combines two or more arrays.
+      * @param items Additional items to add to the end of array1.
+      */
+    concat<T>(array: ArrayLike<T>, ...items: (T[]| T)[]): T[];
+    /**
+      * Adds all the elements of an array separated by the specified separator string.
+      * @param separator A string used to separate one element of an array from the next in the resulting String. If omitted, the array elements are separated with a comma.
+      */
+    join<T>(array: ArrayLike<T>, separator?: string): string;
+    /**
+      * Reverses the elements in an Array.
+      */
+    reverse<T>(array: ArrayLike<T>): T[];
+    /**
+      * Removes the first element from an array and returns it.
+      */
+    shift<T>(array: ArrayLike<T>): T;
+    /**
+      * Returns a section of an array.
+      * @param start The beginning of the specified portion of the array.
+      * @param end The end of the specified portion of the array.
+      */
+    slice<T>(array: ArrayLike<T>, start?: number, end?: number): T[];
+
+    /**
+      * Sorts an array.
+      * @param compareFn The name of the function used to determine the order of the elements. If omitted, the elements are sorted in ascending, ASCII character order.
+      */
+    sort<T>(array: ArrayLike<T>, compareFn?: (a: T, b: T) => number): T[];
+
+    /**
+      * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
+      * @param start The zero-based location in the array from which to start removing elements.
+      */
+    splice<T>(array: ArrayLike<T>, start: number): T[];
+
+    /**
+      * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
+      * @param start The zero-based location in the array from which to start removing elements.
+      * @param deleteCount The number of elements to remove.
+      * @param items Elements to insert into the array in place of the deleted elements.
+      */
+    splice<T>(array: ArrayLike<T>, start: number, deleteCount: number, ...items: T[]): T[];
+
+    /**
+      * Inserts new elements at the start of an array.
+      * @param items  Elements to insert at the start of the Array.
+      */
+    unshift<T>(array: ArrayLike<T>, ...items: T[]): number;
+
+    /**
+      * Returns the index of the first occurrence of a value in an array.
+      * @param searchElement The value to locate in the array.
+      * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at index 0.
+      */
+    indexOf<T>(array: ArrayLike<T>, searchElement: T, fromIndex?: number): number;
+
+    /**
+      * Returns the index of the last occurrence of a specified value in an array.
+      * @param searchElement The value to locate in the array.
+      * @param fromIndex The array index at which to begin the search. If fromIndex is omitted, the search starts at the last index in the array.
+      */
+    lastIndexOf<T>(array: ArrayLike<T>, earchElement: T, fromIndex?: number): number;
+
+    /**
+      * Determines whether all the members of an array satisfy the specified test.
+      * @param callbackfn A function that accepts up to three arguments. The every method calls the callbackfn function for each element in array1 until the callbackfn returns false, or until the end of the array.
+      * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+      */
+    every<T>(array: ArrayLike<T>, callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
+
+    /**
+      * Determines whether the specified callback function returns true for any element of an array.
+      * @param callbackfn A function that accepts up to three arguments. The some method calls the callbackfn function for each element in array1 until the callbackfn returns true, or until the end of the array.
+      * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+      */
+    some<T>(array: ArrayLike<T>, callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
+
+    /**
+      * Performs the specified action for each element in an array.
+      * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array.
+      * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+      */
+    forEach<T>(array: ArrayLike<T>, callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void;
+
+    /**
+      * Calls a defined callback function on each element of an array, and returns an array that contains the results.
+      * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array.
+      * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+      */
+    map<T, U>(array: ArrayLike<T>, callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];
+
+    /**
+      * Returns the elements of an array that meet the condition specified in a callback function.
+      * @param callbackfn A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array.
+      * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+      */
+    filter<T>(array: ArrayLike<T>, callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): T[];
+
+    /**
+      * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
+      * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+      */
+    reduce<T, U>(array: ArrayLike<T>, callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
+
+    /**
+      * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
+      * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+      */
+    reduce<T>(array: ArrayLike<T>, callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
+
+    /**
+      * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
+      * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+      */
+    reduceRight<T, U>(array: ArrayLike<T>, callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
+
+    /**
+      * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
+      * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+      */
+    reduceRight<T>(array: ArrayLike<T>, callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
+
+    /**
+      * Returns an array of key, value pairs for every entry in the array
+      */
+    entries<T>(array: ArrayLike<T>): IterableIterator<[number, T]>;
+
+    /**
+      * Returns an list of keys in the array
+      */
+    keys<T>(array: ArrayLike<T>): IterableIterator<number>;
+
+    /**
+      * Returns an list of values in the array
+      */
+    values<T>(array: ArrayLike<T>): IterableIterator<T>;
+
+    /**
+      * Returns the value of the first element in the array where predicate is true, and undefined
+      * otherwise.
+      * @param predicate find calls predicate once for each element of the array, in ascending
+      * order, until it finds one where predicate returns true. If such an element is found, find
+      * immediately returns that element value. Otherwise, find returns undefined.
+      * @param thisArg If provided, it will be used as the this value for each invocation of
+      * predicate. If it is not provided, undefined is used instead.
+      */
+    find<T>(array: ArrayLike<T>, predicate: (value: T, index: number, obj: Array<T>) => boolean, thisArg?: any): T;
+
+    /**
+      * Returns the index of the first element in the array where predicate is true, and undefined
+      * otherwise.
+      * @param predicate find calls predicate once for each element of the array, in ascending
+      * order, until it finds one where predicate returns true. If such an element is found, find
+      * immediately returns that element value. Otherwise, find returns undefined.
+      * @param thisArg If provided, it will be used as the this value for each invocation of
+      * predicate. If it is not provided, undefined is used instead.
+      */
+    findIndex<T>(array: ArrayLike<T>, predicate: (value: T) => boolean, thisArg?: any): number;
+
+    /**
+      * Returns the this object after filling the section identified by start and end with value
+      * @param value value to fill array section with
+      * @param start index to start filling the array at. If start is negative, it is treated as
+      * length+start where length is the length of the array.
+      * @param end index to stop filling the array at. If end is negative, it is treated as
+      * length+end.
+      */
+    fill<T>(array: ArrayLike<T>, value: T, start?: number, end?: number): T[];
+
+    /**
+      * Returns the this object after copying a section of the array identified by start and end
+      * to the same array starting at position target
+      * @param target If target is negative, it is treated as length+target where length is the
+      * length of the array.
+      * @param start If start is negative, it is treated as length+start. If end is negative, it
+      * is treated as length+end.
+      * @param end If not specified, length of the this object is used as its default value.
+      */
+    copyWithin<T>(array: ArrayLike<T>, target: number, start: number, end?: number): T[];
+
+    includes<T>(array: ArrayLike<T>, value: T, fromIndex?: number): boolean;
+    turn<T, U>(array: ArrayLike<T>, callbackfn: (memo: U, value: T, index: number, array: Array<T>) => void, memo?: U): U;
+    turn<T>(array: ArrayLike<T>, callbackfn: (memo: Array<T>, value: T, index: number, array: Array<T>) => void, memo?: Array<T>): Array<T>;
+}
+
+// #############################################################################################
+// Object - https://github.com/zloirock/core-js/#object
+// Modules: core.object
+// #############################################################################################
+
+interface ObjectConstructor {
+    /**
+      * Non-standard.
+      */
+    isObject(value: any): boolean;
+
+    /**
+      * Non-standard.
+      */
+    classof(value: any): string;
+
+    /**
+      * Non-standard.
+      */
+    define<T>(target: T, mixin: any): T;
+
+    /**
+      * Non-standard.
+      */
+    make<T>(proto: T, mixin?: any): T;
+}
+
+// #############################################################################################
+// Console - https://github.com/zloirock/core-js/#console
+// Modules: core.log
+// #############################################################################################
+
+interface Log extends Console {
+    (message?: any, ...optionalParams: any[]): void;
+    enable(): void;
+    disable(): void;
+}
+
+/**
+  * Non-standard.
+  */
+declare var log: Log;
+
+// #############################################################################################
+// Dict - https://github.com/zloirock/core-js/#dict
+// Modules: core.dict
+// #############################################################################################
+
+interface Dict<T> {
+    [key: string]: T;
+    [key: number]: T;
+    //[key: symbol]: T;
+}
+
+interface DictConstructor {
+    prototype: Dict<any>;
+
+    new <T>(value?: Dict<T>): Dict<T>;
+    new (value?: any): Dict<any>;
+    <T>(value?: Dict<T>): Dict<T>;
+    (value?: any): Dict<any>;
+
+    isDict(value: any): boolean;
+    values<T>(object: Dict<T>): IterableIterator<T>;
+    keys<T>(object: Dict<T>): IterableIterator<PropertyKey>;
+    entries<T>(object: Dict<T>): IterableIterator<[PropertyKey, T]>;
+    has<T>(object: Dict<T>, key: PropertyKey): boolean;
+    get<T>(object: Dict<T>, key: PropertyKey): T;
+    set<T>(object: Dict<T>, key: PropertyKey, value: T): Dict<T>;
+    forEach<T>(object: Dict<T>, callbackfn: (value: T, key: PropertyKey, dict: Dict<T>) => void, thisArg?: any): void;
+    map<T, U>(object: Dict<T>, callbackfn: (value: T, key: PropertyKey, dict: Dict<T>) => U, thisArg?: any): Dict<U>;
+    mapPairs<T, U>(object: Dict<T>, callbackfn: (value: T, key: PropertyKey, dict: Dict<T>) => [PropertyKey, U], thisArg?: any): Dict<U>;
+    filter<T>(object: Dict<T>, callbackfn: (value: T, key: PropertyKey, dict: Dict<T>) => boolean, thisArg?: any): Dict<T>;
+    some<T>(object: Dict<T>, callbackfn: (value: T, key: PropertyKey, dict: Dict<T>) => boolean, thisArg?: any): boolean;
+    every<T>(object: Dict<T>, callbackfn: (value: T, key: PropertyKey, dict: Dict<T>) => boolean, thisArg?: any): boolean;
+    find<T>(object: Dict<T>, callbackfn: (value: T, key: PropertyKey, dict: Dict<T>) => boolean, thisArg?: any): T;
+    findKey<T>(object: Dict<T>, callbackfn: (value: T, key: PropertyKey, dict: Dict<T>) => boolean, thisArg?: any): PropertyKey;
+    keyOf<T>(object: Dict<T>, value: T): PropertyKey;
+    includes<T>(object: Dict<T>, value: T): boolean;
+    reduce<T, U>(object: Dict<T>, callbackfn: (previousValue: U, value: T, key: PropertyKey, dict: Dict<T>) => U, initialValue: U): U;
+    reduce<T>(object: Dict<T>, callbackfn: (previousValue: T, value: T, key: PropertyKey, dict: Dict<T>) => T, initialValue?: T): T;
+    turn<T, U>(object: Dict<T>, callbackfn: (memo: Dict<U>, value: T, key: PropertyKey, dict: Dict<T>) => void, memo: Dict<U>): Dict<U>;
+    turn<T>(object: Dict<T>, callbackfn: (memo: Dict<T>, value: T, key: PropertyKey, dict: Dict<T>) => void, memo?: Dict<T>): Dict<T>;
+}
+
+/**
+  * Non-standard.
+  */
+declare var Dict: DictConstructor;
+
+// #############################################################################################
+// Partial application - https://github.com/zloirock/core-js/#partial-application
+// Modules: core.function.part
+// #############################################################################################
+
+interface Function {
+    /**
+      * Non-standard.
+      */
+    part(...args: any[]): any;
+}
+
+// #############################################################################################
+// Date formatting - https://github.com/zloirock/core-js/#date-formatting
+// Modules: core.date
+// #############################################################################################
+
+interface Date {
+    /**
+      * Non-standard.
+      */
+    format(template: string, locale?: string): string;
+
+    /**
+      * Non-standard.
+      */
+    formatUTC(template: string, locale?: string): string;
+}
+
+// #############################################################################################
+// Array - https://github.com/zloirock/core-js/#array
+// Modules: core.array.turn
+// #############################################################################################
+
+interface Array<T> {
+    /**
+      * Non-standard.
+      */
+    turn<U>(callbackfn: (memo: U, value: T, index: number, array: Array<T>) => void, memo?: U): U;
+
+    /**
+      * Non-standard.
+      */
+    turn(callbackfn: (memo: Array<T>, value: T, index: number, array: Array<T>) => void, memo?: Array<T>): Array<T>;
+}
+
+// #############################################################################################
+// Number - https://github.com/zloirock/core-js/#number
+// Modules: core.number.iterator
+// #############################################################################################
+
+interface Number {
+    /**
+      * Non-standard.
+      */
+    [Symbol.iterator](): IterableIterator<number>;
+}
+
+// #############################################################################################
+// Escaping characters - https://github.com/zloirock/core-js/#escaping-characters
+// Modules: core.string.escape-html
+// #############################################################################################
+
+interface String {
+    /**
+      * Non-standard.
+      */
+    escapeHTML(): string;
+
+    /**
+      * Non-standard.
+      */
+    unescapeHTML(): string;
+}
+
+// #############################################################################################
+// delay - https://github.com/zloirock/core-js/#delay
+// Modules: core.delay
+// #############################################################################################
+
+declare function delay(msec: number): Promise<void>;
+
+declare module core {
+    module Reflect {
+        function apply(target: Function, thisArgument: any, argumentsList: ArrayLike<any>): any;
+        function construct(target: Function, argumentsList: ArrayLike<any>): any;
+        function defineProperty(target: any, propertyKey: PropertyKey, attributes: PropertyDescriptor): boolean;
+        function deleteProperty(target: any, propertyKey: PropertyKey): boolean;
+        function enumerate(target: any): IterableIterator<any>;
+        function get(target: any, propertyKey: PropertyKey, receiver?: any): any;
+        function getOwnPropertyDescriptor(target: any, propertyKey: PropertyKey): PropertyDescriptor;
+        function getPrototypeOf(target: any): any;
+        function has(target: any, propertyKey: string): boolean;
+        function has(target: any, propertyKey: symbol): boolean;
+        function isExtensible(target: any): boolean;
+        function ownKeys(target: any): Array<PropertyKey>;
+        function preventExtensions(target: any): boolean;
+        function set(target: any, propertyKey: PropertyKey, value: any, receiver?: any): boolean;
+        function setPrototypeOf(target: any, proto: any): boolean;
+    }
+
+    var Object: {
+        getPrototypeOf(o: any): any;
+        getOwnPropertyDescriptor(o: any, p: string): PropertyDescriptor;
+        getOwnPropertyNames(o: any): string[];
+        create(o: any, properties?: PropertyDescriptorMap): any;
+        defineProperty(o: any, p: string, attributes: PropertyDescriptor): any;
+        defineProperties(o: any, properties: PropertyDescriptorMap): any;
+        seal<T>(o: T): T;
+        freeze<T>(o: T): T;
+        preventExtensions<T>(o: T): T;
+        isSealed(o: any): boolean;
+        isFrozen(o: any): boolean;
+        isExtensible(o: any): boolean;
+        keys(o: any): string[];
+        assign(target: any, ...sources: any[]): any;
+        is(value1: any, value2: any): boolean;
+        setPrototypeOf(o: any, proto: any): any;
+        getOwnPropertySymbols(o: any): symbol[];
+        getOwnPropertyDescriptor(o: any, propertyKey: PropertyKey): PropertyDescriptor;
+        defineProperty(o: any, propertyKey: PropertyKey, attributes: PropertyDescriptor): any;
+        values(object: any): any[];
+        entries(object: any): any[];
+        getOwnPropertyDescriptors(object: any): PropertyDescriptorMap;
+        isObject(value: any): boolean;
+        classof(value: any): string;
+        define<T>(target: T, mixin: any): T;
+        make<T>(proto: T, mixin?: any): T;
+    };
+
+    var Function: {
+        bind(target: Function, thisArg: any, ...argArray: any[]): any;
+        part(target: Function, ...args: any[]): any;
+    };
+
+    var Array: {
+        from<T, U>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => U, thisArg?: any): Array<U>;
+        from<T, U>(iterable: Iterable<T>, mapfn: (v: T, k: number) => U, thisArg?: any): Array<U>;
+        from<T>(arrayLike: ArrayLike<T>): Array<T>;
+        from<T>(iterable: Iterable<T>): Array<T>;
+        of<T>(...items: T[]): Array<T>;
+        push<T>(array: ArrayLike<T>, ...items: T[]): number;
+        pop<T>(array: ArrayLike<T>): T;
+        concat<T>(array: ArrayLike<T>, ...items: (T[]| T)[]): T[];
+        join<T>(array: ArrayLike<T>, separator?: string): string;
+        reverse<T>(array: ArrayLike<T>): T[];
+        shift<T>(array: ArrayLike<T>): T;
+        slice<T>(array: ArrayLike<T>, start?: number, end?: number): T[];
+        sort<T>(array: ArrayLike<T>, compareFn?: (a: T, b: T) => number): T[];
+        splice<T>(array: ArrayLike<T>, start: number): T[];
+        splice<T>(array: ArrayLike<T>, start: number, deleteCount: number, ...items: T[]): T[];
+        unshift<T>(array: ArrayLike<T>, ...items: T[]): number;
+        indexOf<T>(array: ArrayLike<T>, searchElement: T, fromIndex?: number): number;
+        lastIndexOf<T>(array: ArrayLike<T>, earchElement: T, fromIndex?: number): number;
+        every<T>(array: ArrayLike<T>, callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
+        some<T>(array: ArrayLike<T>, callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
+        forEach<T>(array: ArrayLike<T>, callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void;
+        map<T, U>(array: ArrayLike<T>, callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];
+        filter<T>(array: ArrayLike<T>, callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): T[];
+        reduce<T>(array: ArrayLike<T>, callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
+        reduce<T, U>(array: ArrayLike<T>, callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
+        reduceRight<T>(array: ArrayLike<T>, callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
+        reduceRight<T, U>(array: ArrayLike<T>, callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
+        entries<T>(array: ArrayLike<T>): IterableIterator<[number, T]>;
+        keys<T>(array: ArrayLike<T>): IterableIterator<number>;
+        values<T>(array: ArrayLike<T>): IterableIterator<T>;
+        find<T>(array: ArrayLike<T>, predicate: (value: T, index: number, obj: Array<T>) => boolean, thisArg?: any): T;
+        findIndex<T>(array: ArrayLike<T>, predicate: (value: T) => boolean, thisArg?: any): number;
+        fill<T>(array: ArrayLike<T>, value: T, start?: number, end?: number): T[];
+        copyWithin<T>(array: ArrayLike<T>, target: number, start: number, end?: number): T[];
+        includes<T>(array: ArrayLike<T>, value: T, fromIndex?: number): boolean;
+        turn<T>(array: ArrayLike<T>, callbackfn: (memo: Array<T>, value: T, index: number, array: Array<T>) => void, memo?: Array<T>): Array<T>;
+        turn<T, U>(array: ArrayLike<T>, callbackfn: (memo: U, value: T, index: number, array: Array<T>) => void, memo?: U): U;
+    };
+
+    var String: {
+        codePointAt(text: string, pos: number): number;
+        includes(text: string, searchString: string, position?: number): boolean;
+        endsWith(text: string, searchString: string, endPosition?: number): boolean;
+        repeat(text: string, count: number): string;
+        fromCodePoint(...codePoints: number[]): string;
+        raw(template: TemplateStringsArray, ...substitutions: any[]): string;
+        startsWith(text: string, searchString: string, position?: number): boolean;
+        at(text: string, index: number): string;
+        lpad(text: string, length: number, fillStr?: string): string;
+        rpad(text: string, length: number, fillStr?: string): string;
+        escapeHTML(text: string): string;
+        unescapeHTML(text: string): string;
+    };
+
+    var Date: {
+        now(): number;
+        toISOString(date: Date): string;
+        format(date: Date, template: string, locale?: string): string;
+        formatUTC(date: Date, template: string, locale?: string): string;
+    };
+
+    var Number: {
+        EPSILON: number;
+        isFinite(number: number): boolean;
+        isInteger(number: number): boolean;
+        isNaN(number: number): boolean;
+        isSafeInteger(number: number): boolean;
+        MAX_SAFE_INTEGER: number;
+        MIN_SAFE_INTEGER: number;
+        parseFloat(string: string): number;
+        parseInt(string: string, radix?: number): number;
+        clz32(x: number): number;
+        imul(x: number, y: number): number;
+        sign(x: number): number;
+        log10(x: number): number;
+        log2(x: number): number;
+        log1p(x: number): number;
+        expm1(x: number): number;
+        cosh(x: number): number;
+        sinh(x: number): number;
+        tanh(x: number): number;
+        acosh(x: number): number;
+        asinh(x: number): number;
+        atanh(x: number): number;
+        hypot(...values: number[]): number;
+        trunc(x: number): number;
+        fround(x: number): number;
+        cbrt(x: number): number;
+        random(lim?: number): number;
+    };
+
+    var Math: {
+        clz32(x: number): number;
+        imul(x: number, y: number): number;
+        sign(x: number): number;
+        log10(x: number): number;
+        log2(x: number): number;
+        log1p(x: number): number;
+        expm1(x: number): number;
+        cosh(x: number): number;
+        sinh(x: number): number;
+        tanh(x: number): number;
+        acosh(x: number): number;
+        asinh(x: number): number;
+        atanh(x: number): number;
+        hypot(...values: number[]): number;
+        trunc(x: number): number;
+        fround(x: number): number;
+        cbrt(x: number): number;
+    };
+
+    var RegExp: {
+        escape(str: string): string;
+    };
+
+    var Map: MapConstructor;
+    var Set: SetConstructor;
+    var WeakMap: WeakMapConstructor;
+    var WeakSet: WeakSetConstructor;
+    var Promise: PromiseConstructor;
+    var Symbol: SymbolConstructor;
+    var Dict: DictConstructor;
+    var global: any;
+    var log: Log;
+    var _: boolean;
+
+    function setTimeout(handler: any, timeout?: any, ...args: any[]): number;
+
+    function setInterval(handler: any, timeout?: any, ...args: any[]): number;
+
+    function setImmediate(expression: any, ...args: any[]): number;
+
+    function clearImmediate(handle: number): void;
+
+    function $for<T>(iterable: Iterable<T>): $for<T>;
+
+    function isIterable(value: any): boolean;
+
+    function getIterator<T>(iterable: Iterable<T>): Iterator<T>;
+
+    interface Locale {
+        weekdays: string;
+        months: string;
+    }
+
+    function addLocale(lang: string, locale: Locale): typeof core;
+
+    function locale(lang?: string): string;
+
+    function delay(msec: number): Promise<void>;
+}
+
+declare module "core-js" {
+    export = core;
+}
+declare module "core-js/shim" {
+    export = core;
+}
+declare module "core-js/core" {
+    export = core;
+}
+declare module "core-js/core/$for" {
+    import $for = core.$for;
+    export = $for;
+}
+declare module "core-js/core/_" {
+    var _: typeof core._;
+    export = _;
+}
+declare module "core-js/core/array" {
+    var Array: typeof core.Array;
+    export = Array;
+}
+declare module "core-js/core/date" {
+    var Date: typeof core.Date;
+    export = Date;
+}
+declare module "core-js/core/delay" {
+    var delay: typeof core.delay;
+    export = delay;
+}
+declare module "core-js/core/dict" {
+    var Dict: typeof core.Dict;
+    export = Dict;
+}
+declare module "core-js/core/function" {
+    var Function: typeof core.Function;
+    export = Function;
+}
+declare module "core-js/core/global" {
+    var global: typeof core.global;
+    export = global;
+}
+declare module "core-js/core/log" {
+    var log: typeof core.log;
+    export = log;
+}
+declare module "core-js/core/number" {
+    var Number: typeof core.Number;
+    export = Number;
+}
+declare module "core-js/core/object" {
+    var Object: typeof core.Object;
+    export = Object;
+}
+declare module "core-js/core/string" {
+    var String: typeof core.String;
+    export = String;
+}
+declare module "core-js/fn/$for" {
+    import $for = core.$for;
+    export = $for;
+}
+declare module "core-js/fn/_" {
+    var _: typeof core._;
+    export = _;
+}
+declare module "core-js/fn/clear-immediate" {
+    var clearImmediate: typeof core.clearImmediate;
+    export = clearImmediate;
+}
+declare module "core-js/fn/delay" {
+    var delay: typeof core.delay;
+    export = delay;
+}
+declare module "core-js/fn/dict" {
+    var Dict: typeof core.Dict;
+    export = Dict;
+}
+declare module "core-js/fn/get-iterator" {
+    var getIterator: typeof core.getIterator;
+    export = getIterator;
+}
+declare module "core-js/fn/global" {
+    var global: typeof core.global;
+    export = global;
+}
+declare module "core-js/fn/is-iterable" {
+    var isIterable: typeof core.isIterable;
+    export = isIterable;
+}
+declare module "core-js/fn/log" {
+    var log: typeof core.log;
+    export = log;
+}
+declare module "core-js/fn/map" {
+    var Map: typeof core.Map;
+    export = Map;
+}
+declare module "core-js/fn/promise" {
+    var Promise: typeof core.Promise;
+    export = Promise;
+}
+declare module "core-js/fn/set" {
+    var Set: typeof core.Set;
+    export = Set;
+}
+declare module "core-js/fn/set-immediate" {
+    var setImmediate: typeof core.setImmediate;
+    export = setImmediate;
+}
+declare module "core-js/fn/set-interval" {
+    var setInterval: typeof core.setInterval;
+    export = setInterval;
+}
+declare module "core-js/fn/set-timeout" {
+    var setTimeout: typeof core.setTimeout;
+    export = setTimeout;
+}
+declare module "core-js/fn/weak-map" {
+    var WeakMap: typeof core.WeakMap;
+    export = WeakMap;
+}
+declare module "core-js/fn/weak-set" {
+    var WeakSet: typeof core.WeakSet;
+    export = WeakSet;
+}
+declare module "core-js/fn/array" {
+    var Array: typeof core.Array;
+    export = Array;
+}
+declare module "core-js/fn/array/concat" {
+    var concat: typeof core.Array.concat;
+    export = concat;
+}
+declare module "core-js/fn/array/copy-within" {
+    var copyWithin: typeof core.Array.copyWithin;
+    export = copyWithin;
+}
+declare module "core-js/fn/array/entries" {
+    var entries: typeof core.Array.entries;
+    export = entries;
+}
+declare module "core-js/fn/array/every" {
+    var every: typeof core.Array.every;
+    export = every;
+}
+declare module "core-js/fn/array/fill" {
+    var fill: typeof core.Array.fill;
+    export = fill;
+}
+declare module "core-js/fn/array/filter" {
+    var filter: typeof core.Array.filter;
+    export = filter;
+}
+declare module "core-js/fn/array/find" {
+    var find: typeof core.Array.find;
+    export = find;
+}
+declare module "core-js/fn/array/find-index" {
+    var findIndex: typeof core.Array.findIndex;
+    export = findIndex;
+}
+declare module "core-js/fn/array/for-each" {
+    var forEach: typeof core.Array.forEach;
+    export = forEach;
+}
+declare module "core-js/fn/array/from" {
+    var from: typeof core.Array.from;
+    export = from;
+}
+declare module "core-js/fn/array/includes" {
+    var includes: typeof core.Array.includes;
+    export = includes;
+}
+declare module "core-js/fn/array/index-of" {
+    var indexOf: typeof core.Array.indexOf;
+    export = indexOf;
+}
+declare module "core-js/fn/array/join" {
+    var join: typeof core.Array.join;
+    export = join;
+}
+declare module "core-js/fn/array/keys" {
+    var keys: typeof core.Array.keys;
+    export = keys;
+}
+declare module "core-js/fn/array/last-index-of" {
+    var lastIndexOf: typeof core.Array.lastIndexOf;
+    export = lastIndexOf;
+}
+declare module "core-js/fn/array/map" {
+    var map: typeof core.Array.map;
+    export = map;
+}
+declare module "core-js/fn/array/of" {
+    var of: typeof core.Array.of;
+    export = of;
+}
+declare module "core-js/fn/array/pop" {
+    var pop: typeof core.Array.pop;
+    export = pop;
+}
+declare module "core-js/fn/array/push" {
+    var push: typeof core.Array.push;
+    export = push;
+}
+declare module "core-js/fn/array/reduce" {
+    var reduce: typeof core.Array.reduce;
+    export = reduce;
+}
+declare module "core-js/fn/array/reduce-right" {
+    var reduceRight: typeof core.Array.reduceRight;
+    export = reduceRight;
+}
+declare module "core-js/fn/array/reverse" {
+    var reverse: typeof core.Array.reverse;
+    export = reverse;
+}
+declare module "core-js/fn/array/shift" {
+    var shift: typeof core.Array.shift;
+    export = shift;
+}
+declare module "core-js/fn/array/slice" {
+    var slice: typeof core.Array.slice;
+    export = slice;
+}
+declare module "core-js/fn/array/some" {
+    var some: typeof core.Array.some;
+    export = some;
+}
+declare module "core-js/fn/array/sort" {
+    var sort: typeof core.Array.sort;
+    export = sort;
+}
+declare module "core-js/fn/array/splice" {
+    var splice: typeof core.Array.splice;
+    export = splice;
+}
+declare module "core-js/fn/array/turn" {
+    var turn: typeof core.Array.turn;
+    export = turn;
+}
+declare module "core-js/fn/array/unshift" {
+    var unshift: typeof core.Array.unshift;
+    export = unshift;
+}
+declare module "core-js/fn/array/values" {
+    var values: typeof core.Array.values;
+    export = values;
+}
+declare module "core-js/fn/date" {
+    var Date: typeof core.Date;
+    export = Date;
+}
+declare module "core-js/fn/date/add-locale" {
+    var addLocale: typeof core.addLocale;
+    export = addLocale;
+}
+declare module "core-js/fn/date/format" {
+    var format: typeof core.Date.format;
+    export = format;
+}
+declare module "core-js/fn/date/formatUTC" {
+    var formatUTC: typeof core.Date.formatUTC;
+    export = formatUTC;
+}
+declare module "core-js/fn/function" {
+    var Function: typeof core.Function;
+    export = Function;
+}
+declare module "core-js/fn/function/has-instance" {
+    var hasInstance: (value: any) => boolean;
+    export = hasInstance;
+}
+declare module "core-js/fn/function/name"
+{
+}
+declare module "core-js/fn/function/part" {
+    var part: typeof core.Function.part;
+    export = part;
+}
+declare module "core-js/fn/math" {
+    var Math: typeof core.Math;
+    export = Math;
+}
+declare module "core-js/fn/math/acosh" {
+    var acosh: typeof core.Math.acosh;
+    export = acosh;
+}
+declare module "core-js/fn/math/asinh" {
+    var asinh: typeof core.Math.asinh;
+    export = asinh;
+}
+declare module "core-js/fn/math/atanh" {
+    var atanh: typeof core.Math.atanh;
+    export = atanh;
+}
+declare module "core-js/fn/math/cbrt" {
+    var cbrt: typeof core.Math.cbrt;
+    export = cbrt;
+}
+declare module "core-js/fn/math/clz32" {
+    var clz32: typeof core.Math.clz32;
+    export = clz32;
+}
+declare module "core-js/fn/math/cosh" {
+    var cosh: typeof core.Math.cosh;
+    export = cosh;
+}
+declare module "core-js/fn/math/expm1" {
+    var expm1: typeof core.Math.expm1;
+    export = expm1;
+}
+declare module "core-js/fn/math/fround" {
+    var fround: typeof core.Math.fround;
+    export = fround;
+}
+declare module "core-js/fn/math/hypot" {
+    var hypot: typeof core.Math.hypot;
+    export = hypot;
+}
+declare module "core-js/fn/math/imul" {
+    var imul: typeof core.Math.imul;
+    export = imul;
+}
+declare module "core-js/fn/math/log10" {
+    var log10: typeof core.Math.log10;
+    export = log10;
+}
+declare module "core-js/fn/math/log1p" {
+    var log1p: typeof core.Math.log1p;
+    export = log1p;
+}
+declare module "core-js/fn/math/log2" {
+    var log2: typeof core.Math.log2;
+    export = log2;
+}
+declare module "core-js/fn/math/sign" {
+    var sign: typeof core.Math.sign;
+    export = sign;
+}
+declare module "core-js/fn/math/sinh" {
+    var sinh: typeof core.Math.sinh;
+    export = sinh;
+}
+declare module "core-js/fn/math/tanh" {
+    var tanh: typeof core.Math.tanh;
+    export = tanh;
+}
+declare module "core-js/fn/math/trunc" {
+    var trunc: typeof core.Math.trunc;
+    export = trunc;
+}
+declare module "core-js/fn/number" {
+    var Number: typeof core.Number;
+    export = Number;
+}
+declare module "core-js/fn/number/epsilon" {
+    var EPSILON: typeof core.Number.EPSILON;
+    export = EPSILON;
+}
+declare module "core-js/fn/number/is-finite" {
+    var isFinite: typeof core.Number.isFinite;
+    export = isFinite;
+}
+declare module "core-js/fn/number/is-integer" {
+    var isInteger: typeof core.Number.isInteger;
+    export = isInteger;
+}
+declare module "core-js/fn/number/is-nan" {
+    var isNaN: typeof core.Number.isNaN;
+    export = isNaN;
+}
+declare module "core-js/fn/number/is-safe-integer" {
+    var isSafeInteger: typeof core.Number.isSafeInteger;
+    export = isSafeInteger;
+}
+declare module "core-js/fn/number/max-safe-integer" {
+    var MAX_SAFE_INTEGER: typeof core.Number.MAX_SAFE_INTEGER;
+    export = MAX_SAFE_INTEGER;
+}
+declare module "core-js/fn/number/min-safe-interger" {
+    var MIN_SAFE_INTEGER: typeof core.Number.MIN_SAFE_INTEGER;
+    export = MIN_SAFE_INTEGER;
+}
+declare module "core-js/fn/number/parse-float" {
+    var parseFloat: typeof core.Number.parseFloat;
+    export = parseFloat;
+}
+declare module "core-js/fn/number/parse-int" {
+    var parseInt: typeof core.Number.parseInt;
+    export = parseInt;
+}
+declare module "core-js/fn/number/random" {
+    var random: typeof core.Number.random;
+    export = random;
+}
+declare module "core-js/fn/object" {
+    var Object: typeof core.Object;
+    export = Object;
+}
+declare module "core-js/fn/object/assign" {
+    var assign: typeof core.Object.assign;
+    export = assign;
+}
+declare module "core-js/fn/object/classof" {
+    var classof: typeof core.Object.classof;
+    export = classof;
+}
+declare module "core-js/fn/object/create" {
+    var create: typeof core.Object.create;
+    export = create;
+}
+declare module "core-js/fn/object/define" {
+    var define: typeof core.Object.define;
+    export = define;
+}
+declare module "core-js/fn/object/define-properties" {
+    var defineProperties: typeof core.Object.defineProperties;
+    export = defineProperties;
+}
+declare module "core-js/fn/object/define-property" {
+    var defineProperty: typeof core.Object.defineProperty;
+    export = defineProperty;
+}
+declare module "core-js/fn/object/entries" {
+    var entries: typeof core.Object.entries;
+    export = entries;
+}
+declare module "core-js/fn/object/freeze" {
+    var freeze: typeof core.Object.freeze;
+    export = freeze;
+}
+declare module "core-js/fn/object/get-own-property-descriptor" {
+    var getOwnPropertyDescriptor: typeof core.Object.getOwnPropertyDescriptor;
+    export = getOwnPropertyDescriptor;
+}
+declare module "core-js/fn/object/get-own-property-descriptors" {
+    var getOwnPropertyDescriptors: typeof core.Object.getOwnPropertyDescriptors;
+    export = getOwnPropertyDescriptors;
+}
+declare module "core-js/fn/object/get-own-property-names" {
+    var getOwnPropertyNames: typeof core.Object.getOwnPropertyNames;
+    export = getOwnPropertyNames;
+}
+declare module "core-js/fn/object/get-own-property-symbols" {
+    var getOwnPropertySymbols: typeof core.Object.getOwnPropertySymbols;
+    export = getOwnPropertySymbols;
+}
+declare module "core-js/fn/object/get-prototype-of" {
+    var getPrototypeOf: typeof core.Object.getPrototypeOf;
+    export = getPrototypeOf;
+}
+declare module "core-js/fn/object/is" {
+    var is: typeof core.Object.is;
+    export = is;
+}
+declare module "core-js/fn/object/is-extensible" {
+    var isExtensible: typeof core.Object.isExtensible;
+    export = isExtensible;
+}
+declare module "core-js/fn/object/is-frozen" {
+    var isFrozen: typeof core.Object.isFrozen;
+    export = isFrozen;
+}
+declare module "core-js/fn/object/is-object" {
+    var isObject: typeof core.Object.isObject;
+    export = isObject;
+}
+declare module "core-js/fn/object/is-sealed" {
+    var isSealed: typeof core.Object.isSealed;
+    export = isSealed;
+}
+declare module "core-js/fn/object/keys" {
+    var keys: typeof core.Object.keys;
+    export = keys;
+}
+declare module "core-js/fn/object/make" {
+    var make: typeof core.Object.make;
+    export = make;
+}
+declare module "core-js/fn/object/prevent-extensions" {
+    var preventExtensions: typeof core.Object.preventExtensions;
+    export = preventExtensions;
+}
+declare module "core-js/fn/object/seal" {
+    var seal: typeof core.Object.seal;
+    export = seal;
+}
+declare module "core-js/fn/object/set-prototype-of" {
+    var setPrototypeOf: typeof core.Object.setPrototypeOf;
+    export = setPrototypeOf;
+}
+declare module "core-js/fn/object/values" {
+    var values: typeof core.Object.values;
+    export = values;
+}
+declare module "core-js/fn/reflect" {
+    var Reflect: typeof core.Reflect;
+    export = Reflect;
+}
+declare module "core-js/fn/reflect/apply" {
+    var apply: typeof core.Reflect.apply;
+    export = apply;
+}
+declare module "core-js/fn/reflect/construct" {
+    var construct: typeof core.Reflect.construct;
+    export = construct;
+}
+declare module "core-js/fn/reflect/define-property" {
+    var defineProperty: typeof core.Reflect.defineProperty;
+    export = defineProperty;
+}
+declare module "core-js/fn/reflect/delete-property" {
+    var deleteProperty: typeof core.Reflect.deleteProperty;
+    export = deleteProperty;
+}
+declare module "core-js/fn/reflect/enumerate" {
+    var enumerate: typeof core.Reflect.enumerate;
+    export = enumerate;
+}
+declare module "core-js/fn/reflect/get" {
+    var get: typeof core.Reflect.get;
+    export = get;
+}
+declare module "core-js/fn/reflect/get-own-property-descriptor" {
+    var getOwnPropertyDescriptor: typeof core.Reflect.getOwnPropertyDescriptor;
+    export = getOwnPropertyDescriptor;
+}
+declare module "core-js/fn/reflect/get-prototype-of" {
+    var getPrototypeOf: typeof core.Reflect.getPrototypeOf;
+    export = getPrototypeOf;
+}
+declare module "core-js/fn/reflect/has" {
+    var has: typeof core.Reflect.has;
+    export = has;
+}
+declare module "core-js/fn/reflect/is-extensible" {
+    var isExtensible: typeof core.Reflect.isExtensible;
+    export = isExtensible;
+}
+declare module "core-js/fn/reflect/own-keys" {
+    var ownKeys: typeof core.Reflect.ownKeys;
+    export = ownKeys;
+}
+declare module "core-js/fn/reflect/prevent-extensions" {
+    var preventExtensions: typeof core.Reflect.preventExtensions;
+    export = preventExtensions;
+}
+declare module "core-js/fn/reflect/set" {
+    var set: typeof core.Reflect.set;
+    export = set;
+}
+declare module "core-js/fn/reflect/set-prototype-of" {
+    var setPrototypeOf: typeof core.Reflect.setPrototypeOf;
+    export = setPrototypeOf;
+}
+declare module "core-js/fn/regexp" {
+    var RegExp: typeof core.RegExp;
+    export = RegExp;
+}
+declare module "core-js/fn/regexp/escape" {
+    var escape: typeof core.RegExp.escape;
+    export = escape;
+}
+declare module "core-js/fn/string" {
+    var String: typeof core.String;
+    export = String;
+}
+declare module "core-js/fn/string/at" {
+    var at: typeof core.String.at;
+    export = at;
+}
+declare module "core-js/fn/string/code-point-at" {
+    var codePointAt: typeof core.String.codePointAt;
+    export = codePointAt;
+}
+declare module "core-js/fn/string/ends-with" {
+    var endsWith: typeof core.String.endsWith;
+    export = endsWith;
+}
+declare module "core-js/fn/string/escape-html" {
+    var escapeHTML: typeof core.String.escapeHTML;
+    export = escapeHTML;
+}
+declare module "core-js/fn/string/from-code-point" {
+    var fromCodePoint: typeof core.String.fromCodePoint;
+    export = fromCodePoint;
+}
+declare module "core-js/fn/string/includes" {
+    var includes: typeof core.String.includes;
+    export = includes;
+}
+declare module "core-js/fn/string/lpad" {
+    var lpad: typeof core.String.lpad;
+    export = lpad;
+}
+declare module "core-js/fn/string/raw" {
+    var raw: typeof core.String.raw;
+    export = raw;
+}
+declare module "core-js/fn/string/repeat" {
+    var repeat: typeof core.String.repeat;
+    export = repeat;
+}
+declare module "core-js/fn/string/rpad" {
+    var rpad: typeof core.String.rpad;
+    export = rpad;
+}
+declare module "core-js/fn/string/starts-with" {
+    var startsWith: typeof core.String.startsWith;
+    export = startsWith;
+}
+declare module "core-js/fn/string/unescape-html" {
+    var unescapeHTML: typeof core.String.unescapeHTML;
+    export = unescapeHTML;
+}
+declare module "core-js/fn/symbol" {
+    var Symbol: typeof core.Symbol;
+    export = Symbol;
+}
+declare module "core-js/fn/symbol/for" {
+    var _for: typeof core.Symbol.for;
+    export = _for;
+}
+declare module "core-js/fn/symbol/has-instance" {
+    var hasInstance: typeof core.Symbol.hasInstance;
+    export = hasInstance;
+}
+declare module "core-js/fn/symbol/is-concat-spreadable" {
+    var isConcatSpreadable: typeof core.Symbol.isConcatSpreadable;
+    export = isConcatSpreadable;
+}
+declare module "core-js/fn/symbol/iterator" {
+    var iterator: typeof core.Symbol.iterator;
+    export = iterator;
+}
+declare module "core-js/fn/symbol/key-for" {
+    var keyFor: typeof core.Symbol.keyFor;
+    export = keyFor;
+}
+declare module "core-js/fn/symbol/match" {
+    var match: typeof core.Symbol.match;
+    export = match;
+}
+declare module "core-js/fn/symbol/replace" {
+    var replace: typeof core.Symbol.replace;
+    export = replace;
+}
+declare module "core-js/fn/symbol/search" {
+    var search: typeof core.Symbol.search;
+    export = search;
+}
+declare module "core-js/fn/symbol/species" {
+    var species: typeof core.Symbol.species;
+    export = species;
+}
+declare module "core-js/fn/symbol/split" {
+    var split: typeof core.Symbol.split;
+    export = split;
+}
+declare module "core-js/fn/symbol/to-primitive" {
+    var toPrimitive: typeof core.Symbol.toPrimitive;
+    export = toPrimitive;
+}
+declare module "core-js/fn/symbol/to-string-tag" {
+    var toStringTag: typeof core.Symbol.toStringTag;
+    export = toStringTag;
+}
+declare module "core-js/fn/symbol/unscopables" {
+    var unscopables: typeof core.Symbol.unscopables;
+    export = unscopables;
+}
+declare module "core-js/es5" {
+    export = core;
+}
+declare module "core-js/es6" {
+    export = core;
+}
+declare module "core-js/es6/array" {
+    var Array: typeof core.Array;
+    export = Array;
+}
+declare module "core-js/es6/function" {
+    var Function: typeof core.Function;
+    export = Function;
+}
+declare module "core-js/es6/map" {
+    var Map: typeof core.Map;
+    export = Map;
+}
+declare module "core-js/es6/math" {
+    var Math: typeof core.Math;
+    export = Math;
+}
+declare module "core-js/es6/number" {
+    var Number: typeof core.Number;
+    export = Number;
+}
+declare module "core-js/es6/object" {
+    var Object: typeof core.Object;
+    export = Object;
+}
+declare module "core-js/es6/promise" {
+    var Promise: typeof core.Promise;
+    export = Promise;
+}
+declare module "core-js/es6/reflect" {
+    var Reflect: typeof core.Reflect;
+    export = Reflect;
+}
+declare module "core-js/es6/regexp" {
+    var RegExp: typeof core.RegExp;
+    export = RegExp;
+}
+declare module "core-js/es6/set" {
+    var Set: typeof core.Set;
+    export = Set;
+}
+declare module "core-js/es6/string" {
+    var String: typeof core.String;
+    export = String;
+}
+declare module "core-js/es6/symbol" {
+    var Symbol: typeof core.Symbol;
+    export = Symbol;
+}
+declare module "core-js/es6/weak-map" {
+    var WeakMap: typeof core.WeakMap;
+    export = WeakMap;
+}
+declare module "core-js/es6/weak-set" {
+    var WeakSet: typeof core.WeakSet;
+    export = WeakSet;
+}
+declare module "core-js/es7" {
+    export = core;
+}
+declare module "core-js/es7/array" {
+    var Array: typeof core.Array;
+    export = Array;
+}
+declare module "core-js/es7/map" {
+    var Map: typeof core.Map;
+    export = Map;
+}
+declare module "core-js/es7/object" {
+    var Object: typeof core.Object;
+    export = Object;
+}
+declare module "core-js/es7/regexp" {
+    var RegExp: typeof core.RegExp;
+    export = RegExp;
+}
+declare module "core-js/es7/set" {
+    var Set: typeof core.Set;
+    export = Set;
+}
+declare module "core-js/es7/string" {
+    var String: typeof core.String;
+    export = String;
+}
+declare module "core-js/js" {
+    export = core;
+}
+declare module "core-js/js/array" {
+    var Array: typeof core.Array;
+    export = Array;
+}
+declare module "core-js/web" {
+    export = core;
+}
+declare module "core-js/web/dom" {
+    export = core;
+}
+declare module "core-js/web/immediate" {
+    export = core;
+}
+declare module "core-js/web/timers" {
+    export = core;
+}
+declare module "core-js/library" {
+    export = core;
+}
+declare module "core-js/library/shim" {
+    export = core;
+}
+declare module "core-js/library/core" {
+    export = core;
+}
+declare module "core-js/library/core/$for" {
+    import $for = core.$for;
+    export = $for;
+}
+declare module "core-js/library/core/_" {
+    var _: typeof core._;
+    export = _;
+}
+declare module "core-js/library/core/array" {
+    var Array: typeof core.Array;
+    export = Array;
+}
+declare module "core-js/library/core/date" {
+    var Date: typeof core.Date;
+    export = Date;
+}
+declare module "core-js/library/core/delay" {
+    var delay: typeof core.delay;
+    export = delay;
+}
+declare module "core-js/library/core/dict" {
+    var Dict: typeof core.Dict;
+    export = Dict;
+}
+declare module "core-js/library/core/function" {
+    var Function: typeof core.Function;
+    export = Function;
+}
+declare module "core-js/library/core/global" {
+    var global: typeof core.global;
+    export = global;
+}
+declare module "core-js/library/core/log" {
+    var log: typeof core.log;
+    export = log;
+}
+declare module "core-js/library/core/number" {
+    var Number: typeof core.Number;
+    export = Number;
+}
+declare module "core-js/library/core/object" {
+    var Object: typeof core.Object;
+    export = Object;
+}
+declare module "core-js/library/core/string" {
+    var String: typeof core.String;
+    export = String;
+}
+declare module "core-js/library/fn/$for" {
+    import $for = core.$for;
+    export = $for;
+}
+declare module "core-js/library/fn/_" {
+    var _: typeof core._;
+    export = _;
+}
+declare module "core-js/library/fn/clear-immediate" {
+    var clearImmediate: typeof core.clearImmediate;
+    export = clearImmediate;
+}
+declare module "core-js/library/fn/delay" {
+    var delay: typeof core.delay;
+    export = delay;
+}
+declare module "core-js/library/fn/dict" {
+    var Dict: typeof core.Dict;
+    export = Dict;
+}
+declare module "core-js/library/fn/get-iterator" {
+    var getIterator: typeof core.getIterator;
+    export = getIterator;
+}
+declare module "core-js/library/fn/global" {
+    var global: typeof core.global;
+    export = global;
+}
+declare module "core-js/library/fn/is-iterable" {
+    var isIterable: typeof core.isIterable;
+    export = isIterable;
+}
+declare module "core-js/library/fn/log" {
+    var log: typeof core.log;
+    export = log;
+}
+declare module "core-js/library/fn/map" {
+    var Map: typeof core.Map;
+    export = Map;
+}
+declare module "core-js/library/fn/promise" {
+    var Promise: typeof core.Promise;
+    export = Promise;
+}
+declare module "core-js/library/fn/set" {
+    var Set: typeof core.Set;
+    export = Set;
+}
+declare module "core-js/library/fn/set-immediate" {
+    var setImmediate: typeof core.setImmediate;
+    export = setImmediate;
+}
+declare module "core-js/library/fn/set-interval" {
+    var setInterval: typeof core.setInterval;
+    export = setInterval;
+}
+declare module "core-js/library/fn/set-timeout" {
+    var setTimeout: typeof core.setTimeout;
+    export = setTimeout;
+}
+declare module "core-js/library/fn/weak-map" {
+    var WeakMap: typeof core.WeakMap;
+    export = WeakMap;
+}
+declare module "core-js/library/fn/weak-set" {
+    var WeakSet: typeof core.WeakSet;
+    export = WeakSet;
+}
+declare module "core-js/library/fn/array" {
+    var Array: typeof core.Array;
+    export = Array;
+}
+declare module "core-js/library/fn/array/concat" {
+    var concat: typeof core.Array.concat;
+    export = concat;
+}
+declare module "core-js/library/fn/array/copy-within" {
+    var copyWithin: typeof core.Array.copyWithin;
+    export = copyWithin;
+}
+declare module "core-js/library/fn/array/entries" {
+    var entries: typeof core.Array.entries;
+    export = entries;
+}
+declare module "core-js/library/fn/array/every" {
+    var every: typeof core.Array.every;
+    export = every;
+}
+declare module "core-js/library/fn/array/fill" {
+    var fill: typeof core.Array.fill;
+    export = fill;
+}
+declare module "core-js/library/fn/array/filter" {
+    var filter: typeof core.Array.filter;
+    export = filter;
+}
+declare module "core-js/library/fn/array/find" {
+    var find: typeof core.Array.find;
+    export = find;
+}
+declare module "core-js/library/fn/array/find-index" {
+    var findIndex: typeof core.Array.findIndex;
+    export = findIndex;
+}
+declare module "core-js/library/fn/array/for-each" {
+    var forEach: typeof core.Array.forEach;
+    export = forEach;
+}
+declare module "core-js/library/fn/array/from" {
+    var from: typeof core.Array.from;
+    export = from;
+}
+declare module "core-js/library/fn/array/includes" {
+    var includes: typeof core.Array.includes;
+    export = includes;
+}
+declare module "core-js/library/fn/array/index-of" {
+    var indexOf: typeof core.Array.indexOf;
+    export = indexOf;
+}
+declare module "core-js/library/fn/array/join" {
+    var join: typeof core.Array.join;
+    export = join;
+}
+declare module "core-js/library/fn/array/keys" {
+    var keys: typeof core.Array.keys;
+    export = keys;
+}
+declare module "core-js/library/fn/array/last-index-of" {
+    var lastIndexOf: typeof core.Array.lastIndexOf;
+    export = lastIndexOf;
+}
+declare module "core-js/library/fn/array/map" {
+    var map: typeof core.Array.map;
+    export = map;
+}
+declare module "core-js/library/fn/array/of" {
+    var of: typeof core.Array.of;
+    export = of;
+}
+declare module "core-js/library/fn/array/pop" {
+    var pop: typeof core.Array.pop;
+    export = pop;
+}
+declare module "core-js/library/fn/array/push" {
+    var push: typeof core.Array.push;
+    export = push;
+}
+declare module "core-js/library/fn/array/reduce" {
+    var reduce: typeof core.Array.reduce;
+    export = reduce;
+}
+declare module "core-js/library/fn/array/reduce-right" {
+    var reduceRight: typeof core.Array.reduceRight;
+    export = reduceRight;
+}
+declare module "core-js/library/fn/array/reverse" {
+    var reverse: typeof core.Array.reverse;
+    export = reverse;
+}
+declare module "core-js/library/fn/array/shift" {
+    var shift: typeof core.Array.shift;
+    export = shift;
+}
+declare module "core-js/library/fn/array/slice" {
+    var slice: typeof core.Array.slice;
+    export = slice;
+}
+declare module "core-js/library/fn/array/some" {
+    var some: typeof core.Array.some;
+    export = some;
+}
+declare module "core-js/library/fn/array/sort" {
+    var sort: typeof core.Array.sort;
+    export = sort;
+}
+declare module "core-js/library/fn/array/splice" {
+    var splice: typeof core.Array.splice;
+    export = splice;
+}
+declare module "core-js/library/fn/array/turn" {
+    var turn: typeof core.Array.turn;
+    export = turn;
+}
+declare module "core-js/library/fn/array/unshift" {
+    var unshift: typeof core.Array.unshift;
+    export = unshift;
+}
+declare module "core-js/library/fn/array/values" {
+    var values: typeof core.Array.values;
+    export = values;
+}
+declare module "core-js/library/fn/date" {
+    var Date: typeof core.Date;
+    export = Date;
+}
+declare module "core-js/library/fn/date/add-locale" {
+    var addLocale: typeof core.addLocale;
+    export = addLocale;
+}
+declare module "core-js/library/fn/date/format" {
+    var format: typeof core.Date.format;
+    export = format;
+}
+declare module "core-js/library/fn/date/formatUTC" {
+    var formatUTC: typeof core.Date.formatUTC;
+    export = formatUTC;
+}
+declare module "core-js/library/fn/function" {
+    var Function: typeof core.Function;
+    export = Function;
+}
+declare module "core-js/library/fn/function/has-instance" {
+    var hasInstance: (value: any) => boolean;
+    export = hasInstance;
+}
+declare module "core-js/library/fn/function/name" {
+}
+declare module "core-js/library/fn/function/part" {
+    var part: typeof core.Function.part;
+    export = part;
+}
+declare module "core-js/library/fn/math" {
+    var Math: typeof core.Math;
+    export = Math;
+}
+declare module "core-js/library/fn/math/acosh" {
+    var acosh: typeof core.Math.acosh;
+    export = acosh;
+}
+declare module "core-js/library/fn/math/asinh" {
+    var asinh: typeof core.Math.asinh;
+    export = asinh;
+}
+declare module "core-js/library/fn/math/atanh" {
+    var atanh: typeof core.Math.atanh;
+    export = atanh;
+}
+declare module "core-js/library/fn/math/cbrt" {
+    var cbrt: typeof core.Math.cbrt;
+    export = cbrt;
+}
+declare module "core-js/library/fn/math/clz32" {
+    var clz32: typeof core.Math.clz32;
+    export = clz32;
+}
+declare module "core-js/library/fn/math/cosh" {
+    var cosh: typeof core.Math.cosh;
+    export = cosh;
+}
+declare module "core-js/library/fn/math/expm1" {
+    var expm1: typeof core.Math.expm1;
+    export = expm1;
+}
+declare module "core-js/library/fn/math/fround" {
+    var fround: typeof core.Math.fround;
+    export = fround;
+}
+declare module "core-js/library/fn/math/hypot" {
+    var hypot: typeof core.Math.hypot;
+    export = hypot;
+}
+declare module "core-js/library/fn/math/imul" {
+    var imul: typeof core.Math.imul;
+    export = imul;
+}
+declare module "core-js/library/fn/math/log10" {
+    var log10: typeof core.Math.log10;
+    export = log10;
+}
+declare module "core-js/library/fn/math/log1p" {
+    var log1p: typeof core.Math.log1p;
+    export = log1p;
+}
+declare module "core-js/library/fn/math/log2" {
+    var log2: typeof core.Math.log2;
+    export = log2;
+}
+declare module "core-js/library/fn/math/sign" {
+    var sign: typeof core.Math.sign;
+    export = sign;
+}
+declare module "core-js/library/fn/math/sinh" {
+    var sinh: typeof core.Math.sinh;
+    export = sinh;
+}
+declare module "core-js/library/fn/math/tanh" {
+    var tanh: typeof core.Math.tanh;
+    export = tanh;
+}
+declare module "core-js/library/fn/math/trunc" {
+    var trunc: typeof core.Math.trunc;
+    export = trunc;
+}
+declare module "core-js/library/fn/number" {
+    var Number: typeof core.Number;
+    export = Number;
+}
+declare module "core-js/library/fn/number/epsilon" {
+    var EPSILON: typeof core.Number.EPSILON;
+    export = EPSILON;
+}
+declare module "core-js/library/fn/number/is-finite" {
+    var isFinite: typeof core.Number.isFinite;
+    export = isFinite;
+}
+declare module "core-js/library/fn/number/is-integer" {
+    var isInteger: typeof core.Number.isInteger;
+    export = isInteger;
+}
+declare module "core-js/library/fn/number/is-nan" {
+    var isNaN: typeof core.Number.isNaN;
+    export = isNaN;
+}
+declare module "core-js/library/fn/number/is-safe-integer" {
+    var isSafeInteger: typeof core.Number.isSafeInteger;
+    export = isSafeInteger;
+}
+declare module "core-js/library/fn/number/max-safe-integer" {
+    var MAX_SAFE_INTEGER: typeof core.Number.MAX_SAFE_INTEGER;
+    export = MAX_SAFE_INTEGER;
+}
+declare module "core-js/library/fn/number/min-safe-interger" {
+    var MIN_SAFE_INTEGER: typeof core.Number.MIN_SAFE_INTEGER;
+    export = MIN_SAFE_INTEGER;
+}
+declare module "core-js/library/fn/number/parse-float" {
+    var parseFloat: typeof core.Number.parseFloat;
+    export = parseFloat;
+}
+declare module "core-js/library/fn/number/parse-int" {
+    var parseInt: typeof core.Number.parseInt;
+    export = parseInt;
+}
+declare module "core-js/library/fn/number/random" {
+    var random: typeof core.Number.random;
+    export = random;
+}
+declare module "core-js/library/fn/object" {
+    var Object: typeof core.Object;
+    export = Object;
+}
+declare module "core-js/library/fn/object/assign" {
+    var assign: typeof core.Object.assign;
+    export = assign;
+}
+declare module "core-js/library/fn/object/classof" {
+    var classof: typeof core.Object.classof;
+    export = classof;
+}
+declare module "core-js/library/fn/object/create" {
+    var create: typeof core.Object.create;
+    export = create;
+}
+declare module "core-js/library/fn/object/define" {
+    var define: typeof core.Object.define;
+    export = define;
+}
+declare module "core-js/library/fn/object/define-properties" {
+    var defineProperties: typeof core.Object.defineProperties;
+    export = defineProperties;
+}
+declare module "core-js/library/fn/object/define-property" {
+    var defineProperty: typeof core.Object.defineProperty;
+    export = defineProperty;
+}
+declare module "core-js/library/fn/object/entries" {
+    var entries: typeof core.Object.entries;
+    export = entries;
+}
+declare module "core-js/library/fn/object/freeze" {
+    var freeze: typeof core.Object.freeze;
+    export = freeze;
+}
+declare module "core-js/library/fn/object/get-own-property-descriptor" {
+    var getOwnPropertyDescriptor: typeof core.Object.getOwnPropertyDescriptor;
+    export = getOwnPropertyDescriptor;
+}
+declare module "core-js/library/fn/object/get-own-property-descriptors" {
+    var getOwnPropertyDescriptors: typeof core.Object.getOwnPropertyDescriptors;
+    export = getOwnPropertyDescriptors;
+}
+declare module "core-js/library/fn/object/get-own-property-names" {
+    var getOwnPropertyNames: typeof core.Object.getOwnPropertyNames;
+    export = getOwnPropertyNames;
+}
+declare module "core-js/library/fn/object/get-own-property-symbols" {
+    var getOwnPropertySymbols: typeof core.Object.getOwnPropertySymbols;
+    export = getOwnPropertySymbols;
+}
+declare module "core-js/library/fn/object/get-prototype-of" {
+    var getPrototypeOf: typeof core.Object.getPrototypeOf;
+    export = getPrototypeOf;
+}
+declare module "core-js/library/fn/object/is" {
+    var is: typeof core.Object.is;
+    export = is;
+}
+declare module "core-js/library/fn/object/is-extensible" {
+    var isExtensible: typeof core.Object.isExtensible;
+    export = isExtensible;
+}
+declare module "core-js/library/fn/object/is-frozen" {
+    var isFrozen: typeof core.Object.isFrozen;
+    export = isFrozen;
+}
+declare module "core-js/library/fn/object/is-object" {
+    var isObject: typeof core.Object.isObject;
+    export = isObject;
+}
+declare module "core-js/library/fn/object/is-sealed" {
+    var isSealed: typeof core.Object.isSealed;
+    export = isSealed;
+}
+declare module "core-js/library/fn/object/keys" {
+    var keys: typeof core.Object.keys;
+    export = keys;
+}
+declare module "core-js/library/fn/object/make" {
+    var make: typeof core.Object.make;
+    export = make;
+}
+declare module "core-js/library/fn/object/prevent-extensions" {
+    var preventExtensions: typeof core.Object.preventExtensions;
+    export = preventExtensions;
+}
+declare module "core-js/library/fn/object/seal" {
+    var seal: typeof core.Object.seal;
+    export = seal;
+}
+declare module "core-js/library/fn/object/set-prototype-of" {
+    var setPrototypeOf: typeof core.Object.setPrototypeOf;
+    export = setPrototypeOf;
+}
+declare module "core-js/library/fn/object/values" {
+    var values: typeof core.Object.values;
+    export = values;
+}
+declare module "core-js/library/fn/reflect" {
+    var Reflect: typeof core.Reflect;
+    export = Reflect;
+}
+declare module "core-js/library/fn/reflect/apply" {
+    var apply: typeof core.Reflect.apply;
+    export = apply;
+}
+declare module "core-js/library/fn/reflect/construct" {
+    var construct: typeof core.Reflect.construct;
+    export = construct;
+}
+declare module "core-js/library/fn/reflect/define-property" {
+    var defineProperty: typeof core.Reflect.defineProperty;
+    export = defineProperty;
+}
+declare module "core-js/library/fn/reflect/delete-property" {
+    var deleteProperty: typeof core.Reflect.deleteProperty;
+    export = deleteProperty;
+}
+declare module "core-js/library/fn/reflect/enumerate" {
+    var enumerate: typeof core.Reflect.enumerate;
+    export = enumerate;
+}
+declare module "core-js/library/fn/reflect/get" {
+    var get: typeof core.Reflect.get;
+    export = get;
+}
+declare module "core-js/library/fn/reflect/get-own-property-descriptor" {
+    var getOwnPropertyDescriptor: typeof core.Reflect.getOwnPropertyDescriptor;
+    export = getOwnPropertyDescriptor;
+}
+declare module "core-js/library/fn/reflect/get-prototype-of" {
+    var getPrototypeOf: typeof core.Reflect.getPrototypeOf;
+    export = getPrototypeOf;
+}
+declare module "core-js/library/fn/reflect/has" {
+    var has: typeof core.Reflect.has;
+    export = has;
+}
+declare module "core-js/library/fn/reflect/is-extensible" {
+    var isExtensible: typeof core.Reflect.isExtensible;
+    export = isExtensible;
+}
+declare module "core-js/library/fn/reflect/own-keys" {
+    var ownKeys: typeof core.Reflect.ownKeys;
+    export = ownKeys;
+}
+declare module "core-js/library/fn/reflect/prevent-extensions" {
+    var preventExtensions: typeof core.Reflect.preventExtensions;
+    export = preventExtensions;
+}
+declare module "core-js/library/fn/reflect/set" {
+    var set: typeof core.Reflect.set;
+    export = set;
+}
+declare module "core-js/library/fn/reflect/set-prototype-of" {
+    var setPrototypeOf: typeof core.Reflect.setPrototypeOf;
+    export = setPrototypeOf;
+}
+declare module "core-js/library/fn/regexp" {
+    var RegExp: typeof core.RegExp;
+    export = RegExp;
+}
+declare module "core-js/library/fn/regexp/escape" {
+    var escape: typeof core.RegExp.escape;
+    export = escape;
+}
+declare module "core-js/library/fn/string" {
+    var String: typeof core.String;
+    export = String;
+}
+declare module "core-js/library/fn/string/at" {
+    var at: typeof core.String.at;
+    export = at;
+}
+declare module "core-js/library/fn/string/code-point-at" {
+    var codePointAt: typeof core.String.codePointAt;
+    export = codePointAt;
+}
+declare module "core-js/library/fn/string/ends-with" {
+    var endsWith: typeof core.String.endsWith;
+    export = endsWith;
+}
+declare module "core-js/library/fn/string/escape-html" {
+    var escapeHTML: typeof core.String.escapeHTML;
+    export = escapeHTML;
+}
+declare module "core-js/library/fn/string/from-code-point" {
+    var fromCodePoint: typeof core.String.fromCodePoint;
+    export = fromCodePoint;
+}
+declare module "core-js/library/fn/string/includes" {
+    var includes: typeof core.String.includes;
+    export = includes;
+}
+declare module "core-js/library/fn/string/lpad" {
+    var lpad: typeof core.String.lpad;
+    export = lpad;
+}
+declare module "core-js/library/fn/string/raw" {
+    var raw: typeof core.String.raw;
+    export = raw;
+}
+declare module "core-js/library/fn/string/repeat" {
+    var repeat: typeof core.String.repeat;
+    export = repeat;
+}
+declare module "core-js/library/fn/string/rpad" {
+    var rpad: typeof core.String.rpad;
+    export = rpad;
+}
+declare module "core-js/library/fn/string/starts-with" {
+    var startsWith: typeof core.String.startsWith;
+    export = startsWith;
+}
+declare module "core-js/library/fn/string/unescape-html" {
+    var unescapeHTML: typeof core.String.unescapeHTML;
+    export = unescapeHTML;
+}
+declare module "core-js/library/fn/symbol" {
+    var Symbol: typeof core.Symbol;
+    export = Symbol;
+}
+declare module "core-js/library/fn/symbol/for" {
+    var _for: typeof core.Symbol.for;
+    export = _for;
+}
+declare module "core-js/library/fn/symbol/has-instance" {
+    var hasInstance: typeof core.Symbol.hasInstance;
+    export = hasInstance;
+}
+declare module "core-js/library/fn/symbol/is-concat-spreadable" {
+    var isConcatSpreadable: typeof core.Symbol.isConcatSpreadable;
+    export = isConcatSpreadable;
+}
+declare module "core-js/library/fn/symbol/iterator" {
+    var iterator: typeof core.Symbol.iterator;
+    export = iterator;
+}
+declare module "core-js/library/fn/symbol/key-for" {
+    var keyFor: typeof core.Symbol.keyFor;
+    export = keyFor;
+}
+declare module "core-js/library/fn/symbol/match" {
+    var match: typeof core.Symbol.match;
+    export = match;
+}
+declare module "core-js/library/fn/symbol/replace" {
+    var replace: typeof core.Symbol.replace;
+    export = replace;
+}
+declare module "core-js/library/fn/symbol/search" {
+    var search: typeof core.Symbol.search;
+    export = search;
+}
+declare module "core-js/library/fn/symbol/species" {
+    var species: typeof core.Symbol.species;
+    export = species;
+}
+declare module "core-js/library/fn/symbol/split" {
+    var split: typeof core.Symbol.split;
+    export = split;
+}
+declare module "core-js/library/fn/symbol/to-primitive" {
+    var toPrimitive: typeof core.Symbol.toPrimitive;
+    export = toPrimitive;
+}
+declare module "core-js/library/fn/symbol/to-string-tag" {
+    var toStringTag: typeof core.Symbol.toStringTag;
+    export = toStringTag;
+}
+declare module "core-js/library/fn/symbol/unscopables" {
+    var unscopables: typeof core.Symbol.unscopables;
+    export = unscopables;
+}
+declare module "core-js/library/es5" {
+    export = core;
+}
+declare module "core-js/library/es6" {
+    export = core;
+}
+declare module "core-js/library/es6/array" {
+    var Array: typeof core.Array;
+    export = Array;
+}
+declare module "core-js/library/es6/function" {
+    var Function: typeof core.Function;
+    export = Function;
+}
+declare module "core-js/library/es6/map" {
+    var Map: typeof core.Map;
+    export = Map;
+}
+declare module "core-js/library/es6/math" {
+    var Math: typeof core.Math;
+    export = Math;
+}
+declare module "core-js/library/es6/number" {
+    var Number: typeof core.Number;
+    export = Number;
+}
+declare module "core-js/library/es6/object" {
+    var Object: typeof core.Object;
+    export = Object;
+}
+declare module "core-js/library/es6/promise" {
+    var Promise: typeof core.Promise;
+    export = Promise;
+}
+declare module "core-js/library/es6/reflect" {
+    var Reflect: typeof core.Reflect;
+    export = Reflect;
+}
+declare module "core-js/library/es6/regexp" {
+    var RegExp: typeof core.RegExp;
+    export = RegExp;
+}
+declare module "core-js/library/es6/set" {
+    var Set: typeof core.Set;
+    export = Set;
+}
+declare module "core-js/library/es6/string" {
+    var String: typeof core.String;
+    export = String;
+}
+declare module "core-js/library/es6/symbol" {
+    var Symbol: typeof core.Symbol;
+    export = Symbol;
+}
+declare module "core-js/library/es6/weak-map" {
+    var WeakMap: typeof core.WeakMap;
+    export = WeakMap;
+}
+declare module "core-js/library/es6/weak-set" {
+    var WeakSet: typeof core.WeakSet;
+    export = WeakSet;
+}
+declare module "core-js/library/es7" {
+    export = core;
+}
+declare module "core-js/library/es7/array" {
+    var Array: typeof core.Array;
+    export = Array;
+}
+declare module "core-js/library/es7/map" {
+    var Map: typeof core.Map;
+    export = Map;
+}
+declare module "core-js/library/es7/object" {
+    var Object: typeof core.Object;
+    export = Object;
+}
+declare module "core-js/library/es7/regexp" {
+    var RegExp: typeof core.RegExp;
+    export = RegExp;
+}
+declare module "core-js/library/es7/set" {
+    var Set: typeof core.Set;
+    export = Set;
+}
+declare module "core-js/library/es7/string" {
+    var String: typeof core.String;
+    export = String;
+}
+declare module "core-js/library/js" {
+    export = core;
+}
+declare module "core-js/library/js/array" {
+    var Array: typeof core.Array;
+    export = Array;
+}
+declare module "core-js/library/web" {
+    export = core;
+}
+declare module "core-js/library/web/dom" {
+    export = core;
+}
+declare module "core-js/library/web/immediate" {
+    export = core;
+}
+declare module "core-js/library/web/timers" {
+    export = core;
+}

--- a/examples/browserify-typescript-gulp-example/src/typings/custom/pure-render-decorator.d.ts
+++ b/examples/browserify-typescript-gulp-example/src/typings/custom/pure-render-decorator.d.ts
@@ -1,0 +1,5 @@
+// Definitions by: Stephen Jelfs <https://github.com/stephenjelfs>
+
+declare module "pure-render-decorator" {
+    export default function pureRenderDecorator(component: any): void;
+}

--- a/examples/browserify-typescript-gulp-example/src/typings/custom/react-tap-event-plugin.d.ts
+++ b/examples/browserify-typescript-gulp-example/src/typings/custom/react-tap-event-plugin.d.ts
@@ -1,0 +1,5 @@
+// Definitions by: Stephen Jelfs <https://github.com/stephenjelfs>
+
+declare module "react-tap-event-plugin" {
+    export default function injectTapEventPlugin(): void;
+}

--- a/examples/browserify-typescript-gulp-example/src/typings/material-ui/material-ui.d.ts
+++ b/examples/browserify-typescript-gulp-example/src/typings/material-ui/material-ui.d.ts
@@ -1,0 +1,2347 @@
+// Type definitions for material-ui v0.13.1
+// Project: https://github.com/callemall/material-ui
+// Definitions by: Nathan Brown <https://github.com/ngbrown>, Oliver Herrmann <https://github.com/herrmanno>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+///<reference path='../react/react.d.ts' />
+
+declare module "material-ui" {
+    export import AppBar = __MaterialUI.AppBar; // require('material-ui/lib/app-bar');
+    export import AppCanvas = __MaterialUI.AppCanvas; // require('material-ui/lib/app-canvas');
+    export import Avatar = __MaterialUI.Avatar; // require('material-ui/lib/avatar');
+    export import Badge = __MaterialUI.Badge; // require('material-ui/lib/badge');
+    export import BeforeAfterWrapper = __MaterialUI.BeforeAfterWrapper; // require('material-ui/lib/before-after-wrapper');
+    export import Card = __MaterialUI.Card.Card; // require('material-ui/lib/card/card');
+    export import CardActions = __MaterialUI.Card.CardActions; // require('material-ui/lib/card/card-actions');
+    export import CardExpandable = __MaterialUI.Card.CardExpandable; // require('material-ui/lib/card/card-expandable');
+    export import CardHeader = __MaterialUI.Card.CardHeader; // require('material-ui/lib/card/card-header');
+    export import CardMedia = __MaterialUI.Card.CardMedia; // require('material-ui/lib/card/card-media');
+    export import CardText = __MaterialUI.Card.CardText; // require('material-ui/lib/card/card-text');
+    export import CardTitle = __MaterialUI.Card.CardTitle; // require('material-ui/lib/card/card-title');
+    export import Checkbox = __MaterialUI.Checkbox; // require('material-ui/lib/checkbox');
+    export import CircularProgress = __MaterialUI.CircularProgress; // require('material-ui/lib/circular-progress');
+    export import ClearFix = __MaterialUI.ClearFix; // require('material-ui/lib/clearfix');
+    export import DatePicker = __MaterialUI.DatePicker.DatePicker; // require('material-ui/lib/date-picker/date-picker');
+    export import DatePickerDialog = __MaterialUI.DatePicker.DatePickerDialog; // require('material-ui/lib/date-picker/date-picker-dialog');
+    export import Dialog = __MaterialUI.Dialog // require('material-ui/lib/dialog');
+    export import DropDownIcon = __MaterialUI.DropDownIcon; // require('material-ui/lib/drop-down-icon');
+    export import DropDownMenu = __MaterialUI.DropDownMenu; // require('material-ui/lib/drop-down-menu');
+    export import EnhancedButton = __MaterialUI.EnhancedButton; // require('material-ui/lib/enhanced-button');
+    export import FlatButton = __MaterialUI.FlatButton; // require('material-ui/lib/flat-button');
+    export import FloatingActionButton = __MaterialUI.FloatingActionButton; // require('material-ui/lib/floating-action-button');
+    export import FontIcon = __MaterialUI.FontIcon; // require('material-ui/lib/font-icon');
+    export import IconButton = __MaterialUI.IconButton; // require('material-ui/lib/icon-button');
+    export import IconMenu = __MaterialUI.Menus.IconMenu; // require('material-ui/lib/menus/icon-menu');
+    export import LeftNav = __MaterialUI.LeftNav; // require('material-ui/lib/left-nav');
+    export import LinearProgress = __MaterialUI.LinearProgress; // require('material-ui/lib/linear-progress');
+    export import List = __MaterialUI.Lists.List; // require('material-ui/lib/lists/list');
+    export import ListDivider = __MaterialUI.Lists.ListDivider; // require('material-ui/lib/lists/list-divider');
+    export import ListItem = __MaterialUI.Lists.ListItem; // require('material-ui/lib/lists/list-item');
+    export import Menu = __MaterialUI.Menu.Menu; // require('material-ui/lib/menu/menu');
+    export import MenuItem = __MaterialUI.Menu.MenuItem; // require('material-ui/lib/menu/menu-item');
+    export import Mixins = __MaterialUI.Mixins; // require('material-ui/lib/mixins/');
+    export import Overlay = __MaterialUI.Overlay; // require('material-ui/lib/overlay');
+    export import Paper = __MaterialUI.Paper; // require('material-ui/lib/paper');
+    export import RadioButton = __MaterialUI.RadioButton; // require('material-ui/lib/radio-button');
+    export import RadioButtonGroup = __MaterialUI.RadioButtonGroup; // require('material-ui/lib/radio-button-group');
+    export import RaisedButton = __MaterialUI.RaisedButton; // require('material-ui/lib/raised-button');
+    export import RefreshIndicator = __MaterialUI.RefreshIndicator; // require('material-ui/lib/refresh-indicator');
+    export import Ripples = __MaterialUI.Ripples; // require('material-ui/lib/ripples/');
+    export import SelectField = __MaterialUI.SelectField; // require('material-ui/lib/select-field');
+    export import Slider = __MaterialUI.Slider; // require('material-ui/lib/slider');
+    export import SvgIcon = __MaterialUI.SvgIcon; // require('material-ui/lib/svg-icon');
+    export import Icons = __MaterialUI.Icons;
+    export import Styles = __MaterialUI.Styles; // require('material-ui/lib/styles/');
+    export import Snackbar = __MaterialUI.Snackbar; // require('material-ui/lib/snackbar');
+    export import Tab = __MaterialUI.Tabs.Tab; // require('material-ui/lib/tabs/tab');
+    export import Tabs = __MaterialUI.Tabs.Tabs; // require('material-ui/lib/tabs/tabs');
+    export import Table = __MaterialUI.Table.Table; // require('material-ui/lib/table/table');
+    export import TableBody = __MaterialUI.Table.TableBody; // require('material-ui/lib/table/table-body');
+    export import TableFooter = __MaterialUI.Table.TableFooter; // require('material-ui/lib/table/table-footer');
+    export import TableHeader = __MaterialUI.Table.TableHeader; // require('material-ui/lib/table/table-header');
+    export import TableHeaderColumn = __MaterialUI.Table.TableHeaderColumn; // require('material-ui/lib/table/table-header-column');
+    export import TableRow = __MaterialUI.Table.TableRow; // require('material-ui/lib/table/table-row');
+    export import TableRowColumn = __MaterialUI.Table.TableRowColumn; // require('material-ui/lib/table/table-row-column');
+    export import ThemeWrapper = __MaterialUI.ThemeWrapper; // require('material-ui/lib/theme-wrapper');
+    export import Toggle = __MaterialUI.Toggle; // require('material-ui/lib/toggle');
+    export import TimePicker = __MaterialUI.TimePicker; // require('material-ui/lib/time-picker');
+    export import TextField = __MaterialUI.TextField; // require('material-ui/lib/text-field');
+    export import Toolbar = __MaterialUI.Toolbar.Toolbar; // require('material-ui/lib/toolbar/toolbar');
+    export import ToolbarGroup = __MaterialUI.Toolbar.ToolbarGroup; // require('material-ui/lib/toolbar/toolbar-group');
+    export import ToolbarSeparator = __MaterialUI.Toolbar.ToolbarSeparator; // require('material-ui/lib/toolbar/toolbar-separator');
+    export import ToolbarTitle = __MaterialUI.Toolbar.ToolbarTitle; // require('material-ui/lib/toolbar/toolbar-title');
+    export import Tooltip = __MaterialUI.Tooltip; // require('material-ui/lib/tooltip');
+    export import Utils = __MaterialUI.Utils; // require('material-ui/lib/utils/');
+    
+    export import GridList = __MaterialUI.GridList.GridList; // require('material-ui/lib/gridlist/grid-list');
+    export import GridTile = __MaterialUI.GridList.GridTile; // require('material-ui/lib/gridlist/grid-tile');
+
+    // export type definitions
+    export type TouchTapEvent = __MaterialUI.TouchTapEvent;
+    export type TouchTapEventHandler = __MaterialUI.TouchTapEventHandler;
+    export type DialogAction = __MaterialUI.DialogAction;
+}
+
+declare namespace __MaterialUI {
+    import React = __React;
+
+    // ReactLink is from "react/addons"
+    interface ReactLink<T> {
+        value: T;
+        requestChange(newValue: T): void;
+    }
+
+    // What's common between React.TouchEvent and React.MouseEvent
+    interface TouchTapEvent extends React.SyntheticEvent {
+        altKey: boolean;
+        ctrlKey: boolean;
+        getModifierState(key: string): boolean;
+        metaKey: boolean;
+        shiftKey: boolean;
+    }
+
+    // What's common between React.TouchEventHandler and React.MouseEventHandler
+    interface TouchTapEventHandler extends React.EventHandler<TouchTapEvent> { }
+
+    // more specific than React.HTMLAttributes
+
+    interface AppBarProps extends React.Props<AppBar> {
+        iconClassNameLeft?: string;
+        iconClassNameRight?: string;
+        iconElementLeft?: React.ReactElement<any>;
+        iconElementRight?: React.ReactElement<any>;
+        iconStyleRight?: string;
+        style?: React.CSSProperties;
+        showMenuIconButton?: boolean;
+        title?: React.ReactNode;
+        zDepth?: number;
+
+        onLeftIconButtonTouchTap?: TouchTapEventHandler;
+        onRightIconButtonTouchTap?: TouchTapEventHandler;
+    }
+    export class AppBar extends React.Component<AppBarProps, {}>{
+    }
+
+    interface AppCanvasProps extends React.Props<AppCanvas> {
+    }
+    export class AppCanvas extends React.Component<AppCanvasProps, {}> {
+    }
+
+    interface AvatarProps extends React.Props<Avatar> {
+        icon?: React.ReactElement<any>;
+        backgroundColor?: string;
+        color?: string;
+        size?: number;
+        src?: string;
+        style?: React.CSSProperties;
+    }
+    export class Avatar extends React.Component<AvatarProps, {}> {
+    }
+
+    interface BadgeProps extends React.Props<Badge> {
+        badgeContent: React.ReactElement<any> | string | number;
+        primary?: boolean;
+        secondary?: boolean;
+        style?: React.CSSProperties;
+        badgeStyle?: React.CSSProperties;
+    }
+    export class Badge extends React.Component<BadgeProps, {}> {
+    }
+
+    interface BeforeAfterWrapperProps extends React.Props<BeforeAfterWrapper> {
+        beforeStyle?: React.CSSProperties;
+        afterStyle?: React.CSSProperties;
+        beforeElementType?: string;
+        afterElementType?: string;
+        elementType?: string;
+    }
+    export class BeforeAfterWrapper extends React.Component<BeforeAfterWrapperProps, {}> {
+    }
+
+    namespace Card {
+
+        interface CardProps extends React.Props<Card> {
+            expandable?: boolean;
+            initiallyExpanded?: boolean;
+            onExpandedChange?: (isExpanded: boolean) => void;
+            style?: React.CSSProperties;
+        }
+        export class Card extends React.Component<CardProps, {}> {
+        }
+
+        interface CardActionsProps extends React.Props<CardActions> {
+            expandable?: boolean;
+            showExpandableButton?: boolean;
+            style?: React.CSSProperties;
+        }
+        export class CardActions extends React.Component<CardActionsProps, {}> {
+        }
+
+        interface CardExpandableProps extends React.Props<CardExpandable> {
+            onExpanding?: (isExpanded: boolean) => void;
+            expanded?: boolean;
+            style?: React.CSSProperties;
+        }
+        export class CardExpandable extends React.Component<CardExpandableProps, {}> {
+        }
+
+        interface CardHeaderProps extends React.Props<CardHeader> {
+            expandable?: boolean;
+            showExpandableButton?: boolean;
+            title?: string | React.ReactElement<any>;
+            titleColor?: string;
+            titleStyle?: React.CSSProperties;
+            subtitle?: string | React.ReactElement<any>;
+            subtitleColor?: string;
+            subtitleStyle?: React.CSSProperties;
+            textStyle?: React.CSSProperties;
+            style?: React.CSSProperties;
+            avatar: React.ReactElement<any> | string;
+        }
+        export class CardHeader extends React.Component<CardHeaderProps, {}> {
+        }
+
+        interface CardMediaProps extends React.Props<CardMedia> {
+            expandable?: boolean;
+            overlay?: React.ReactNode;
+            overlayStyle?: React.CSSProperties;
+            overlayContainerStyle?: React.CSSProperties;
+            overlayContentStyle?: React.CSSProperties;
+            mediaStyle?: React.CSSProperties;
+            style?: React.CSSProperties;
+        }
+        export class CardMedia extends React.Component<CardMediaProps, {}> {
+        }
+
+        interface CardTextProps extends React.Props<CardText> {
+            expandable?: boolean;
+            color?: string;
+            style?: React.CSSProperties;
+        }
+        export class CardText extends React.Component<CardTextProps, {}> {
+        }
+
+        interface CardTitleProps extends React.Props<CardTitle> {
+            expandable?: boolean;
+            showExpandableButton?: boolean;
+            title?: string | React.ReactElement<any>;
+            titleColor?: string;
+            titleStyle?: React.CSSProperties;
+            subtitle?: string | React.ReactElement<any>;
+            subtitleColor?: string;
+            subtitleStyle?: React.CSSProperties;
+            textStyle?: React.CSSProperties;
+            style?: React.CSSProperties;
+        }
+        export class CardTitle extends React.Component<CardTitleProps, {}> {
+        }
+    }
+
+    // what's not commonly overridden by Checkbox, RadioButton, or Toggle
+    interface CommonEnhancedSwitchProps<T> extends React.HTMLAttributes, React.Props<T> {
+        // <input/> is root element
+        id?: string;
+        iconStyle?: React.CSSProperties;
+        labelStyle?: React.CSSProperties;
+        rippleStyle?: React.CSSProperties;
+        thumbStyle?: React.CSSProperties;
+        trackStyle?: React.CSSProperties;
+        name?: string;
+        value?: string;
+        label?: string;
+        required?: boolean;
+        disabled?: boolean;
+        defaultSwitched?: boolean;
+        disableFocusRipple?: boolean;
+        disableTouchRipple?: boolean;
+    }
+
+    interface EnhancedSwitchProps extends CommonEnhancedSwitchProps<EnhancedSwitch> {
+        // <input/> is root element
+        inputType: string;
+        switchElement: React.ReactElement<any>;
+        onParentShouldUpdate: (isInputChecked: boolean) => void;
+        switched: boolean;
+        rippleColor?: string;
+        onSwitch?: (e: React.MouseEvent, isInputChecked: boolean) => void;
+        labelPosition?: string;
+    }
+    export class EnhancedSwitch extends React.Component<EnhancedSwitchProps, {}> {
+        isSwitched(): boolean;
+        setSwitched(newSwitchedValue: boolean): void;
+        getValue(): any;
+        isKeyboardFocused(): boolean;
+    }
+
+    interface CheckboxProps extends CommonEnhancedSwitchProps<Checkbox> {
+        // <EnhancedSwitch/> is root element
+        checkedIcon?: React.ReactElement<{ style?: React.CSSProperties }>; // Normally an SvgIcon
+        defaultChecked?: boolean;
+        iconStyle?: React.CSSProperties;
+        label?: string;
+        labelStyle?: React.CSSProperties;
+        labelPosition?: string;
+        style?: React.CSSProperties;
+        checked?: boolean;
+        unCheckedIcon?: React.ReactElement<{ style?: React.CSSProperties }>; // Normally an SvgIcon
+
+        disabled?: boolean;
+        valueLink?: ReactLink<boolean>;
+        checkedLink?: ReactLink<boolean>;
+
+        onCheck?: (event: React.MouseEvent, checked: boolean) => void;
+    }
+    export class Checkbox extends React.Component<CheckboxProps, {}> {
+        isChecked(): void;
+        setChecked(newCheckedValue: boolean): void;
+    }
+
+    interface CircularProgressProps extends React.Props<CircularProgress> {
+        mode?: string;
+        value?: number;
+        min?: number;
+        max?: number;
+        size?: number;
+        color?: string;
+        innerStyle?: React.CSSProperties;
+        style?: React.CSSProperties;
+
+    }
+    export class CircularProgress extends React.Component<CircularProgressProps, {}> {
+    }
+
+    interface ClearFixProps extends React.Props<ClearFix> {
+    }
+    export class ClearFix extends React.Component<ClearFixProps, {}> {
+    }
+
+    namespace DatePicker {
+        interface DatePickerProps extends React.Props<DatePicker> {
+            autoOk?: boolean;
+            defaultDate?: Date;
+            formatDate?: string;
+            hintText?: string;
+            floatingLabelText?: string;
+            hideToolbarYearChange?: boolean;
+            maxDate?: Date;
+            minDate?: Date;
+            mode?: string;
+            onDismiss?: () => void;
+
+            // e is always null
+            onChange?: (e: any, d: Date) => void;
+
+            onFocus?: React.FocusEventHandler;
+            onShow?: () => void;
+            onTouchTap?: React.TouchEventHandler;
+            shouldDisableDate?: (day: Date) => boolean;
+            showYearSelector?: boolean;
+            textFieldStyle?: React.CSSProperties;
+        }
+        export class DatePicker extends React.Component<DatePickerProps, {}> {
+        }
+
+        interface DatePickerDialogProps extends React.Props<DatePickerDialog> {
+            disableYearSelection?: boolean;
+            initialDate?: Date;
+            maxDate?: Date;
+            minDate?: Date;
+            onAccept?: (d: Date) => void;
+            onClickAway?: () => void;
+            onDismiss?: () => void;
+            onShow?: () => void;
+            shouldDisableDate?: (day: Date) => boolean;
+            showYearSelector?: boolean;
+        }
+        export class DatePickerDialog extends React.Component<DatePickerDialogProps, {}> {
+        }
+    }
+
+    export interface DialogAction {
+        id?: string;
+        text: string;
+        ref?: string;
+
+        onTouchTap?: TouchTapEventHandler;
+        onClick?: React.MouseEventHandler;
+    }
+    interface DialogProps extends React.Props<Dialog> {
+        actions?: Array<DialogAction | React.ReactElement<any>>;
+        actionFocus?: string;
+        autoDetectWindowHeight?: boolean;
+        autoScrollBodyContent?: boolean;
+        style?: React.CSSProperties;
+        bodyStyle?: React.CSSProperties;
+        contentClassName?: string;
+        contentInnerStyle?: React.CSSProperties;
+        contentStyle?: React.CSSProperties;
+        modal?: boolean;
+        openImmediately?: boolean;
+        repositionOnUpdate?: boolean;
+        title?: React.ReactNode;
+
+        onClickAway?: () => void;
+        onDismiss?: () => void;
+        onShow?: () => void;
+    }
+    export class Dialog extends React.Component<DialogProps, {}> {
+        dismiss(): void;
+        show(): void;
+    }
+
+    interface DropDownIconProps extends React.Props<DropDownIcon> {
+        menuItems: Menu.MenuItemRequest[];
+        closeOnMenuItemTouchTap?: boolean;
+        iconStyle?: React.CSSProperties;
+        iconClassName?: string;
+        iconLigature?: string;
+
+        onChange?: Menu.ItemTapEventHandler;
+    }
+    export class DropDownIcon extends React.Component<DropDownIconProps, {}> {
+    }
+
+    interface DropDownMenuProps extends React.Props<DropDownMenu> {
+        displayMember?: string;
+        valueMember?: string;
+        autoWidth?: boolean;
+        menuItems: Menu.MenuItemRequest[];
+        menuItemStyle?: React.CSSProperties;
+        selectedIndex?: number;
+        underlineStyle?: React.CSSProperties;
+        iconStyle?: React.CSSProperties;
+        labelStyle?: React.CSSProperties;
+        style?: React.CSSProperties;
+        disabled?: boolean;
+        valueLink?: ReactLink<any>;
+        value?: number;
+
+        onChange?: Menu.ItemTapEventHandler;
+    }
+    export class DropDownMenu extends React.Component<DropDownMenuProps, {}> {
+    }
+
+    // non generally overridden elements of EnhancedButton
+    interface SharedEnhancedButtonProps<T> extends React.HTMLAttributes, React.Props<T> {
+        centerRipple?: boolean;
+        containerElement?: string | React.ReactElement<any>;
+        disabled?: boolean;
+        disableFocusRipple?: boolean;
+        disableKeyboardFocus?: boolean;
+        disableTouchRipple?: boolean;
+        keyboardFocused?: boolean;
+        linkButton?: boolean;
+        focusRippleColor?: string;
+        focusRippleOpacity?: number;
+        touchRippleOpacity?: number;
+        tabIndex?: number;
+
+        onBlur?: React.FocusEventHandler;
+        onFocus?: React.FocusEventHandler;
+        onKeyboardFocus?: (e: React.FocusEvent, isKeyboardFocused: boolean) => void;
+        onKeyDown?: React.KeyboardEventHandler;
+        onKeyUp?: React.KeyboardEventHandler;
+        onMouseEnter?: React.MouseEventHandler;
+        onMouseLeave?: React.MouseEventHandler;
+        onTouchStart?: React.TouchEventHandler;
+        onTouchEnd?: React.TouchEventHandler;
+        onTouchTap?: TouchTapEventHandler;
+    }
+
+    interface EnhancedButtonProps extends SharedEnhancedButtonProps<EnhancedButton> {
+        touchRippleColor?: string;
+        focusRippleColor?: string;
+        style?: React.CSSProperties;
+    }
+    export class EnhancedButton extends React.Component<EnhancedButtonProps, {}> {
+    }
+
+    interface FlatButtonProps extends SharedEnhancedButtonProps<FlatButton> {
+        hoverColor?: string;
+        label?: string;
+        labelPosition?: string;
+        labelStyle?: React.CSSProperties;
+        linkButton?: boolean;
+        primary?: boolean;
+        secondary?: boolean;
+        rippleColor?: string;
+        style?: React.CSSProperties;
+    }
+    export class FlatButton extends React.Component<FlatButtonProps, {}> {
+    }
+
+    interface FloatingActionButtonProps extends SharedEnhancedButtonProps<FloatingActionButton> {
+        backgroundColor?: string;
+        disabled?: boolean;
+        disabledColor?: string;
+        iconClassName?: string;
+        iconStyle?: React.CSSProperties;
+        mini?: boolean;
+        secondary?: boolean;
+        style?: React.CSSProperties;
+    }
+    export class FloatingActionButton extends React.Component<FloatingActionButtonProps, {}> {
+    }
+
+    interface FontIconProps extends React.Props<FontIcon> {
+        color?: string;
+        hoverColor?: string;
+        onMouseLeave?: React.MouseEventHandler;
+        onMouseEnter?: React.MouseEventHandler;
+        style?: React.CSSProperties;
+        className?: string;
+    }
+    export class FontIcon extends React.Component<FontIconProps, {}> {
+    }
+
+    interface IconButtonProps extends SharedEnhancedButtonProps<IconButton> {
+        iconClassName?: string;
+        iconStyle?: React.CSSProperties;
+        style?: React.CSSProperties;
+        tooltip?: string;
+        tooltipPosition?: string;
+        tooltipStyles?: React.CSSProperties;
+        touch?: boolean;
+
+        onBlur?: React.FocusEventHandler;
+        onFocus?: React.FocusEventHandler;
+    }
+    export class IconButton extends React.Component<IconButtonProps, {}> {
+    }
+
+    interface LeftNavProps extends React.Props<LeftNav> {
+        disableSwipeToOpen?: boolean;
+        docked?: boolean;
+        header?: React.ReactElement<any>;
+        menuItems: Menu.MenuItemRequest[];
+        onChange?: Menu.ItemTapEventHandler;
+        onNavOpen?: () => void;
+        onNavClose?: () => void;
+        openRight?: Boolean;
+        selectedIndex?: number;
+        menuItemClassName?: string;
+        menuItemClassNameSubheader?: string;
+        menuItemClassNameLink?: string;
+        style?: React.CSSProperties;
+    }
+    export class LeftNav extends React.Component<LeftNavProps, {}> {
+    }
+
+    interface LinearProgressProps extends React.Props<LinearProgress> {
+        mode?: string;
+        value?: number;
+        min?: number;
+        max?: number;
+    }
+    export class LinearProgress extends React.Component<LinearProgressProps, {}> {
+    }
+
+    namespace Lists {
+        interface ListProps extends React.Props<List> {
+            insetSubheader?: boolean;
+            subheader?: string;
+            subheaderStyle?: React.CSSProperties;
+            zDepth?: number;
+            style?: React.CSSProperties;
+        }
+        export class List extends React.Component<ListProps, {}> {
+        }
+
+        interface ListDividerProps extends React.Props<ListDivider> {
+            inset?: boolean;
+        }
+        export class ListDivider extends React.Component<ListDividerProps, {}> {
+        }
+
+        interface ListItemProps extends React.Props<ListItem> {
+            autoGenerateNestedIndicator?: boolean;
+            disableKeyboardFocus?: boolean;
+            initiallyOpen?: boolean;
+            innerDivStyle?: React.CSSProperties;
+            insetChildren?: boolean;
+            innerStyle?: React.CSSProperties;
+            leftAvatar?: React.ReactElement<any>;
+            leftCheckbox?: React.ReactElement<any>;
+            leftIcon?: React.ReactElement<any>;
+            nestedLevel?: number;
+            nestedItems?: React.ReactElement<any>[];
+            onKeyboardFocus?: React.FocusEventHandler;
+            onNestedListToggle?: (item: ListItem) => void;
+            rightAvatar?: React.ReactElement<any>;
+            rightIcon?: React.ReactElement<any>;
+            rightIconButton?: React.ReactElement<any>;
+            rightToggle?: React.ReactElement<any>;
+            primaryText?: React.ReactNode;
+            secondaryText?: React.ReactNode;
+            secondaryTextLines?: number;
+            style?: React.CSSProperties;
+        }
+        export class ListItem extends React.Component<ListItemProps, {}> {
+        }
+    }
+
+    // Old menu implementation.  Being replaced by new "menus".
+    namespace Menu {
+        interface ItemTapEventHandler {
+            (e: TouchTapEvent, index: number, menuItem: MenuItemRequest): void;
+        }
+
+        // almost extends MenuItemProps, but certain required items are generated in Menu and not passed here.
+        interface MenuItemRequest extends React.Props<MenuItem> {
+            // use value from MenuItem.Types.*
+            type?: string;
+
+            text?: string;
+            data?: string;
+            payload?: string;
+            icon?: React.ReactElement<any>;
+            attribute?: string;
+            number?: string;
+            toggle?: boolean;
+            onTouchTap?: TouchTapEventHandler;
+            isDisabled?: boolean;
+            style?: React.CSSProperties;
+
+            // for MenuItems.Types.NESTED
+            items?: MenuItemRequest[];
+
+            // for custom text or payloads
+            [propertyName: string]: any;
+        }
+
+        interface MenuProps extends React.Props<Menu> {
+            index: number;
+            text?: string;
+            menuItems: MenuItemRequest[];
+            zDepth?: number;
+            active?: boolean;
+            onItemTap?: ItemTapEventHandler;
+            menuItemStyle?: React.CSSProperties;
+            style?: React.CSSProperties;
+        }
+        export class Menu extends React.Component<MenuProps, {}> {
+        }
+
+        interface MenuItemProps extends React.Props<MenuItem> {
+            index: number;
+            icon?: React.ReactElement<any>;
+            iconClassName?: string;
+            iconRightClassName?: string;
+            iconStyle?: React.CSSProperties;
+            iconRightStyle?: React.CSSProperties;
+            attribute?: string;
+            number?: string;
+            data?: string;
+            toggle?: boolean;
+            onTouchTap?: (e: React.MouseEvent, key: number) => void;
+            onToggle?: (e: React.MouseEvent, key: number, toggled: boolean) => void;
+            selected?: boolean;
+            active?: boolean;
+            style?: React.CSSProperties;
+        }
+        export class MenuItem extends React.Component<MenuItemProps, {}> {
+            static Types: { LINK: string, SUBHEADER: string, NESTED: string, }
+        }
+    }
+
+    export namespace Mixins {
+        interface ClickAwayable extends React.Mixin<any, any> {
+        }
+        var ClickAwayable: ClickAwayable;
+
+        interface WindowListenable extends React.Mixin<any, any> {
+        }
+        var WindowListenable: WindowListenable;
+
+        interface StylePropable extends React.Mixin<any, any> {
+        }
+        var StylePropable: StylePropable
+
+        interface StyleResizable extends React.Mixin<any, any> {
+        }
+        var StyleResizable: StyleResizable
+    }
+
+    interface OverlayProps extends React.Props<Overlay> {
+        autoLockScrolling?: boolean;
+        show?: boolean;
+        transitionEnabled?: boolean;
+    }
+    export class Overlay extends React.Component<OverlayProps, {}> {
+    }
+
+    interface PaperProps extends React.HTMLAttributes, React.Props<Paper> {
+        circle?: boolean;
+        rounded?: boolean;
+        transitionEnabled?: boolean;
+        zDepth?: number;
+    }
+    export class Paper extends React.Component<PaperProps, {}> {
+    }
+
+    interface RadioButtonProps extends CommonEnhancedSwitchProps<RadioButton> {
+        // <EnhancedSwitch/> is root element
+        defaultChecked?: boolean;
+        iconStyle?: React.CSSProperties;
+        label?: string;
+        labelStyle?: React.CSSProperties;
+        labelPosition?: string;
+        style?: React.CSSProperties;
+        value?: string;
+
+        onCheck?: (e: React.FormEvent, selected: string) => void;
+    }
+    export class RadioButton extends React.Component<RadioButtonProps, {}> {
+    }
+
+    interface RadioButtonGroupProps extends React.Props<RadioButtonGroup> {
+        defaultSelected?: string;
+        labelPosition?: string;
+        name: string;
+        style?: React.CSSProperties;
+        valueSelected?: string;
+
+        onChange?: (e: React.FormEvent, selected: string) => void;
+    }
+    export class RadioButtonGroup extends React.Component<RadioButtonGroupProps, {}> {
+        getSelectedValue(): string;
+        setSelectedValue(newSelectionValue: string): void;
+        clearValue(): void;
+    }
+
+    interface RaisedButtonProps extends SharedEnhancedButtonProps<RaisedButton> {
+        className?: string;
+        disabled?: boolean;
+        label?: string;
+        primary?: boolean;
+        secondary?: boolean;
+        labelStyle?: React.CSSProperties;
+        backgroundColor?: string;
+        labelColor?: string;
+        disabledBackgroundColor?: string;
+        disabledLabelColor?: string;
+        fullWidth?: boolean;
+    }
+    export class RaisedButton extends React.Component<RaisedButtonProps, {}> {
+    }
+
+    interface RefreshIndicatorProps extends React.Props<RefreshIndicator> {
+        left: number;
+        percentage?: number;
+        size?: number;
+        status?: string;
+        top: number;
+        style?: React.CSSProperties;
+    }
+    export class RefreshIndicator extends React.Component<RefreshIndicatorProps, {}> {
+    }
+
+    namespace Ripples {
+        interface CircleRippleProps extends React.Props<CircleRipple> {
+            color?: string;
+            opacity?: number;
+            style?: React.CSSProperties;
+        }
+        export class CircleRipple extends React.Component<CircleRippleProps, {}> {
+        }
+
+        interface FocusRippleProps extends React.Props<FocusRipple> {
+            color?: string;
+            style?: React.CSSProperties;
+            innerStyle?: React.CSSProperties;
+            opacity?: number;
+            show?: boolean;
+        }
+        export class FocusRipple extends React.Component<FocusRippleProps, {}> {
+        }
+
+        interface TouchRippleProps extends React.Props<TouchRipple> {
+            centerRipple?: boolean;
+            color?: string;
+            opacity?: number;
+            style?: React.CSSProperties;
+        }
+        export class TouchRipple extends React.Component<TouchRippleProps, {}> {
+        }
+    }
+
+    interface SelectFieldProps extends React.Props<SelectField> {
+        // passed to TextField
+        errorStyle?: React.CSSProperties;
+        errorText?: string;
+        floatingLabelText?: string;
+        floatingLabelStyle?: React.CSSProperties;
+        fullWidth?: boolean;
+        hintText?: string | React.ReactElement<any>;
+
+        // passed to DropDownMenu
+        displayMember?: string;
+        valueMember?: string;
+        autoWidth?: boolean;
+        menuItems: Menu.MenuItemRequest[];
+        menuItemStyle?: React.CSSProperties;
+        selectedIndex?: number;
+        underlineStyle?: React.CSSProperties;
+        iconStyle?: React.CSSProperties;
+        labelStyle?: React.CSSProperties;
+        style?: React.CSSProperties;
+        disabled?: boolean;
+        valueLink?: ReactLink<any>;
+        value?: number;
+
+        onChange?: Menu.ItemTapEventHandler;
+        onEnterKeyDown?: React.KeyboardEventHandler;
+
+        // own properties
+        selectFieldRoot?: string;
+        multiLine?: boolean;
+        type?: string;
+        rows?: number;
+        inputStyle?: React.CSSProperties;
+    }
+    export class SelectField extends React.Component<SelectFieldProps, {}> {
+    }
+
+    interface SliderProps extends React.Props<Slider> {
+        name: string;
+        defaultValue?: number;
+        description?: string;
+        error?: string;
+        max?: number;
+        min?: number;
+        required?: boolean;
+        step?: number;
+        value?: number;
+        style?: React.CSSProperties;
+    }
+    export class Slider extends React.Component<SliderProps, {}> {
+    }
+
+    interface SvgIconProps extends React.Props<SvgIcon> {
+        color?: string;
+        hoverColor?: string;
+        viewBox?: string;
+        style?: React.CSSProperties;
+    }
+    export class SvgIcon extends React.Component<SvgIconProps, {}> {
+    }
+
+    export namespace Icons {
+        export import NavigationMenu = __MaterialUI.NavigationMenu;
+        export import NavigationChevronLeft = __MaterialUI.NavigationChevronLeft;
+        export import NavigationChevronRight = __MaterialUI.NavigationChevronRight;
+    }
+
+    interface NavigationMenuProps extends React.Props<NavigationMenu> {
+    }
+    export class NavigationMenu extends React.Component<NavigationMenuProps, {}> {
+    }
+
+    interface NavigationChevronLeftProps extends React.Props<NavigationChevronLeft> {
+    }
+    export class NavigationChevronLeft extends React.Component<NavigationChevronLeftProps, {}> {
+    }
+
+    interface NavigationChevronRightProps extends React.Props<NavigationChevronRight> {
+    }
+    export class NavigationChevronRight extends React.Component<NavigationChevronRightProps, {}> {
+    }
+
+    export namespace Styles {
+        interface AutoPrefix {
+            all(styles: React.CSSProperties): React.CSSProperties;
+            set(style: React.CSSProperties, key: string, value: string | number): void;
+            single(key: string): string;
+            singleHyphened(key: string): string;
+        }
+        export var AutoPrefix: AutoPrefix;
+
+        interface Spacing {
+            iconSize?: number;
+
+            desktopGutter?: number;
+            desktopGutterMore?: number;
+            desktopGutterLess?: number;
+            desktopGutterMini?: number;
+            desktopKeylineIncrement?: number;
+            desktopDropDownMenuItemHeight?: number;
+            desktopDropDownMenuFontSize?: number;
+            desktopLeftNavMenuItemHeight?: number;
+            desktopSubheaderHeight?: number;
+            desktopToolbarHeight?: number;
+        }
+        interface ThemePalette {
+            primary1Color?: string;
+            primary2Color?: string;
+            primary3Color?: string;
+            accent1Color?: string;
+            accent2Color?: string;
+            accent3Color?: string;
+            textColor?: string;
+            canvasColor?: string;
+            borderColor?: string;
+            disabledColor?: string;
+            alternateTextColor?: string;
+        }
+        interface MuiTheme {
+            rawTheme: RawTheme;
+            static: boolean;
+            appBar?: {
+                color?: string,
+                textColor?: string,
+                height?: number
+            },
+            avatar?: {
+                borderColor?: string;
+            }
+            button?: {
+                height?: number,
+                minWidth?: number,
+                iconButtonSize?: number
+            },
+            checkbox?: {
+                boxColor?: string,
+                checkedColor?: string,
+                requiredColor?: string,
+                disabledColor?: string,
+                labelColor?: string,
+                labelDisabledColor?: string
+            },
+            datePicker?: {
+                color?: string,
+                textColor?: string,
+                calendarTextColor?: string,
+                selectColor?: string,
+                selectTextColor?: string,
+            },
+            dropDownMenu?: {
+                accentColor?: string,
+            },
+            flatButton?: {
+                color?: string,
+                textColor?: string,
+                primaryTextColor?: string,
+                secondaryTextColor?: string,
+                disabledColor?: string
+            },
+            floatingActionButton?: {
+                buttonSize?: number,
+                miniSize?: number,
+                color?: string,
+                iconColor?: string,
+                secondaryColor?: string,
+                secondaryIconColor?: string,
+                disabledColor?: string,
+                disabledTextColor?: string
+            },
+            inkBar?: {
+                backgroundColor?: string;
+            },
+            leftNav?: {
+                width?: number,
+                color?: string,
+            },
+            listItem?: {
+                nestedLevelDepth?: number;
+            },
+            menu?: {
+                backgroundColor?: string,
+                containerBackgroundColor?: string,
+            },
+            menuItem?: {
+                dataHeight?: number,
+                height?: number,
+                hoverColor?: string,
+                padding?: number,
+                selectedTextColor?: string,
+            },
+            menuSubheader?: {
+                padding?: number,
+                borderColor?: string,
+                textColor?: string,
+            },
+            paper?: {
+                backgroundColor?: string,
+            },
+            radioButton?: {
+                borderColor?: string,
+                backgroundColor?: string,
+                checkedColor?: string,
+                requiredColor?: string,
+                disabledColor?: string,
+                size?: number,
+                labelColor?: string,
+                labelDisabledColor?: string
+            },
+            raisedButton?: {
+                color?: string,
+                textColor?: string,
+                primaryColor?: string,
+                primaryTextColor?: string,
+                secondaryColor?: string,
+                secondaryTextColor?: string,
+                disabledColor?: string,
+                disabledTextColor?: string
+            },
+            refreshIndicator?: {
+                strokeColor?: string;
+                loadingStrokeColor?: string;
+            };
+            slider?: {
+                trackSize?: number,
+                trackColor?: string,
+                trackColorSelected?: string,
+                handleSize?: number,
+                handleSizeActive?: number,
+                handleSizeDisabled?: number,
+                handleColorZero?: string,
+                handleFillColor?: string,
+                selectionColor?: string,
+                rippleColor?: string,
+            },
+            snackbar?: {
+                textColor?: string,
+                backgroundColor?: string,
+                actionColor?: string,
+            },
+            table?: {
+                backgroundColor?: string;
+            };
+            tableHeader?: {
+                borderColor?: string;
+            };
+            tableHeaderColumn?: {
+                textColor?: string;
+            };
+            tableFooter?: {
+                borderColor?: string;
+                textColor?: string;
+            };
+            tableRow?: {
+                hoverColor?: string;
+                stripeColor?: string;
+                selectedColor?: string;
+                textColor?: string;
+                borderColor?: string;
+            };
+            tableRowColumn?: {
+                height?: number;
+                spacing?: number;
+            };
+            timePicker?: {
+                color?: string;
+                textColor?: string;
+                accentColor?: string;
+                clockColor?: string;
+                selectColor?: string;
+                selectTextColor?: string;
+            };
+            toggle?: {
+                thumbOnColor?: string,
+                thumbOffColor?: string,
+                thumbDisabledColor?: string,
+                thumbRequiredColor?: string,
+                trackOnColor?: string,
+                trackOffColor?: string,
+                trackDisabledColor?: string,
+                trackRequiredColor?: string,
+                labelColor?: string,
+                labelDisabledColor?: string
+            },
+            toolbar?: {
+                backgroundColor?: string,
+                height?: number,
+                titleFontSize?: number,
+                iconColor?: string,
+                separatorColor?: string,
+                menuHoverColor?: string,
+            };
+            tabs?: {
+                backgroundColor?: string;
+            };
+            textField?: {
+                textColor?: string;
+                hintColor?: string;
+                floatingLabelColor?: string;
+                disabledTextColor?: string;
+                errorColor?: string;
+                focusColor?: string;
+                backgroundColor?: string;
+                borderColor?: string;
+            };
+            isRtl: boolean;
+        }
+
+        interface RawTheme {
+            spacing: Spacing;
+            fontFamily?: string;
+            palette: ThemePalette;
+        }
+
+        export function ThemeDecorator(muiTheme: Styles.MuiTheme): <P>(Component: React.ComponentClass<P>) => React.ComponentClass<P>;
+
+        interface ThemeManager {
+            getMuiTheme(rawTheme: RawTheme): MuiTheme;
+            modifyRawThemeSpacing(muiTheme: MuiTheme, newSpacing: Spacing): MuiTheme;
+            modifyRawThemePalette(muiTheme: MuiTheme, newPaletteKeys: ThemePalette): MuiTheme;
+            modifyRawThemeFontFamily(muiTheme: MuiTheme, newFontFamily: string): MuiTheme;
+        }
+        export var ThemeManager: ThemeManager;
+
+        interface Transitions {
+            easeOut(duration?: string, property?: string | string[], delay?: string, easeFunction?: string): string;
+            create(duration?: string, property?: string, delay?: string, easeFunction?: string): string;
+            easeOutFunction: string;
+            easeInOutFunction: string;
+        }
+        export var Transitions: Transitions;
+
+        interface Typography {
+            textFullBlack: string;
+            textDarkBlack: string;
+            textLightBlack: string;
+            textMinBlack: string;
+            textFullWhite: string;
+            textDarkWhite: string;
+            textLightWhite: string;
+
+            // font weight
+            fontWeightLight: number;
+            fontWeightNormal: number;
+            fontWeightMedium: number;
+
+            fontStyleButtonFontSize: number;
+        }
+        export var Typography: Typography;
+
+        export var DarkRawTheme: RawTheme;
+        export var LightRawTheme: RawTheme;
+    }
+
+    interface SnackbarProps extends React.Props<Snackbar> {
+        message: string;
+        action?: string;
+        autoHideDuration?: number;
+        onActionTouchTap?: React.TouchEventHandler;
+        onShow?: () => void;
+        onDismiss?: () => void;
+        openOnMount?: boolean;
+        style?: React.CSSProperties;
+    }
+    export class Snackbar extends React.Component<SnackbarProps, {}> {
+    }
+
+    namespace Tabs {
+        interface TabProps extends React.Props<Tab> {
+            label?: string;
+            value?: string;
+            selected?: boolean;
+            width?: string;
+            style?: React.CSSProperties;
+
+            // Called by Tabs component
+            onActive?: (tab: Tab) => void;
+
+            onTouchTap?: (value: string, e: TouchTapEvent, tab: Tab) => void;
+        }
+        export class Tab extends React.Component<TabProps, {}> {
+        }
+
+        interface TabsProps extends React.Props<Tabs> {
+            contentContainerStyle?: React.CSSProperties;
+            initialSelectedIndex?: number;
+            inkBarStyle?: React.CSSProperties;
+            style?: React.CSSProperties;
+            tabItemContainerStyle?: React.CSSProperties;
+            tabWidth?: number;
+            value?: string | number;
+            tabTemplate?: __React.ComponentClass<any>;
+
+            onChange?: (value: string | number, e: React.FormEvent, tab: Tab) => void;
+        }
+        export class Tabs extends React.Component<TabsProps, {}> {
+        }
+    }
+
+    namespace Table {
+        interface TableProps extends React.Props<Table> {
+            allRowsSelected?: boolean;
+            fixedFooter?: boolean;
+            fixedHeader?: boolean;
+            height?: string;
+            multiSelectable?: boolean;
+            onCellClick?: (row: number, column: number) => void;
+            onCellHover?: (row: number, column: number) => void;
+            onCellHoverExit?: (row: number, column: number) => void;
+            onRowHover?: (row: number) => void;
+            onRowHoverExit?: (row: number) => void;
+            onRowSelection?: (selectedRows: number[]) => void;
+            selectable?: boolean;
+            style?: React.CSSProperties;
+        }
+        export class Table extends React.Component<TableProps, {}> {
+        }
+
+        interface TableBodyProps extends React.Props<TableBody> {
+            allRowsSelected?: boolean;
+            deselectOnClickaway?: boolean;
+            displayRowCheckbox?: boolean;
+            multiSelectable?: boolean;
+            onCellClick?: (row: number, column: number) => void;
+            onCellHover?: (row: number, column: number) => void;
+            onCellHoverExit?: (row: number, column: number) => void;
+            onRowHover?: (row: number) => void;
+            onRowHoverExit?: (row: number) => void;
+            onRowSelection?: (selectedRows: number[]) => void;
+            preScanRows?: boolean;
+            selectable?: boolean;
+            showRowHover?: boolean;
+            stripedRows?: boolean;
+            style?: React.CSSProperties;
+        }
+        export class TableBody extends React.Component<TableBodyProps, {}> {
+        }
+
+        interface TableFooterProps extends React.Props<TableFooter> {
+            adjustForCheckbox?: boolean;
+            style?: React.CSSProperties;
+        }
+        export class TableFooter extends React.Component<TableFooterProps, {}> {
+        }
+
+        interface TableHeaderProps extends React.Props<TableHeader> {
+            adjustForCheckbox?: boolean;
+            displaySelectAll?: boolean;
+            enableSelectAll?: boolean;
+            onSelectAll?: (event: React.MouseEvent) => void;
+            selectAllSelected?: boolean;
+            style?: React.CSSProperties;
+        }
+        export class TableHeader extends React.Component<TableHeaderProps, {}> {
+        }
+
+        interface TableHeaderColumnProps extends React.Props<TableHeaderColumn> {
+            columnNumber?: number;
+            onClick?: (e: React.MouseEvent, column: number) => void;
+            tooltip?: string;
+            tooltipStyle?: React.CSSProperties;
+            style?: React.CSSProperties;
+        }
+        export class TableHeaderColumn extends React.Component<TableHeaderColumnProps, {}> {
+        }
+
+        interface TableRowProps extends React.Props<TableRow> {
+            displayBorder?: boolean;
+            hoverable?: boolean;
+            onCellClick?: (e: React.MouseEvent, row: number, column: number) => void;
+            onCellHover?: (e: React.MouseEvent, row: number, column: number) => void;
+            onCellHoverExit?: (e: React.MouseEvent, row: number, column: number) => void;
+            onRowClick?: (e: React.MouseEvent, row: number) => void;
+            onRowHover?: (e: React.MouseEvent, row: number) => void;
+            onRowHoverExit?: (e: React.MouseEvent, row: number) => void;
+            rowNumber?: number;
+            selectable?: boolean;
+            selected?: boolean;
+            striped?: boolean;
+            style?: React.CSSProperties;
+        }
+        export class TableRow extends React.Component<TableRowProps, {}> {
+        }
+
+        interface TableRowColumnProps extends React.Props<TableRowColumn> {
+            columnNumber?: number;
+            hoverable?: boolean;
+            onHover?: (e: React.MouseEvent, column: number) => void;
+            onHoverExit?: (e: React.MouseEvent, column: number) => void;
+            style?: React.CSSProperties;
+        }
+        export class TableRowColumn extends React.Component<TableRowColumnProps, {}> {
+        }
+    }
+
+    interface ThemeWrapperProps extends React.Props<ThemeWrapper> {
+        theme: Styles.MuiTheme;
+    }
+    export class ThemeWrapper extends React.Component<ThemeWrapperProps, {}> {
+    }
+
+    interface ToggleProps extends CommonEnhancedSwitchProps<Toggle> {
+        // <EnhancedSwitch/> is root element
+
+        elementStyle?: React.CSSProperties;
+        labelStyle?: React.CSSProperties;
+        onToggle?: (e: React.MouseEvent, isInputChecked: boolean) => void;
+        toggled?: boolean;
+        defaultToggled?: boolean;
+    }
+    export class Toggle extends React.Component<ToggleProps, {}> {
+        isToggled(): boolean;
+        setToggled(newToggledValue: boolean): void;
+    }
+
+    interface TimePickerProps extends React.Props<TimePicker> {
+        defaultTime?: Date;
+        format?: string;
+        pedantic?: boolean;
+        style?: __React.CSSProperties;
+        textFieldStye?: __React.CSSProperties;
+        autoOk?: boolean;
+        openDialog?: () => void;
+        onFocus?: React.FocusEventHandler;
+        onTouchTap?: TouchTapEventHandler;
+        onChange?: (e: any, time: Date) => void;
+        onShow?: () => void;
+        onDismiss?: () => void;
+    }
+    export class TimePicker extends React.Component<TimePickerProps, {}> {
+    }
+
+    interface TextFieldProps extends React.Props<TextField> {
+        errorStyle?: React.CSSProperties;
+        errorText?: string;
+        floatingLabelText?: string;
+        floatingLabelStyle?: React.CSSProperties;
+        fullWidth?: boolean;
+        hintText?: string | React.ReactElement<any>;
+        id?: string;
+        inputStyle?: React.CSSProperties;
+        multiLine?: boolean;
+        onEnterKeyDown?: React.KeyboardEventHandler;
+        style?: React.CSSProperties;
+        rows?: number,
+        underlineStyle?: React.CSSProperties;
+        underlineFocusStyle?: React.CSSProperties;
+        underlineDisabledStyle?: React.CSSProperties;
+        type?: string;
+        hintStyle?: React.CSSProperties;
+
+        disabled?: boolean;
+        isRtl?: boolean;
+        value?: string;
+        defaultValue?: string;
+        valueLink?: ReactLink<string>;
+
+        onBlur?: React.FocusEventHandler;
+        onChange?: React.FormEventHandler;
+        onFocus?: React.FocusEventHandler;
+        onKeyDown?: React.KeyboardEventHandler;
+    }
+    export class TextField extends React.Component<TextFieldProps, {}> {
+        blur(): void;
+        clearValue(): void;
+        focus(): void;
+        getValue(): string;
+        setErrorText(newErrorText: string): void;
+        setValue(newValue: string): void;
+    }
+
+    namespace Toolbar {
+        interface ToolbarProps extends React.Props<Toolbar> {
+            style?: React.CSSProperties;
+        }
+        export class Toolbar extends React.Component<ToolbarProps, {}> {
+        }
+
+        interface ToolbarGroupProps extends React.Props<ToolbarGroup> {
+            float?: string;
+            style?: React.CSSProperties;
+        }
+        export class ToolbarGroup extends React.Component<ToolbarGroupProps, {}> {
+        }
+
+        interface ToolbarSeparatorProps extends React.Props<ToolbarSeparator> {
+            style?: React.CSSProperties;
+        }
+        export class ToolbarSeparator extends React.Component<ToolbarSeparatorProps, {}> {
+        }
+
+        interface ToolbarTitleProps extends React.HTMLAttributes, React.Props<ToolbarTitle> {
+            text?: string;
+            style?: React.CSSProperties;
+        }
+        export class ToolbarTitle extends React.Component<ToolbarTitleProps, {}> {
+        }
+    }
+
+    interface TooltipProps extends React.Props<Tooltip> {
+        label: string;
+        show?: boolean;
+        touch?: boolean;
+        verticalPosition?: string;
+        horizontalPosition?: string;
+    }
+    export class Tooltip extends React.Component<TooltipProps, {}> {
+    }
+
+    export namespace Utils {
+        interface ContrastLevel {
+            range: [number, number];
+            color: string;
+        }
+        interface ColorManipulator {
+            fade(color: string, amount: string | number): string;
+            lighten(color: string, amount: string | number): string;
+            darken(color: string, amount: string | number): string;
+            contrastRatio(background: string, foreground: string): number;
+            contrastRatioLevel(background: string, foreground: string): ContrastLevel;
+        }
+        export var ColorManipulator: ColorManipulator;
+
+        interface CssEvent {
+            transitionEndEventName(): string;
+            animationEndEventName(): string;
+            onTransitionEnd(el: Element, callback: () => void): void;
+            onAnimationEnd(el: Element, callback: () => void): void;
+        }
+        export var CssEvent: CssEvent;
+
+        interface Dom {
+            isDescendant(parent: Node, child: Node): boolean;
+            offset(el: Element): { top: number, left: number };
+            getStyleAttributeAsNumber(el: HTMLElement, attr: string): number;
+            addClass(el: Element, className: string): void;
+            removeClass(el: Element, className: string): void;
+            hasClass(el: Element, className: string): boolean;
+            toggleClass(el: Element, className: string): void;
+            forceRedraw(el: HTMLElement): void;
+            withoutTransition(el: HTMLElement, callback: () => void): void;
+        }
+        export var Dom: Dom;
+
+        interface Events {
+            once(el: Element, type: string, callback: EventListener): void;
+            on(el: Element, type: string, callback: EventListener): void;
+            off(el: Element, type: string, callback: EventListener): void;
+            isKeyboard(e: Event): boolean;
+        }
+        export var Events: Events;
+
+        function Extend<T, S1>(base: T, override: S1): (T & S1);
+
+        interface ImmutabilityHelper {
+            merge(base: any, ...args: any[]): any;
+            mergeItem(obj: any, key: any, newValueObject: any): any;
+            push(array: any[], obj: any): any[];
+            shift(array: any[]): any[];
+        }
+        export var ImmutabilityHelper: ImmutabilityHelper;
+
+        interface KeyCode {
+            DOWN: number;
+            ESC: number;
+            ENTER: number;
+            LEFT: number;
+            RIGHT: number;
+            SPACE: number;
+            TAB: number;
+            UP: number;
+        }
+        var KeyCode: KeyCode;
+
+        interface KeyLine {
+            Desktop: {
+                GUTTER: number;
+                GUTTER_LESS: number;
+                INCREMENT: number;
+                MENU_ITEM_HEIGHT: number;
+            };
+
+            getIncrementalDim(dim: number): number;
+        }
+        export var KeyLine: KeyLine;
+
+        interface UniqueId {
+            generate(): string;
+        }
+        export var UniqueId: UniqueId;
+
+        interface Styles {
+            mergeAndPrefix(base: any, ...args: any[]): React.CSSProperties;
+        }
+        export var Styles: Styles;
+    }
+
+    // New menus available only through requiring directly to the end file
+    namespace Menus {
+        interface IconMenuProps extends React.Props<IconMenu> {
+            closeOnItemTouchTap?: boolean;
+            desktop?: boolean;
+            iconButtonElement: React.ReactElement<IconButtonProps>;
+            openDirection?: string;
+            menuStyle?: React.CSSProperties;
+            multiple?: boolean;
+            value?: string | Array<string>;
+            width?: string | number;
+            touchTapCloseDelay?: number;
+            style?: React.CSSProperties;
+
+            onKeyboardFocus?: React.FocusEventHandler;
+            onItemTouchTap?: (e: TouchTapEvent, item: React.ReactElement<any>) => void;
+            onChange?: (e: React.FormEvent, value: string | Array<string>) => void;
+        }
+        export class IconMenu extends React.Component<IconMenuProps, {}> {
+        }
+
+        interface MenuProps extends React.Props<Menu> {
+            animated?: boolean;
+            autoWidth?: boolean;
+            desktop?: boolean;
+            listStyle?: React.CSSProperties;
+            maxHeight?: number;
+            multiple?: boolean;
+            openDirection?: string;
+            value?: string | Array<string>;
+            width?: string | number;
+            zDepth?: number;
+            style?: React.CSSProperties;
+        }
+        export class Menu extends React.Component<MenuProps, {}>{
+        }
+
+        interface MenuItemProps extends React.Props<MenuItem> {
+            checked?: boolean;
+            desktop?: boolean;
+            disabled?: boolean;
+            innerDivStyle?: React.CSSProperties;
+            insetChildren?: boolean;
+            leftIcon?: React.ReactElement<any>;
+            primaryText?: string | React.ReactElement<any>;
+            rightIcon?: React.ReactElement<any>;
+            secondaryText?: React.ReactNode;
+            value?: string;
+            style?: React.CSSProperties;
+
+            onEscKeyDown?: React.KeyboardEventHandler;
+            onItemTouchTap?: (e: TouchTapEvent, item: React.ReactElement<any>) => void;
+            onChange?: (e: React.FormEvent, value: string) => void;
+        }
+        export class MenuItem extends React.Component<MenuItemProps, {}>{
+        }
+
+        interface MenuDividerProps extends React.Props<MenuDivider> {
+            inset?: boolean;
+            style?: React.CSSProperties;
+        }
+        export class MenuDivider extends React.Component<MenuDividerProps, {}>{
+        }
+    }
+    
+    namespace GridList {
+        
+        interface GridListProps extends React.Props<GridList> {
+            cols?: number;
+            padding?: number;
+            cellHeight?: number;
+        }
+        
+        export class GridList extends React.Component<GridListProps, {}>{
+        }
+        
+        interface GridTileProps extends React.Props<GridTile> {
+            title?: string;
+            subtitle?: __React.ReactNode;
+            titlePosition?: string; //"top"|"bottom"
+            titleBackground?: string;
+            actionIcon?: __React.ReactElement<any>;
+            actionPosition?: string; //"left"|"right"
+            cols?: number;
+            rows?: number;
+            rootClass?: string | __React.Component<any,any>;
+        }
+        
+        export class GridTile extends React.Component<GridTileProps, {}>{
+        }
+        
+    }
+}    // __MaterialUI
+
+declare module 'material-ui/lib/app-bar' {
+    import AppBar = __MaterialUI.AppBar;
+    export = AppBar;
+}
+
+declare module 'material-ui/lib/app-canvas' {
+    import AppCanvas = __MaterialUI.AppCanvas;
+    export = AppCanvas;
+}
+
+declare module 'material-ui/lib/avatar' {
+    import Avatar = __MaterialUI.Avatar;
+    export = Avatar;
+}
+
+declare module "material-ui/lib/badge" {
+    import Badge = __MaterialUI.Badge;
+    export = Badge;
+}
+
+declare module 'material-ui/lib/before-after-wrapper' {
+    import BeforeAfterWrapper = __MaterialUI.BeforeAfterWrapper;
+    export = BeforeAfterWrapper;
+}
+
+declare module 'material-ui/lib/card/card' {
+    import Card = __MaterialUI.Card.Card;
+    export = Card;
+}
+
+declare module 'material-ui/lib/card/card-actions' {
+    import CardActions = __MaterialUI.Card.CardActions;
+    export = CardActions;
+}
+
+declare module 'material-ui/lib/card/card-expandable' {
+    import CardExpandable = __MaterialUI.Card.CardExpandable;
+    export = CardExpandable;
+}
+
+declare module 'material-ui/lib/card/card-header' {
+    import CardHeader = __MaterialUI.Card.CardHeader;
+    export = CardHeader;
+}
+
+declare module 'material-ui/lib/card/card-media' {
+    import CardMedia = __MaterialUI.Card.CardMedia;
+    export = CardMedia;
+}
+
+declare module 'material-ui/lib/card/card-text' {
+    import CardText = __MaterialUI.Card.CardText;
+    export = CardText;
+}
+
+declare module 'material-ui/lib/card/card-title' {
+    import CardTitle = __MaterialUI.Card.CardTitle;
+    export = CardTitle;
+}
+
+declare module 'material-ui/lib/checkbox' {
+    import Checkbox = __MaterialUI.Checkbox;
+    export = Checkbox;
+}
+
+declare module 'material-ui/lib/circular-progress' {
+    import CircularProgress = __MaterialUI.CircularProgress;
+    export = CircularProgress;
+}
+
+declare module 'material-ui/lib/clearfix' {
+    import ClearFix = __MaterialUI.ClearFix;
+    export = ClearFix;
+}
+
+declare module 'material-ui/lib/date-picker/date-picker' {
+    import DatePicker = __MaterialUI.DatePicker.DatePicker;
+    export = DatePicker;
+}
+
+declare module 'material-ui/lib/date-picker/date-picker-dialog' {
+    import DatePickerDialog = __MaterialUI.DatePicker.DatePickerDialog;
+    export = DatePickerDialog;
+}
+
+declare module 'material-ui/lib/dialog' {
+    import Dialog = __MaterialUI.Dialog;
+    export = Dialog;
+}
+
+declare module 'material-ui/lib/drop-down-icon' {
+    import DropDownIcon = __MaterialUI.DropDownIcon;
+    export = DropDownIcon;
+}
+
+declare module 'material-ui/lib/drop-down-menu' {
+    import DropDownMenu = __MaterialUI.DropDownMenu;
+    export = DropDownMenu;
+}
+
+declare module 'material-ui/lib/enhanced-button' {
+    import EnhancedButton = __MaterialUI.EnhancedButton;
+    export = EnhancedButton;
+}
+
+declare module 'material-ui/lib/flat-button' {
+    import FlatButton = __MaterialUI.FlatButton;
+    export = FlatButton;
+}
+
+declare module 'material-ui/lib/floating-action-button' {
+    import FloatingActionButton = __MaterialUI.FloatingActionButton;
+    export = FloatingActionButton;
+}
+
+declare module 'material-ui/lib/font-icon' {
+    import FontIcon = __MaterialUI.FontIcon;
+    export = FontIcon;
+}
+
+declare module 'material-ui/lib/icon-button' {
+    import IconButton = __MaterialUI.IconButton;
+    export = IconButton;
+}
+
+declare module 'material-ui/lib/left-nav' {
+    import LeftNav = __MaterialUI.LeftNav;
+    export = LeftNav;
+}
+
+declare module 'material-ui/lib/linear-progress' {
+    import LinearProgress = __MaterialUI.LinearProgress;
+    export = LinearProgress;
+}
+
+declare module 'material-ui/lib/lists/list' {
+    import List = __MaterialUI.Lists.List;
+    export = List;
+}
+
+declare module 'material-ui/lib/lists/list-divider' {
+    import ListDivider = __MaterialUI.Lists.ListDivider;
+    export = ListDivider;
+}
+
+declare module 'material-ui/lib/lists/list-item' {
+    import ListItem = __MaterialUI.Lists.ListItem;
+    export = ListItem;
+}
+
+declare module 'material-ui/lib/menu/menu' {
+    import Menu = __MaterialUI.Menu.Menu;
+    export = Menu;
+}
+
+declare module 'material-ui/lib/menu/menu-item' {
+    import MenuItem = __MaterialUI.Menu.MenuItem;
+    export = MenuItem;
+}
+
+declare module 'material-ui/lib/mixins/' {
+    export import ClickAwayable = __MaterialUI.Mixins.ClickAwayable; // require('material-ui/lib/mixins/click-awayable');
+    export import WindowListenable = __MaterialUI.Mixins.WindowListenable; // require('material-ui/lib/mixins/window-listenable');
+    export import StylePropable = __MaterialUI.Mixins.StylePropable; // require('material-ui/lib/mixins/style-propable');
+    export import StyleResizable = __MaterialUI.Mixins.StyleResizable; // require('material-ui/lib/mixins/style-resizable');
+}
+
+declare module 'material-ui/lib/mixins/click-awayable' {
+    import ClickAwayable = __MaterialUI.Mixins.ClickAwayable;
+    export = ClickAwayable;
+}
+
+declare module 'material-ui/lib/mixins/window-listenable' {
+    import WindowListenable = __MaterialUI.Mixins.WindowListenable;
+    export = WindowListenable;
+}
+
+declare module 'material-ui/lib/mixins/style-propable' {
+    import StylePropable = __MaterialUI.Mixins.StylePropable;
+    export = StylePropable;
+}
+
+declare module 'material-ui/lib/mixins/style-resizable' {
+    import StyleResizable = __MaterialUI.Mixins.StyleResizable;
+    export = StyleResizable;
+}
+
+declare module 'material-ui/lib/overlay' {
+    import Overlay = __MaterialUI.Overlay;
+    export = Overlay;
+}
+
+declare module 'material-ui/lib/paper' {
+    import Paper = __MaterialUI.Paper;
+    export = Paper;
+}
+
+declare module 'material-ui/lib/radio-button' {
+    import RadioButton = __MaterialUI.RadioButton;
+    export = RadioButton;
+}
+
+declare module 'material-ui/lib/radio-button-group' {
+    import RadioButtonGroup = __MaterialUI.RadioButtonGroup;
+    export = RadioButtonGroup;
+}
+
+declare module 'material-ui/lib/raised-button' {
+    import RaisedButton = __MaterialUI.RaisedButton;
+    export = RaisedButton;
+}
+
+declare module 'material-ui/lib/refresh-indicator' {
+    import RefreshIndicator = __MaterialUI.RefreshIndicator;
+    export = RefreshIndicator;
+}
+
+declare module 'material-ui/lib/ripples/' {
+    export import CircleRipple = __MaterialUI.Ripples.CircleRipple;
+    export import FocusRipple = __MaterialUI.Ripples.FocusRipple;
+    export import TouchRipple = __MaterialUI.Ripples.TouchRipple;
+}
+
+declare module 'material-ui/lib/select-field' {
+    import SelectField = __MaterialUI.SelectField;
+    export = SelectField;
+}
+
+declare module 'material-ui/lib/slider' {
+    import Slider = __MaterialUI.Slider;
+    export = Slider;
+}
+
+declare module 'material-ui/lib/svg-icon' {
+    import SvgIcon = __MaterialUI.SvgIcon;
+    export = SvgIcon;
+}
+
+declare module 'material-ui/lib/svg-icons/navigation/menu' {
+    import NavigationMenu = __MaterialUI.NavigationMenu;
+    export = NavigationMenu;
+}
+
+declare module 'material-ui/lib/svg-icons/navigation/chevron-left' {
+    import NavigationChevronLeft = __MaterialUI.NavigationChevronLeft;
+    export = NavigationChevronLeft;
+}
+
+declare module 'material-ui/lib/svg-icons/navigation/chevron-right' {
+    import NavigationChevronRight = __MaterialUI.NavigationChevronRight;
+    export = NavigationChevronRight;
+}
+
+declare module 'material-ui/lib/styles/' {
+    export import AutoPrefix = __MaterialUI.Styles.AutoPrefix; // require('material-ui/lib/styles/auto-prefix');
+    export import Colors = __MaterialUI.Styles.Colors; // require('material-ui/lib/styles/colors');
+    export import Spacing = require('material-ui/lib/styles/spacing');
+    export import ThemeManager = __MaterialUI.Styles.ThemeManager; // require('material-ui/lib/styles/theme-manager');
+    export import Transitions = __MaterialUI.Styles.Transitions; // require('material-ui/lib/styles/transitions');
+    export import Typography = __MaterialUI.Styles.Typography; // require('material-ui/lib/styles/typography');
+    export import LightRawTheme = __MaterialUI.Styles.LightRawTheme; // require('material-ui/lib/styles/raw-themes/light-raw-theme'),
+    export import DarkRawTheme = __MaterialUI.Styles.DarkRawTheme; // require('material-ui/lib/styles/raw-themes/dark-raw-theme'),
+    export import ThemeDecorator = __MaterialUI.Styles.ThemeDecorator; //require('material-ui/lib/styles/theme-decorator');
+}
+
+declare module 'material-ui/lib/styles/auto-prefix' {
+    import AutoPrefix = __MaterialUI.Styles.AutoPrefix;
+    export = AutoPrefix;
+}
+
+declare module 'material-ui/lib/styles/spacing' {
+    type Spacing = __MaterialUI.Styles.Spacing;
+    var Spacing: Spacing;
+    export = Spacing;
+}
+
+declare module 'material-ui/lib/styles/theme-manager' {
+    import ThemeManager = __MaterialUI.Styles.ThemeManager;
+    export = ThemeManager;
+}
+
+declare module 'material-ui/lib/styles/transitions' {
+    import Transitions = __MaterialUI.Styles.Transitions;
+    export = Transitions;
+}
+
+declare module 'material-ui/lib/styles/typography' {
+    import Typography = __MaterialUI.Styles.Typography;
+    export = Typography;
+}
+
+declare module 'material-ui/lib/styles/raw-themes/light-raw-theme' {
+    import LightRawTheme = __MaterialUI.Styles.LightRawTheme;
+    export = LightRawTheme;
+}
+
+declare module 'material-ui/lib/styles/raw-themes/dark-raw-theme' {
+    import DarkRawTheme = __MaterialUI.Styles.DarkRawTheme;
+    export = DarkRawTheme;
+}
+
+declare module 'material-ui/lib/styles/theme-decorator' {
+    import ThemeDecorator = __MaterialUI.Styles.ThemeDecorator;
+    export = ThemeDecorator;
+}
+
+
+declare module 'material-ui/lib/snackbar' {
+    import Snackbar = __MaterialUI.Snackbar;
+    export = Snackbar;
+}
+
+declare module 'material-ui/lib/tabs/tab' {
+    import Tab = __MaterialUI.Tabs.Tab;
+    export = Tab;
+}
+
+declare module 'material-ui/lib/tabs/tabs' {
+    import Tabs = __MaterialUI.Tabs.Tabs;
+    export = Tabs;
+}
+
+declare module 'material-ui/lib/table/table' {
+    import Table = __MaterialUI.Table.Table;
+    export = Table;
+}
+
+declare module 'material-ui/lib/table/table-body' {
+    import TableBody = __MaterialUI.Table.TableBody;
+    export = TableBody;
+}
+
+declare module 'material-ui/lib/table/table-footer' {
+    import TableFooter = __MaterialUI.Table.TableFooter;
+    export = TableFooter;
+}
+
+declare module 'material-ui/lib/table/table-header' {
+    import TableHeader = __MaterialUI.Table.TableHeader;
+    export = TableHeader;
+}
+
+declare module 'material-ui/lib/table/table-header-column' {
+    import TableHeaderColumn = __MaterialUI.Table.TableHeaderColumn;
+    export = TableHeaderColumn;
+}
+
+declare module 'material-ui/lib/table/table-row' {
+    import TableRow = __MaterialUI.Table.TableRow;
+    export = TableRow;
+}
+
+declare module 'material-ui/lib/table/table-row-column' {
+    import TableRowColumn = __MaterialUI.Table.TableRowColumn;
+    export = TableRowColumn;
+}
+
+declare module 'material-ui/lib/theme-wrapper' {
+    import ThemeWrapper = __MaterialUI.ThemeWrapper;
+    export = ThemeWrapper;
+}
+
+declare module 'material-ui/lib/toggle' {
+    import Toggle = __MaterialUI.Toggle;
+    export = Toggle;
+}
+
+declare module 'material-ui/lib/time-picker' {
+    import TimePicker = __MaterialUI.TimePicker;
+    export = TimePicker;
+}
+
+declare module 'material-ui/lib/text-field' {
+    import TextField = __MaterialUI.TextField;
+    export = TextField;
+}
+
+declare module 'material-ui/lib/toolbar/toolbar' {
+    import Toolbar = __MaterialUI.Toolbar.Toolbar;
+    export = Toolbar;
+}
+
+declare module 'material-ui/lib/toolbar/toolbar-group' {
+    import ToolbarGroup = __MaterialUI.Toolbar.ToolbarGroup;
+    export = ToolbarGroup;
+}
+
+declare module 'material-ui/lib/toolbar/toolbar-separator' {
+    import ToolbarSeparator = __MaterialUI.Toolbar.ToolbarSeparator;
+    export = ToolbarSeparator;
+}
+
+declare module 'material-ui/lib/toolbar/toolbar-title' {
+    import ToolbarTitle = __MaterialUI.Toolbar.ToolbarTitle;
+    export = ToolbarTitle;
+}
+
+declare module 'material-ui/lib/tooltip' {
+    import Tooltip = __MaterialUI.Tooltip;
+    export = Tooltip;
+}
+
+declare module 'material-ui/lib/utils/' {
+    export import ColorManipulator = __MaterialUI.Utils.ColorManipulator; // require('material-ui/lib/utils/color-manipulator');
+    export import CssEvent = __MaterialUI.Utils.CssEvent; // require('material-ui/lib/utils/css-event');
+    export import Dom = __MaterialUI.Utils.Dom; // require('material-ui/lib/utils/dom');
+    export import Events = __MaterialUI.Utils.Events; // require('material-ui/lib/utils/events');
+    export import Extend = __MaterialUI.Utils.Extend; // require('material-ui/lib/utils/extend');
+    export import ImmutabilityHelper = __MaterialUI.Utils.ImmutabilityHelper; // require('material-ui/lib/utils/immutability-helper');
+    export import KeyCode = __MaterialUI.Utils.KeyCode; // require('material-ui/lib/utils/key-code');
+    export import KeyLine = __MaterialUI.Utils.KeyLine; // require('material-ui/lib/utils/key-line');
+    export import UniqueId = __MaterialUI.Utils.UniqueId; // require('material-ui/lib/utils/unique-id');
+    export import Styles = __MaterialUI.Utils.Styles; // require('material-ui/lib/utils/styles');
+}
+
+declare module 'material-ui/lib/utils/color-manipulator' {
+    import ColorManipulator = __MaterialUI.Utils.ColorManipulator;
+    export = ColorManipulator;
+}
+
+declare module 'material-ui/lib/utils/css-event' {
+    import CssEvent = __MaterialUI.Utils.CssEvent;
+    export = CssEvent;
+}
+
+declare module 'material-ui/lib/utils/dom' {
+    import Dom = __MaterialUI.Utils.Dom;
+    export = Dom;
+}
+
+declare module 'material-ui/lib/utils/events' {
+    import Events = __MaterialUI.Utils.Events;
+    export = Events;
+}
+
+declare module 'material-ui/lib/utils/extend' {
+    import Extend = __MaterialUI.Utils.Extend;
+    export = Extend;
+}
+
+declare module 'material-ui/lib/utils/immutability-helper' {
+    import ImmutabilityHelper = __MaterialUI.Utils.ImmutabilityHelper;
+    export = ImmutabilityHelper;
+}
+
+declare module 'material-ui/lib/utils/key-code' {
+    import KeyCode = __MaterialUI.Utils.KeyCode;
+    export = KeyCode;
+}
+
+declare module 'material-ui/lib/utils/key-line' {
+    import KeyLine = __MaterialUI.Utils.KeyLine;
+    export = KeyLine;
+}
+
+declare module 'material-ui/lib/utils/unique-id' {
+    import UniqueId = __MaterialUI.Utils.UniqueId;
+    export = UniqueId;
+}
+
+declare module 'material-ui/lib/utils/styles' {
+    import Styles = __MaterialUI.Utils.Styles;
+    export = Styles;
+}
+
+declare module "material-ui/lib/menus/icon-menu" {
+    import IconMenu = __MaterialUI.Menus.IconMenu;
+    export = IconMenu;
+}
+
+declare module "material-ui/lib/menus/menu" {
+    import Menu = __MaterialUI.Menus.Menu;
+    export = Menu;
+}
+
+declare module "material-ui/lib/menus/menu-item" {
+    import MenuItem = __MaterialUI.Menus.MenuItem;
+    export = MenuItem;
+}
+
+declare module "material-ui/lib/menus/menu-divider" {
+    import MenuDivider = __MaterialUI.Menus.MenuDivider;
+    export = MenuDivider;
+}
+
+declare module "material-ui/lib/grid-list/grid-list" {
+    import GridList = __MaterialUI.GridList.GridList;
+    export = GridList;
+}
+
+declare module "material-ui/lib/grid-list/grid-tile" {
+    import GridTile = __MaterialUI.GridList.GridTile;
+    export = GridTile;
+}
+
+declare module "material-ui/lib/styles/colors" {
+    import Colors = __MaterialUI.Styles.Colors;
+    export = Colors;
+}
+
+declare namespace __MaterialUI.Styles {
+    interface Colors {
+        red50: string;
+        red100: string;
+        red200: string;
+        red300: string;
+        red400: string;
+        red500: string;
+        red600: string;
+        red700: string;
+        red800: string;
+        red900: string;
+        redA100: string;
+        redA200: string;
+        redA400: string;
+        redA700: string;
+
+        pink50: string;
+        pink100: string;
+        pink200: string;
+        pink300: string;
+        pink400: string;
+        pink500: string;
+        pink600: string;
+        pink700: string;
+        pink800: string;
+        pink900: string;
+        pinkA100: string;
+        pinkA200: string;
+        pinkA400: string;
+        pinkA700: string;
+
+        purple50: string;
+        purple100: string;
+        purple200: string;
+        purple300: string;
+        purple400: string;
+        purple500: string;
+        purple600: string;
+        purple700: string;
+        purple800: string;
+        purple900: string;
+        purpleA100: string;
+        purpleA200: string;
+        purpleA400: string;
+        purpleA700: string;
+
+        deepPurple50: string;
+        deepPurple100: string;
+        deepPurple200: string;
+        deepPurple300: string;
+        deepPurple400: string;
+        deepPurple500: string;
+        deepPurple600: string;
+        deepPurple700: string;
+        deepPurple800: string;
+        deepPurple900: string;
+        deepPurpleA100: string;
+        deepPurpleA200: string;
+        deepPurpleA400: string;
+        deepPurpleA700: string;
+
+        indigo50: string;
+        indigo100: string;
+        indigo200: string;
+        indigo300: string;
+        indigo400: string;
+        indigo500: string;
+        indigo600: string;
+        indigo700: string;
+        indigo800: string;
+        indigo900: string;
+        indigoA100: string;
+        indigoA200: string;
+        indigoA400: string;
+        indigoA700: string;
+
+        blue50: string;
+        blue100: string;
+        blue200: string;
+        blue300: string;
+        blue400: string;
+        blue500: string;
+        blue600: string;
+        blue700: string;
+        blue800: string;
+        blue900: string;
+        blueA100: string;
+        blueA200: string;
+        blueA400: string;
+        blueA700: string;
+
+        lightBlue50: string;
+        lightBlue100: string;
+        lightBlue200: string;
+        lightBlue300: string;
+        lightBlue400: string;
+        lightBlue500: string;
+        lightBlue600: string;
+        lightBlue700: string;
+        lightBlue800: string;
+        lightBlue900: string;
+        lightBlueA100: string;
+        lightBlueA200: string;
+        lightBlueA400: string;
+        lightBlueA700: string;
+
+        cyan50: string;
+        cyan100: string;
+        cyan200: string;
+        cyan300: string;
+        cyan400: string;
+        cyan500: string;
+        cyan600: string;
+        cyan700: string;
+        cyan800: string;
+        cyan900: string;
+        cyanA100: string;
+        cyanA200: string;
+        cyanA400: string;
+        cyanA700: string;
+
+        teal50: string;
+        teal100: string;
+        teal200: string;
+        teal300: string;
+        teal400: string;
+        teal500: string;
+        teal600: string;
+        teal700: string;
+        teal800: string;
+        teal900: string;
+        tealA100: string;
+        tealA200: string;
+        tealA400: string;
+        tealA700: string;
+
+        green50: string;
+        green100: string;
+        green200: string;
+        green300: string;
+        green400: string;
+        green500: string;
+        green600: string;
+        green700: string;
+        green800: string;
+        green900: string;
+        greenA100: string;
+        greenA200: string;
+        greenA400: string;
+        greenA700: string;
+
+        lightGreen50: string;
+        lightGreen100: string;
+        lightGreen200: string;
+        lightGreen300: string;
+        lightGreen400: string;
+        lightGreen500: string;
+        lightGreen600: string;
+        lightGreen700: string;
+        lightGreen800: string;
+        lightGreen900: string;
+        lightGreenA100: string;
+        lightGreenA200: string;
+        lightGreenA400: string;
+        lightGreenA700: string;
+
+        lime50: string;
+        lime100: string;
+        lime200: string;
+        lime300: string;
+        lime400: string;
+        lime500: string;
+        lime600: string;
+        lime700: string;
+        lime800: string;
+        lime900: string;
+        limeA100: string;
+        limeA200: string;
+        limeA400: string;
+        limeA700: string;
+
+        yellow50: string;
+        yellow100: string;
+        yellow200: string;
+        yellow300: string;
+        yellow400: string;
+        yellow500: string;
+        yellow600: string;
+        yellow700: string;
+        yellow800: string;
+        yellow900: string;
+        yellowA100: string;
+        yellowA200: string;
+        yellowA400: string;
+        yellowA700: string;
+
+        amber50: string;
+        amber100: string;
+        amber200: string;
+        amber300: string;
+        amber400: string;
+        amber500: string;
+        amber600: string;
+        amber700: string;
+        amber800: string;
+        amber900: string;
+        amberA100: string;
+        amberA200: string;
+        amberA400: string;
+        amberA700: string;
+
+        orange50: string;
+        orange100: string;
+        orange200: string;
+        orange300: string;
+        orange400: string;
+        orange500: string;
+        orange600: string;
+        orange700: string;
+        orange800: string;
+        orange900: string;
+        orangeA100: string;
+        orangeA200: string;
+        orangeA400: string;
+        orangeA700: string;
+
+        deepOrange50: string;
+        deepOrange100: string;
+        deepOrange200: string;
+        deepOrange300: string;
+        deepOrange400: string;
+        deepOrange500: string;
+        deepOrange600: string;
+        deepOrange700: string;
+        deepOrange800: string;
+        deepOrange900: string;
+        deepOrangeA100: string;
+        deepOrangeA200: string;
+        deepOrangeA400: string;
+        deepOrangeA700: string;
+
+        brown50: string;
+        brown100: string;
+        brown200: string;
+        brown300: string;
+        brown400: string;
+        brown500: string;
+        brown600: string;
+        brown700: string;
+        brown800: string;
+        brown900: string;
+
+        blueGrey50: string;
+        blueGrey100: string;
+        blueGrey200: string;
+        blueGrey300: string;
+        blueGrey400: string;
+        blueGrey500: string;
+        blueGrey600: string;
+        blueGrey700: string;
+        blueGrey800: string;
+        blueGrey900: string;
+
+        grey50: string;
+        grey100: string;
+        grey200: string;
+        grey300: string;
+        grey400: string;
+        grey500: string;
+        grey600: string;
+        grey700: string;
+        grey800: string;
+        grey900: string;
+
+        black: string;
+        white: string;
+
+        transparent: string;
+        fullBlack: string;
+        darkBlack: string;
+        lightBlack: string;
+        minBlack: string;
+        faintBlack: string;
+        fullWhite: string;
+        darkWhite: string;
+        lightWhite: string;
+    }
+    export var Colors: Colors;
+}

--- a/examples/browserify-typescript-gulp-example/src/typings/react/react-dom.d.ts
+++ b/examples/browserify-typescript-gulp-example/src/typings/react/react-dom.d.ts
@@ -1,0 +1,66 @@
+// Type definitions for React v0.14 (react-dom)
+// Project: http://facebook.github.io/react/
+// Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="react.d.ts" />
+
+declare namespace __React {
+    namespace __DOM {
+        function findDOMNode<E extends Element>(instance: ReactInstance): E;
+        function findDOMNode(instance: ReactInstance): Element;
+
+        function render<P>(
+            element: DOMElement<P>,
+            container: Element,
+            callback?: (element: Element) => any): Element;
+        function render<P, S>(
+            element: ClassicElement<P>,
+            container: Element,
+            callback?: (component: ClassicComponent<P, S>) => any): ClassicComponent<P, S>;
+        function render<P, S>(
+            element: ReactElement<P>,
+            container: Element,
+            callback?: (component: Component<P, S>) => any): Component<P, S>;
+
+        function unmountComponentAtNode(container: Element): boolean;
+
+        var version: string;
+
+        function unstable_batchedUpdates<A, B>(callback: (a: A, b: B) => any, a: A, b: B): void;
+        function unstable_batchedUpdates<A>(callback: (a: A) => any, a: A): void;
+        function unstable_batchedUpdates(callback: () => any): void;
+
+        function unstable_renderSubtreeIntoContainer<P>(
+            parentComponent: Component<any, any>,
+            nextElement: DOMElement<P>,
+            container: Element,
+            callback?: (element: Element) => any): Element;
+        function unstable_renderSubtreeIntoContainer<P, S>(
+            parentComponent: Component<any, any>,
+            nextElement: ClassicElement<P>,
+            container: Element,
+            callback?: (component: ClassicComponent<P, S>) => any): ClassicComponent<P, S>;
+        function unstable_renderSubtreeIntoContainer<P, S>(
+            parentComponent: Component<any, any>,
+            nextElement: ReactElement<P>,
+            container: Element,
+            callback?: (component: Component<P, S>) => any): Component<P, S>;
+    }
+
+    namespace __DOMServer {
+        function renderToString(element: ReactElement<any>): string;
+        function renderToStaticMarkup(element: ReactElement<any>): string;
+        var version: string;
+    }
+}
+
+declare module "react-dom" {
+    import DOM = __React.__DOM;
+    export = DOM;
+}
+
+declare module "react-dom/server" {
+    import DOMServer = __React.__DOMServer;
+    export = DOMServer;
+}

--- a/examples/browserify-typescript-gulp-example/src/typings/react/react.d.ts
+++ b/examples/browserify-typescript-gulp-example/src/typings/react/react.d.ts
@@ -1,0 +1,2263 @@
+// Type definitions for React v0.14
+// Project: http://facebook.github.io/react/
+// Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare namespace __React {
+    //
+    // React Elements
+    // ----------------------------------------------------------------------
+
+    type ReactType = string | ComponentClass<any> | StatelessComponent<any>;
+
+    interface ReactElement<P extends Props<any>> {
+        type: string | ComponentClass<P> | StatelessComponent<P>;
+        props: P;
+        key: string | number;
+        ref: string | ((component: Component<P, any> | Element) => any);
+    }
+
+    interface ClassicElement<P> extends ReactElement<P> {
+        type: ClassicComponentClass<P>;
+        ref: string | ((component: ClassicComponent<P, any>) => any);
+    }
+
+    interface DOMElement<P extends Props<Element>> extends ReactElement<P> {
+        type: string;
+        ref: string | ((element: Element) => any);
+    }
+
+    interface ReactHTMLElement extends DOMElement<HTMLProps<HTMLElement>> {
+        ref: string | ((element: HTMLElement) => any);
+    }
+
+    interface ReactSVGElement extends DOMElement<SVGProps> {
+        ref: string | ((element: SVGElement) => any);
+    }
+
+    //
+    // Factories
+    // ----------------------------------------------------------------------
+
+    interface Factory<P> {
+        (props?: P, ...children: ReactNode[]): ReactElement<P>;
+    }
+
+    interface ClassicFactory<P> extends Factory<P> {
+        (props?: P, ...children: ReactNode[]): ClassicElement<P>;
+    }
+
+    interface DOMFactory<P extends Props<Element>> extends Factory<P> {
+        (props?: P, ...children: ReactNode[]): DOMElement<P>;
+    }
+
+    type HTMLFactory = DOMFactory<HTMLProps<HTMLElement>>;
+    type SVGFactory = DOMFactory<SVGProps>;
+
+    //
+    // React Nodes
+    // http://facebook.github.io/react/docs/glossary.html
+    // ----------------------------------------------------------------------
+
+    type ReactText = string | number;
+    type ReactChild = ReactElement<any> | ReactText;
+
+    // Should be Array<ReactNode> but type aliases cannot be recursive
+    type ReactFragment = {} | Array<ReactChild | any[] | boolean>;
+    type ReactNode = ReactChild | ReactFragment | boolean;
+
+    //
+    // Top Level API
+    // ----------------------------------------------------------------------
+
+    function createClass<P, S>(spec: ComponentSpec<P, S>): ClassicComponentClass<P>;
+
+    function createFactory<P>(type: string): DOMFactory<P>;
+    function createFactory<P>(type: ClassicComponentClass<P>): ClassicFactory<P>;
+    function createFactory<P>(type: ComponentClass<P> | StatelessComponent<P>): Factory<P>;
+
+    function createElement<P>(
+        type: string,
+        props?: P,
+        ...children: ReactNode[]): DOMElement<P>;
+    function createElement<P>(
+        type: ClassicComponentClass<P>,
+        props?: P,
+        ...children: ReactNode[]): ClassicElement<P>;
+    function createElement<P>(
+        type: ComponentClass<P> | StatelessComponent<P>,
+        props?: P,
+        ...children: ReactNode[]): ReactElement<P>;
+
+    function cloneElement<P>(
+        element: DOMElement<P>,
+        props?: P,
+        ...children: ReactNode[]): DOMElement<P>;
+    function cloneElement<P>(
+        element: ClassicElement<P>,
+        props?: P,
+        ...children: ReactNode[]): ClassicElement<P>;
+    function cloneElement<P>(
+        element: ReactElement<P>,
+        props?: P,
+        ...children: ReactNode[]): ReactElement<P>;
+
+    function isValidElement(object: {}): boolean;
+
+    var DOM: ReactDOM;
+    var PropTypes: ReactPropTypes;
+    var Children: ReactChildren;
+
+    //
+    // Component API
+    // ----------------------------------------------------------------------
+
+    type ReactInstance = Component<any, any> | Element;
+
+    // Base component for plain JS classes
+    class Component<P, S> implements ComponentLifecycle<P, S> {
+        constructor(props?: P, context?: any);
+        setState(f: (prevState: S, props: P) => S, callback?: () => any): void;
+        setState(state: S, callback?: () => any): void;
+        forceUpdate(callBack?: () => any): void;
+        render(): JSX.Element;
+        props: P;
+        state: S;
+        context: {};
+        refs: {
+            [key: string]: ReactInstance
+        };
+    }
+
+    interface ClassicComponent<P, S> extends Component<P, S> {
+        replaceState(nextState: S, callback?: () => any): void;
+        isMounted(): boolean;
+        getInitialState?(): S;
+    }
+
+    interface ChildContextProvider<CC> {
+        getChildContext(): CC;
+    }
+
+    //
+    // Class Interfaces
+    // ----------------------------------------------------------------------
+
+    interface StatelessComponent<P> {
+        (props?: P, context?: any): ReactElement<any>;
+        propTypes?: ValidationMap<P>;
+        contextTypes?: ValidationMap<any>;
+        defaultProps?: P;
+    }
+
+    interface ComponentClass<P> {
+        new(props?: P, context?: any): Component<P, any>;
+        propTypes?: ValidationMap<P>;
+        contextTypes?: ValidationMap<any>;
+        childContextTypes?: ValidationMap<any>;
+        defaultProps?: P;
+    }
+
+    interface ClassicComponentClass<P> extends ComponentClass<P> {
+        new(props?: P, context?: any): ClassicComponent<P, any>;
+        getDefaultProps?(): P;
+        displayName?: string;
+    }
+
+    //
+    // Component Specs and Lifecycle
+    // ----------------------------------------------------------------------
+
+    interface ComponentLifecycle<P, S> {
+        componentWillMount?(): void;
+        componentDidMount?(): void;
+        componentWillReceiveProps?(nextProps: P, nextContext: any): void;
+        shouldComponentUpdate?(nextProps: P, nextState: S, nextContext: any): boolean;
+        componentWillUpdate?(nextProps: P, nextState: S, nextContext: any): void;
+        componentDidUpdate?(prevProps: P, prevState: S, prevContext: any): void;
+        componentWillUnmount?(): void;
+    }
+
+    interface Mixin<P, S> extends ComponentLifecycle<P, S> {
+        mixins?: Mixin<P, S>;
+        statics?: {
+            [key: string]: any;
+        };
+
+        displayName?: string;
+        propTypes?: ValidationMap<any>;
+        contextTypes?: ValidationMap<any>;
+        childContextTypes?: ValidationMap<any>;
+
+        getDefaultProps?(): P;
+        getInitialState?(): S;
+    }
+
+    interface ComponentSpec<P, S> extends Mixin<P, S> {
+        render(): ReactElement<any>;
+
+        [propertyName: string]: any;
+    }
+
+    //
+    // Event System
+    // ----------------------------------------------------------------------
+
+    interface SyntheticEvent {
+        bubbles: boolean;
+        cancelable: boolean;
+        currentTarget: EventTarget;
+        defaultPrevented: boolean;
+        eventPhase: number;
+        isTrusted: boolean;
+        nativeEvent: Event;
+        preventDefault(): void;
+        stopPropagation(): void;
+        target: EventTarget;
+        timeStamp: Date;
+        type: string;
+    }
+
+    interface ClipboardEvent extends SyntheticEvent {
+        clipboardData: DataTransfer;
+    }
+
+    interface CompositionEvent extends SyntheticEvent {
+        data: string;
+    }
+
+    interface DragEvent extends SyntheticEvent {
+        dataTransfer: DataTransfer;
+    }
+
+    interface FocusEvent extends SyntheticEvent {
+        relatedTarget: EventTarget;
+    }
+
+    interface FormEvent extends SyntheticEvent {
+    }
+
+    interface KeyboardEvent extends SyntheticEvent {
+        altKey: boolean;
+        charCode: number;
+        ctrlKey: boolean;
+        getModifierState(key: string): boolean;
+        key: string;
+        keyCode: number;
+        locale: string;
+        location: number;
+        metaKey: boolean;
+        repeat: boolean;
+        shiftKey: boolean;
+        which: number;
+    }
+
+    interface MouseEvent extends SyntheticEvent {
+        altKey: boolean;
+        button: number;
+        buttons: number;
+        clientX: number;
+        clientY: number;
+        ctrlKey: boolean;
+        getModifierState(key: string): boolean;
+        metaKey: boolean;
+        pageX: number;
+        pageY: number;
+        relatedTarget: EventTarget;
+        screenX: number;
+        screenY: number;
+        shiftKey: boolean;
+    }
+
+    interface TouchEvent extends SyntheticEvent {
+        altKey: boolean;
+        changedTouches: TouchList;
+        ctrlKey: boolean;
+        getModifierState(key: string): boolean;
+        metaKey: boolean;
+        shiftKey: boolean;
+        targetTouches: TouchList;
+        touches: TouchList;
+    }
+
+    interface UIEvent extends SyntheticEvent {
+        detail: number;
+        view: AbstractView;
+    }
+
+    interface WheelEvent extends SyntheticEvent {
+        deltaMode: number;
+        deltaX: number;
+        deltaY: number;
+        deltaZ: number;
+    }
+
+    //
+    // Event Handler Types
+    // ----------------------------------------------------------------------
+
+    interface EventHandler<E extends SyntheticEvent> {
+        (event: E): void;
+    }
+
+    type ReactEventHandler = EventHandler<SyntheticEvent>;
+
+    type ClipboardEventHandler = EventHandler<ClipboardEvent>;
+    type CompositionEventHandler = EventHandler<CompositionEvent>;
+    type DragEventHandler = EventHandler<DragEvent>;
+    type FocusEventHandler = EventHandler<FocusEvent>;
+    type FormEventHandler = EventHandler<FormEvent>;
+    type KeyboardEventHandler = EventHandler<KeyboardEvent>;
+    type MouseEventHandler = EventHandler<MouseEvent>;
+    type TouchEventHandler = EventHandler<TouchEvent>;
+    type UIEventHandler = EventHandler<UIEvent>;
+    type WheelEventHandler = EventHandler<WheelEvent>;
+
+    //
+    // Props / DOM Attributes
+    // ----------------------------------------------------------------------
+
+    interface Props<T> {
+        children?: ReactNode;
+        key?: string | number;
+        ref?: string | ((component: T) => any);
+    }
+
+    interface HTMLProps<T> extends HTMLAttributes, Props<T> {
+    }
+
+    interface SVGProps extends SVGAttributes, Props<SVGElement> {
+    }
+
+    interface DOMAttributes {
+        dangerouslySetInnerHTML?: {
+            __html: string;
+        };
+
+        // Clipboard Events
+        onCopy?: ClipboardEventHandler;
+        onCut?: ClipboardEventHandler;
+        onPaste?: ClipboardEventHandler;
+
+        // Composition Events
+        onCompositionEnd?: CompositionEventHandler;
+        onCompositionStart?: CompositionEventHandler;
+        onCompositionUpdate?: CompositionEventHandler;
+
+        // Focus Events
+        onFocus?: FocusEventHandler;
+        onBlur?: FocusEventHandler;
+
+        // Form Events
+        onChange?: FormEventHandler;
+        onInput?: FormEventHandler;
+        onSubmit?: FormEventHandler;
+
+        // Image Events
+        onLoad?: ReactEventHandler;
+        onError?: ReactEventHandler; // also a Media Event
+
+        // Keyboard Events
+        onKeyDown?: KeyboardEventHandler;
+        onKeyPress?: KeyboardEventHandler;
+        onKeyUp?: KeyboardEventHandler;
+
+        // Media Events
+        onAbort?: ReactEventHandler;
+        onCanPlay?: ReactEventHandler;
+        onCanPlayThrough?: ReactEventHandler;
+        onDurationChange?: ReactEventHandler;
+        onEmptied?: ReactEventHandler;
+        onEncrypted?: ReactEventHandler;
+        onEnded?: ReactEventHandler;
+        onLoadedData?: ReactEventHandler;
+        onLoadedMetadata?: ReactEventHandler;
+        onLoadStart?: ReactEventHandler;
+        onPause?: ReactEventHandler;
+        onPlay?: ReactEventHandler;
+        onPlaying?: ReactEventHandler;
+        onProgress?: ReactEventHandler;
+        onRateChange?: ReactEventHandler;
+        onSeeked?: ReactEventHandler;
+        onSeeking?: ReactEventHandler;
+        onStalled?: ReactEventHandler;
+        onSuspend?: ReactEventHandler;
+        onTimeUpdate?: ReactEventHandler;
+        onVolumeChange?: ReactEventHandler;
+        onWaiting?: ReactEventHandler;
+
+        // MouseEvents
+        onClick?: MouseEventHandler;
+        onContextMenu?: MouseEventHandler;
+        onDoubleClick?: MouseEventHandler;
+        onDrag?: DragEventHandler;
+        onDragEnd?: DragEventHandler;
+        onDragEnter?: DragEventHandler;
+        onDragExit?: DragEventHandler;
+        onDragLeave?: DragEventHandler;
+        onDragOver?: DragEventHandler;
+        onDragStart?: DragEventHandler;
+        onDrop?: DragEventHandler;
+        onMouseDown?: MouseEventHandler;
+        onMouseEnter?: MouseEventHandler;
+        onMouseLeave?: MouseEventHandler;
+        onMouseMove?: MouseEventHandler;
+        onMouseOut?: MouseEventHandler;
+        onMouseOver?: MouseEventHandler;
+        onMouseUp?: MouseEventHandler;
+
+        // Selection Events
+        onSelect?: ReactEventHandler;
+
+        // Touch Events
+        onTouchCancel?: TouchEventHandler;
+        onTouchEnd?: TouchEventHandler;
+        onTouchMove?: TouchEventHandler;
+        onTouchStart?: TouchEventHandler;
+
+        // UI Events
+        onScroll?: UIEventHandler;
+
+        // Wheel Events
+        onWheel?: WheelEventHandler;
+    }
+
+    // This interface is not complete. Only properties accepting
+    // unitless numbers are listed here (see CSSProperty.js in React)
+    interface CSSProperties {
+        boxFlex?: number;
+        boxFlexGroup?: number;
+        columnCount?: number;
+        flex?: number | string;
+        flexGrow?: number;
+        flexShrink?: number;
+        fontWeight?: number | string;
+        lineClamp?: number;
+        lineHeight?: number | string;
+        opacity?: number;
+        order?: number;
+        orphans?: number;
+        widows?: number;
+        zIndex?: number;
+        zoom?: number;
+
+        fontSize?: number | string;
+
+        // SVG-related properties
+        fillOpacity?: number;
+        strokeOpacity?: number;
+        strokeWidth?: number;
+
+        // Remaining properties auto-extracted from http://docs.webplatform.org.
+        // License: http://docs.webplatform.org/wiki/Template:CC-by-3.0
+        /**
+         * Aligns a flex container's lines within the flex container when there is extra space in the cross-axis, similar to how justify-content aligns individual items within the main-axis.
+         */
+        alignContent?: any;
+
+        /**
+         * Sets the default alignment in the cross axis for all of the flex container's items, including anonymous flex items, similarly to how justify-content aligns items along the main axis.
+         */
+        alignItems?: any;
+
+        /**
+         * Allows the default alignment to be overridden for individual flex items.
+         */
+        alignSelf?: any;
+
+        /**
+         * This property allows precise alignment of elements, such as graphics, that do not have a baseline-table or lack the desired baseline in their baseline-table. With the alignment-adjust property, the position of the baseline identified by the alignment-baseline can be explicitly determined. It also determines precisely the alignment point for each glyph within a textual element.
+         */
+        alignmentAdjust?: any;
+
+        alignmentBaseline?: any;
+
+        /**
+         * Defines a length of time to elapse before an animation starts, allowing an animation to begin execution some time after it is applied.
+         */
+        animationDelay?: any;
+
+        /**
+         * Defines whether an animation should run in reverse on some or all cycles.
+         */
+        animationDirection?: any;
+
+        /**
+         * Specifies how many times an animation cycle should play.
+         */
+        animationIterationCount?: any;
+
+        /**
+         * Defines the list of animations that apply to the element.
+         */
+        animationName?: any;
+
+        /**
+         * Defines whether an animation is running or paused.
+         */
+        animationPlayState?: any;
+
+        /**
+         * Allows changing the style of any element to platform-based interface elements or vice versa.
+         */
+        appearance?: any;
+
+        /**
+         * Determines whether or not the “back” side of a transformed element is visible when facing the viewer.
+         */
+        backfaceVisibility?: any;
+
+        /**
+         * This property describes how the element's background images should blend with each other and the element's background color.
+         * The value is a list of blend modes that corresponds to each background image. Each element in the list will apply to the corresponding element of background-image. If a property doesn’t have enough comma-separated values to match the number of layers, the UA must calculate its used value by repeating the list of values until there are enough.
+         */
+        backgroundBlendMode?: any;
+
+        backgroundComposite?: any;
+
+        /**
+         * Applies one or more background images to an element. These can be any valid CSS image, including url() paths to image files or CSS gradients.
+         */
+        backgroundImage?: any;
+
+        /**
+         * Specifies what the background-position property is relative to.
+         */
+        backgroundOrigin?: any;
+
+        /**
+         * Sets the horizontal position of a background image.
+         */
+        backgroundPositionX?: any;
+
+        /**
+         * Background-repeat defines if and how background images will be repeated after they have been sized and positioned
+         */
+        backgroundRepeat?: any;
+
+        /**
+         * Obsolete - spec retired, not implemented.
+         */
+        baselineShift?: any;
+
+        /**
+         * Non standard. Sets or retrieves the location of the Dynamic HTML (DHTML) behavior.
+         */
+        behavior?: any;
+
+        /**
+         * Shorthand property that defines the different properties of all four sides of an element's border in a single declaration. It can be used to set border-width, border-style and border-color, or a subset of these.
+         */
+        border?: any;
+
+        /**
+         * Defines the shape of the border of the bottom-left corner.
+         */
+        borderBottomLeftRadius?: any;
+
+        /**
+         * Defines the shape of the border of the bottom-right corner.
+         */
+        borderBottomRightRadius?: any;
+
+        /**
+         * Sets the width of an element's bottom border. To set all four borders, use the border-width shorthand property which sets the values simultaneously for border-top-width, border-right-width, border-bottom-width, and border-left-width.
+         */
+        borderBottomWidth?: any;
+
+        /**
+         * Border-collapse can be used for collapsing the borders between table cells
+         */
+        borderCollapse?: any;
+
+        /**
+         * The CSS border-color property sets the color of an element's four borders. This property can have from one to four values, made up of the elementary properties:     •       border-top-color
+         *      •       border-right-color
+         *      •       border-bottom-color
+         *      •       border-left-color The default color is the currentColor of each of these values.
+         * If you provide one value, it sets the color for the element. Two values set the horizontal and vertical values, respectively. Providing three values sets the top, vertical, and bottom values, in that order. Four values set all for sides: top, right, bottom, and left, in that order.
+         */
+        borderColor?: any;
+
+        /**
+         * Specifies different corner clipping effects, such as scoop (inner curves), bevel (straight cuts) or notch (cut-off rectangles). Works along with border-radius to specify the size of each corner effect.
+         */
+        borderCornerShape?: any;
+
+        /**
+         * The property border-image-source is used to set the image to be used instead of the border style. If this is set to none the border-style is used instead.
+         */
+        borderImageSource?: any;
+
+        /**
+         * The border-image-width CSS property defines the offset to use for dividing the border image in nine parts, the top-left corner, central top edge, top-right-corner, central right edge, bottom-right corner, central bottom edge, bottom-left corner, and central right edge. They represent inward distance from the top, right, bottom, and left edges.
+         */
+        borderImageWidth?: any;
+
+        /**
+         * Shorthand property that defines the border-width, border-style and border-color of an element's left border in a single declaration. Note that you can use the corresponding longhand properties to set specific individual properties of the left border — border-left-width, border-left-style and border-left-color.
+         */
+        borderLeft?: any;
+
+        /**
+         * The CSS border-left-color property sets the color of an element's left border. This page explains the border-left-color value, but often you will find it more convenient to fix the border's left color as part of a shorthand set, either border-left or border-color.
+         * Colors can be defined several ways. For more information, see Usage.
+         */
+        borderLeftColor?: any;
+
+        /**
+         * Sets the style of an element's left border. To set all four borders, use the shorthand property, border-style. Otherwise, you can set the borders individually with border-top-style, border-right-style, border-bottom-style, border-left-style.
+         */
+        borderLeftStyle?: any;
+
+        /**
+         * Sets the width of an element's left border. To set all four borders, use the border-width shorthand property which sets the values simultaneously for border-top-width, border-right-width, border-bottom-width, and border-left-width.
+         */
+        borderLeftWidth?: any;
+
+        /**
+         * Shorthand property that defines the border-width, border-style and border-color of an element's right border in a single declaration. Note that you can use the corresponding longhand properties to set specific individual properties of the right border — border-right-width, border-right-style and border-right-color.
+         */
+        borderRight?: any;
+
+        /**
+         * Sets the color of an element's right border. This page explains the border-right-color value, but often you will find it more convenient to fix the border's right color as part of a shorthand set, either border-right or border-color.
+         * Colors can be defined several ways. For more information, see Usage.
+         */
+        borderRightColor?: any;
+
+        /**
+         * Sets the style of an element's right border. To set all four borders, use the shorthand property, border-style. Otherwise, you can set the borders individually with border-top-style, border-right-style, border-bottom-style, border-left-style.
+         */
+        borderRightStyle?: any;
+
+        /**
+         * Sets the width of an element's right border. To set all four borders, use the border-width shorthand property which sets the values simultaneously for border-top-width, border-right-width, border-bottom-width, and border-left-width.
+         */
+        borderRightWidth?: any;
+
+        /**
+         * Specifies the distance between the borders of adjacent cells.
+         */
+        borderSpacing?: any;
+
+        /**
+         * Sets the style of an element's four borders. This property can have from one to four values. With only one value, the value will be applied to all four borders; otherwise, this works as a shorthand property for each of border-top-style, border-right-style, border-bottom-style, border-left-style, where each border style may be assigned a separate value.
+         */
+        borderStyle?: any;
+
+        /**
+         * Shorthand property that defines the border-width, border-style and border-color of an element's top border in a single declaration. Note that you can use the corresponding longhand properties to set specific individual properties of the top border — border-top-width, border-top-style and border-top-color.
+         */
+        borderTop?: any;
+
+        /**
+         * Sets the color of an element's top border. This page explains the border-top-color value, but often you will find it more convenient to fix the border's top color as part of a shorthand set, either border-top or border-color.
+         * Colors can be defined several ways. For more information, see Usage.
+         */
+        borderTopColor?: any;
+
+        /**
+         * Sets the rounding of the top-left corner of the element.
+         */
+        borderTopLeftRadius?: any;
+
+        /**
+         * Sets the rounding of the top-right corner of the element.
+         */
+        borderTopRightRadius?: any;
+
+        /**
+         * Sets the style of an element's top border. To set all four borders, use the shorthand property, border-style. Otherwise, you can set the borders individually with border-top-style, border-right-style, border-bottom-style, border-left-style.
+         */
+        borderTopStyle?: any;
+
+        /**
+         * Sets the width of an element's top border. To set all four borders, use the border-width shorthand property which sets the values simultaneously for border-top-width, border-right-width, border-bottom-width, and border-left-width.
+         */
+        borderTopWidth?: any;
+
+        /**
+         * Sets the width of an element's four borders. This property can have from one to four values. This is a shorthand property for setting values simultaneously for border-top-width, border-right-width, border-bottom-width, and border-left-width.
+         */
+        borderWidth?: any;
+
+        /**
+         * Obsolete.
+         */
+        boxAlign?: any;
+
+        /**
+         * Breaks a box into fragments creating new borders, padding and repeating backgrounds or lets it stay as a continuous box on a page break, column break, or, for inline elements, at a line break.
+         */
+        boxDecorationBreak?: any;
+
+        /**
+         * Deprecated
+         */
+        boxDirection?: any;
+
+        /**
+         * Do not use. This property has been replaced by the flex-wrap property.
+         * Gets or sets a value that specifies the direction to add successive rows or columns when the value of box-lines is set to multiple.
+         */
+        boxLineProgression?: any;
+
+        /**
+         * Do not use. This property has been replaced by the flex-wrap property.
+         * Gets or sets a value that specifies whether child elements wrap onto multiple lines or columns based on the space available in the object.
+         */
+        boxLines?: any;
+
+        /**
+         * Do not use. This property has been replaced by flex-order.
+         * Specifies the ordinal group that a child element of the object belongs to. This ordinal value identifies the display order (along the axis defined by the box-orient property) for the group.
+         */
+        boxOrdinalGroup?: any;
+
+        /**
+         * The CSS break-after property allows you to force a break on multi-column layouts. More specifically, it allows you to force a break after an element. It allows you to determine if a break should occur, and what type of break it should be. The break-after CSS property describes how the page, column or region break behaves after the generated box. If there is no generated box, the property is ignored.
+         */
+        breakAfter?: any;
+
+        /**
+         * Control page/column/region breaks that fall above a block of content
+         */
+        breakBefore?: any;
+
+        /**
+         * Control page/column/region breaks that fall within a block of content
+         */
+        breakInside?: any;
+
+        /**
+         * The clear CSS property specifies if an element can be positioned next to or must be positioned below the floating elements that precede it in the markup.
+         */
+        clear?: any;
+
+        /**
+         * Deprecated; see clip-path.
+         * Lets you specify the dimensions of an absolutely positioned element that should be visible, and the element is clipped into this shape, and displayed.
+         */
+        clip?: any;
+
+        /**
+         * Clipping crops an graphic, so that only a portion of the graphic is rendered, or filled. This clip-rule property, when used with the clip-path property, defines which clip rule, or algorithm, to use when filling the different parts of a graphics.
+         */
+        clipRule?: any;
+
+        /**
+         * The color property sets the color of an element's foreground content (usually text), accepting any standard CSS color from keywords and hex values to RGB(a) and HSL(a).
+         */
+        color?: any;
+
+        /**
+         * Specifies how to fill columns (balanced or sequential).
+         */
+        columnFill?: any;
+
+        /**
+         * The column-gap property controls the width of the gap between columns in multi-column elements.
+         */
+        columnGap?: any;
+
+        /**
+         * Sets the width, style, and color of the rule between columns.
+         */
+        columnRule?: any;
+
+        /**
+         * Specifies the color of the rule between columns.
+         */
+        columnRuleColor?: any;
+
+        /**
+         * Specifies the width of the rule between columns.
+         */
+        columnRuleWidth?: any;
+
+        /**
+         * The column-span CSS property makes it possible for an element to span across all columns when its value is set to all. An element that spans more than one column is called a spanning element.
+         */
+        columnSpan?: any;
+
+        /**
+         * Specifies the width of columns in multi-column elements.
+         */
+        columnWidth?: any;
+
+        /**
+         * This property is a shorthand property for setting column-width and/or column-count.
+         */
+        columns?: any;
+
+        /**
+         * The counter-increment property accepts one or more names of counters (identifiers), each one optionally followed by an integer which specifies the value by which the counter should be incremented (e.g. if the value is 2, the counter increases by 2 each time it is invoked).
+         */
+        counterIncrement?: any;
+
+        /**
+         * The counter-reset property contains a list of one or more names of counters, each one optionally followed by an integer (otherwise, the integer defaults to 0.) Each time the given element is invoked, the counters specified by the property are set to the given integer.
+         */
+        counterReset?: any;
+
+        /**
+         * The cue property specifies sound files (known as an "auditory icon") to be played by speech media agents before and after presenting an element's content; if only one file is specified, it is played both before and after. The volume at which the file(s) should be played, relative to the volume of the main element, may also be specified. The icon files may also be set separately with the cue-before and cue-after properties.
+         */
+        cue?: any;
+
+        /**
+         * The cue-after property specifies a sound file (known as an "auditory icon") to be played by speech media agents after presenting an element's content; the volume at which the file should be played may also be specified. The shorthand property cue sets cue sounds for both before and after the element is presented.
+         */
+        cueAfter?: any;
+
+        /**
+         * The direction CSS property specifies the text direction/writing direction. The rtl is used for Hebrew or Arabic text, the ltr is for other languages.
+         */
+        direction?: any;
+
+        /**
+         * This property specifies the type of rendering box used for an element. It is a shorthand property for many other display properties.
+         */
+        display?: any;
+
+        /**
+         * The ‘fill’ property paints the interior of the given graphical element. The area to be painted consists of any areas inside the outline of the shape. To determine the inside of the shape, all subpaths are considered, and the interior is determined according to the rules associated with the current value of the ‘fill-rule’ property. The zero-width geometric outline of a shape is included in the area to be painted.
+         */
+        fill?: any;
+
+        /**
+         * The ‘fill-rule’ property indicates the algorithm which is to be used to determine what parts of the canvas are included inside the shape. For a simple, non-intersecting path, it is intuitively clear what region lies "inside"; however, for a more complex path, such as a path that intersects itself or where one subpath encloses another, the interpretation of "inside" is not so obvious.
+         * The ‘fill-rule’ property provides two options for how the inside of a shape is determined:
+         */
+        fillRule?: any;
+
+        /**
+         * Applies various image processing effects. This property is largely unsupported. See Compatibility section for more information.
+         */
+        filter?: any;
+
+        /**
+         * Obsolete, do not use. This property has been renamed to align-items.
+         * Specifies the alignment (perpendicular to the layout axis defined by the flex-direction property) of child elements of the object.
+         */
+        flexAlign?: any;
+
+        /**
+         * The flex-basis CSS property describes the initial main size of the flex item before any free space is distributed according to the flex factors described in the flex property (flex-grow and flex-shrink).
+         */
+        flexBasis?: any;
+
+        /**
+         * The flex-direction CSS property describes how flex items are placed in the flex container, by setting the direction of the flex container's main axis.
+         */
+        flexDirection?: any;
+
+        /**
+         * The flex-flow CSS property defines the flex container's main and cross axis. It is a shorthand property for the flex-direction and flex-wrap properties.
+         */
+        flexFlow?: any;
+
+        /**
+         * Do not use. This property has been renamed to align-self
+         * Specifies the alignment (perpendicular to the layout axis defined by flex-direction) of child elements of the object.
+         */
+        flexItemAlign?: any;
+
+        /**
+         * Do not use. This property has been renamed to align-content.
+         * Specifies how a flexbox's lines align within the flexbox when there is extra space along the axis that is perpendicular to the axis defined by the flex-direction property.
+         */
+        flexLinePack?: any;
+
+        /**
+         * Gets or sets a value that specifies the ordinal group that a flexbox element belongs to. This ordinal value identifies the display order for the group.
+         */
+        flexOrder?: any;
+
+        /**
+         * Elements which have the style float are floated horizontally. These elements can move as far to the left or right of the containing element. All elements after the floating element will flow around it, but elements before the floating element are not impacted. If several floating elements are placed after each other, they will float next to each other as long as there is room.
+         */
+        float?: any;
+
+        /**
+         * Flows content from a named flow (specified by a corresponding flow-into) through selected elements to form a dynamic chain of layout regions.
+         */
+        flowFrom?: any;
+
+        /**
+         * The font property is shorthand that allows you to do one of two things: you can either set up six of the most mature font properties in one line, or you can set one of a choice of keywords to adopt a system font setting.
+         */
+        font?: any;
+
+        /**
+         * The font-family property allows one or more font family names and/or generic family names to be specified for usage on the selected element(s)' text. The browser then goes through the list; for each character in the selection it applies the first font family that has an available glyph for that character.
+         */
+        fontFamily?: any;
+
+        /**
+         * The font-kerning property allows contextual adjustment of inter-glyph spacing, i.e. the spaces between the characters in text. This property controls <bold>metric kerning</bold> - that utilizes adjustment data contained in the font. Optical Kerning is not supported as yet.
+         */
+        fontKerning?: any;
+
+        /**
+         * The font-size-adjust property adjusts the font-size of the fallback fonts defined with font-family, so that the x-height is the same no matter what font is used. This preserves the readability of the text when fallback happens.
+         */
+        fontSizeAdjust?: any;
+
+        /**
+         * Allows you to expand or condense the widths for a normal, condensed, or expanded font face.
+         */
+        fontStretch?: any;
+
+        /**
+         * The font-style property allows normal, italic, or oblique faces to be selected. Italic forms are generally cursive in nature while oblique faces are typically sloped versions of the regular face. Oblique faces can be simulated by artificially sloping the glyphs of the regular face.
+         */
+        fontStyle?: any;
+
+        /**
+         * This value specifies whether the user agent is allowed to synthesize bold or oblique font faces when a font family lacks bold or italic faces.
+         */
+        fontSynthesis?: any;
+
+        /**
+         * The font-variant property enables you to select the small-caps font within a font family.
+         */
+        fontVariant?: any;
+
+        /**
+         * Fonts can provide alternate glyphs in addition to default glyph for a character. This property provides control over the selection of these alternate glyphs.
+         */
+        fontVariantAlternates?: any;
+
+        /**
+         * Lays out one or more grid items bound by 4 grid lines. Shorthand for setting grid-column-start, grid-column-end, grid-row-start, and grid-row-end in a single declaration.
+         */
+        gridArea?: any;
+
+        /**
+         * Controls a grid item's placement in a grid area, particularly grid position and a grid span. Shorthand for setting grid-column-start and grid-column-end in a single declaration.
+         */
+        gridColumn?: any;
+
+        /**
+         * Controls a grid item's placement in a grid area as well as grid position and a grid span. The grid-column-end property (with grid-row-start, grid-row-end, and grid-column-start) determines a grid item's placement by specifying the grid lines of a grid item's grid area.
+         */
+        gridColumnEnd?: any;
+
+        /**
+         * Determines a grid item's placement by specifying the starting grid lines of a grid item's grid area . A grid item's placement in a grid area consists of a grid position and a grid span. See also ( grid-row-start, grid-row-end, and grid-column-end)
+         */
+        gridColumnStart?: any;
+
+        /**
+         * Gets or sets a value that indicates which row an element within a Grid should appear in. Shorthand for setting grid-row-start and grid-row-end in a single declaration.
+         */
+        gridRow?: any;
+
+        /**
+         * Determines a grid item’s placement by specifying the block-end. A grid item's placement in a grid area consists of a grid position and a grid span. The grid-row-end property (with grid-row-start, grid-column-start, and grid-column-end) determines a grid item's placement by specifying the grid lines of a grid item's grid area.
+         */
+        gridRowEnd?: any;
+
+        /**
+         * Specifies a row position based upon an integer location, string value, or desired row size.
+         * css/properties/grid-row is used as short-hand for grid-row-position and grid-row-position
+         */
+        gridRowPosition?: any;
+
+        gridRowSpan?: any;
+
+        /**
+         * Specifies named grid areas which are not associated with any particular grid item, but can be referenced from the grid-placement properties. The syntax of the grid-template-areas property also provides a visualization of the structure of the grid, making the overall layout of the grid container easier to understand.
+         */
+        gridTemplateAreas?: any;
+
+        /**
+         * Specifies (with grid-template-rows) the line names and track sizing functions of the grid. Each sizing function can be specified as a length, a percentage of the grid container’s size, a measurement of the contents occupying the column or row, or a fraction of the free space in the grid.
+         */
+        gridTemplateColumns?: any;
+
+        /**
+         * Specifies (with grid-template-columns) the line names and track sizing functions of the grid. Each sizing function can be specified as a length, a percentage of the grid container’s size, a measurement of the contents occupying the column or row, or a fraction of the free space in the grid.
+         */
+        gridTemplateRows?: any;
+
+        /**
+         * Sets the height of an element. The content area of the element height does not include the padding, border, and margin of the element.
+         */
+        height?: any;
+
+        /**
+         * Specifies the minimum number of characters in a hyphenated word
+         */
+        hyphenateLimitChars?: any;
+
+        /**
+         * Indicates the maximum number of successive hyphenated lines in an element. The ‘no-limit’ value means that there is no limit.
+         */
+        hyphenateLimitLines?: any;
+
+        /**
+         * Specifies the maximum amount of trailing whitespace (before justification) that may be left in a line before hyphenation is triggered to pull part of a word from the next line back up into the current one.
+         */
+        hyphenateLimitZone?: any;
+
+        /**
+         * Specifies whether or not words in a sentence can be split by the use of a manual or automatic hyphenation mechanism.
+         */
+        hyphens?: any;
+
+        imeMode?: any;
+
+        layoutGrid?: any;
+
+        layoutGridChar?: any;
+
+        layoutGridLine?: any;
+
+        layoutGridMode?: any;
+
+        layoutGridType?: any;
+
+        /**
+         * Sets the left edge of an element
+         */
+        left?: any;
+
+        /**
+         * The letter-spacing CSS property specifies the spacing behavior between text characters.
+         */
+        letterSpacing?: any;
+
+        /**
+         * Deprecated. Gets or sets line-breaking rules for text in selected languages such as Japanese, Chinese, and Korean.
+         */
+        lineBreak?: any;
+
+        /**
+         * Shorthand property that sets the list-style-type, list-style-position and list-style-image properties in one declaration.
+         */
+        listStyle?: any;
+
+        /**
+         * This property sets the image that will be used as the list item marker. When the image is available, it will replace the marker set with the 'list-style-type' marker. That also means that if the image is not available, it will show the style specified by list-style-property
+         */
+        listStyleImage?: any;
+
+        /**
+         * Specifies if the list-item markers should appear inside or outside the content flow.
+         */
+        listStylePosition?: any;
+
+        /**
+         * Specifies the type of list-item marker in a list.
+         */
+        listStyleType?: any;
+
+        /**
+         * The margin property is shorthand to allow you to set all four margins of an element at once. Its equivalent longhand properties are margin-top, margin-right, margin-bottom and margin-left. Negative values are also allowed.
+         */
+        margin?: any;
+
+        /**
+         * margin-bottom sets the bottom margin of an element.
+         */
+        marginBottom?: any;
+
+        /**
+         * margin-left sets the left margin of an element.
+         */
+        marginLeft?: any;
+
+        /**
+         * margin-right sets the right margin of an element.
+         */
+        marginRight?: any;
+
+        /**
+         * margin-top sets the top margin of an element.
+         */
+        marginTop?: any;
+
+        /**
+         * The marquee-direction determines the initial direction in which the marquee content moves.
+         */
+        marqueeDirection?: any;
+
+        /**
+         * The 'marquee-style' property determines a marquee's scrolling behavior.
+         */
+        marqueeStyle?: any;
+
+        /**
+         * This property is shorthand for setting mask-image, mask-mode, mask-repeat, mask-position, mask-clip, mask-origin, mask-composite and mask-size. Omitted values are set to their original properties' initial values.
+         */
+        mask?: any;
+
+        /**
+         * This property is shorthand for setting mask-border-source, mask-border-slice, mask-border-width, mask-border-outset, and mask-border-repeat. Omitted values are set to their original properties' initial values.
+         */
+        maskBorder?: any;
+
+        /**
+         * This property specifies how the images for the sides and the middle part of the mask image are scaled and tiled. The first keyword applies to the horizontal sides, the second one applies to the vertical ones. If the second keyword is absent, it is assumed to be the same as the first, similar to the CSS border-image-repeat property.
+         */
+        maskBorderRepeat?: any;
+
+        /**
+         * This property specifies inward offsets from the top, right, bottom, and left edges of the mask image, dividing it into nine regions: four corners, four edges, and a middle. The middle image part is discarded and treated as fully transparent black unless the fill keyword is present. The four values set the top, right, bottom and left offsets in that order, similar to the CSS border-image-slice property.
+         */
+        maskBorderSlice?: any;
+
+        /**
+         * Specifies an image to be used as a mask. An image that is empty, fails to download, is non-existent, or cannot be displayed is ignored and does not mask the element.
+         */
+        maskBorderSource?: any;
+
+        /**
+         * This property sets the width of the mask box image, similar to the CSS border-image-width property.
+         */
+        maskBorderWidth?: any;
+
+        /**
+         * Determines the mask painting area, which defines the area that is affected by the mask. The painted content of an element may be restricted to this area.
+         */
+        maskClip?: any;
+
+        /**
+         * For elements rendered as a single box, specifies the mask positioning area. For elements rendered as multiple boxes (e.g., inline boxes on several lines, boxes on several pages) specifies which boxes box-decoration-break operates on to determine the mask positioning area(s).
+         */
+        maskOrigin?: any;
+
+        /**
+         * This property must not be used. It is no longer included in any standard or standard track specification, nor is it implemented in any browser. It is only used when the text-align-last property is set to size. It controls allowed adjustments of font-size to fit line content.
+         */
+        maxFontSize?: any;
+
+        /**
+         * Sets the maximum height for an element. It prevents the height of the element to exceed the specified value. If min-height is specified and is greater than max-height, max-height is overridden.
+         */
+        maxHeight?: any;
+
+        /**
+         * Sets the maximum width for an element. It limits the width property to be larger than the value specified in max-width.
+         */
+        maxWidth?: any;
+
+        /**
+         * Sets the minimum width of an element. It limits the width property to be not smaller than the value specified in min-width.
+         */
+        minWidth?: any;
+
+        /**
+         * The CSS outline property is a shorthand property for setting one or more of the individual outline properties outline-style, outline-width and outline-color in a single rule. In most cases the use of this shortcut is preferable and more convenient.
+         * Outlines differ from borders in the following ways:  •       Outlines do not take up space, they are drawn above the content.
+         *      •       Outlines may be non-rectangular. They are rectangular in Gecko/Firefox. Internet Explorer attempts to place the smallest contiguous outline around all elements or shapes that are indicated to have an outline. Opera draws a non-rectangular shape around a construct.
+         */
+        outline?: any;
+
+        /**
+         * The outline-color property sets the color of the outline of an element. An outline is a line that is drawn around elements, outside the border edge, to make the element stand out.
+         */
+        outlineColor?: any;
+
+        /**
+         * The outline-offset property offsets the outline and draw it beyond the border edge.
+         */
+        outlineOffset?: any;
+
+        /**
+         * The overflow property controls how extra content exceeding the bounding box of an element is rendered. It can be used in conjunction with an element that has a fixed width and height, to eliminate text-induced page distortion.
+         */
+        overflow?: any;
+
+        /**
+         * Specifies the preferred scrolling methods for elements that overflow.
+         */
+        overflowStyle?: any;
+
+        /**
+         * The overflow-x property is a specific case of the generic overflow property. It controls how extra content exceeding the x-axis of the bounding box of an element is rendered.
+         */
+        overflowX?: any;
+
+        /**
+         * The padding optional CSS property sets the required padding space on one to four sides of an element. The padding area is the space between an element and its border. Negative values are not allowed but decimal values are permitted. The element size is treated as fixed, and the content of the element shifts toward the center as padding is increased.
+         * The padding property is a shorthand to avoid setting each side separately (padding-top, padding-right, padding-bottom, padding-left).
+         */
+        padding?: any;
+
+        /**
+         * The padding-bottom CSS property of an element sets the padding space required on the bottom of an element. The padding area is the space between the content of the element and its border. Contrary to margin-bottom values, negative values of padding-bottom are invalid.
+         */
+        paddingBottom?: any;
+
+        /**
+         * The padding-left CSS property of an element sets the padding space required on the left side of an element. The padding area is the space between the content of the element and its border. Contrary to margin-left values, negative values of padding-left are invalid.
+         */
+        paddingLeft?: any;
+
+        /**
+         * The padding-right CSS property of an element sets the padding space required on the right side of an element. The padding area is the space between the content of the element and its border. Contrary to margin-right values, negative values of padding-right are invalid.
+         */
+        paddingRight?: any;
+
+        /**
+         * The padding-top CSS property of an element sets the padding space required on the top of an element. The padding area is the space between the content of the element and its border. Contrary to margin-top values, negative values of padding-top are invalid.
+         */
+        paddingTop?: any;
+
+        /**
+         * The page-break-after property is supported in all major browsers. With CSS3, page-break-* properties are only aliases of the break-* properties. The CSS3 Fragmentation spec defines breaks for all CSS box fragmentation.
+         */
+        pageBreakAfter?: any;
+
+        /**
+         * The page-break-before property sets the page-breaking behavior before an element. With CSS3, page-break-* properties are only aliases of the break-* properties. The CSS3 Fragmentation spec defines breaks for all CSS box fragmentation.
+         */
+        pageBreakBefore?: any;
+
+        /**
+         * Sets the page-breaking behavior inside an element. With CSS3, page-break-* properties are only aliases of the break-* properties. The CSS3 Fragmentation spec defines breaks for all CSS box fragmentation.
+         */
+        pageBreakInside?: any;
+
+        /**
+         * The pause property determines how long a speech media agent should pause before and after presenting an element. It is a shorthand for the pause-before and pause-after properties.
+         */
+        pause?: any;
+
+        /**
+         * The pause-after property determines how long a speech media agent should pause after presenting an element. It may be replaced by the shorthand property pause, which sets pause time before and after.
+         */
+        pauseAfter?: any;
+
+        /**
+         * The pause-before property determines how long a speech media agent should pause before presenting an element. It may be replaced by the shorthand property pause, which sets pause time before and after.
+         */
+        pauseBefore?: any;
+
+        /**
+         * The perspective property defines how far an element is placed from the view on the z-axis, from the screen to the viewer.
+         * Perspective defines how an object is viewed. In graphic arts, perspective is the representation on a flat surface of what the viewer's eye would see in a 3D space. (See Wikipedia for more information about graphical perspective and for related illustrations.)
+         * The illusion of perspective on a flat surface, such as a computer screen, is created by projecting points on the flat surface as they would appear if the flat surface were a window through which the viewer was looking at the object. In discussion of virtual environments, this flat surface is called a projection plane.
+         */
+        perspective?: any;
+
+        /**
+         * The perspective-origin property establishes the origin for the perspective property. It effectively sets the X and Y position at which the viewer appears to be looking at the children of the element.
+         * When used with perspective, perspective-origin changes the appearance of an object, as if a viewer were looking at it from a different origin. An object appears differently if a viewer is looking directly at it versus looking at it from below, above, or from the side. Thus, the perspective-origin is like a vanishing point.
+         * The default value of perspective-origin is 50% 50%. This displays an object as if the viewer's eye were positioned directly at the center of the screen, both top-to-bottom and left-to-right. A value of 0% 0% changes the object as if the viewer was looking toward the top left angle. A value of 100% 100% changes the appearance as if viewed toward the bottom right angle.
+         */
+        perspectiveOrigin?: any;
+
+        /**
+         * The pointer-events property allows you to control whether an element can be the target for the pointing device (e.g, mouse, pen) events.
+         */
+        pointerEvents?: any;
+
+        /**
+         * The position property controls the type of positioning used by an element within its parent elements. The effect of the position property depends on a lot of factors, for example the position property of parent elements.
+         */
+        position?: any;
+
+        /**
+         * Obsolete: unsupported.
+         * This property determines whether or not a full-width punctuation mark character should be trimmed if it appears at the beginning of a line, so that its "ink" lines up with the first glyph in the line above and below.
+         */
+        punctuationTrim?: any;
+
+        /**
+         * Sets the type of quotation marks for embedded quotations.
+         */
+        quotes?: any;
+
+        /**
+         * Controls whether the last region in a chain displays additional 'overset' content according its default overflow property, or if it displays a fragment of content as if it were flowing into a subsequent region.
+         */
+        regionFragment?: any;
+
+        /**
+         * The rest-after property determines how long a speech media agent should pause after presenting an element's main content, before presenting that element's exit cue sound. It may be replaced by the shorthand property rest, which sets rest time before and after.
+         */
+        restAfter?: any;
+
+        /**
+         * The rest-before property determines how long a speech media agent should pause after presenting an intro cue sound for an element, before presenting that element's main content. It may be replaced by the shorthand property rest, which sets rest time before and after.
+         */
+        restBefore?: any;
+
+        /**
+         * Specifies the position an element in relation to the right side of the containing element.
+         */
+        right?: any;
+
+        rubyAlign?: any;
+
+        rubyPosition?: any;
+
+        /**
+         * Defines the alpha channel threshold used to extract a shape from an image. Can be thought of as a "minimum opacity" threshold; that is, a value of 0.5 means that the shape will enclose all the pixels that are more than 50% opaque.
+         */
+        shapeImageThreshold?: any;
+
+        /**
+         * A future level of CSS Shapes will define a shape-inside property, which will define a shape to wrap content within the element. See Editor's Draft <http://dev.w3.org/csswg/css-shapes/> and CSSWG wiki page on next-level plans <http://wiki.csswg.org/spec/css-shapes>
+         */
+        shapeInside?: any;
+
+        /**
+         * Adds a margin to a shape-outside. In effect, defines a new shape that is the smallest contour around all the points that are the shape-margin distance outward perpendicular to each point on the underlying shape. For points where a perpendicular direction is not defined (e.g., a triangle corner), takes all points on a circle centered at the point and with a radius of the shape-margin distance. This property accepts only non-negative values.
+         */
+        shapeMargin?: any;
+
+        /**
+         * Declares a shape around which text should be wrapped, with possible modifications from the shape-margin property. The shape defined by shape-outside and shape-margin changes the geometry of a float element's float area.
+         */
+        shapeOutside?: any;
+
+        /**
+         * The speak property determines whether or not a speech synthesizer will read aloud the contents of an element.
+         */
+        speak?: any;
+
+        /**
+         * The speak-as property determines how the speech synthesizer interprets the content: words as whole words or as a sequence of letters, numbers as a numerical value or a sequence of digits, punctuation as pauses in speech or named punctuation characters.
+         */
+        speakAs?: any;
+
+        /**
+         * The tab-size CSS property is used to customise the width of a tab (U+0009) character.
+         */
+        tabSize?: any;
+
+        /**
+         * The 'table-layout' property controls the algorithm used to lay out the table cells, rows, and columns.
+         */
+        tableLayout?: any;
+
+        /**
+         * The text-align CSS property describes how inline content like text is aligned in its parent block element. text-align does not control the alignment of block elements itself, only their inline content.
+         */
+        textAlign?: any;
+
+        /**
+         * The text-align-last CSS property describes how the last line of a block element or a line before line break is aligned in its parent block element.
+         */
+        textAlignLast?: any;
+
+        /**
+         * The text-decoration CSS property is used to set the text formatting to underline, overline, line-through or blink. 
+         * underline and overline decorations are positioned under the text, line-through over it.
+         */
+        textDecoration?: any;
+
+        /**
+         * Sets the color of any text decoration, such as underlines, overlines, and strike throughs.
+         */
+        textDecorationColor?: any;
+
+        /**
+         * Sets what kind of line decorations are added to an element, such as underlines, overlines, etc.
+         */
+        textDecorationLine?: any;
+
+        textDecorationLineThrough?: any;
+
+        textDecorationNone?: any;
+
+        textDecorationOverline?: any;
+
+        /**
+         * Specifies what parts of an element’s content are skipped over when applying any text decoration.
+         */
+        textDecorationSkip?: any;
+
+        /**
+         * This property specifies the style of the text decoration line drawn on the specified element. The intended meaning for the values are the same as those of the border-style-properties.
+         */
+        textDecorationStyle?: any;
+
+        textDecorationUnderline?: any;
+
+        /**
+         * The text-emphasis property will apply special emphasis marks to the elements text. Slightly similar to the text-decoration property only that this property can have affect on the line-height. It also is noted that this is shorthand for text-emphasis-style and for text-emphasis-color.
+         */
+        textEmphasis?: any;
+
+        /**
+         * The text-emphasis-color property specifies the foreground color of the emphasis marks.
+         */
+        textEmphasisColor?: any;
+
+        /**
+         * The text-emphasis-style property applies special emphasis marks to an element's text.
+         */
+        textEmphasisStyle?: any;
+
+        /**
+         * This property helps determine an inline box's block-progression dimension, derived from the text-height and font-size properties for non-replaced elements, the height or the width for replaced elements, and the stacked block-progression dimension for inline-block elements. The block-progression dimension determines the position of the padding, border and margin for the element.
+         */
+        textHeight?: any;
+
+        /**
+         * Specifies the amount of space horizontally that should be left on the first line of the text of an element. This horizontal spacing is at the beginning of the first line and is in respect to the left edge of the containing block box.
+         */
+        textIndent?: any;
+
+        textJustifyTrim?: any;
+
+        textKashidaSpace?: any;
+
+        /**
+         * The text-line-through property is a shorthand property for text-line-through-style, text-line-through-color and text-line-through-mode. (Considered obsolete; use text-decoration instead.)
+         */
+        textLineThrough?: any;
+
+        /**
+         * Specifies the line colors for the line-through text decoration.
+         * (Considered obsolete; use text-decoration-color instead.)
+         */
+        textLineThroughColor?: any;
+
+        /**
+         * Sets the mode for the line-through text decoration, determining whether the text decoration affects the space characters or not.
+         * (Considered obsolete; use text-decoration-skip instead.)
+         */
+        textLineThroughMode?: any;
+
+        /**
+         * Specifies the line style for line-through text decoration.
+         * (Considered obsolete; use text-decoration-style instead.)
+         */
+        textLineThroughStyle?: any;
+
+        /**
+         * Specifies the line width for the line-through text decoration.
+         */
+        textLineThroughWidth?: any;
+
+        /**
+         * The text-overflow shorthand CSS property determines how overflowed content that is not displayed is signaled to the users. It can be clipped, display an ellipsis ('…', U+2026 HORIZONTAL ELLIPSIS) or a Web author-defined string. It covers the two long-hand properties text-overflow-mode and text-overflow-ellipsis
+         */
+        textOverflow?: any;
+
+        /**
+         * The text-overline property is the shorthand for the text-overline-style, text-overline-width, text-overline-color, and text-overline-mode properties.
+         */
+        textOverline?: any;
+
+        /**
+         * Specifies the line color for the overline text decoration.
+         */
+        textOverlineColor?: any;
+
+        /**
+         * Sets the mode for the overline text decoration, determining whether the text decoration affects the space characters or not.
+         */
+        textOverlineMode?: any;
+
+        /**
+         * Specifies the line style for overline text decoration.
+         */
+        textOverlineStyle?: any;
+
+        /**
+         * Specifies the line width for the overline text decoration.
+         */
+        textOverlineWidth?: any;
+
+        /**
+         * The text-rendering CSS property provides information to the browser about how to optimize when rendering text. Options are: legibility, speed or geometric precision.
+         */
+        textRendering?: any;
+
+        /**
+         * Obsolete: unsupported.
+         */
+        textScript?: any;
+
+        /**
+         * The CSS text-shadow property applies one or more drop shadows to the text and <text-decorations> of an element. Each shadow is specified as an offset from the text, along with optional color and blur radius values.
+         */
+        textShadow?: any;
+
+        /**
+         * This property transforms text for styling purposes. (It has no effect on the underlying content.)
+         */
+        textTransform?: any;
+
+        /**
+         * Unsupported.
+         * This property will add a underline position value to the element that has an underline defined.
+         */
+        textUnderlinePosition?: any;
+
+        /**
+         * After review this should be replaced by text-decoration should it not?
+         * This property will set the underline style for text with a line value for underline, overline, and line-through.
+         */
+        textUnderlineStyle?: any;
+
+        /**
+         * This property specifies how far an absolutely positioned box's top margin edge is offset below the top edge of the box's containing block. For relatively positioned boxes, the offset is with respect to the top edges of the box itself (i.e., the box is given a position in the normal flow, then offset from that position according to these properties).
+         */
+        top?: any;
+
+        /**
+         * Determines whether touch input may trigger default behavior supplied by the user agent, such as panning or zooming.
+         */
+        touchAction?: any;
+
+        /**
+         * CSS transforms allow elements styled with CSS to be transformed in two-dimensional or three-dimensional space. Using this property, elements can be translated, rotated, scaled, and skewed. The value list may consist of 2D and/or 3D transform values.
+         */
+        transform?: any;
+
+        /**
+         * This property defines the origin of the transformation axes relative to the element to which the transformation is applied.
+         */
+        transformOrigin?: any;
+
+        /**
+         * This property allows you to define the relative position of the origin of the transformation grid along the z-axis.
+         */
+        transformOriginZ?: any;
+
+        /**
+         * This property specifies how nested elements are rendered in 3D space relative to their parent.
+         */
+        transformStyle?: any;
+
+        /**
+         * The transition CSS property is a shorthand property for transition-property, transition-duration, transition-timing-function, and transition-delay. It allows to define the transition between two states of an element.
+         */
+        transition?: any;
+
+        /**
+         * Defines when the transition will start. A value of ‘0s’ means the transition will execute as soon as the property is changed. Otherwise, the value specifies an offset from the moment the property is changed, and the transition will delay execution by that offset.
+         */
+        transitionDelay?: any;
+
+        /**
+         * The 'transition-duration' property specifies the length of time a transition animation takes to complete.
+         */
+        transitionDuration?: any;
+
+        /**
+         * The 'transition-property' property specifies the name of the CSS property to which the transition is applied.
+         */
+        transitionProperty?: any;
+
+        /**
+         * Sets the pace of action within a transition
+         */
+        transitionTimingFunction?: any;
+
+        /**
+         * The unicode-bidi CSS property specifies the level of embedding with respect to the bidirectional algorithm.
+         */
+        unicodeBidi?: any;
+
+        /**
+         * unicode-range allows you to set a specific range of characters to be downloaded from a font (embedded using @font-face) and made available for use on the current page.
+         */
+        unicodeRange?: any;
+
+        /**
+         * This is for all the high level UX stuff.
+         */
+        userFocus?: any;
+
+        /**
+         * For inputing user content
+         */
+        userInput?: any;
+
+        /**
+         * The vertical-align property controls how inline elements or text are vertically aligned compared to the baseline. If this property is used on table-cells it controls the vertical alignment of content of the table cell.
+         */
+        verticalAlign?: any;
+
+        /**
+         * The visibility property specifies whether the boxes generated by an element are rendered.
+         */
+        visibility?: any;
+
+        /**
+         * The voice-balance property sets the apparent position (in stereo sound) of the synthesized voice for spoken media.
+         */
+        voiceBalance?: any;
+
+        /**
+         * The voice-duration property allows the author to explicitly set the amount of time it should take a speech synthesizer to read an element's content, for example to allow the speech to be synchronized with other media. With a value of auto (the default) the length of time it takes to read the content is determined by the content itself and the voice-rate property.
+         */
+        voiceDuration?: any;
+
+        /**
+         * The voice-family property sets the speaker's voice used by a speech media agent to read an element. The speaker may be specified as a named character (to match a voice option in the speech reading software) or as a generic description of the age and gender of the voice. Similar to the font-family property for visual media, a comma-separated list of fallback options may be given in case the speech reader does not recognize the character name or cannot synthesize the requested combination of generic properties.
+         */
+        voiceFamily?: any;
+
+        /**
+         * The voice-pitch property sets pitch or tone (high or low) for the synthesized speech when reading an element; the pitch may be specified absolutely or relative to the normal pitch for the voice-family used to read the text.
+         */
+        voicePitch?: any;
+
+        /**
+         * The voice-range property determines how much variation in pitch or tone will be created by the speech synthesize when reading an element. Emphasized text, grammatical structures and punctuation may all be rendered as changes in pitch, this property determines how strong or obvious those changes are; large ranges are associated with enthusiastic or emotional speech, while small ranges are associated with flat or mechanical speech.
+         */
+        voiceRange?: any;
+
+        /**
+         * The voice-rate property sets the speed at which the voice synthesized by a speech media agent will read content.
+         */
+        voiceRate?: any;
+
+        /**
+         * The voice-stress property sets the level of vocal emphasis to be used for synthesized speech reading the element.
+         */
+        voiceStress?: any;
+
+        /**
+         * The voice-volume property sets the volume for spoken content in speech media. It replaces the deprecated volume property.
+         */
+        voiceVolume?: any;
+
+        /**
+         * The white-space property controls whether and how white space inside the element is collapsed, and whether lines may wrap at unforced "soft wrap" opportunities.
+         */
+        whiteSpace?: any;
+
+        /**
+         * Obsolete: unsupported.
+         */
+        whiteSpaceTreatment?: any;
+
+        /**
+         * Specifies the width of the content area of an element. The content area of the element width does not include the padding, border, and margin of the element.
+         */
+        width?: any;
+
+        /**
+         * The word-break property is often used when there is long generated content that is strung together without and spaces or hyphens to beak apart. A common case of this is when there is a long URL that does not have any hyphens. This case could potentially cause the breaking of the layout as it could extend past the parent element.
+         */
+        wordBreak?: any;
+
+        /**
+         * The word-spacing CSS property specifies the spacing behavior between "words".
+         */
+        wordSpacing?: any;
+
+        /**
+         * An alias of css/properties/overflow-wrap, word-wrap defines whether to break words when the content exceeds the boundaries of its container.
+         */
+        wordWrap?: any;
+
+        /**
+         * Specifies how exclusions affect inline content within block-level elements. Elements lay out their inline content in their content area but wrap around exclusion areas.
+         */
+        wrapFlow?: any;
+
+        /**
+         * Set the value that is used to offset the inner wrap shape from other shapes. Inline content that intersects a shape with this property will be pushed by this shape's margin.
+         */
+        wrapMargin?: any;
+
+        /**
+         * Obsolete and unsupported. Do not use.
+         * This CSS property controls the text when it reaches the end of the block in which it is enclosed.
+         */
+        wrapOption?: any;
+
+        /**
+         * writing-mode specifies if lines of text are laid out horizontally or vertically, and the direction which lines of text and blocks progress.
+         */
+        writingMode?: any;
+
+
+        [propertyName: string]: any;
+    }
+
+    interface HTMLAttributes extends DOMAttributes {
+        // React-specific Attributes
+        defaultChecked?: boolean;
+        defaultValue?: string | string[];
+
+        // Standard HTML Attributes
+        accept?: string;
+        acceptCharset?: string;
+        accessKey?: string;
+        action?: string;
+        allowFullScreen?: boolean;
+        allowTransparency?: boolean;
+        alt?: string;
+        async?: boolean;
+        autoComplete?: string;
+        autoFocus?: boolean;
+        autoPlay?: boolean;
+        capture?: boolean;
+        cellPadding?: number | string;
+        cellSpacing?: number | string;
+        charSet?: string;
+        challenge?: string;
+        checked?: boolean;
+        classID?: string;
+        className?: string;
+        cols?: number;
+        colSpan?: number;
+        content?: string;
+        contentEditable?: boolean;
+        contextMenu?: string;
+        controls?: boolean;
+        coords?: string;
+        crossOrigin?: string;
+        data?: string;
+        dateTime?: string;
+        default?: boolean;
+        defer?: boolean;
+        dir?: string;
+        disabled?: boolean;
+        download?: any;
+        draggable?: boolean;
+        encType?: string;
+        form?: string;
+        formAction?: string;
+        formEncType?: string;
+        formMethod?: string;
+        formNoValidate?: boolean;
+        formTarget?: string;
+        frameBorder?: number | string;
+        headers?: string;
+        height?: number | string;
+        hidden?: boolean;
+        high?: number;
+        href?: string;
+        hrefLang?: string;
+        htmlFor?: string;
+        httpEquiv?: string;
+        icon?: string;
+        id?: string;
+        inputMode?: string;
+        integrity?: string;
+        is?: string;
+        keyParams?: string;
+        keyType?: string;
+        kind?: string;
+        label?: string;
+        lang?: string;
+        list?: string;
+        loop?: boolean;
+        low?: number;
+        manifest?: string;
+        marginHeight?: number;
+        marginWidth?: number;
+        max?: number | string;
+        maxLength?: number;
+        media?: string;
+        mediaGroup?: string;
+        method?: string;
+        min?: number | string;
+        minLength?: number;
+        multiple?: boolean;
+        muted?: boolean;
+        name?: string;
+        noValidate?: boolean;
+        open?: boolean;
+        optimum?: number;
+        pattern?: string;
+        placeholder?: string;
+        poster?: string;
+        preload?: string;
+        radioGroup?: string;
+        readOnly?: boolean;
+        rel?: string;
+        required?: boolean;
+        role?: string;
+        rows?: number;
+        rowSpan?: number;
+        sandbox?: string;
+        scope?: string;
+        scoped?: boolean;
+        scrolling?: string;
+        seamless?: boolean;
+        selected?: boolean;
+        shape?: string;
+        size?: number;
+        sizes?: string;
+        span?: number;
+        spellCheck?: boolean;
+        src?: string;
+        srcDoc?: string;
+        srcLang?: string;
+        srcSet?: string;
+        start?: number;
+        step?: number | string;
+        style?: CSSProperties;
+        summary?: string;
+        tabIndex?: number;
+        target?: string;
+        title?: string;
+        type?: string;
+        useMap?: string;
+        value?: string | string[];
+        width?: number | string;
+        wmode?: string;
+        wrap?: string;
+
+        // RDFa Attributes
+        about?: string;
+        datatype?: string;
+        inlist?: any;
+        prefix?: string;
+        property?: string;
+        resource?: string;
+        typeof?: string;
+        vocab?: string;
+
+        // Non-standard Attributes
+        autoCapitalize?: boolean;
+        autoCorrect?: string;
+        autoSave?: string;
+        color?: string;
+        itemProp?: string;
+        itemScope?: boolean;
+        itemType?: string;
+        itemID?: string;
+        itemRef?: string;
+        results?: number;
+        security?: string;
+        unselectable?: boolean;
+    }
+
+    interface SVGAttributes extends HTMLAttributes {
+        clipPath?: string;
+        cx?: number | string;
+        cy?: number | string;
+        d?: string;
+        dx?: number | string;
+        dy?: number | string;
+        fill?: string;
+        fillOpacity?: number | string;
+        fontFamily?: string;
+        fontSize?: number | string;
+        fx?: number | string;
+        fy?: number | string;
+        gradientTransform?: string;
+        gradientUnits?: string;
+        markerEnd?: string;
+        markerMid?: string;
+        markerStart?: string;
+        offset?: number | string;
+        opacity?: number | string;
+        patternContentUnits?: string;
+        patternUnits?: string;
+        points?: string;
+        preserveAspectRatio?: string;
+        r?: number | string;
+        rx?: number | string;
+        ry?: number | string;
+        spreadMethod?: string;
+        stopColor?: string;
+        stopOpacity?: number | string;
+        stroke?: string;
+        strokeDasharray?: string;
+        strokeLinecap?: string;
+        strokeOpacity?: number | string;
+        strokeWidth?: number | string;
+        textAnchor?: string;
+        transform?: string;
+        version?: string;
+        viewBox?: string;
+        x1?: number | string;
+        x2?: number | string;
+        x?: number | string;
+        xlinkActuate?: string;
+        xlinkArcrole?: string;
+        xlinkHref?: string;
+        xlinkRole?: string;
+        xlinkShow?: string;
+        xlinkTitle?: string;
+        xlinkType?: string;
+        xmlBase?: string;
+        xmlLang?: string;
+        xmlSpace?: string;
+        y1?: number | string;
+        y2?: number | string;
+        y?: number | string;
+    }
+
+    //
+    // React.DOM
+    // ----------------------------------------------------------------------
+
+    interface ReactDOM {
+        // HTML
+        a: HTMLFactory;
+        abbr: HTMLFactory;
+        address: HTMLFactory;
+        area: HTMLFactory;
+        article: HTMLFactory;
+        aside: HTMLFactory;
+        audio: HTMLFactory;
+        b: HTMLFactory;
+        base: HTMLFactory;
+        bdi: HTMLFactory;
+        bdo: HTMLFactory;
+        big: HTMLFactory;
+        blockquote: HTMLFactory;
+        body: HTMLFactory;
+        br: HTMLFactory;
+        button: HTMLFactory;
+        canvas: HTMLFactory;
+        caption: HTMLFactory;
+        cite: HTMLFactory;
+        code: HTMLFactory;
+        col: HTMLFactory;
+        colgroup: HTMLFactory;
+        data: HTMLFactory;
+        datalist: HTMLFactory;
+        dd: HTMLFactory;
+        del: HTMLFactory;
+        details: HTMLFactory;
+        dfn: HTMLFactory;
+        dialog: HTMLFactory;
+        div: HTMLFactory;
+        dl: HTMLFactory;
+        dt: HTMLFactory;
+        em: HTMLFactory;
+        embed: HTMLFactory;
+        fieldset: HTMLFactory;
+        figcaption: HTMLFactory;
+        figure: HTMLFactory;
+        footer: HTMLFactory;
+        form: HTMLFactory;
+        h1: HTMLFactory;
+        h2: HTMLFactory;
+        h3: HTMLFactory;
+        h4: HTMLFactory;
+        h5: HTMLFactory;
+        h6: HTMLFactory;
+        head: HTMLFactory;
+        header: HTMLFactory;
+        hr: HTMLFactory;
+        html: HTMLFactory;
+        i: HTMLFactory;
+        iframe: HTMLFactory;
+        img: HTMLFactory;
+        input: HTMLFactory;
+        ins: HTMLFactory;
+        kbd: HTMLFactory;
+        keygen: HTMLFactory;
+        label: HTMLFactory;
+        legend: HTMLFactory;
+        li: HTMLFactory;
+        link: HTMLFactory;
+        main: HTMLFactory;
+        map: HTMLFactory;
+        mark: HTMLFactory;
+        menu: HTMLFactory;
+        menuitem: HTMLFactory;
+        meta: HTMLFactory;
+        meter: HTMLFactory;
+        nav: HTMLFactory;
+        noscript: HTMLFactory;
+        object: HTMLFactory;
+        ol: HTMLFactory;
+        optgroup: HTMLFactory;
+        option: HTMLFactory;
+        output: HTMLFactory;
+        p: HTMLFactory;
+        param: HTMLFactory;
+        picture: HTMLFactory;
+        pre: HTMLFactory;
+        progress: HTMLFactory;
+        q: HTMLFactory;
+        rp: HTMLFactory;
+        rt: HTMLFactory;
+        ruby: HTMLFactory;
+        s: HTMLFactory;
+        samp: HTMLFactory;
+        script: HTMLFactory;
+        section: HTMLFactory;
+        select: HTMLFactory;
+        small: HTMLFactory;
+        source: HTMLFactory;
+        span: HTMLFactory;
+        strong: HTMLFactory;
+        style: HTMLFactory;
+        sub: HTMLFactory;
+        summary: HTMLFactory;
+        sup: HTMLFactory;
+        table: HTMLFactory;
+        tbody: HTMLFactory;
+        td: HTMLFactory;
+        textarea: HTMLFactory;
+        tfoot: HTMLFactory;
+        th: HTMLFactory;
+        thead: HTMLFactory;
+        time: HTMLFactory;
+        title: HTMLFactory;
+        tr: HTMLFactory;
+        track: HTMLFactory;
+        u: HTMLFactory;
+        ul: HTMLFactory;
+        "var": HTMLFactory;
+        video: HTMLFactory;
+        wbr: HTMLFactory;
+
+        // SVG
+        svg: SVGFactory;
+        circle: SVGFactory;
+        defs: SVGFactory;
+        ellipse: SVGFactory;
+        g: SVGFactory;
+        image: SVGFactory;
+        line: SVGFactory;
+        linearGradient: SVGFactory;
+        mask: SVGFactory;
+        path: SVGFactory;
+        pattern: SVGFactory;
+        polygon: SVGFactory;
+        polyline: SVGFactory;
+        radialGradient: SVGFactory;
+        rect: SVGFactory;
+        stop: SVGFactory;
+        text: SVGFactory;
+        tspan: SVGFactory;
+    }
+
+    //
+    // React.PropTypes
+    // ----------------------------------------------------------------------
+
+    interface Validator<T> {
+        (object: T, key: string, componentName: string): Error;
+    }
+
+    interface Requireable<T> extends Validator<T> {
+        isRequired: Validator<T>;
+    }
+
+    interface ValidationMap<T> {
+        [key: string]: Validator<T>;
+    }
+
+    interface ReactPropTypes {
+        any: Requireable<any>;
+        array: Requireable<any>;
+        bool: Requireable<any>;
+        func: Requireable<any>;
+        number: Requireable<any>;
+        object: Requireable<any>;
+        string: Requireable<any>;
+        node: Requireable<any>;
+        element: Requireable<any>;
+        instanceOf(expectedClass: {}): Requireable<any>;
+        oneOf(types: any[]): Requireable<any>;
+        oneOfType(types: Validator<any>[]): Requireable<any>;
+        arrayOf(type: Validator<any>): Requireable<any>;
+        objectOf(type: Validator<any>): Requireable<any>;
+        shape(type: ValidationMap<any>): Requireable<any>;
+    }
+
+    //
+    // React.Children
+    // ----------------------------------------------------------------------
+
+    interface ReactChildren {
+        map<T>(children: ReactNode, fn: (child: ReactChild, index: number) => T): T[];
+        forEach(children: ReactNode, fn: (child: ReactChild, index: number) => any): void;
+        count(children: ReactNode): number;
+        only(children: ReactNode): ReactChild;
+        toArray(children: ReactNode): ReactChild[];
+    }
+
+    //
+    // Browser Interfaces
+    // https://github.com/nikeee/2048-typescript/blob/master/2048/js/touch.d.ts
+    // ----------------------------------------------------------------------
+
+    interface AbstractView {
+        styleMedia: StyleMedia;
+        document: Document;
+    }
+
+    interface Touch {
+        identifier: number;
+        target: EventTarget;
+        screenX: number;
+        screenY: number;
+        clientX: number;
+        clientY: number;
+        pageX: number;
+        pageY: number;
+    }
+
+    interface TouchList {
+        [index: number]: Touch;
+        length: number;
+        item(index: number): Touch;
+        identifiedTouch(identifier: number): Touch;
+    }
+}
+
+declare module "react" {
+    export = __React;
+}
+
+declare namespace JSX {
+    import React = __React;
+
+    interface Element extends React.ReactElement<any> { }
+    interface ElementClass extends React.Component<any, any> {
+        render(): JSX.Element;
+    }
+    interface ElementAttributesProperty { props: {}; }
+
+    interface IntrinsicAttributes {
+        key?: string | number;
+    }
+
+    interface IntrinsicClassAttributes<T> {
+        ref?: string | ((classInstance: T) => void);
+    }
+
+    interface IntrinsicElements {
+        // HTML
+        a: React.HTMLProps<HTMLAnchorElement>;
+        abbr: React.HTMLProps<HTMLElement>;
+        address: React.HTMLProps<HTMLElement>;
+        area: React.HTMLProps<HTMLAreaElement>;
+        article: React.HTMLProps<HTMLElement>;
+        aside: React.HTMLProps<HTMLElement>;
+        audio: React.HTMLProps<HTMLAudioElement>;
+        b: React.HTMLProps<HTMLElement>;
+        base: React.HTMLProps<HTMLBaseElement>;
+        bdi: React.HTMLProps<HTMLElement>;
+        bdo: React.HTMLProps<HTMLElement>;
+        big: React.HTMLProps<HTMLElement>;
+        blockquote: React.HTMLProps<HTMLElement>;
+        body: React.HTMLProps<HTMLBodyElement>;
+        br: React.HTMLProps<HTMLBRElement>;
+        button: React.HTMLProps<HTMLButtonElement>;
+        canvas: React.HTMLProps<HTMLCanvasElement>;
+        caption: React.HTMLProps<HTMLElement>;
+        cite: React.HTMLProps<HTMLElement>;
+        code: React.HTMLProps<HTMLElement>;
+        col: React.HTMLProps<HTMLTableColElement>;
+        colgroup: React.HTMLProps<HTMLTableColElement>;
+        data: React.HTMLProps<HTMLElement>;
+        datalist: React.HTMLProps<HTMLDataListElement>;
+        dd: React.HTMLProps<HTMLElement>;
+        del: React.HTMLProps<HTMLElement>;
+        details: React.HTMLProps<HTMLElement>;
+        dfn: React.HTMLProps<HTMLElement>;
+        dialog: React.HTMLProps<HTMLElement>;
+        div: React.HTMLProps<HTMLDivElement>;
+        dl: React.HTMLProps<HTMLDListElement>;
+        dt: React.HTMLProps<HTMLElement>;
+        em: React.HTMLProps<HTMLElement>;
+        embed: React.HTMLProps<HTMLEmbedElement>;
+        fieldset: React.HTMLProps<HTMLFieldSetElement>;
+        figcaption: React.HTMLProps<HTMLElement>;
+        figure: React.HTMLProps<HTMLElement>;
+        footer: React.HTMLProps<HTMLElement>;
+        form: React.HTMLProps<HTMLFormElement>;
+        h1: React.HTMLProps<HTMLHeadingElement>;
+        h2: React.HTMLProps<HTMLHeadingElement>;
+        h3: React.HTMLProps<HTMLHeadingElement>;
+        h4: React.HTMLProps<HTMLHeadingElement>;
+        h5: React.HTMLProps<HTMLHeadingElement>;
+        h6: React.HTMLProps<HTMLHeadingElement>;
+        head: React.HTMLProps<HTMLHeadElement>;
+        header: React.HTMLProps<HTMLElement>;
+        hr: React.HTMLProps<HTMLHRElement>;
+        html: React.HTMLProps<HTMLHtmlElement>;
+        i: React.HTMLProps<HTMLElement>;
+        iframe: React.HTMLProps<HTMLIFrameElement>;
+        img: React.HTMLProps<HTMLImageElement>;
+        input: React.HTMLProps<HTMLInputElement>;
+        ins: React.HTMLProps<HTMLModElement>;
+        kbd: React.HTMLProps<HTMLElement>;
+        keygen: React.HTMLProps<HTMLElement>;
+        label: React.HTMLProps<HTMLLabelElement>;
+        legend: React.HTMLProps<HTMLLegendElement>;
+        li: React.HTMLProps<HTMLLIElement>;
+        link: React.HTMLProps<HTMLLinkElement>;
+        main: React.HTMLProps<HTMLElement>;
+        map: React.HTMLProps<HTMLMapElement>;
+        mark: React.HTMLProps<HTMLElement>;
+        menu: React.HTMLProps<HTMLElement>;
+        menuitem: React.HTMLProps<HTMLElement>;
+        meta: React.HTMLProps<HTMLMetaElement>;
+        meter: React.HTMLProps<HTMLElement>;
+        nav: React.HTMLProps<HTMLElement>;
+        noscript: React.HTMLProps<HTMLElement>;
+        object: React.HTMLProps<HTMLObjectElement>;
+        ol: React.HTMLProps<HTMLOListElement>;
+        optgroup: React.HTMLProps<HTMLOptGroupElement>;
+        option: React.HTMLProps<HTMLOptionElement>;
+        output: React.HTMLProps<HTMLElement>;
+        p: React.HTMLProps<HTMLParagraphElement>;
+        param: React.HTMLProps<HTMLParamElement>;
+        picture: React.HTMLProps<HTMLElement>;
+        pre: React.HTMLProps<HTMLPreElement>;
+        progress: React.HTMLProps<HTMLProgressElement>;
+        q: React.HTMLProps<HTMLQuoteElement>;
+        rp: React.HTMLProps<HTMLElement>;
+        rt: React.HTMLProps<HTMLElement>;
+        ruby: React.HTMLProps<HTMLElement>;
+        s: React.HTMLProps<HTMLElement>;
+        samp: React.HTMLProps<HTMLElement>;
+        script: React.HTMLProps<HTMLElement>;
+        section: React.HTMLProps<HTMLElement>;
+        select: React.HTMLProps<HTMLSelectElement>;
+        small: React.HTMLProps<HTMLElement>;
+        source: React.HTMLProps<HTMLSourceElement>;
+        span: React.HTMLProps<HTMLSpanElement>;
+        strong: React.HTMLProps<HTMLElement>;
+        style: React.HTMLProps<HTMLStyleElement>;
+        sub: React.HTMLProps<HTMLElement>;
+        summary: React.HTMLProps<HTMLElement>;
+        sup: React.HTMLProps<HTMLElement>;
+        table: React.HTMLProps<HTMLTableElement>;
+        tbody: React.HTMLProps<HTMLTableSectionElement>;
+        td: React.HTMLProps<HTMLTableDataCellElement>;
+        textarea: React.HTMLProps<HTMLTextAreaElement>;
+        tfoot: React.HTMLProps<HTMLTableSectionElement>;
+        th: React.HTMLProps<HTMLTableHeaderCellElement>;
+        thead: React.HTMLProps<HTMLTableSectionElement>;
+        time: React.HTMLProps<HTMLElement>;
+        title: React.HTMLProps<HTMLTitleElement>;
+        tr: React.HTMLProps<HTMLTableRowElement>;
+        track: React.HTMLProps<HTMLTrackElement>;
+        u: React.HTMLProps<HTMLElement>;
+        ul: React.HTMLProps<HTMLUListElement>;
+        "var": React.HTMLProps<HTMLElement>;
+        video: React.HTMLProps<HTMLVideoElement>;
+        wbr: React.HTMLProps<HTMLElement>;
+
+        // SVG
+        svg: React.SVGProps;
+
+        circle: React.SVGProps;
+        defs: React.SVGProps;
+        ellipse: React.SVGProps;
+        g: React.SVGProps;
+        image: React.SVGProps;
+        line: React.SVGProps;
+        linearGradient: React.SVGProps;
+        mask: React.SVGProps;
+        path: React.SVGProps;
+        pattern: React.SVGProps;
+        polygon: React.SVGProps;
+        polyline: React.SVGProps;
+        radialGradient: React.SVGProps;
+        rect: React.SVGProps;
+        stop: React.SVGProps;
+        text: React.SVGProps;
+        tspan: React.SVGProps;
+    }
+}

--- a/examples/browserify-typescript-gulp-example/src/typings/tsd.d.ts
+++ b/examples/browserify-typescript-gulp-example/src/typings/tsd.d.ts
@@ -1,0 +1,6 @@
+/// <reference path="core-js/core-js.d.ts" />
+/// <reference path="material-ui/material-ui.d.ts" />
+/// <reference path="react/react.d.ts" />
+/// <reference path="react/react-dom.d.ts" />
+/// <reference path="custom/react-tap-event-plugin.d.ts" />
+/// <reference path="custom/pure-render-decorator.d.ts"/>

--- a/examples/browserify-typescript-gulp-example/src/www/index.html
+++ b/examples/browserify-typescript-gulp-example/src/www/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html class="no-js" lang="">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Material UI Example</title>
+  <meta name="description" content="Google's material design UI components built with React.">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" type="text/css" href="main.css">
+</head>
+
+<body>
+  <div id="app"></div>
+  
+  <!-- This script adds the Roboto font to our project. For more detail go to this site:  http://www.google.com/fonts#UsePlace:use/Collection:Roboto:400,300,500 -->
+  <script>
+    var WebFontConfig = {
+      google: { families: [ 'Roboto:400,300,500:latin' ] }
+    };
+    (function() {
+      var wf = document.createElement('script');
+      wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
+      '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
+      wf.type = 'text/javascript';
+      wf.async = 'true';
+      var s = document.getElementsByTagName('script')[0];
+      s.parentNode.insertBefore(wf, s);
+    })();
+  </script>
+  <script src="app.js"></script>
+</body>
+
+</html>

--- a/examples/browserify-typescript-gulp-example/src/www/main.css
+++ b/examples/browserify-typescript-gulp-example/src/www/main.css
@@ -1,0 +1,8 @@
+html {
+  font-family: 'Roboto', sans-serif;
+}
+
+body {
+  font-size: 13px;
+  line-height: 20px;
+}

--- a/examples/browserify-typescript-gulp-example/tsconfig.json
+++ b/examples/browserify-typescript-gulp-example/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compileOnSave": false,
+    "compilerOptions": {
+        "noImplicitAny": true,
+        "experimentalDecorators": true,
+        "emitDecoratorMetadata": true,
+        "jsx": "React"
+    },
+    "exclude": [
+        "node_modules"
+    ]
+}

--- a/examples/browserify-typescript-gulp-example/tsd.json
+++ b/examples/browserify-typescript-gulp-example/tsd.json
@@ -1,0 +1,21 @@
+{
+  "version": "v4",
+  "repo": "borisyankov/DefinitelyTyped",
+  "ref": "master",
+  "path": "src/typings",
+  "bundle": "src/typings/tsd.d.ts",
+  "installed": {
+    "core-js/core-js.d.ts": {
+      "commit": "e5a27ea95e47b95333784f1f0d590127b4e39a89"
+    },
+    "react/react.d.ts": {
+      "commit": "e5a27ea95e47b95333784f1f0d590127b4e39a89"
+    },
+    "material-ui/material-ui.d.ts": {
+      "commit": "e5a27ea95e47b95333784f1f0d590127b4e39a89"
+    },
+    "react/react-dom.d.ts": {
+      "commit": "e5a27ea95e47b95333784f1f0d590127b4e39a89"
+    }
+  }
+}


### PR DESCRIPTION
Typescript 1.6 now supports JSX and can be used really nicely with React and Material-UI.  This pull request creates a new example project (based on the existing browserify one) to demonstrate how great these things now work together--please include it in the base fork :)

In addition, the example project uses the 'material-ui' typescript definitions created by @subjectix, @ngbrown, and others. These definitions are great but maybe we should consider adding them to the main material-ui project too? This would encourage more 'material-ui' contributors (any myself) to help maintain them, and should help keep any changes in-sync. What do you think?    