### PR TITLE
Created custom stylable decorator

### DIFF
--- a/src/app-canvas.jsx
+++ b/src/app-canvas.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import StylePropable from './mixins/style-propable';
+import Stylable from './mixins/stylable';
 import DefaultRawTheme from './styles/raw-themes/light-raw-theme';
 import ThemeManager from './styles/theme-manager';
-import {mixin} from 'core-decorators';
 
-@mixin(StylePropable)
+@Stylable
 export default class AppCanvas extends React.Component {
   constructor(props, context) {
     super(props, context);
@@ -17,15 +16,15 @@ export default class AppCanvas extends React.Component {
   //for passing default theme context to children
   static childContextTypes = {
     muiTheme: React.PropTypes.object,
-  }
+  };
 
   static contextTypes = {
     muiTheme: React.PropTypes.object,
-  }
+  };
 
   static propTypes = {
     children: React.PropTypes.node,
-  }
+  };
 
   getChildContext() {
     return {

--- a/src/mixins/stylable.js
+++ b/src/mixins/stylable.js
@@ -1,0 +1,12 @@
+import StylePropable from './style-propable';
+
+export default function(target) {
+  target.propTypes = {
+    ...StylePropable.propTypes,
+    ...target.propTypes,
+  };
+
+  target.prototype.mergeStyles = StylePropable.mergeStyles;
+  target.prototype.mergeAndPrefix = StylePropable.mergeAndPrefix;
+  target.prototype.prepareStyles = StylePropable.prepareStyles;
+}


### PR DESCRIPTION
So after some investigation, I learned that the mixin library I found doesn't really work well with React, in the sense it doesn't do field merging for static properties or function-call chaining for react built-in methods. I tried this to investigate an alternative, where I created a custom decorator for StylePropable (called Stylable) which performs the same action as using a mixin on an es5 component. So now the parallel for using StylePropable mixin in the es5 syntax is using the Stylable decorator in the es6 syntax.

This was just an experiment and I'm open to feedback. The alternative, in the style of the mixin decorator, is just making a custom mixin decorator which is React-aware. I investigated this as well, and would likely be able to use a lot of the code from the React library which does the mixin merging (I might try making a library which does this).