### PR TITLE
Move a few components to es6 with mixin decorator

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babelify": "^6.1.3",
     "browserify-istanbul": "^0.2.1",
     "chai": "^3.2.0",
+    "core-decorators": "^0.9.1",
     "eslint": "^1.8.0",
     "eslint-loader": "^1.0.0",
     "eslint-plugin-react": "^3.2.2",

--- a/src/app-bar.jsx
+++ b/src/app-bar.jsx
@@ -7,27 +7,34 @@ import DefaultRawTheme from './styles/raw-themes/light-raw-theme';
 import ThemeManager from './styles/theme-manager';
 import Paper from './paper';
 import PropTypes from './utils/prop-types';
+import {mixin, autobind} from 'core-decorators';
 
-const AppBar = React.createClass({
-
-  mixins: [StylePropable],
-
-  contextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  //for passing default theme context to children
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
+@mixin(StylePropable)
+export default class AppBar extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+    this.state = {
+      muiTheme: context.muiTheme
+        ? context.muiTheme
+        : ThemeManager.getMuiTheme(DefaultRawTheme),
     };
-  },
+  }
 
-  propTypes: {
+  static childContextTypes = {
+    muiTheme: React.PropTypes.object,
+  }
+
+  static contextTypes = {
+    muiTheme: React.PropTypes.object,
+  }
+
+  static defaultProps = {
+    showMenuIconButton: true,
+    title: '',
+    zDepth: 1,
+  }
+
+  static propTypes = {
     /**
      * Can be used to render a tab inside an app bar for instance.
      */
@@ -107,28 +114,20 @@ const AppBar = React.createClass({
      * The shadow of the app bar is also dependent on this property.
      */
     zDepth: PropTypes.zDepth,
-  },
+  };
 
-  getInitialState() {
+  getChildContext() {
     return {
-      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
+      muiTheme: this.state.muiTheme,
     };
-  },
+  }
 
   //to update theme inside state whenever a new theme is passed down
   //from the parent / owner using context
   componentWillReceiveProps(nextProps, nextContext) {
     let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
     this.setState({muiTheme: newMuiTheme});
-  },
-
-  getDefaultProps() {
-    return {
-      showMenuIconButton: true,
-      title: '',
-      zDepth: 1,
-    };
-  },
+  }
 
   componentDidMount() {
     if (process.env.NODE_ENV !== 'production') {
@@ -146,7 +145,7 @@ const AppBar = React.createClass({
         );
       }
     }
-  },
+  }
 
   getStyles() {
     let spacing = this.state.muiTheme.rawTheme.spacing;
@@ -199,7 +198,7 @@ const AppBar = React.createClass({
     };
 
     return styles;
-  },
+  }
 
   render() {
     let {
@@ -314,26 +313,26 @@ const AppBar = React.createClass({
           {children}
       </Paper>
     );
-  },
+  }
 
+  @autobind
   _onLeftIconButtonTouchTap(event) {
     if (this.props.onLeftIconButtonTouchTap) {
       this.props.onLeftIconButtonTouchTap(event);
     }
-  },
+  }
 
+  @autobind
   _onRightIconButtonTouchTap(event) {
     if (this.props.onRightIconButtonTouchTap) {
       this.props.onRightIconButtonTouchTap(event);
     }
-  },
+  }
 
+  @autobind
   _onTitleTouchTap(event) {
     if (this.props.onTitleTouchTap) {
       this.props.onTitleTouchTap(event);
     }
-  },
-
-});
-
-export default AppBar;
+  }
+}

--- a/src/app-canvas.jsx
+++ b/src/app-canvas.jsx
@@ -2,42 +2,45 @@ import React from 'react';
 import StylePropable from './mixins/style-propable';
 import DefaultRawTheme from './styles/raw-themes/light-raw-theme';
 import ThemeManager from './styles/theme-manager';
+import {mixin} from 'core-decorators';
 
