### PR TITLE
[Menus] Fix _handleMenuItemTouchTap error when children is only child

### DIFF
--- a/src/menus/menu.jsx
+++ b/src/menus/menu.jsx
@@ -400,11 +400,12 @@ const Menu = React.createClass({
   },
 
   _handleMenuItemTouchTap(e, item) {
+    let children = this.props.children;
     let multiple = this.props.multiple;
     let valueLink = this.getValueLink(this.props);
     let menuValue = valueLink.value;
     let itemValue = item.props.value;
-    let focusIndex = this.props.children.indexOf(item);
+    let focusIndex = React.isValidElement(children) ? 0 : children.indexOf(item);
 
     this._setFocusIndex(focusIndex, false);
 


### PR DESCRIPTION
As title, when `children` property is only one child like: <MenuItem />. then `children.indexOf` is not a function.