### PR TITLE
[TextField] Separate TextFieldHint into separate internal component.

### DIFF
--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -8,6 +8,7 @@ import EnhancedTextarea from '../enhanced-textarea';
 import DefaultRawTheme from '../styles/raw-themes/light-raw-theme';
 import ThemeManager from '../styles/theme-manager';
 import ContextPure from '../mixins/context-pure';
+import TextFieldHint from './TextFieldHint';
 import TextFieldUnderline from './TextFieldUnderline';
 import warning from 'warning';
 
@@ -178,13 +179,17 @@ const TextField = React.createClass({
         color: errorColor,
         transition: Transitions.easeOut(),
       },
-      hint: {
+      floatingLabel: {
         position: 'absolute',
         lineHeight: '22px',
+        top: 38,
         opacity: 1,
         color: hintColor,
         transition: Transitions.easeOut(),
-        bottom: 12,
+        zIndex: 1, // Needed to display label above Chrome's autocomplete field background
+        cursor: 'text',
+        transform: 'scale(1) translate3d(0, 0, 0)',
+        transformOrigin: 'left top',
       },
       input: {
         tapHighlightColor: 'rgba(0,0,0,0)',
@@ -202,17 +207,6 @@ const TextField = React.createClass({
 
     styles.error = this.mergeStyles(styles.error, props.errorStyle);
 
-    styles.floatingLabel = this.mergeStyles(styles.hint, {
-      lineHeight: '22px',
-      top: 38,
-      bottom: 'none',
-      opacity: 1,
-      zIndex: 1, // Needed to display label above Chrome's autocomplete field background
-      cursor: 'text',
-      transform: 'scale(1) translate3d(0, 0, 0)',
-      transformOrigin: 'left top',
-    });
-
     styles.textarea = this.mergeStyles(styles.input, {
       marginTop: props.floatingLabelText ? 36 : 12,
       marginBottom: props.floatingLabelText ? -36 : -12,
@@ -229,16 +223,10 @@ const TextField = React.createClass({
     if (this.state.hasValue) {
       styles.floatingLabel.color = ColorManipulator.fade(props.disabled ? disabledTextColor : floatingLabelColor, 0.5);
       styles.floatingLabel.transform = 'perspective(1px) scale(0.75) translate3d(2px, -28px, 0)';
-      styles.hint.opacity = 0;
     }
 
     if (props.floatingLabelText) {
-      styles.hint.opacity = 0;
       styles.input.boxSizing = 'border-box';
-
-      if (this.state.isFocused && !this.state.hasValue) {
-        styles.hint.opacity = 1;
-      }
 
       if (!props.multiLine) {
         styles.input.marginTop = 14;
@@ -247,10 +235,6 @@ const TextField = React.createClass({
       if (this.state.errorText) {
         styles.error.bottom = styles.error.fontSize + 3;
       }
-    }
-
-    if (props.style && props.style.height) {
-      styles.hint.lineHeight = props.style.height;
     }
 
     if (this.state.errorText) {
@@ -277,6 +261,7 @@ const TextField = React.createClass({
       onBlur,
       onChange,
       onFocus,
+      style,
       type,
       underlineDisabledStyle,
       underlineFocusStyle,
@@ -293,10 +278,6 @@ const TextField = React.createClass({
 
     let errorTextElement = this.state.errorText ? (
       <div style={this.prepareStyles(styles.error)}>{this.state.errorText}</div>
-    ) : null;
-
-    let hintTextElement = hintText ? (
-      <div style={this.prepareStyles(styles.hint, hintStyle)}>{hintText}</div>
     ) : null;
 
     let floatingLabelTextElement = floatingLabelText ? (
@@ -354,9 +335,17 @@ const TextField = React.createClass({
     return (
       <div className={className} style={this.prepareStyles(styles.root, this.props.style)}>
         {floatingLabelTextElement}
-        {hintTextElement}
+        {hintText ?
+          <TextFieldHint
+            hidden={this.state.hasValue || (floatingLabelText && !this.state.isFocused)}
+            muiTheme={this.state.muiTheme}
+            style={hintStyle}
+            text={hintText}
+          /> :
+          null
+        }
         {inputElement}
-        {this.props.underlineShow ?
+        {underlineShow ?
           <TextFieldUnderline
             disabled={disabled}
             disabledStyle={underlineDisabledStyle}

--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -337,8 +337,8 @@ const TextField = React.createClass({
         {floatingLabelTextElement}
         {hintText ?
           <TextFieldHint
-            hidden={this.state.hasValue || (floatingLabelText && !this.state.isFocused)}
             muiTheme={this.state.muiTheme}
+            show={!(this.state.hasValue || (floatingLabelText && !this.state.isFocused))}
             style={hintStyle}
             text={hintText}
           /> :

--- a/src/TextField/TextFieldHint.jsx
+++ b/src/TextField/TextFieldHint.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import Transitions from '../styles/transitions';
+import styleUtils from '../utils/styles';
+
+const propTypes = {
+  /**
+   * True if the hint text should be hidden.
+   */
+  hidden: React.PropTypes.bool,
+
+  /**
+   * The material-ui theme applied to this component.
+   */
+  muiTheme: React.PropTypes.object.isRequired,
+
+  /**
+   * Override the inline-styles of the hint text.
+   */
+  style: React.PropTypes.object,
+
+  /**
+   * The hint text displayed.
+   */
+  text: React.PropTypes.string,
+};
+
+const defaultProps = {
+  visible: true,
+};
+
+const TextFieldHint = (props) => {
+
+  const {
+    hidden,
+    muiTheme,
+    style,
+    text,
+  } = props;
+
+  const {
+    textField: {
+      hintColor,
+    },
+  } = muiTheme;
+
+  const styles = {
+    root: {
+      position: 'absolute',
+      opacity: hidden ? 0 : 1,
+      color: hintColor,
+      transition: Transitions.easeOut(),
+      bottom: 12,
+    },
+  };
+
+  return (
+    <div
+      style={styleUtils.prepareStyles(muiTheme, styles.root, style)}>{text}
+    </div>
+  );
+};
+
+TextFieldHint.propTypes = propTypes;
+TextFieldHint.defaultProps = defaultProps;
+
+export default TextFieldHint;

--- a/src/TextField/TextFieldHint.jsx
+++ b/src/TextField/TextFieldHint.jsx
@@ -4,14 +4,14 @@ import styleUtils from '../utils/styles';
 
 const propTypes = {
   /**
-   * True if the hint text should be hidden.
-   */
-  hidden: React.PropTypes.bool,
-
-  /**
    * The material-ui theme applied to this component.
    */
   muiTheme: React.PropTypes.object.isRequired,
+
+  /**
+   * True if the hint text should be visible.
+   */
+  show: React.PropTypes.bool,
 
   /**
    * Override the inline-styles of the hint text.
@@ -25,14 +25,14 @@ const propTypes = {
 };
 
 const defaultProps = {
-  visible: true,
+  show: true,
 };
 
 const TextFieldHint = (props) => {
 
   const {
-    hidden,
     muiTheme,
+    show,
     style,
     text,
   } = props;
@@ -46,7 +46,7 @@ const TextFieldHint = (props) => {
   const styles = {
     root: {
       position: 'absolute',
-      opacity: hidden ? 0 : 1,
+      opacity: show ? 1 : 0,
       color: hintColor,
       transition: Transitions.easeOut(),
       bottom: 12,


### PR DESCRIPTION
This is one of the tasks in #2555. It seeks to simplify the `TextField.jsx` component by extracting the hint text and its styling logic into its own separate internal component. 

**Note:** I saw this if condition on lines [L252-254](https://github.com/callemall/material-ui/blob/master/src/TextField/TextField.jsx#L252-L254) that applies a line height to the hint text if a height property is found on the custom root style that is provided. This has not been accounted for, and am wondering if we really want to properly support changing heights of TextFields. If so, we should probably do it differently.