### PR TITLE
Fix for TextFieldHint incorrect text type

### DIFF
--- a/src/TextField/TextFieldHint.jsx
+++ b/src/TextField/TextFieldHint.jsx
@@ -21,7 +21,7 @@ const propTypes = {
   /**
    * The hint text displayed.
    */
-  text: React.PropTypes.string,
+  text: React.PropTypes.node,
 };
 
 const defaultProps = {


### PR DESCRIPTION
Fix for TextFieldHint incorrect text type (now node, instead of string)