### PR TITLE
[Doc] Slightly improved propsTable layout #2425

### DIFF
--- a/docs/src/app/components/PropTypeDescription.jsx
+++ b/docs/src/app/components/PropTypeDescription.jsx
@@ -3,6 +3,8 @@ import {parse} from 'react-docgen';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import MarkdownElement from './MarkdownElement';
 
+require('./prop-type-description.css');
+
 function generatePropType(type) {
   switch (type.name) {
     case 'func':
@@ -51,7 +53,9 @@ const PropTypeDescription = React.createClass({
     }
 
     return (
-      <MarkdownElement text={text} />
+      <div className="propTypeDescription">
+        <MarkdownElement text={text} />
+      </div>
     );
   },
 });

--- a/docs/src/app/components/prop-type-description.css
+++ b/docs/src/app/components/prop-type-description.css
@@ -1,0 +1,43 @@
+.propTypeDescription table tr:nth-child(2n) {
+  background-color: #fff;
+}
+
+.propTypeDescription table td, .propTypeDescription table th {
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+  border-left: 0 none;
+  border-right: 0 none;
+  display: table-cell;
+  vertical-align: top;
+}
+
+.propTypeDescription table th {
+  border-bottom: 2px solid rgba(0, 0, 0, 0.06);
+  border-top: 0 none;
+  color: #888;
+  display: table-cell;
+  font-weight: normal;
+  text-align: left;
+}
+
+.propTypeDescription table td {
+  color: #266d90;
+  font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
+  font-size: 90%;
+}
+
+.propTypeDescription table td + td {
+  color: #bf2a5c;
+}
+
+.propTypeDescription table td + td + td {
+  color: #666;
+  font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
+  font-size: 90%;
+}
+
+.propTypeDescription table td + td + td + td {
+  color: rgba(51, 51, 51, 0.9);
+  font-family: "Roboto", sans-serif;
+  font-size: 95%;
+  min-width: 250px;
+}


### PR DESCRIPTION
Because styling a table in markdown is not directly supported, I have reverted to a pure css solution and wrapped the `<MarkdownElement>` in `<PropTypeDescription>` with a div.

Fix https://github.com/callemall/material-ui/issues/2425