### PR TITLE
Modified deprecatedExport function to better support non-components

### DIFF
--- a/src/utils/deprecatedExport.js
+++ b/src/utils/deprecatedExport.js
@@ -1,9 +1,11 @@
 import warning from 'warning';
 
-function deprecatedExport(Component, deprecatedPath, supportedPath) {
+const getName = (object) => object.displayName ? `${object.displayName} ` : '';
+
+function deprecatedExport(object, deprecatedPath, supportedPath) {
   warning(false,
-    `Importing ${Component.displayName} from '${deprecatedPath}' has been deprecated, use '${supportedPath}' instead.`);
-  return Component;
+    `Importing ${getName(object)}from '${deprecatedPath}' has been deprecated, use '${supportedPath}' instead.`);
+  return object;
 }
 
 export default deprecatedExport;


### PR DESCRIPTION
This implements the fix to `deprecatedExport` as suggested in #2541. It now will behave like this:

```js
// Component.displayName = 'Component': 
export default deprecatedExport(
  Component,
  'material-ui/lib/component',
  'material-ui/lib/Component'
);
/* Warning: Importing Component from 'material-ui/lib/component' has been deprecated, use 'material-ui/lib/Component' instead.
```

```js
//utilityObject.displayName is undefined: 
export default deprecatedExport(
  utilityObject,
  'material-ui/lib/utility-object',
  'material-ui/lib/utilityObject'
);
/* Warning: Importing from 'material-ui/lib/utility-object' has been deprecated, use 'material-ui/lib/UtilityObject' instead.
```
