### PR TITLE
Fix typo in table doc page

### DIFF
--- a/docs/src/app/components/pages/components/table.jsx
+++ b/docs/src/app/components/pages/components/table.jsx
@@ -23,7 +23,7 @@ export default class TablePage extends React.Component {
     super(props);
 
     this._onToggle = this._onToggle.bind(this);
-    this.onChange = this._onChange.bind(this);
+    this._onChange = this._onChange.bind(this);
     this._onRowSelection = this._onRowSelection.bind(this);
 
     this.state = {


### PR DESCRIPTION
Changing `Table Body Height` textbox throws error and does not update the table height. This fixes that.