### PR TITLE
[DatePicker] Fix year selection #2010

### DIFF
--- a/src/date-picker/calendar.jsx
+++ b/src/date-picker/calendar.jsx
@@ -217,6 +217,10 @@ const Calendar = React.createClass({
   },
 
   isSelectedDateDisabled() {
+    if (!this.state.displayMonthDay) {
+      return false;
+    }
+
     return this.refs.calendar.isSelectedDateDisabled();
   },
 


### PR DESCRIPTION
This is a simple fix for #2010.
The `DatePicker` is extensively using ref, at some point we should move to a more declarative way.
