### PR TITLE
[Divider] Initial implementation

### DIFF
--- a/docs/src/app/app-routes.jsx
+++ b/docs/src/app/app-routes.jsx
@@ -28,6 +28,7 @@ import Buttons from './components/pages/components/buttons';
 import Cards from './components/pages/components/cards';
 import DatePicker from './components/pages/components/date-picker';
 import Dialog from './components/pages/components/dialog';
+import Divider from './components/pages/components/divider';
 import DropDownMenu from './components/pages/components/drop-down-menu';
 import GridList from './components/pages/components/grid-list';
 import Icons from './components/pages/components/icons';
@@ -87,6 +88,7 @@ const AppRoutes = (
       <Route path="cards" component={Cards} />
       <Route path="date-picker" component={DatePicker} />
       <Route path="dialog" component={Dialog} />
+      <Route path="divider" component={Divider} />
       <Route path="dropdown-menu" component={DropDownMenu} />
       <Route path="grid-list" component={GridList} />
       <Route path="icons" component={Icons} />

--- a/docs/src/app/components/Divider/ExampleForm.jsx
+++ b/docs/src/app/components/Divider/ExampleForm.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import Divider from 'material-ui/lib/divider';
+import Paper from 'material-ui/lib/paper';
+import TextField from 'material-ui/lib/text-field';
+
+const underlineStyle = {
+  display: 'none',
+};
+
+const style = {
+  marginLeft: 20,
+};
+
+const DividerExampleForm = () => (
+  <Paper zDepth={2}>
+    <TextField hintText="First name" underlineStyle={underlineStyle} style={style} />
+    <Divider />
+    <TextField hintText="Middle name" underlineStyle={underlineStyle} style={style} />
+    <Divider />
+    <TextField hintText="Last name" underlineStyle={underlineStyle} style={style} />
+    <Divider />
+    <TextField hintText="Email address" underlineStyle={underlineStyle} style={style} />
+    <Divider />
+  </Paper>
+);
+
+export default DividerExampleForm;

--- a/docs/src/app/components/Divider/ExampleList.jsx
+++ b/docs/src/app/components/Divider/ExampleList.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Divider from 'material-ui/lib/divider';
+import List from 'material-ui/lib/lists/list';
+import ListItem from 'material-ui/lib/lists/list-item';
+
+import MobileTearSheet from '../mobile-tear-sheet';
+
+const DividerExampleList = () => (
+  <MobileTearSheet height={250}>
+    <List>
+      <ListItem insetChildren={true} primaryText="Janet Perkins Bennet" />
+      <ListItem insetChildren={true} primaryText="Peter Carlsson" />
+    </List>
+    <Divider inset={true}/>
+    <List>
+      <ListItem insetChildren={true} primaryText="Aaron Bennet" />
+      <ListItem insetChildren={true} primaryText="Abbey Christensen" />
+    </List>
+  </MobileTearSheet>
+);
+
+export default DividerExampleList;

--- a/docs/src/app/components/Divider/ExampleMenu.jsx
+++ b/docs/src/app/components/Divider/ExampleMenu.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Divider from 'material-ui/lib/divider';
+import Menu from 'material-ui/lib/menus/menu';
+import MenuItem from 'material-ui/lib/menus/menu-item';
+
+const DividerExampleMenu = () => (
+  <Menu desktop={true} width={200}>
+    <MenuItem primaryText="Settings" />
+    <MenuItem primaryText="Help & feedback" />
+    <Divider/>
+    <MenuItem primaryText="Sign out" />
+  </Menu>
+);
+
+export default DividerExampleMenu;

--- a/docs/src/app/components/Divider/README.md
+++ b/docs/src/app/components/Divider/README.md
@@ -1,0 +1,5 @@
+## Divider
+
+[Dividers](https://www.google.com/design/spec/components/dividers.html) group and separate content within lists and page layouts. The divider is a thin rule, lightweight yet sufficient to distinguish content visually and spatially.
+
+### Examples

--- a/docs/src/app/components/app-left-nav.jsx
+++ b/docs/src/app/components/app-left-nav.jsx
@@ -7,7 +7,7 @@ import {
 
 import List from 'material-ui/lib/lists/list';
 import ListItem from 'material-ui/lib/lists/list-item';
-import ListDivider from 'material-ui/lib/lists/list-divider';
+import Divider from 'material-ui/lib/divider';
 import {SelectableContainerEnhance} from 'material-ui/hoc/selectable-enhance';
 
 const {Colors, Spacing, Typography} = Styles;
@@ -78,7 +78,7 @@ const AppLeftNav = React.createClass({
             primaryText="Components"
           />
         </SelectableList>
-        <ListDivider />
+        <Divider />
         <SelectableList
           subheader="Resources"
           valueLink={{

--- a/docs/src/app/components/pages/components.jsx
+++ b/docs/src/app/components/pages/components.jsx
@@ -13,6 +13,7 @@ export default class Components extends React.Component {
       {route: '/components/cards', text: 'Cards'},
       {route: '/components/date-picker', text: 'Date Picker'},
       {route: '/components/dialog', text: 'Dialog'},
+      {route: '/components/divider', text: 'Divider'},
       {route: '/components/dropdown-menu', text: 'Dropdown Menu'},
       {route: '/components/grid-list', text: 'Grid List'},
       {route: '/components/icons', text: 'Icons'},

--- a/docs/src/app/components/pages/components/divider.jsx
+++ b/docs/src/app/components/pages/components/divider.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import dividerCode from '!raw!material-ui/lib/divider';
+import CodeExample from '../../code-example/code-example';
+import PropTypeDescription from '../../PropTypeDescription';
+import DividerExampleForm from '../../Divider/ExampleForm';
+import dividerExampleFormCode from '!raw!../../Divider/ExampleForm';
+import DividerExampleList from '../../Divider/ExampleList';
+import dividerExampleListCode from '!raw!../../Divider/ExampleList';
+import DividerExampleMenu from '../../Divider/ExampleMenu';
+import dividerExampleMenuCode from '!raw!../../Divider/ExampleMenu';
+import MarkdownElement from '../../MarkdownElement';
+import dividerReadmeText from '../../Divider/README';
+
+const DividerPage = () => {
+  return (
+    <div>
+      <MarkdownElement text={dividerReadmeText} />
+      <CodeExample code={dividerExampleFormCode}>
+        <DividerExampleForm />
+      </CodeExample>
+      <CodeExample code={dividerExampleListCode}>
+        <DividerExampleList />
+      </CodeExample>
+      <CodeExample code={dividerExampleMenuCode}>
+        <DividerExampleMenu />
+      </CodeExample>
+      <PropTypeDescription code={dividerCode}/>
+    </div>
+  );
+};
+
+export default DividerPage;

--- a/docs/src/app/components/pages/components/icon-menus.jsx
+++ b/docs/src/app/components/pages/components/icon-menus.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {IconButton, Paper} from 'material-ui';
 import IconMenu from 'menus/icon-menu';
 import MenuItem from 'menus/menu-item';
-import MenuDivider from 'menus/menu-divider';
+import Divider from 'divider';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 import ComponentDoc from '../../component-doc';
 
@@ -286,7 +286,7 @@ export default class IconMenus extends React.Component {
               <MenuItem primaryText="Home" />
               <MenuItem primaryText="Back" />
               <MenuItem primaryText="Forward" disabled={true} />
-              <MenuDivider />
+              <Divider />
               <MenuItem primaryText="Recently closed" disabled={true} />
               <MenuItem primaryText="Google" disabled={true} />
               <MenuItem primaryText="YouTube" />
@@ -297,10 +297,10 @@ export default class IconMenus extends React.Component {
               <MenuItem primaryText="Preview" leftIcon={<RemoveRedEye />} />
               <MenuItem primaryText="Share" leftIcon={<PersonAdd />} />
               <MenuItem primaryText="Get link" leftIcon={<ContentLink />} />
-              <MenuDivider />
+              <Divider />
               <MenuItem primaryText="Make a copy" leftIcon={<ContentCopy />} />
               <MenuItem primaryText="Download" leftIcon={<Download />} />
-              <MenuDivider />
+              <Divider />
               <MenuItem primaryText="Remove" leftIcon={<Delete />} />
             </IconMenu>
           </div>
@@ -314,10 +314,10 @@ export default class IconMenus extends React.Component {
               <MenuItem primaryText="Preview" leftIcon={<RemoveRedEye />} />
               <MenuItem primaryText="Share" leftIcon={<PersonAdd />} />
               <MenuItem primaryText="Get link" leftIcon={<ContentLink />} />
-              <MenuDivider />
+              <Divider />
               <MenuItem primaryText="Make a copy" leftIcon={<ContentCopy />} />
               <MenuItem primaryText="Download" leftIcon={<Download />} />
-              <MenuDivider />
+              <Divider />
               <MenuItem primaryText="Remove" leftIcon={<Delete />} />
             </IconMenu>
           </div>

--- a/docs/src/app/components/pages/components/lists.jsx
+++ b/docs/src/app/components/pages/components/lists.jsx
@@ -21,7 +21,7 @@ const {
   Checkbox,
   IconButton,
   List,
-  ListDivider,
+  Divider,
   ListItem,
   Styles,
   Toggle,
@@ -345,7 +345,7 @@ This is automatically disabled if leftCheckbox or rightToggle is set.`,
           {
             `//Import statement:
 import List from 'material-ui/lib/lists/list';
-import ListDivider from 'material-ui/lib/lists/list-divider';
+import Divider from 'material-ui/lib/divider';
 import ListItem from 'material-ui/lib/lists/list-item';
 
 //See material-ui/lib/index.js for more
@@ -363,7 +363,7 @@ import ListItem from 'material-ui/lib/lists/list-item';
               <ListItem primaryText="Drafts"leftIcon={<ContentDrafts />} />
               <ListItem primaryText="Inbox"leftIcon={<ContentInbox />} />
             </List>
-            <ListDivider />
+            <Divider />
             <List>
               <ListItem primaryText="All mail" rightIcon={<ActionInfo />} />
               <ListItem primaryText="Trash" rightIcon={<ActionInfo />} />
@@ -395,7 +395,7 @@ import ListItem from 'material-ui/lib/lists/list-item';
                 leftAvatar={<Avatar src="images/raquelromanp-128.jpg" />}
                 rightIcon={<CommunicationChatBubble />} />
             </List>
-            <ListDivider />
+            <Divider />
             <List subheader="Previous chats">
               <ListItem
                 primaryText="Chelsea Otakan"
@@ -425,7 +425,7 @@ import ListItem from 'material-ui/lib/lists/list-item';
                 insetChildren={true}
                 rightAvatar={<Avatar src="images/kerem-128.jpg" />} />
             </List>
-            <ListDivider inset={true} />
+            <Divider inset={true} />
             <List>
               <ListItem
                 primaryText="Adelle Charles"
@@ -465,7 +465,7 @@ import ListItem from 'material-ui/lib/lists/list-item';
                 primaryText="Work"
                 secondaryText="Jan 28, 2014" />
             </List>
-            <ListDivider inset={true} />
+            <Divider inset={true} />
             <List subheader="Files" insetSubheader={true}>
               <ListItem
                 leftAvatar={<Avatar icon={<ActionAssignment />} backgroundColor={Colors.blue500} />}
@@ -510,7 +510,7 @@ import ListItem from 'material-ui/lib/lists/list-item';
                 primaryText="Show your status"
                 secondaryText="Your status is visible to everyone you use with" />
             </List>
-            <ListDivider />
+            <Divider />
             <List subheader="Hangout notifications">
               <ListItem
                 leftCheckbox={<Checkbox />}
@@ -532,13 +532,13 @@ import ListItem from 'material-ui/lib/lists/list-item';
                 primaryText="When calls and notifications arrive"
                 secondaryText="Always interrupt" />
             </List>
-            <ListDivider />
+            <Divider />
             <List subheader="Priority interruptions">
               <ListItem primaryText="Events and reminders" rightToggle={<Toggle />} />
               <ListItem primaryText="Calls" rightToggle={<Toggle />} />
               <ListItem primaryText="Messages" rightToggle={<Toggle />} />
             </List>
-            <ListDivider />
+            <Divider />
             <List subheader="Hangout notifications">
               <ListItem primaryText="Notifications" leftCheckbox={<Checkbox />} />
               <ListItem primaryText="Sounds" leftCheckbox={<Checkbox />} />
@@ -559,7 +559,7 @@ import ListItem from 'material-ui/lib/lists/list-item';
                 primaryText="(323) 555 - 6789"
                 secondaryText="Work" />
             </List>
-            <ListDivider inset={true} />
+            <Divider inset={true} />
             <List>
               <ListItem
                 leftIcon={<CommunicationEmail color={Colors.indigo500} />}
@@ -583,7 +583,7 @@ import ListItem from 'material-ui/lib/lists/list-item';
                     I&apos;ll be in your neighborhood this weekend.
                   </p>
                 } />
-              <ListDivider inset={true} />
+              <Divider inset={true} />
               <ListItem
                 leftAvatar={<Avatar src="images/kolage-128.jpg" />}
                 primaryText={
@@ -595,7 +595,7 @@ import ListItem from 'material-ui/lib/lists/list-item';
                     Wish I could but I can
                   </p>
                 } />
-              <ListDivider inset={true} />
+              <Divider inset={true} />
               <ListItem
                 leftAvatar={<Avatar src="images/uxceo-128.jpg" />}
                 primaryText="Oui oui"
@@ -605,7 +605,7 @@ import ListItem from 'material-ui/lib/lists/list-item';
                     Do you have Paris recommendations?
                   </p>
                 } />
-              <ListDivider inset={true} />
+              <Divider inset={true} />
               <ListItem
                 leftAvatar={<Avatar src="images/kerem-128.jpg" />}
                 primaryText="Birthday gift"
@@ -615,7 +615,7 @@ import ListItem from 'material-ui/lib/lists/list-item';
                     Do you have any ideas on what I
                   </p>
                 } />
-              <ListDivider inset={true} />
+              <Divider inset={true} />
               <ListItem
                 leftAvatar={<Avatar src="images/raquelromanp-128.jpg" />}
                 primaryText="Recipe to try"
@@ -625,7 +625,7 @@ import ListItem from 'material-ui/lib/lists/list-item';
                     We should eat this: grated cheese
                   </p>
                 } />
-              <ListDivider inset={true} />
+              <Divider inset={true} />
               <ListItem
                 leftAvatar={<Avatar src="images/chexee-128.jpg" />}
                 primaryText="Giants game"
@@ -650,7 +650,7 @@ import ListItem from 'material-ui/lib/lists/list-item';
                   </p>
                 }
                 secondaryTextLines={2} />
-              <ListDivider inset={true} />
+              <Divider inset={true} />
               <ListItem
                 leftAvatar={<Avatar src="images/kolage-128.jpg" />}
                 primaryText={
@@ -663,7 +663,7 @@ import ListItem from 'material-ui/lib/lists/list-item';
                   </p>
                 }
                 secondaryTextLines={2} />
-              <ListDivider inset={true} />
+              <Divider inset={true} />
               <ListItem
                 leftAvatar={<Avatar src="images/uxceo-128.jpg" />}
                 primaryText="Oui oui"
@@ -674,7 +674,7 @@ import ListItem from 'material-ui/lib/lists/list-item';
                   </p>
                 }
                 secondaryTextLines={2} />
-              <ListDivider inset={true} />
+              <Divider inset={true} />
               <ListItem
                 leftAvatar={<Avatar src="images/kerem-128.jpg" />}
                 primaryText="Birdthday gift"
@@ -685,7 +685,7 @@ import ListItem from 'material-ui/lib/lists/list-item';
                   </p>
                 }
                 secondaryTextLines={2} />
-              <ListDivider inset={true} />
+              <Divider inset={true} />
               <ListItem
                 leftAvatar={<Avatar src="images/raquelromanp-128.jpg" />}
                 primaryText="Recipe to try"
@@ -712,7 +712,7 @@ import ListItem from 'material-ui/lib/lists/list-item';
                   </p>
                 }
                 secondaryTextLines={2} />
-              <ListDivider inset={true} />
+              <Divider inset={true} />
               <ListItem
                 leftAvatar={<Avatar src="images/kolage-128.jpg" />}
                 rightIconButton={rightIconMenu}
@@ -724,7 +724,7 @@ import ListItem from 'material-ui/lib/lists/list-item';
                   </p>
                 }
                 secondaryTextLines={2} />
-              <ListDivider inset={true} />
+              <Divider inset={true} />
               <ListItem
                 leftAvatar={<Avatar src="images/uxceo-128.jpg" />}
                 rightIconButton={rightIconMenu}
@@ -736,7 +736,7 @@ import ListItem from 'material-ui/lib/lists/list-item';
                   </p>
                 }
                 secondaryTextLines={2} />
-              <ListDivider inset={true} />
+              <Divider inset={true} />
               <ListItem
                 leftAvatar={<Avatar src="images/kerem-128.jpg" />}
                 rightIconButton={rightIconMenu}
@@ -748,7 +748,7 @@ import ListItem from 'material-ui/lib/lists/list-item';
                   </p>
                 }
                 secondaryTextLines={2} />
-              <ListDivider inset={true} />
+              <Divider inset={true} />
               <ListItem
                 leftAvatar={<Avatar src="images/raquelromanp-128.jpg" />}
                 rightIconButton={rightIconMenu}

--- a/docs/src/app/components/pages/components/menus.jsx
+++ b/docs/src/app/components/pages/components/menus.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Paper from 'paper';
 import Menu from 'menus/menu';
 import MenuItem from 'menus/menu-item';
-import MenuDivider from 'menus/menu-divider';
+import Divider from 'divider';
 import ComponentDoc from '../../component-doc';
 
 import ArrowDropRight from 'material-ui/svg-icons/navigation-arrow-drop-right';
@@ -233,7 +233,7 @@ export default class MenusPage extends React.Component {
             `//Import statement:
 import Menu from 'material-ui/lib/menus/menu';
 import MenuItem from 'material-ui/lib/menus/menu-item';
-import MenuDivider from 'material-ui/lib/menus/menu-divider';
+import Divider from 'material-ui/lib/menus/menu-divider';
 
 //See material-ui/lib/index.js for more
           `
@@ -259,7 +259,7 @@ import MenuDivider from 'material-ui/lib/menus/menu-divider';
           <Menu style={styles.menu} desktop={true}>
             <MenuItem primaryText="Back" />
             <MenuItem primaryText="Forward" disabled={true} />
-            <MenuDivider />
+            <Divider />
             <MenuItem primaryText="Recently closed" disabled={true} />
             <MenuItem primaryText="Google" disabled={true} />
             <MenuItem primaryText="YouTube" />
@@ -269,17 +269,17 @@ import MenuDivider from 'material-ui/lib/menus/menu-divider';
             <MenuItem primaryText="Preview" leftIcon={<RemoveRedEye />} />
             <MenuItem primaryText="Share" leftIcon={<PersonAdd />} />
             <MenuItem primaryText="Get links" leftIcon={<ContentLink />} />
-            <MenuDivider />
+            <Divider />
             <MenuItem primaryText="Make a copy" leftIcon={<ContentCopy />} />
             <MenuItem primaryText="Download" leftIcon={<Download />} />
-            <MenuDivider />
+            <Divider />
             <MenuItem primaryText="Remove" leftIcon={<Delete />} />
           </Menu>
 
           <Menu style={styles.menu} desktop={true}>
             <MenuItem primaryText="Undo" />
             <MenuItem primaryText="Redo" disabled={true} />
-            <MenuDivider />
+            <Divider />
             <MenuItem primaryText="Cut" disabled={true} />
             <MenuItem primaryText="Copy" disabled={true} />
             <MenuItem primaryText="Paste" />
@@ -316,13 +316,13 @@ import MenuDivider from 'material-ui/lib/menus/menu-divider';
             <MenuItem primaryText="Strikethrough" secondaryText="Alt+Shift+5" />
             <MenuItem primaryText="Superscript" secondaryText="&#8984;." />
             <MenuItem primaryText="Subscript" secondaryText="&#8984;," />
-            <MenuDivider />
+            <Divider />
             <MenuItem primaryText="Paragraph styles" rightIcon={<ArrowDropRight />} />
             <MenuItem primaryText="Align" rightIcon={<ArrowDropRight />} />
             <MenuItem primaryText="Line spacing" rightIcon={<ArrowDropRight />} />
             <MenuItem primaryText="Numbered list" rightIcon={<ArrowDropRight />} />
             <MenuItem primaryText="List options" rightIcon={<ArrowDropRight />} />
-            <MenuDivider />
+            <Divider />
             <MenuItem primaryText="Clear formatting" secondaryText="&#8984;/" />
           </Menu>
 
@@ -341,10 +341,10 @@ import MenuDivider from 'material-ui/lib/menus/menu-divider';
               <MenuItem primaryText="Page breaks" insetChildren={true} />,
               <MenuItem primaryText="Rules" checked={true} />,
             ]} />
