### PR TITLE
[WIP] Proposal: Parameterized mui-themeable hoc

### DIFF
--- a/src/divider.jsx
+++ b/src/divider.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import DefaultRawTheme from './styles/raw-themes/light-raw-theme';
-import ThemeManager from './styles/theme-manager';
+import muiThemeable from './mui-themeable';
 import styleUtils from './utils/styles';
 
 const propTypes = {
@@ -20,19 +19,11 @@ const propTypes = {
   style: React.PropTypes.object,
 };
 
-const contextTypes = {
-  muiTheme: React.PropTypes.object,
-};
-
-const childContextTypes = {
-  muiTheme: React.PropTypes.object,
-};
-
 const defaultProps = {
   inset: false,
 };
 
-const Divider = ({inset, style, ...other}, {muiTheme = ThemeManager.getMuiTheme(DefaultRawTheme)}) => {
+let Divider = ({inset, muiTheme, style, ...other}) => {
   const styles = {
     root: {
       margin: 0,
@@ -51,7 +42,6 @@ const Divider = ({inset, style, ...other}, {muiTheme = ThemeManager.getMuiTheme(
 
 Divider.propTypes = propTypes;
 Divider.defaultProps = defaultProps;
-Divider.contextTypes = contextTypes;
-Divider.childContextTypes = childContextTypes;
+Divider = muiThemeable(Divider);
 
 export default Divider;

--- a/src/divider.jsx
+++ b/src/divider.jsx
@@ -31,7 +31,7 @@ let Divider = ({inset, muiTheme, style, ...other}) => {
       marginLeft: inset ? 72 : 0,
       height: 1,
       border: 'none',
-      backgroundColor: muiTheme.rawTheme.palette.borderColor,
+      backgroundColor: muiTheme.borderColor,
     },
   };
 
@@ -40,8 +40,12 @@ let Divider = ({inset, muiTheme, style, ...other}) => {
   );
 };
 
+
 Divider.propTypes = propTypes;
 Divider.defaultProps = defaultProps;
-Divider = muiThemeable(Divider);
+
+Divider = muiThemeable((baseTheme) => ({
+  borderColor: baseTheme.palette.borderColor,
+}))(Divider);
 
 export default Divider;

--- a/src/mui-theme-provider.jsx
+++ b/src/mui-theme-provider.jsx
@@ -1,0 +1,23 @@
+import {Component, PropTypes} from 'react';
+
+class ThemeProvider extends Component {
+  getChildContext() {
+    return {
+      muiTheme: this.props.muiTheme,
+    };
+  }
+  render() {
+    return this.props.children;
+  }
+}
+
+ThemeProvider.propTypes = {
+  children: PropTypes.element,
+  muiTheme: PropTypes.object,
+};
+
+ThemeProvider.childContextTypes = {
+  muiTheme: PropTypes.object,
+};
+
+export default ThemeProvider;

--- a/src/mui-themeable.js
+++ b/src/mui-themeable.js
@@ -1,23 +1,25 @@
 import React from 'react';
 import DefaultRawTheme from './styles/raw-themes/light-raw-theme';
-import ThemeManager from './styles/theme-manager';
 
 function getDisplayName(WrappedComponent) {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component';
 }
 
-export default function muiThemeable(WrappedComponent) {
-  const MuiComponent = (props, {muiTheme = ThemeManager.getMuiTheme(DefaultRawTheme)}) => {
-    return <WrappedComponent {...props} muiTheme={muiTheme} />;
-  };
+export default function muiThemeable(mapBaseTheme) {
+  return function muiThemeable(WrappedComponent) {
 
-  MuiComponent.displayName = `mui(${getDisplayName(WrappedComponent)})`;
-  MuiComponent.contextTypes = {
-    muiTheme: React.PropTypes.object,
-  };
-  MuiComponent.childContextTypes = {
-    muiTheme: React.PropTypes.object,
-  };
+    const MuiComponent = (props, {muiBaseTheme = DefaultRawTheme}) => {
+      return <WrappedComponent {...props} muiTheme={mapBaseTheme(muiBaseTheme)} />;
+    };
 
-  return MuiComponent;
+    MuiComponent.displayName = `mui(${getDisplayName(WrappedComponent)})`;
+    MuiComponent.contextTypes = {
+      muiTheme: React.PropTypes.object,
+    };
+    MuiComponent.childContextTypes = {
+      muiTheme: React.PropTypes.object,
+    };
+
+    return MuiComponent;
+  };
 }

--- a/src/mui-themeable.js
+++ b/src/mui-themeable.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import DefaultRawTheme from './styles/raw-themes/light-raw-theme';
+import ThemeManager from './styles/theme-manager';
+
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+}
+
+export default function muiThemeable(WrappedComponent) {
+  const MuiComponent = (props, {muiTheme = ThemeManager.getMuiTheme(DefaultRawTheme)}) => {
+    return <WrappedComponent {...props} muiTheme={muiTheme} />;
+  };
+
+  MuiComponent.displayName = `mui(${getDisplayName(WrappedComponent)})`;
+  MuiComponent.contextTypes = {
+    muiTheme: React.PropTypes.object,
+  };
+  MuiComponent.childContextTypes = {
+    muiTheme: React.PropTypes.object,
+  };
+
+  return MuiComponent;
+}


### PR DESCRIPTION
This is an extension of #2493. This pull request explores approaches to not needing a `ThemeManager` at all (at least in user space).

**Note:** Once again, just throwing this out there for discussion.

This idea is inspired react-redux. In this pull request, the `mui-themeable` component created in #2493 now accepts a mapping function that computes a calculated theme from a `rawTheme` object (simliar to react-redux's connect higher order component's `mapStateToProps` function). 

For example, currently `text-field.jsx` accepts a `muiTheme` object in context, then uses calculated theme provided by `ThemeManager` at the key of `textField`. It would get the computed result of:

```js
      textField: {
        textColor: rawTheme.palette.textColor,
        hintColor: rawTheme.palette.disabledColor,
        floatingLabelColor: rawTheme.palette.textColor,
        disabledTextColor: rawTheme.palette.disabledColor,
        errorColor: Colors.red500,
        focusColor: rawTheme.palette.primary1Color,
        backgroundColor: 'transparent',
        borderColor: rawTheme.palette.borderColor,
      },
```

In this pull request's implementation, in `text-field.jsx`, you could decorate TextField like this:
```js
TextField = muiThemeable((rawTheme) => ({
  textColor: rawTheme.palette.textColor,
  hintColor: rawTheme.palette.disabledColor,
  floatingLabelColor: rawTheme.palette.textColor,
  disabledTextColor: rawTheme.palette.disabledColor,
  errorColor: Colors.red500,
  focusColor: rawTheme.palette.primary1Color,
  backgroundColor: 'transparent',
  borderColor: rawTheme.palette.borderColor,
}))(TextField);
```
This means that when users supply a theme, they would only need to supply a `rawTheme`:

```jsx
import DefaultRawTheme from './styles/raw-themes/light-raw-theme';

const App = (props) => {
  return (
    <ThemeProvider muiTheme={DefaultRawTheme}>
      {props.children} 
    </ThemeProvider>
  );
};

```