### PR TITLE
[EnhancedSwitch] Use theme font family as default font for label

### DIFF
--- a/src/enhanced-switch.jsx
+++ b/src/enhanced-switch.jsx
@@ -175,6 +175,7 @@ const EnhancedSwitch = React.createClass({
         width: labelWidth,
         lineHeight: '24px',
         color: this.getTheme().textColor,
+        fontFamily: this.state.muiTheme.rawTheme.fontFamily,
       },
       wrap: {
         transition: Transitions.easeOut(),

--- a/src/radio-button.jsx
+++ b/src/radio-button.jsx
@@ -90,6 +90,7 @@ const RadioButton = React.createClass({
       },
       label: {
         color: this.props.disabled ? this.getTheme().labelDisabledColor : this.getTheme().labelColor,
+        fontFamily: this.state.muiTheme.rawTheme.fontFamily,
       },
     };
 

--- a/src/radio-button.jsx
+++ b/src/radio-button.jsx
@@ -90,7 +90,6 @@ const RadioButton = React.createClass({
       },
       label: {
         color: this.props.disabled ? this.getTheme().labelDisabledColor : this.getTheme().labelColor,
-        fontFamily: this.state.muiTheme.rawTheme.fontFamily,
       },
     };
 


### PR DESCRIPTION
The label for a RadioButton was not using the default font from the theme. This would make use of the default font family from the current theme, and of course, it can be overridden via the labelStyle prop.