### PR TITLE
Proposal: mui-themeable higher order component

### DIFF
--- a/src/divider.jsx
+++ b/src/divider.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import DefaultRawTheme from './styles/raw-themes/light-raw-theme';
-import ThemeManager from './styles/theme-manager';
+import muiThemeable from './mui-themeable';
 import styleUtils from './utils/styles';
 
 const propTypes = {
@@ -20,19 +19,11 @@ const propTypes = {
   style: React.PropTypes.object,
 };
 
-const contextTypes = {
-  muiTheme: React.PropTypes.object,
-};
-
-const childContextTypes = {
-  muiTheme: React.PropTypes.object,
-};
-
 const defaultProps = {
   inset: false,
 };
 
-const Divider = ({inset, style, ...other}, {muiTheme = ThemeManager.getMuiTheme(DefaultRawTheme)}) => {
+let Divider = ({inset, muiTheme, style, ...other}) => {
   const styles = {
     root: {
       margin: 0,
@@ -49,9 +40,9 @@ const Divider = ({inset, style, ...other}, {muiTheme = ThemeManager.getMuiTheme(
   );
 };
 
+Divider.displayName = 'Divider';
 Divider.propTypes = propTypes;
 Divider.defaultProps = defaultProps;
-Divider.contextTypes = contextTypes;
-Divider.childContextTypes = childContextTypes;
+Divider = muiThemeable(Divider);
 
 export default Divider;

--- a/src/mui-theme-provider.jsx
+++ b/src/mui-theme-provider.jsx
@@ -1,0 +1,25 @@
+import {Component, PropTypes} from 'react';
+
+class ThemeProvider extends Component {
+
+  static propTypes = {
+    children: PropTypes.element,
+    muiTheme: PropTypes.object,
+  };
+
+  static childContextTypes = {
+    muiTheme: PropTypes.object,
+  };
+
+  getChildContext() {
+    return {
+      muiTheme: this.props.muiTheme,
+    };
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
+export default ThemeProvider;

--- a/src/mui-themeable.js
+++ b/src/mui-themeable.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import DefaultRawTheme from './styles/raw-themes/light-raw-theme';
+import ThemeManager from './styles/theme-manager';
+
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+}
+
+export default function muiThemeable(WrappedComponent) {
+  const MuiComponent = (props, {muiTheme = ThemeManager.getMuiTheme(DefaultRawTheme)}) => {
+    return <WrappedComponent {...props} muiTheme={muiTheme} />;
+  };
+
+  MuiComponent.displayName = getDisplayName(WrappedComponent);
+  MuiComponent.contextTypes = {
+    muiTheme: React.PropTypes.object,
+  };
+  MuiComponent.childContextTypes = {
+    muiTheme: React.PropTypes.object,
+  };
+
+  return MuiComponent;
+}


### PR DESCRIPTION
I'm just opening this up for discussion, something we could consider at a later date.

The React documentation on [context](https://facebook.github.io/react/docs/context.html) says: 

> Regardless of whether you're building an application or a library, try to isolate your use of context to a small area and avoid using the context API directly when possible so that it's easier to upgrade when the API changes.

This pull request shows an approach to implementing context for the purpose of themes in a higher order `mui-themeable.js` component. It allows us to develop material-ui components without having to use context directly, and instead receive the `muiTheme` as a prop (even though the higher order component is providing the `muiTheme` prop from context). I also changed the current `Divider.jsx` implementation as an example of how it's used.

**Note:** This current implementation technically should work as a `@muiThemeable` decorator on classes as well, but since `Divider.jsx` is a function, I couldn't show that as an example. 
