### PR TITLE
[Documentation] AppBar examples overlap page header #2393

### DIFF
--- a/docs/src/app/components/pages/components/app-bar.jsx
+++ b/docs/src/app/components/pages/components/app-bar.jsx
@@ -129,6 +129,12 @@ export default class AppBarPage extends React.Component {
   }
 
   render() {
+    let styles = {
+      root: {
+        zIndex: 3,
+      },
+    };
+
     return (
       <ComponentDoc
         name="AppBar"
@@ -150,12 +156,14 @@ import AppBar from 'material-ui/lib/app-bar';
         <CodeExample code={Code}>
           <AppBar
             title="Title"
-            iconClassNameRight="muidocs-icon-navigation-expand-more" />
+            iconClassNameRight="muidocs-icon-navigation-expand-more"
+            style={styles.root} />
           <br />
           <AppBar
             title={<span style={styles.title} onTouchTap={this._onTouchTap}>Title</span>}
             iconElementLeft={<IconButton><NavigationClose /></IconButton>}
-            iconElementRight={<FlatButton label="Save" />} />
+            iconElementRight={<FlatButton label="Save" />}
+            style={styles.root} />
           <br />
           <AppBar
             title="Title"
@@ -172,7 +180,8 @@ import AppBar from 'material-ui/lib/app-bar';
                 <MenuItem primaryText="Help" />
                 <MenuItem primaryText="Sign out" />
               </IconMenu>
-          } />
+            }
+            style={styles.root} />
         </CodeExample>
       </ComponentDoc>
     );


### PR DESCRIPTION
Lowers the z-index on the AppBars from 5 to 3. 

<img width="1426" alt="screen shot 2015-12-06 at 1 45 11 pm" src="https://cloud.githubusercontent.com/assets/264547/11615823/aba667da-9c1f-11e5-9e04-4a0af2bc0a82.png">