-            <MenuDivider />
+            <Divider />
             <MenuItem primaryText="Add space before paragraph" />
             <MenuItem primaryText="Add space after paragraph" />
-            <MenuDivider />
+            <Divider />
             <MenuItem primaryText="Custom spacing..." />
           </Menu>
 

--- a/docs/src/app/components/raw-code/icon-menus-code.txt
+++ b/docs/src/app/components/raw-code/icon-menus-code.txt
@@ -3,7 +3,7 @@
 //require them like this:
 
 import MenuItem from 'material-ui/lib/menus/menu-item';
-import MenuDivider from 'material-ui/lib/menus/menu-divider';
+import Divider from 'material-ui/lib/divider';
 
 <IconMenu iconButtonElement={iconButtonElement}>
   <MenuItem primaryText="Refresh" />

--- a/docs/src/app/components/raw-code/lists-code.txt
+++ b/docs/src/app/components/raw-code/lists-code.txt
@@ -6,7 +6,7 @@
   <ListItem primaryText="Drafts" leftIcon={<ContentDrafts />} />
   <ListItem primaryText="Inbox" leftIcon={<ContentInbox />} />
 </List>
-<ListDivider />
+<Divider />
 <List>
   <ListItem primaryText="All mail" rightIcon={<ActionInfo />} />
   <ListItem primaryText="Trash" rightIcon={<ActionInfo />} />
