### PR TITLE
[TextField] Fixes underline custom styles not inherited by focusedUnderline.

### DIFF
--- a/src/TextField/TextFieldUnderline.jsx
+++ b/src/TextField/TextFieldUnderline.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Transitions from '../styles/transitions';
-import Styles from '../utils/styles';
+import styleUtils from '../utils/styles';
 
 const propTypes = {
   /**
@@ -81,7 +81,7 @@ const TextFieldUnderline = (props) => {
   } = muiTheme;
 
 
-  let styles = {
+  const styles = {
     root: {
       border: 'none',
       borderBottom: 'solid 1px',
@@ -108,17 +108,17 @@ const TextFieldUnderline = (props) => {
     },
   };
 
-  let underline = Styles.merge(styles.root, style);
-  let focusedUnderline = Styles.merge(styles.root, styles.focus, focusStyle);
+  let underline = styleUtils.merge(styles.root, style);
+  let focusedUnderline = styleUtils.merge(underline, styles.focus, focusStyle);
 
-  if (disabled) underline = Styles.merge(underline, styles.disabled, disabledStyle);
-  if (focus) focusedUnderline = Styles.merge(focusedUnderline, {transform: 'scaleX(1)'});
-  if (error) focusedUnderline = Styles.merge(focusedUnderline, styles.error);
+  if (disabled) underline = styleUtils.merge(underline, styles.disabled, disabledStyle);
+  if (focus) focusedUnderline = styleUtils.merge(focusedUnderline, {transform: 'scaleX(1)'});
+  if (error) focusedUnderline = styleUtils.merge(focusedUnderline, styles.error);
 
   return (
     <div>
-      <hr style={Styles.prepareStyles(muiTheme, underline)}/>
-      <hr style={Styles.prepareStyles(muiTheme, focusedUnderline)}/>
+      <hr style={styleUtils.prepareStyles(muiTheme, underline)}/>
+      <hr style={styleUtils.prepareStyles(muiTheme, focusedUnderline)}/>
     </div>
   );
 };


### PR DESCRIPTION
This fixes an issue introduced in PR #2476. I noticed in the documentation in `Divider.jsx` that the `TextField`  underline were being hidden using style prop using `display: 'none'`. The underline was invisible when it was not focused, however when it was focused, the underline became visible. The issue was that custom styles passed to underline were not inherited by the `focusedUnderline` which is used when the underline has an error or is focused. Now it does (as demonstrated in lines L111-112).

Before (L111-L112):
```js
-  let underline = Styles.merge(styles.root, style);
-  let focusedUnderline = Styles.merge(styles.root, styles.focus, focusStyle);
```
After (L111-L112):
```js
+  let underline = Styles.merge(styles.root, style);
+  let focusedUnderline = Styles.merge(underline, styles.focus, focusStyle);
```

I also made the following minor code formatting changes:

1. Changed `Styles` to `styleUtils` (a convention that we defined in the `Divider.jsx` pull request)
2. Change styles variable from `let` to `const` (L84)
 