### PR TITLE
Use preventDefault in _onExpandable handler. Fixes #2484

### DIFF
--- a/src/card/card.jsx
+++ b/src/card/card.jsx
@@ -22,7 +22,8 @@ const Card = React.createClass({
     style: React.PropTypes.object,
   },
 
-  _onExpandable() {
+  _onExpandable(event) {
+    event.preventDefault();
     let newExpandedState = !(this.state.expanded === true);
     this.setState({expanded: newExpandedState});
     if (this.props.onExpandChange)


### PR DESCRIPTION
On some touch devices and in certain contexts, a touch event can trigger a second mouse event, causing expandable cards to close as soon as they open. Follows advice from http://www.html5rocks.com/en/mobile/touchandmouse/ to "use preventDefault() inside touch event handlers, so the default mouse-emulation handling doesn’t occur." Even though this can prevent "other default browser behavior (like scrolling)", this shouldn't be a danger in the specific context of this handler.