### PR TITLE
Create deprecatedExport utility function

### DIFF
--- a/src/utils/deprecatedExport.js
+++ b/src/utils/deprecatedExport.js
@@ -1,0 +1,9 @@
+import warning from 'warning';
+
+function deprecatedExport(Component, deprecatedPath, supportedPath) {
+  warning(false,
+    `Importing ${Component.displayName} from '${deprecatedPath}' has been deprecated, use '${supportedPath}' instead.`);
+  return Component;
+}
+
+export default deprecatedExport;


### PR DESCRIPTION
This idea was introduced in #2476. Also related to #1793.

This function will assist us with deprecating modules with "kebab-case" names in favor of more React compatible "PascalCase" names (for example `TextField.jsx` instead of `text-field.jsx`).

It would be used like this:
```js
/* material-ui/lib/text-field.jsx */

import TextField from './TextField'; // new location
import deprecatedExport from './utils/deprecatedExport';

export default deprecatedExport(TextField, 'material-ui/lib/text-field', 'material-ui/lib/TextField');
```