### PR TITLE
[Proposal] Leverage Inheritance to Address Cross-Cutting Concerns

### DIFF
--- a/src/MuiComponent.jsx
+++ b/src/MuiComponent.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import DefaultRawTheme from './styles/raw-themes/light-raw-theme';
+import ThemeManager from './styles/theme-manager';
+
+export default class MuiComponent extends React.Component {
+
+  static DEFAULT_THEME;
+
+  static contextTypes = {
+    muiTheme: React.PropTypes.object,
+  };
+
+  constructor(props, context) {
+    super(props, context);
+
+    if (!context || !context.muiTheme) {
+      if (!MuiComponent.DEFAULT_THEME) {
+        MuiComponent.DEFAULT_THEME = ThemeManager.getMuiTheme(DefaultRawTheme);
+      }
+      this.state = {muiTheme: MuiComponent.DEFAULT_THEME};
+    } else {
+      this.state = {muiTheme: context.muiTheme};
+    }
+  }
+
+  componentWillReceiveProps(nextProps, nextContext) {
+    if (nextContext.muiTheme !== this.state.muiTheme) {
+      this.setState({muiTheme: nextContext.muiTheme});
+    }
+  }
+
+// shouldComponentUpdate Optimazation
+
+// Style Calculation/Memoization!
+
+// All the other cross-cutting concerns can be handled here!
+
+  render() {
+    throw new Error('MuiComponent is abstract, and it\' render method must be overriden.');
+  }
+}

--- a/src/app-bar.jsx
+++ b/src/app-bar.jsx
@@ -1,38 +1,13 @@
 import React from 'react';
-import StylePropable from './mixins/style-propable';
+import MuiComponent from './MuiComponent';
+import styleUtils from './utils/styles';
 import Typography from './styles/typography';
 import IconButton from './icon-button';
 import NavigationMenu from './svg-icons/navigation/menu';
-import DefaultRawTheme from './styles/raw-themes/light-raw-theme';
-import ThemeManager from './styles/theme-manager';
 import Paper from './paper';
 import PropTypes from './utils/prop-types';
-import {autobind, mixin} from 'core-decorators';
 