@@ -27,7 +27,7 @@
       </p>
     }
     secondaryTextLines={2} />
-  <ListDivider inset={true} />
+  <Divider inset={true} />
   <ListItem
     leftAvatar={<Avatar src="images/kolage-128.jpg" />}
     rightIconButton={rightIconMenu}
@@ -39,7 +39,7 @@
       </p>
     }
     secondaryTextLines={2} />
-  <ListDivider inset={true} />
+  <Divider inset={true} />
   <ListItem
     leftAvatar={<Avatar src="images/uxceo-128.jpg" />}
     rightIconButton={rightIconMenu}
@@ -51,7 +51,7 @@
       </p>
     }
     secondaryTextLines={2} />
-  <ListDivider inset={true} />
+  <Divider inset={true} />
   <ListItem
     leftAvatar={<Avatar src="images/kerem-128.jpg" />}
     rightIconButton={rightIconMenu}
@@ -63,7 +63,7 @@
       </p>
     }
     secondaryTextLines={2} />
-  <ListDivider inset={true} />
+  <Divider inset={true} />
   <ListItem
     leftAvatar={<Avatar src="images/raquelromanp-128.jpg" />}
     rightIconButton={rightIconMenu}

--- a/docs/src/app/components/raw-code/menus-code.txt
+++ b/docs/src/app/components/raw-code/menus-code.txt
@@ -4,7 +4,7 @@
 
 import Menu from 'material-ui/lib/menus/menu';
 import MenuItem from 'material-ui/lib/menus/menu-item';
