### PR TITLE
[docs] fixed webpack config for production

### DIFF
--- a/docs/webpack-production.config.js
+++ b/docs/webpack-production.config.js
@@ -23,10 +23,11 @@ var config = {
     modulesDirectories: [
       "web_modules",
       "node_modules",
+      path.resolve(__dirname, "node_modules"),
       path.resolve(__dirname, '../src'),
       path.resolve(__dirname, '../node_modules'),
       path.resolve(__dirname, 'src/app/components/raw-code'),
-      path.resolve(__dirname, 'src/app/components')
+      path.resolve(__dirname, 'src/app/components/markdown')
     ]
   },
   devtool: 'source-map',
@@ -92,7 +93,7 @@ var config = {
           {
             test:/\.md$/,
             loader: 'raw-loader',
-            include: path.resolve(__dirname, 'src/app/components/markdown')
+            include: path.resolve(__dirname, 'src/app/components')
           },
           {
             test: /\.css$/,


### PR DESCRIPTION
I had errors while tying to run 'npm run build' in docs. I realized that webpack-dev-server.config.js had some changes that were missing in webpack-production.config.js. BTW, maybe a better idea would be to have the common parts of these 2 extracted in a separate file so that they will not get un-synced in the future.