### PR TITLE
[package] Removed unused babel-plugin-dev-expression dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "babel-core": "^6.3.21",
     "babel-eslint": "^5.0.0-beta6",
     "babel-loader": "^6.2.0",
-    "babel-plugin-dev-expression": "^0.1.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-dev-warning": "^0.1.0",
     "babel-polyfill": "^6.3.14",


### PR DESCRIPTION
I have forgotten to remove it during the upgrade to babel6