-import MenuDivider from 'material-ui/lib/menus/menu-divider';
+import Divider from 'material-ui/lib/divider';
 
 <Menu>
   <MenuItem primaryText="Maps" />
@@ -20,13 +20,13 @@ import MenuDivider from 'material-ui/lib/menus/menu-divider';
   <MenuItem primaryText="Strikethrough" secondaryText="Alt+Shift+5" />
   <MenuItem primaryText="Superscript" secondaryText="&#8984;." />
   <MenuItem primaryText="Subscript" secondaryText="&#8984;," />
-  <MenuDivider />
+  <Divider />
   <MenuItem primaryText="Paragraph styles" rightIcon={<ArrowDropRight />} />
   <MenuItem primaryText="Align" rightIcon={<ArrowDropRight />} />
   <MenuItem primaryText="Line spacing" rightIcon={<ArrowDropRight />} />
   <MenuItem primaryText="Numbered list" rightIcon={<ArrowDropRight />} />
   <MenuItem primaryText="List options" rightIcon={<ArrowDropRight />} />
-  <MenuDivider />
+  <Divider />
   <MenuItem primaryText="Clear formatting" secondaryText="&#8984;/" />
 </Menu>
 
@@ -47,9 +47,9 @@ import MenuDivider from 'material-ui/lib/menus/menu-divider';
       <MenuItem primaryText="Rules" checked={true} />,
     ]}>
   </MenuItem>
