### PR TITLE
Fix typo for arguments.

### DIFF
--- a/docs/src/app/components/pages/components/select-fields.jsx
+++ b/docs/src/app/components/pages/components/select-fields.jsx
@@ -173,7 +173,7 @@ const SelectFieldsPage = React.createClass({
           },
           {
             name: 'onChange',
-            header: 'function(name, event)',
+            header: 'function(event, name)',
             desc: 'Callback function that is fired when the selectfield\'s value ' +
                   'changes.',
           },


### PR DESCRIPTION
Just a minor order issue, the `event` object is actually the first argument :)