### PR TITLE
Fix selectable=false still selects rows

### DIFF
--- a/src/table/table-row.jsx
+++ b/src/table/table-row.jsx
@@ -162,7 +162,7 @@ const TableRow = React.createClass({
   },
 
   _onRowClick(e) {
-    if (this.props.onRowClick) this.props.onRowClick(e, this.props.rowNumber);
+    if (this.props.selectable && this.props.onRowClick) this.props.onRowClick(e, this.props.rowNumber);
   },
 
   _onRowHover(e) {


### PR DESCRIPTION
The select row function was still called for selectable=false. This patch fixes that.

A possible alternative is to put this check in onCellClick and not calling onRowClick if selectable is false. I'm not sure what you'd prefer but this works for me. 

Fixes #2176 