-  <MenuDivider />
+  <Divider />
   <MenuItem primaryText="Add space before paragraph" />
   <MenuItem primaryText="Add space after paragraph" />
-  <MenuDivider />
+  <Divider />
   <MenuItem primaryText="Custom spacing..." />
 </Menu>

--- a/src/auto-complete.jsx
+++ b/src/auto-complete.jsx
@@ -6,7 +6,7 @@ import KeyCode from './utils/key-code';
 import TextField from './text-field';
 import Menu from './menus/menu';
 import MenuItem from './menus/menu-item';
-import MenuDivider from './menus/menu-divider';
+import Divider from './divider';
 
 const AutoComplete = React.createClass({
 
@@ -311,6 +311,6 @@ const AutoComplete = React.createClass({
 });
 
 AutoComplete.Item = MenuItem;
-AutoComplete.Divider = MenuDivider;
+AutoComplete.Divider = Divider;
 
 export default AutoComplete;

--- a/src/divider.jsx
+++ b/src/divider.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import DefaultRawTheme from './styles/raw-themes/light-raw-theme';
+import ThemeManager from './styles/theme-manager';
+import styleUtils from './utils/styles';
+
+const propTypes = {
+  /**
+   * CSS class that will be added to the divider's root element
+   */
+  className: React.PropTypes.string,
+
+  /**
+   * If true, the divider will be indented 72px
+   */
+  inset: React.PropTypes.bool,
+
+  /**
+   * Override the inline-styles of the list divider's root element
+   */
+  style: React.PropTypes.object,
+};
+
+const contextTypes = {
+  muiTheme: React.PropTypes.object,
+};
+
+const childContextTypes = {
+  muiTheme: React.PropTypes.object,
+};
+
+const defaultProps = {
+  inset: false,
+};
+
+const Divider = ({inset, style, ...other}, {muiTheme = ThemeManager.getMuiTheme(DefaultRawTheme)}) => {
+  const styles = {
+    root: {
+      margin: 0,
+      marginTop: -1,
+      marginLeft: inset ? 72 : 0,
+      height: 1,
+      border: 'none',
+      backgroundColor: muiTheme.rawTheme.palette.borderColor,
+    },
+  };
+
+  return (
+    <hr {...other} style={styleUtils.prepareStyles(muiTheme, styles.root, style)} />
+  );
+};
+
+Divider.propTypes = propTypes;
+Divider.defaultProps = defaultProps;
+Divider.contextTypes = contextTypes;
+Divider.childContextTypes = childContextTypes;
+
+export default Divider;

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ export default {
   DatePicker: require('./date-picker/date-picker'),
   DatePickerDialog: require('./date-picker/date-picker-dialog'),
   Dialog: require('./dialog'),
+  Divider: require('./divider'),
   DropDownIcon: require('./drop-down-icon'),
   DropDownMenu: require('./drop-down-menu'),
   EnhancedButton: require('./enhanced-button'),

--- a/src/lists/list-divider.jsx
+++ b/src/lists/list-divider.jsx
@@ -1,64 +1,15 @@
 import React from 'react';
-import StylePropable from '../mixins/style-propable';
-import DefaultRawTheme from '../styles/raw-themes/light-raw-theme';
-import ThemeManager from '../styles/theme-manager';
+import Divider from '../divider';
+import warning from 'warning';
 
 const ListDivider = React.createClass({
 
-  mixins: [StylePropable],
-
-  contextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  propTypes: {
-    inset: React.PropTypes.bool,
-    style: React.PropTypes.object,
-  },
-
-  //for passing default theme context to children
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
   getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
-    };
-  },
-
-  //to update theme inside state whenever a new theme is passed down
-  //from the parent / owner using context
-  componentWillReceiveProps(nextProps, nextContext) {
-    let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
+    warning(false, '<ListDivider /> has been deprecated. Please use the <Divider /> component.');
   },
 
   render() {
-    const {
-      inset,
-      style,
-      ...other,
-    } = this.props;
-
-    const mergedStyles = this.mergeStyles({
-      margin: 0,
-      marginTop: -1,
-      marginLeft: inset ? 72 : 0,
-      height: 1,
-      border: 'none',
-      backgroundColor: this.state.muiTheme.rawTheme.palette.borderColor,
-    }, style);
-
-    return (
-      <hr {...other} style={this.prepareStyles(mergedStyles)} />
-    );
+    return <Divider {...this.props} />;
   },
 });
 

--- a/src/menus/menu-divider.jsx
+++ b/src/menus/menu-divider.jsx
@@ -1,59 +1,36 @@
 import React from 'react';
-import StylePropable from '../mixins/style-propable';
-import ListDivider from '../lists/list-divider';
-import DefaultRawTheme from '../styles/raw-themes/light-raw-theme';
-import ThemeManager from '../styles/theme-manager';
+import Divider from '../divider';
+import styleUtils from '../utils/styles';
+import warning from 'warning';
 
 const MenuDivider = React.createClass({
-
-  mixins: [StylePropable],
-
-  contextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
 
   propTypes: {
     style: React.PropTypes.object,
   },
 
-  //for passing default theme context to children
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
   getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
-    };
+    warning(false, '<MenuDivider /> has been deprecated. Please use the <Divider /> component.');
   },
 
-  //to update theme inside state whenever a new theme is passed down
-  //from the parent / owner using context
-  componentWillReceiveProps(nextProps, nextContext) {
-    let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
+  getStyles() {
+    return {
+      root: {
+        marginTop: 7,
+        marginBottom: 8,
+      },
+    };
   },
 
   render() {
-    let {
+    const {
       style,
       ...other,
     } = this.props;
 
-    let mergedStyles = this.mergeStyles({
-      marginTop: 7,
-      marginBottom: 8,
-    }, style);
+    const styles = this.getStyles();
 
-    return (
-      <ListDivider {...other} style={mergedStyles} />
-    );
+    return <Divider {...this.props} style={styleUtils.merge(styles.root, style)} />;
   },
 });
 

--- a/src/menus/menu.jsx
+++ b/src/menus/menu.jsx
@@ -164,6 +164,11 @@ const Menu = React.createClass({
         transformOrigin: openLeft ? 'right' : 'left',
       },
 
+      divider: {
+        marginTop: 7,
+        marginBottom: 8,
+      },
+
       list: {
         display: 'table-cell',
         paddingBottom: desktop ? 16 : 8,
@@ -203,7 +208,7 @@ const Menu = React.createClass({
 
     let menuItemIndex = 0;
     let newChildren = React.Children.map(filteredChildren, child => {
-      let childIsADivider = child.type && child.type.displayName === 'MenuDivider';
+      let childIsADivider = child.type && child.type.displayName === 'Divider';
       let childIsDisabled = child.props.disabled;
       let childrenContainerStyles = {};
 
@@ -225,7 +230,7 @@ const Menu = React.createClass({
         });
       }
 
-      let clonedChild = childIsADivider ? child :
+      let clonedChild = childIsADivider ? React.cloneElement(child, {style: styles.divider}) :
         childIsDisabled ? React.cloneElement(child, {desktop: desktop}) :
         this._cloneMenuItem(child, menuItemIndex, styles);
 
@@ -348,7 +353,7 @@ const Menu = React.createClass({
     //max menu height
     filteredChildren.forEach(child => {
       if (currentHeight < maxHeight) {
-        let childIsADivider = child.type && child.type.displayName === 'MenuDivider';
+        let childIsADivider = child.type && child.type.displayName === 'Divider';
 
         currentHeight += childIsADivider ? 16 : menuItemHeight;
         count++;
@@ -361,7 +366,7 @@ const Menu = React.createClass({
   _getMenuItemCount(filteredChildren) {
     let menuItemCount = 0;
     filteredChildren.forEach(child => {
-      let childIsADivider = child.type && child.type.displayName === 'MenuDivider';
+      let childIsADivider = child.type && child.type.displayName === 'Divider';
       let childIsDisabled = child.props.disabled;
       if (!childIsADivider && !childIsDisabled) menuItemCount++;
     });
@@ -373,7 +378,7 @@ const Menu = React.createClass({
     let menuItemIndex = 0;
 
     filteredChildren.forEach(child => {
-      let childIsADivider = child.type && child.type.displayName === 'MenuDivider';
+      let childIsADivider = child.type && child.type.displayName === 'Divider';
 
       if (this._isChildSelected(child, props)) selectedIndex = menuItemIndex;
       if (!childIsADivider) menuItemIndex++;

--- a/src/utils/styles.js
+++ b/src/utils/styles.js
@@ -7,6 +7,10 @@ const reSkew = /((^|\s)skew(x|y)?\()\s*(\-?[\d]+)(deg|rad|grad)(,\s*(\-?[\d]+)(d
 
 export default {
 
+  merge() {
+    return ImmutabilityHelper.merge.apply(this, arguments);
+  },
+
   mergeAndPrefix() {
     let mergedStyles = ImmutabilityHelper.merge.apply(this, arguments);
     return AutoPrefix.all(mergedStyles);


### PR DESCRIPTION
This resolves #2457. 

**Done:**
- Implemented a `divider.jsx` in root with same implementation as original `list-divider.jsx`
- Reimplemented `list-divider.jsx` and `menu-divider.jsx` as stateless components that wrap `divider.jsx` and emit warnings when used. (`menu-divider.jsx` applies original style overrides for backwards compatibility).
- Remove dependencies on `list-divider.jsx` and `menu-divider.jsx` in internal components and documentation.
- Consider adding documentation on `<Divider />` component when used independently of other components.

**Todo:**
