### PR TITLE
npm start errors from docs folder: need to fix imports with uppercase

### DIFF
--- a/docs/src/app/app-routes.jsx
+++ b/docs/src/app/app-routes.jsx
@@ -10,10 +10,10 @@ import Master from './components/master';
 import Home from './components/pages/home';
 
 import GetStarted from './components/pages/get-started';
-import Prerequisites from './components/pages/get-started/Prerequisites';
-import Installation from './components/pages/get-started/Installation';
-import Usage from './components/pages/get-started/Usage';
-import Examples from './components/pages/get-started/Examples';
+import Prerequisites from './components/pages/get-started/prerequisites';
+import Installation from './components/pages/get-started/installation';
+import Usage from './components/pages/get-started/usage';
+import Examples from './components/pages/get-started/examples';
 import Community from './components/pages/get-started/Community';
 
 import Customization from './components/pages/customization';

--- a/docs/src/app/components/pages/components/Divider/Page.jsx
+++ b/docs/src/app/components/pages/components/Divider/Page.jsx
@@ -10,7 +10,7 @@ import DividerExampleList from './ExampleList';
 import dividerExampleListCode from '!raw!./ExampleList';
 import DividerExampleMenu from './ExampleMenu';
 import dividerExampleMenuCode from '!raw!./ExampleMenu';
-import dividerCode from '!raw!material-ui/lib/Divider';
+import dividerCode from '!raw!material-ui/lib/divider';
 
 const DividerPage = () => {
   return (


### PR DESCRIPTION
errors when npm start from docs folder:
```
ERROR in ./src/app/app-routes.jsx
Module not found: Error: Cannot resolve 'file' or 'directory' ./components/pages/get-started/Prerequisites in /home/juanda/material-ui/docs/src/app
 @ ./src/app/app-routes.jsx 27:21-76

ERROR in ./src/app/app-routes.jsx
Module not found: Error: Cannot resolve 'file' or 'directory' ./components/pages/get-started/Installation in /home/juanda/material-ui/docs/src/app
 @ ./src/app/app-routes.jsx 31:20-74

ERROR in ./src/app/app-routes.jsx
Module not found: Error: Cannot resolve 'file' or 'directory' ./components/pages/get-started/Examples in /home/juanda/material-ui/docs/src/app
 @ ./src/app/app-routes.jsx 39:16-66

ERROR in ./src/app/components/pages/components/Divider/Page.jsx
Module not found: Error: Cannot resolve 'file' or 'directory' /home/juanda/material-ui/src/Divider in /home/juanda/material-ui/docs/src/app/components/pages/components/Divider
 @ ./src/app/components/pages/components/Divider/Page.jsx 53:15-54
```

Files from import where uppercase but filenames where lowercase. 