### PR TITLE
[Dialog] clear deprecated api

### DIFF
--- a/docs/src/app/components/pages/components/dialog.jsx
+++ b/docs/src/app/components/pages/components/dialog.jsx
@@ -79,24 +79,12 @@ export default class DialogPage extends React.Component {
             type: 'bool',
             header: 'default: false',
             desc: `Force the user to use one of the actions in the dialog.
-              Clicking outside the dialog will not dismiss the dialog.`,
-          },
-          {
-            name: 'Deprecated: openImmediately',
-            type: 'bool',
-            header: 'default: false',
-            desc: 'Deprecated: Set to true to have the dialog automatically open on mount.',
-          },
-          {
-            name: 'defaultOpen',
-            type: 'bool',
-            header: 'default: false',
-            desc: 'Set to true to have the dialog automatically open on mount.',
+              Clicking outside the dialog will not trigger the onRequestClose.`,
           },
           {
             name: 'open',
             type: 'bool',
-            header: 'default: null',
+            header: 'required',
             desc: 'Controls whether the Dialog is opened or not.',
           },
           {
@@ -128,38 +116,8 @@ export default class DialogPage extends React.Component {
         ],
       },
       {
-        name: 'Methods',
-        infoArray: [
-          {
-            name: 'Deprecated: dismiss',
-            header: 'Dialog.dismiss()',
-            desc: 'Hides the dialog.',
-          },
-          {
-            name: 'Deprecated: show',
-            header: 'Dialog.show()',
-            desc: 'Shows the dialog.',
-          },
-          {
-            name: 'isOpen',
-            header: 'Dialog.isOpen()',
-            desc: 'Get the dialog open state.',
-          },
-        ],
-      },
-      {
         name: 'Events',
         infoArray: [
-          {
-            name: 'Deprecated: onDismiss',
-            header: 'function()',
-            desc: 'Fired when the dialog is dismissed.',
-          },
-          {
-            name: 'Deprecated: onShow',
-            header: 'function()',
-            desc: 'Fired when the dialog is shown.',
-          },
           {
             name: 'onRequestClose',
             header: 'function(buttonClicked)',

--- a/src/date-picker/date-picker-dialog.jsx
+++ b/src/date-picker/date-picker-dialog.jsx
@@ -106,8 +106,6 @@ const DatePickerDialog = React.createClass({
       onAccept,
       style,
       container,
-      onDismiss,
-      onShow,
       ...other,
     } = this.props;
 
@@ -155,14 +153,6 @@ const DatePickerDialog = React.createClass({
       );
     }
 
-    // Those two properties are deprecated, we will remove them at some point
-    if (typeof onDismiss === 'function') {
-      other.onDismiss = onDismiss;
-    }
-    if (typeof onShow === 'function') {
-      other.onShow = onShow;
-    }
-
     // will change later when Popover is available.
     const Container = (container === 'inline' ? DatePickerInline : Dialog);
     return (
@@ -193,12 +183,14 @@ const DatePickerDialog = React.createClass({
   },
 
   show() {
+    if (this.props.onShow && !this.state.open) this.props.onShow();
     this.setState({
       open: true,
     });
   },
 
   dismiss() {
+    if (this.props.onDismiss && this.state.open) this.props.onDismiss();
     this.setState({
       open: false,
     });

--- a/src/dialog.jsx
+++ b/src/dialog.jsx
@@ -10,7 +10,6 @@ import RenderToLayer from './render-to-layer';
 import Paper from './paper';
 import DefaultRawTheme from './styles/raw-themes/light-raw-theme';
 import ThemeManager from './styles/theme-manager';
-import warning from 'warning';
 
 import ReactTransitionGroup from 'react-addons-transition-group';
 
@@ -409,13 +408,9 @@ const Dialog = React.createClass({
     bodyStyle: React.PropTypes.object,
     contentClassName: React.PropTypes.string,
     contentStyle: React.PropTypes.object,
-    defaultOpen: React.PropTypes.bool,
     modal: React.PropTypes.bool,
-    onDismiss: React.PropTypes.func,
     onRequestClose: React.PropTypes.func,
-    onShow: React.PropTypes.func,
-    open: React.PropTypes.bool,
-    openImmediately: React.PropTypes.bool,
+    open: React.PropTypes.bool.isRequired,
     repositionOnUpdate: React.PropTypes.bool,
     style: React.PropTypes.object,
     title: React.PropTypes.node,
@@ -439,26 +434,13 @@ const Dialog = React.createClass({
   },
 
   getInitialState() {
-    if (process.env.NODE_ENV !== 'production') {
-      this._testDeprecations();
-    }
-
-    let open = this.props.open;
-
-    if (open === null) {
-      open = (this.props.openImmediately || this.props.defaultOpen);
-    }
-
     return {
-      open: open,
       muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
     };
   },
 
   getDefaultProps() {
     return {
-      open: null,
-      defaultOpen: false,
       modal: false,
     };
   },
@@ -469,16 +451,6 @@ const Dialog = React.createClass({
     const newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
     this.setState({muiTheme: newMuiTheme});
 
-    if (process.env.NODE_ENV !== 'production') {
-      this._testDeprecations();
-    }
-    if (nextProps.open !== this.props.open) {
-      if (nextProps.open && !this.state.open) {
-        this._show();
-      } else if (!nextProps.open && this.state.open) {
-        this._dismiss();
-      }
-    }
   },
 
   render() {
@@ -489,59 +461,8 @@ const Dialog = React.createClass({
 
   renderLayer() {
     return (
-      <DialogInline {...this.props} onRequestClose={this.props.onRequestClose} open={this.state.open} />
+      <DialogInline {...this.props} onRequestClose={this.props.onRequestClose} open={this.props.open} />
     );
-  },
-
-  _testDeprecations() {
-    warning(!this.props.hasOwnProperty('openImmediately'),
-      'openImmediately has been deprecated in favor of defaultOpen');
-
-    warning(!(typeof this.props.onShow === 'function'),
-      'onShow will be removed in favor of explicitly setting open');
-
-    warning(!(typeof this.props.onDismiss === 'function'),
-      'onDismiss will be removed in favor of explicitly setting open and can be replaced by onRequestClose');
-  },
-
-  show() {
-    warning(false, 'show has been deprecated in favor of explicitly setting the open property.');
-
-    this._show();
-  },
-
-  _onShow() {
-    if (this.props.onShow) {
-      this.props.onShow();
-    }
-  },
-
-  _show() {
-    this.setState({
-      open: true,
-    }, this._onShow);
-  },
-
-  dismiss() {
-    warning(false, 'dismiss has been deprecated in favor of explicitly setting the open property.');
-
-    this._dismiss();
-  },
-
-  _onDismiss() {
-    if (this.props.onDismiss) {
-      this.props.onDismiss();
-    }
-  },
-
-  _dismiss() {
-    this.setState({
-      open: false,
-    }, this._onDismiss);
-  },
-
-  isOpen() {
-    return this.state.openImmediately;
   },
 
 });

--- a/src/time-picker/time-picker-dialog.jsx
+++ b/src/time-picker/time-picker-dialog.jsx
@@ -65,8 +65,6 @@ const TimePickerDialog = React.createClass({
       onAccept,
       format,
       autoOk,
-      onShow,
-      onDismiss,
       ...other,
     } = this.props;
 
@@ -98,14 +96,6 @@ const TimePickerDialog = React.createClass({
 
     const onClockChangeMinutes = (autoOk === true ? this._handleOKTouchTap : undefined);
 
-    // Those two properties are deprecated, we will remove them at some point
-    if (typeof onDismiss === 'function') {
-      other.onDismiss = onDismiss;
-    }
-    if (typeof onShow === 'function') {
-      other.onShow = onShow;
-    }
-
     return (
       <Dialog {...other}
         ref="dialogWindow"
@@ -126,12 +116,14 @@ const TimePickerDialog = React.createClass({
   },
 
   show() {
+    if (this.props.onShow && !this.state.open) this.props.onShow();
     this.setState({
       open: true,
     });
   },
 
   dismiss() {
+    if (this.props.onDismiss && this.state.open) this.props.onDismiss();
     this.setState({
       open: false,
     });


### PR DESCRIPTION
@oliviertassinari I had to remove isOpen() since it makes no sense now. And defaultOpen, I don't think there really is a use-case for this. therefore I made open required. do you think we should ease into this or YOLO?!