### PR TITLE
[Docs] Improve perf of the production build

### DIFF
--- a/docs/.babelrc
+++ b/docs/.babelrc
@@ -1,0 +1,12 @@
+{
+  "presets": ["es2015", "stage-1", "react"],
+  "env": {
+    "production": {
+      "plugins": [
+        "transform-runtime",
+        "transform-react-constant-elements",
+        "transform-react-inline-elements"
+      ]
+    }
+  }
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,12 +10,15 @@
   "scripts": {
     "prestart": "webpack-dev-server --config webpack-dev-server.config.js --progress --colors --inline",
     "start": "open http://localhost:3000",
-    "build": "webpack --config webpack-production.config.js --progress --colors --profile",
-    "prd": "webpack-dev-server --config webpack-production.config.js --progress --colors --profile"
+    "build": "NODE_ENV=production webpack --config webpack-production.config.js --progress --colors --profile",
+    "prd": "NODE_ENV=production webpack-dev-server --config webpack-production.config.js --progress --colors --profile"
   },
   "dependencies": {},
   "devDependencies": {
     "babel-eslint": "^4.1.6",
+    "babel-plugin-transform-react-constant-elements": "^6.3.13",
+    "babel-plugin-transform-react-inline-elements": "^6.3.13",
+    "babel-plugin-transform-runtime": "^6.3.13",
     "css-loader": "^0.23.0",
     "eslint": "^1.10.3",
     "eslint-plugin-react": "^3.13.0",

--- a/docs/src/app/components/pages/components/auto-complete.jsx
+++ b/docs/src/app/components/pages/components/auto-complete.jsx
@@ -1,10 +1,30 @@
 import React from 'react';
-
 import {AutoComplete} from 'material-ui';
 import ComponentDoc from '../../component-doc';
 import CodeExample from '../../CodeExample';
-
 import Code from 'auto-complete-code';
+import MenuItem from 'material-ui/lib/menus/menu-item';
+
+const dataSource = [
+  {
+    text: 'text-value1',
+    value: (
+      <MenuItem
+        primaryText="text-value1"
+        secondaryText="&#9786;"
+      />
+    ),
+  },
+  {
+    text: 'text-value2',
+    value: (
+      <MenuItem
+        primaryText="text-value2"
+        secondaryText="&#9786;"
+      />
+    ),
+  },
+];
 
 class AutoCompletePage extends React.Component {
 
@@ -17,8 +37,29 @@ class AutoCompletePage extends React.Component {
     };
   }
 
-  render() {
+  handleNewRequest = (t) => {
+    console.log(`New request: ${t}`);
+  }
 
+  handleUpdateInput1 = (t) => {
+    this.setState({
+      input1: [t, t + t, t + t + t],
+    });
+  }
+
+  handleUpdateInput2 = (t) => {
+    this.setState({
+      input2: [t, t + t, t + t + t],
+    });
+  }
+
+  handleUpdateInput3 = (t) => {
+    this.setState({
+      input3: [t, t + t, t + t + t],
+    });
+  }
+
+  render() {
     return (
       <ComponentDoc
         name="Auto Complete"
@@ -28,68 +69,51 @@ class AutoCompletePage extends React.Component {
             infoArray: [],
           },
         ]}>
-
         <br/>
-
         <CodeExample code={Code}>
           <AutoComplete
             dataSource={this.state.input1}
-            onUpdateInput={(t) => { console.log(t); this.setState({input1: [t, t + t, t + t + t]}); }}
-            onNewRequest={(t) => { console.log('request:' + t); }} />
-
+            onUpdateInput={this.handleUpdateInput1}
+            onNewRequest={this.handleNewRequest}
+          />
+          <br/>
           <AutoComplete
-            fullWidth={true}
             hintText="hint"
             dataSource={this.state.input2}
-            onUpdateInput={(t) => { console.log(t); this.setState({input2: [t, t + t, t + t + t]}); }}
-            onNewRequest={(t) => { console.log('request:' + t); }} />
-
+            onUpdateInput={this.handleUpdateInput2}
+            onNewRequest={this.handleNewRequest}
+          />
+          <br/>
           <AutoComplete
             fullWidth={true}
-            searchText="***************"
+            searchText="*****"
             errorText="error message"
             dataSource={this.state.input3}
-            onUpdateInput={(t) => { console.log(t); this.setState({input3: [t, t + t, t + t + t]}); }}
-            onNewRequest={(t) => { console.log('request:' + t); }} />
-
+            onUpdateInput={this.handleUpdateInput3}
+            onNewRequest={this.handleNewRequest}
+          />
           <AutoComplete
-            fullWidth={true}
             hintText="text-value data"
-            onUpdateInput={(t) => {
-              console.log(t);
-            }}
             showAllItems={true}
-            dataSource={[
-              {
-                text: 'text-value1',
-                value: (<AutoComplete.Item primaryText={'text-value1'} secondaryText="&#9786;" />),
-              },
-              {
-                text: 'text-value2',
-                value: (<AutoComplete.Item primaryText={'text-value2'} secondaryText="&#9786;" />),
-              },
-            ]}
-            onNewRequest={(t, index) => { console.log('request:' + index); }} />
-
+            dataSource={dataSource}
+            onNewRequest={this.handleNewRequest}
+          />
+          <br/>
           <AutoComplete
             floatingLabelText="floating Label"
-            dataSource={['12345', '23456', '34567']} />
-
+            dataSource={['12345', '23456', '34567']}
+          />
+          <br/>
           <AutoComplete
-            fullWidth={true}
             floatingLabelText="showAllItems"
             showAllItems={true}
             animated={false}
-            dataSource={['12345', '23456', '34567']} />
-
+            dataSource={['12345', '23456', '34567']}
+          />
         </CodeExample>
-
       </ComponentDoc>
     );
-
   }
-
-
 }
 
 export default AutoCompletePage;


### PR DESCRIPTION
- `transform-runtime`: reduce the output build my adding the babel runtime utils only once and not at the top of each files
- `transform-react-constant-elements`: https://babeljs.io/docs/plugins/transform-react-constant-elements/
- `transform-react-inline-elements`: https://babeljs.io/docs/plugins/transform-react-inline-elements/
- I also want to add `react-remove-prop-types` but I'm waiting https://github.com/nkt/babel-plugin-react-remove-prop-types/pull/11 to be merged first