-const AppCanvas = React.createClass({
+@mixin(StylePropable)
+export default class AppCanvas extends React.Component {
+  constructor(props, context) {
+    super(props, context);
 
-  mixins: [StylePropable],
-
-  contextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  propTypes: {
-    children: React.PropTypes.node,
-  },
+    this.state = {
+      muiTheme: context.muiTheme
+        ? context.muiTheme
+        : ThemeManager.getMuiTheme(DefaultRawTheme),
+    };
+  }
 
   //for passing default theme context to children
-  childContextTypes: {
+  static childContextTypes = {
     muiTheme: React.PropTypes.object,
-  },
+  }
+
+  static contextTypes = {
+    muiTheme: React.PropTypes.object,
+  }
+
+  static propTypes = {
+    children: React.PropTypes.node,
+  }
 
   getChildContext() {
     return {
       muiTheme: this.state.muiTheme,
     };
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
-    };
-  },
+  }
 
   //to update theme inside state whenever a new theme is passed down
   //from the parent / owner using context
   componentWillReceiveProps(nextProps, nextContext) {
     let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
     this.setState({muiTheme: newMuiTheme});
-  },
+  }
 
   render() {
     let styles = {
@@ -69,8 +72,5 @@ const AppCanvas = React.createClass({
         {newChildren}
       </div>
     );
-  },
-
-});
-
-export default AppCanvas;
+  }
+}

--- a/src/avatar.jsx
+++ b/src/avatar.jsx
@@ -3,27 +3,36 @@ import StylePropable from './mixins/style-propable';
 import Colors from './styles/colors';
 import DefaultRawTheme from './styles/raw-themes/light-raw-theme';
 import ThemeManager from './styles/theme-manager';
+import {mixin} from 'core-decorators';
 
-const Avatar = React.createClass({
+@mixin(StylePropable)
+export default class Avatar extends React.Component {
+  constructor(props, context) {
+    super(props, context);
 
-  mixins: [StylePropable],
-
-  contextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
+    this.state = {
+      muiTheme: context.muiTheme
+        ? context.muiTheme
+        : ThemeManager.getMuiTheme(DefaultRawTheme),
+    };
+  }
 
   //for passing default theme context to children
-  childContextTypes: {
+  static childContextTypes = {
     muiTheme: React.PropTypes.object,
-  },
+  }
 
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
+  static contextTypes = {
+    muiTheme: React.PropTypes.object,
+  }
 
-  propTypes: {
+  static defaultProps = {
+    backgroundColor: Colors.grey400,
+    color: Colors.white,
+    size: 40,
+  }
+
+  static propTypes = {
     /**
      * The backgroundColor of the avatar. Does not apply to image avatars.
      */
@@ -63,28 +72,20 @@ const Avatar = React.createClass({
      * Override the inline-styles of the root element.
      */
     style: React.PropTypes.object,
-  },
+  }
 
-  getInitialState() {
+  getChildContext() {
     return {
-      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
+      muiTheme: this.state.muiTheme,
     };
-  },
+  }
 
   //to update theme inside state whenever a new theme is passed down
   //from the parent / owner using context
   componentWillReceiveProps(nextProps, nextContext) {
     let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
     this.setState({muiTheme: newMuiTheme});
-  },
-
-  getDefaultProps() {
-    return {
-      backgroundColor: Colors.grey400,
-      color: Colors.white,
-      size: 40,
-    };
-  },
+  }
 
   render() {
     let {
@@ -156,7 +157,5 @@ const Avatar = React.createClass({
         </div>
       );
     }
-  },
-});
-
-export default Avatar;
+  }
+}


### PR DESCRIPTION
This PR moves `app-bar`, `app-canvas`, and `avatar` to es6 style classes with a stage-1 decorator to handle the mixin. Most of the code changes were done with [react-codemod](https://github.com/reactjs/react-codemod) with some minor changes to account for things in es7 syntax the tool does not account for (like `static` properties on the class).

Each component took about 1 minute to migrate from es5 to es6/es7.

No behavioral changes were introduced, the demo still runs as expected, and all tests still pass.

This PR is in reference to #458.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/callemall/material-ui/2436)
<!-- Reviewable:end -->