-@mixin(StylePropable)
-export default class AppBar extends React.Component {
-  constructor(props, context) {
-    super(props, context);
-
-    this.state = {
-      muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
-    };
-  }
-
-  //for passing default theme context to children
-  static childContextTypes = {
-    muiTheme: React.PropTypes.object,
-  }
-
-  static contextTypes = {
-    muiTheme: React.PropTypes.object,
-  }
-
-  static defaultProps = {
-    showMenuIconButton: true,
-    title: '',
-    zDepth: 1,
-  }
+export default class AppBar extends MuiComponent {
 
   static propTypes = {
     /**
@@ -116,17 +91,10 @@ export default class AppBar extends React.Component {
     zDepth: PropTypes.zDepth,
   }
 
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  }
-
-  //to update theme inside state whenever a new theme is passed down
-  //from the parent / owner using context
-  componentWillReceiveProps(nextProps, nextContext) {
-    let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
+  static defaultProps = {
+    showMenuIconButton: true,
+    title: '',
+    zDepth: 1,
   }
 
   componentDidMount() {
@@ -219,10 +187,12 @@ export default class AppBar extends React.Component {
       ...other,
     } = this.props;
 
+    const {muiTheme} = this.state;
+
     let menuElementLeft;
     let menuElementRight;
     let styles = this.getStyles();
-    let iconRightStyle = this.mergeStyles(styles.iconButton.style, {
+    let iconRightStyle = styleUtils.merge(styles.iconButton.style, {
       marginRight: -16,
       marginLeft: 'auto',
     }, iconStyleRight);
@@ -233,11 +203,11 @@ export default class AppBar extends React.Component {
       // If not, just use it as a node.
       titleElement = typeof title === 'string' || title instanceof String ?
         <h1 onTouchTap={this._onTitleTouchTap}
-          style={this.prepareStyles(styles.title, styles.mainElement, titleStyle)}>
+          style={styleUtils.prepareStyles(muiTheme, styles.title, styles.mainElement, titleStyle)}>
           {title}
         </h1> :
         <div onTouchTap={this._onTitleTouchTap}
-          style={this.prepareStyles(styles.title, styles.mainElement, titleStyle)}>
+          style={styleUtils.prepareStyles(muiTheme, styles.title, styles.mainElement, titleStyle)}>
           {title}
         </div>;
     }
@@ -247,22 +217,22 @@ export default class AppBar extends React.Component {
         switch (iconElementLeft.type.displayName) {
           case 'IconButton':
             iconElementLeft = React.cloneElement(iconElementLeft, {
-              iconStyle: this.mergeStyles(styles.iconButton.iconStyle, iconElementLeft.props.iconStyle),
+              iconStyle: styleUtils.merge(styles.iconButton.iconStyle, iconElementLeft.props.iconStyle),
             });
             break;
         }
 
         menuElementLeft = (
-          <div style={this.prepareStyles(styles.iconButton.style)}>
+          <div style={styleUtils.prepareStyles(muiTheme, styles.iconButton.style)}>
             {iconElementLeft}
           </div>
         );
       } else {
-        let child = iconClassNameLeft ? '' : <NavigationMenu style={this.mergeStyles(styles.iconButton.iconStyle)}/>;
+        let child = iconClassNameLeft ? '' : <NavigationMenu style={styleUtils.merge(styles.iconButton.iconStyle)}/>;
         menuElementLeft = (
           <IconButton
-            style={this.mergeStyles(styles.iconButton.style)}
-            iconStyle={this.mergeStyles(styles.iconButton.iconStyle)}
+            style={styleUtils.merge(styles.iconButton.style)}
+            iconStyle={styleUtils.merge(styles.iconButton.iconStyle)}
             iconClassName={iconClassNameLeft}
             onTouchTap={this._onLeftIconButtonTouchTap}>
               {child}
@@ -276,19 +246,19 @@ export default class AppBar extends React.Component {
         case 'IconMenu':
         case 'IconButton':
           iconElementRight = React.cloneElement(iconElementRight, {
-            iconStyle: this.mergeStyles(styles.iconButton.iconStyle, iconElementRight.props.iconStyle),
+            iconStyle: styleUtils.merge(styles.iconButton.iconStyle, iconElementRight.props.iconStyle),
           });
           break;
 
         case 'FlatButton':
           iconElementRight = React.cloneElement(iconElementRight, {
-            style: this.mergeStyles(styles.flatButton, iconElementRight.props.style),
+            style: styleUtils.merge(styles.flatButton, iconElementRight.props.style),
           });
           break;
       }
 
       menuElementRight = (
-        <div style={this.prepareStyles(iconRightStyle)}>
+        <div style={styleUtils.prepareStyles(muiTheme, iconRightStyle)}>
           {iconElementRight}
         </div>
       );
@@ -296,7 +266,7 @@ export default class AppBar extends React.Component {
       menuElementRight = (
         <IconButton
           style={iconRightStyle}
-          iconStyle={this.mergeStyles(styles.iconButton.iconStyle)}
+          iconStyle={styleUtils.merge(styles.iconButton.iconStyle)}
           iconClassName={iconClassNameRight}
           onTouchTap={this._onRightIconButtonTouchTap} />
       );
@@ -307,7 +277,7 @@ export default class AppBar extends React.Component {
         {...other}
         rounded={false}
         className={className}
-        style={this.mergeStyles(styles.root, style)}
+        style={styleUtils.merge(styles.root, style)}
         zDepth={zDepth}>
           {menuElementLeft}
           {titleElement}
@@ -317,22 +287,20 @@ export default class AppBar extends React.Component {
     );
   }
 
-  @autobind
-  _onLeftIconButtonTouchTap(event) {
+
+  _onLeftIconButtonTouchTap = (event) => {
     if (this.props.onLeftIconButtonTouchTap) {
       this.props.onLeftIconButtonTouchTap(event);
     }
   }
 
-  @autobind
-  _onRightIconButtonTouchTap(event) {
+  _onRightIconButtonTouchTap = (event) => {
     if (this.props.onRightIconButtonTouchTap) {
       this.props.onRightIconButtonTouchTap(event);
     }
   }
 
-  @autobind
-  _onTitleTouchTap(event) {
+  _onTitleTouchTap = (event) => {
     if (this.props.onTitleTouchTap) {
       this.props.onTitleTouchTap(event);
     }

--- a/src/avatar.jsx
+++ b/src/avatar.jsx
@@ -1,34 +1,9 @@
 import React from 'react';
-import StylePropable from './mixins/style-propable';
+import MuiComponent from './MuiComponent';
+import styleUtils from './utils/styles';
 import Colors from './styles/colors';
-import DefaultRawTheme from './styles/raw-themes/light-raw-theme';
-import ThemeManager from './styles/theme-manager';
-import {mixin} from 'core-decorators';
 
-@mixin(StylePropable)
-export default class Avatar extends React.Component {
-  constructor(props, context) {
-    super(props, context);
-
-    this.state = {
-      muiTheme: context.muiTheme ? context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
-    };
-  }
-
-  //for passing default theme context to children
-  static childContextTypes = {
-    muiTheme: React.PropTypes.object,
-  }
-
-  static contextTypes = {
-    muiTheme: React.PropTypes.object,
-  }
-
-  static defaultProps = {
-    backgroundColor: Colors.grey400,
-    color: Colors.white,
-    size: 40,
-  }
+export default class Avatar extends MuiComponent {
 
   static propTypes = {
     /**
@@ -72,22 +47,16 @@ export default class Avatar extends React.Component {
     style: React.PropTypes.object,
   }
 
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  }
-
-  //to update theme inside state whenever a new theme is passed down
-  //from the parent / owner using context
-  componentWillReceiveProps(nextProps, nextContext) {
-    let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
+  static defaultProps = {
+    backgroundColor: Colors.grey400,
+    color: Colors.white,
+    size: 40,
   }
 
   render() {
     let {
       backgroundColor,
+      children,
       color,
       icon,
       size,
@@ -96,6 +65,8 @@ export default class Avatar extends React.Component {
       className,
       ...other,
     } = this.props;
+
+    const {muiTheme} = this.state;
 
     let styles = {
       root: {
@@ -108,10 +79,10 @@ export default class Avatar extends React.Component {
     };
 
     if (src) {
-      const borderColor = this.state.muiTheme.avatar.borderColor;
+      const borderColor = muiTheme.avatar.borderColor;
 
       if (borderColor) {
-        styles.root = this.mergeStyles(styles.root, {
+        styles.root = styleUtils.merge(styles.root, {
           height: size - 2,
           width: size - 2,
           border: 'solid 1px ' + borderColor,
@@ -122,12 +93,12 @@ export default class Avatar extends React.Component {
         <img
           {...other}
           src={src}
-          style={this.prepareStyles(styles.root, style)}
+          style={styleUtils.prepareStyles(muiTheme, styles.root, style)}
           className={className}
         />
       );
     } else {
-      styles.root = this.mergeStyles(styles.root, {
+      styles.root = styleUtils.merge(styles.root, {
         backgroundColor: backgroundColor,
         textAlign: 'center',
         lineHeight: size + 'px',
@@ -141,17 +112,17 @@ export default class Avatar extends React.Component {
 
       const iconElement = icon ? React.cloneElement(icon, {
         color: color,
-        style: this.mergeStyles(styleIcon, icon.props.style),
+        style: styleUtils.merge(styleIcon, icon.props.style),
       }) : null;
 
       return (
         <div
           {...other}
-          style={this.prepareStyles(styles.root, style)}
+          style={styleUtils.prepareStyles(muiTheme, styles.root, style)}
           className={className}
         >
           {iconElement}
-          {this.props.children}
+          {children}
         </div>
       );
     }


### PR DESCRIPTION
Recently there has been much discussion of how to get rid of mixins and getting theme from context. all have many short comings:

* **Stateless Functional Wrapper Component**
  1. no `ref`
  2. methods cannot be forwarded at all!
* **HOC** 
  1. Methods cannot be forwarded conveniently
  2. breaks `instanceof`
* **HOC with proxy**
  1. Very hard to maintain!
* **Mixin** 
  1. The people at React make it very clear why they won't support mixins for es6-classes
  2. Very hard to reason about
* **Utility Methods**
  1. Cannot access the component's internal behavior

### Solution:
Inheritance to rescue! This handled a lot of things! Almost all cross-cutting concerns can be handled this way:

1. Themes can be easily added to the state.
2. Changes to theme can be easily detected.
3. Many optimizations can be applied with ease.
4. Most importantly: elements can be checked with: `a.type === Avatar` instead of displayName see [here](https://facebook.github.io/react/blog/#elements-describe-the-tree)! :tada: :tada:
5. Future concerns can be addressed here.
6. communication between the superclass and subclass can be very easily established as opposed to HOCs, the benefits:
  * Memoization of calculated styles can be easily implemented in the super class.
  * Similar components can have a common super class to implement some behaviors

@oliviertassinari @ntgn81 @newoga I want to seriously discuss this before we decide what to do.