### PR TITLE
Fixes #2522 SVGIcon incompatibility with bootstrap

### DIFF
--- a/src/svg-icon.jsx
+++ b/src/svg-icon.jsx
@@ -80,6 +80,8 @@ const SvgIcon = React.createClass({
       width: 24,
       userSelect: 'none',
       transition: Transitions.easeOut(),
+      // Fix incompatibility with Bootstrap (Issue #2522)
+      boxSizing: 'content-box',
     }, style, {
       // Make sure our fill color overrides fill provided in props.style
       fill: this.state.hovered ? onColor : offColor,


### PR DESCRIPTION
Fixes a bug that makes icons in IconMenus partially invisible when bootstrap CSS is included. 

Idea courtesy of "Francois Bissonnette" on #2522 who later deleted his comment.