### PR TITLE
[DatePicker] Call setState-muiTheme in componentWillReceiveProps

### DIFF
--- a/src/date-picker/date-picker.jsx
+++ b/src/date-picker/date-picker.jsx
@@ -79,7 +79,11 @@ const DatePicker = React.createClass({
     };
   },
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps(nextProps, nextContext) {
+    if (nextContext.muiTheme) {
+      this.setState({muiTheme: nextContext.muiTheme});
+    }
+
     if (this._isControlled()) {
       let newDate = this._getControlledDate(nextProps);
       if (!DateTime.isEqualDate(this.state.date, newDate)) {


### PR DESCRIPTION
DatePicker does not update state.muiTheme on componentWillReceiveProps, resulting in the child component (TextField) not receiving updated theme values.

Side note - would this conditional way of calling `this.setState` save a few milliseconds of calculation as compared to calling `this.setState{muiTheme:...}` without any checks like in all other components? 
```js
// Taken from flat-button-label.jsx
  componentWillReceiveProps(nextProps, nextContext) {
    let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
    this.setState({muiTheme: newMuiTheme});
  }
```


![](http://g.recordit.co/z6TcCpk0sX.gif)