### PR TITLE
Bug fix, issue 2566 -- MenuItem right icon loses styles

### DIFF
--- a/docs/src/app/components/pages/components/menus.jsx
+++ b/docs/src/app/components/pages/components/menus.jsx
@@ -4,6 +4,7 @@ import Menu from 'menus/menu';
 import MenuItem from 'menus/menu-item';
 import Divider from 'divider';
 import ComponentDoc from '../../component-doc';
+import FontIcon from 'font-icon';
 
 import ArrowDropRight from 'material-ui/svg-icons/navigation-arrow-drop-right';
 import ContentCopy from 'material-ui/svg-icons/content/content-copy';
@@ -353,6 +354,17 @@ import Divider from 'material-ui/lib/menus/menu-divider';
             <MenuItem primaryText="Grid lines" checked={true} />
             <MenuItem primaryText="Page breaks" insetChildren={true} />
             <MenuItem primaryText="Rules" checked={true} />
+          </Menu>
+
+          <Menu style={styles.menu} desktop={false}>
+            <MenuItem primaryText="Clear Config" />
+            <MenuItem primaryText="New Config" rightIcon={<PersonAdd />} />
+            <MenuItem primaryText="Project" rightIcon={<FontIcon className="material-icons">settings</FontIcon>}/>
+            <MenuItem primaryText="Workspace" rightIcon={
+              <FontIcon className="material-icons" style={{color: '#559'}}>settings</FontIcon>
+              }/>
+            <MenuItem primaryText="Paragraph" rightIcon={<b style={{paddingTop: 0}}>¶</b>} />
+            <MenuItem primaryText="Section" rightIcon={<b style={{paddingTop: 0}}>§</b>} />
           </Menu>
         </CodeExample>
       </ComponentDoc>

--- a/src/menus/menu-item.jsx
+++ b/src/menus/menu-item.jsx
@@ -171,7 +171,7 @@ const MenuItem = React.createClass({
     let rightIconElement;
     if (rightIcon) {
       const mergedRightIconStyles = desktop ?
-        this.mergeStyles(styles.rightIconDesktop, rightIcon.props.style) : null;
+        this.mergeStyles(styles.rightIconDesktop, rightIcon.props.style) : rightIcon.props.style;
       rightIconElement = React.cloneElement(rightIcon, {style: mergedRightIconStyles});
     }
 


### PR DESCRIPTION
fixed bug that null-ed out rightIcon styles with desktop={false} configuration; added example in docs

https://github.com/callemall/material-ui/issues/2566