### PR TITLE
[Docs] Improve the AppLeftNav for mobile

### DIFF
--- a/docs/src/app/components/app-left-nav.jsx
+++ b/docs/src/app/components/app-left-nav.jsx
@@ -58,21 +58,179 @@ const AppLeftNav = React.createClass({
         </div>
         <SelectableList
           valueLink={{
-            value: this._getSelectedIndex(),
+            value: this.props.location.pathname,
             requestChange: this.handleRequestChangeList,
           }}
         >
           <ListItem
-            value="get-started"
             primaryText="Get Started"
+            primaryTogglesNestedList={true}
+            nestedItems={[
+              <ListItem
+                value="/get-started/prerequisites"
+                primaryText="Prerequisites"
+              />,
+              <ListItem
+                value="/get-started/installation"
+                primaryText="Installation"
+              />,
+              <ListItem
+                value="/get-started/usage"
+                primaryText="Usage"
+              />,
+              <ListItem
+                value="/get-started/examples"
+                primaryText="Examples"
+              />,
+              <ListItem
+                value="/get-started/community"
+                primaryText="Community"
+              />,
+            ]}
           />
           <ListItem
-            value="customization"
             primaryText="Customization"
+            primaryTogglesNestedList={true}
+            nestedItems={[
+              <ListItem
+                value="/customization/themes"
+                primaryText="Themes"
+              />,
+              <ListItem
+                value="/customization/inline-styles"
+                primaryText="Inline Styles"
+              />,
+              <ListItem
+                value="/customization/colors"
+                primaryText="Colors"
+              />,
+            ]}
           />
           <ListItem
-            value="components"
             primaryText="Components"
+            primaryTogglesNestedList={true}
+            nestedItems={[
+              <ListItem
+                value="/components/app-bar"
+                primaryText="App Bar"
+              />,
+              <ListItem
+                value="/components/auto-complete"
+                primaryText="Auto Complete"
+              />,
+              <ListItem
+                value="/components/avatar"
+                primaryText="Avatar"
+              />,
+              <ListItem
+                value="/components/badge"
+                primaryText="Badge"
+              />,
+              <ListItem
+                value="/components/buttons"
+                primaryText="Buttons"
+              />,
+              <ListItem
+                value="/components/card"
+                primaryText="Card"
+              />,
+              <ListItem
+                value="/components/date-picker"
+                primaryText="Date Picker"
+              />,
+              <ListItem
+                value="/components/dialog"
+                primaryText="Dialog"
+              />,
+              <ListItem
+                value="/components/divider"
+                primaryText="Divider"
+              />,
+              <ListItem
+                value="/components/dropdown-menu"
+                primaryText="Dropdown Menu"
+              />,
+              <ListItem
+                value="/components/grid-list"
+                primaryText="Grid List"
+              />,
+              <ListItem
+                value="/components/icons"
+                primaryText="Icons"
+              />,
+              <ListItem
+                value="/components/icon-buttons"
+                primaryText="Icon Buttons"
+              />,
+              <ListItem
+                value="/components/icon-menus"
+                primaryText="Icon Menus"
+              />,
+              <ListItem
+                value="/components/left-nav"
+                primaryText="Left Nav"
+              />,
+              <ListItem
+                value="/components/lists"
+                primaryText="Lists"
+              />,
+              <ListItem
+                value="/components/menus"
+                primaryText="Menus"
+              />,
+              <ListItem
+                value="/components/paper"
+                primaryText="Paper"
+              />,
+              <ListItem
+                value="/components/popover"
+                primaryText="Popover"
+              />,
+              <ListItem
+                value="/components/progress"
+                primaryText="Progress"
+              />,
+              <ListItem
+                value="/components/refresh-indicator"
+                primaryText="Refresh Indicator"
+              />,
+              <ListItem
+                value="/components/select-fields"
+                primaryText="Select Fields"
+              />,
+              <ListItem
+                value="/components/sliders"
+                primaryText="Sliders"
+              />,
+              <ListItem
+                value="/components/switches"
+                primaryText="Switches"
+              />,
+              <ListItem
+                value="/components/snackbar"
+                primaryText="Snackbar"
+              />,
+              <ListItem
+                value="/components/table"
+                primaryText="Table"
+              />,
+              <ListItem
+                value="/components/tabs"
+                primaryText="Tabs"
+              />,
+              <ListItem
+                value="/components/text-fields"
+                primaryText="Text Fields"
+              />,
+              <ListItem
+                value="/components/time-picker"
+                primaryText="Time Picker"
+              />,
+              <ListItem
+                value="/components/toolbars"
+                primaryText="Toolbars"
+              />,
+            ]}
           />
         </SelectableList>
         <Divider />
@@ -101,11 +259,9 @@ const AppLeftNav = React.createClass({
   },
 
   toggle() {
-    this.setState({leftNavOpen: !this.state.leftNavOpen});
-  },
-
-  _getSelectedIndex() {
-    return this.props.location.pathname.split('/')[1];
+    this.setState({
+      leftNavOpen: !this.state.leftNavOpen,
+    });
   },
 
   handleChangeRequestLeftNav(open) {

--- a/docs/src/app/components/master.jsx
+++ b/docs/src/app/components/master.jsx
@@ -93,29 +93,10 @@ const Master = React.createClass({
   },
 
   render() {
-    let styles = this.getStyles();
-
-    let githubButton = (
-      <IconButton
-        iconStyle={styles.iconButton}
-        iconClassName="muidocs-icon-custom-github"
-        href="https://github.com/callemall/material-ui"
-        linkButton={true}
-        style={styles.github} />
-    );
-
-    let githubButton2 = (
-      <IconButton
-        iconStyle={styles.iconButton}
-        iconClassName="muidocs-icon-custom-github"
-        href="https://github.com/callemall/material-ui"
-        linkButton={true}/>
-    );
+    const styles = this.getStyles();
     return (
       <AppCanvas>
-        {githubButton}
         {this.state.renderTabs ? this._getTabs() : this._getAppBar()}
-
         {this.props.children}
         <AppLeftNav ref="leftNav" history={this.props.history} location={this.props.location} />
         <FullWidthSection style={styles.footer}>
@@ -125,7 +106,12 @@ const Master = React.createClass({
             awesome <a style={this.prepareStyles(styles.a)}
               href="https://github.com/callemall/material-ui/graphs/contributors">contributors</a>.
           </p>
-          {githubButton2}
+          <IconButton
+            iconStyle={styles.iconButton}
+            iconClassName="muidocs-icon-custom-github"
+            href="https://github.com/callemall/material-ui"
+            linkButton={true}
+          />
         </FullWidthSection>
       </AppCanvas>
     );

--- a/docs/src/app/components/pages/page-with-nav.jsx
+++ b/docs/src/app/components/pages/page-with-nav.jsx
@@ -7,15 +7,18 @@ import MenuItem from 'material-ui/lib/menus/menu-item';
 let {Spacing, Colors} = Styles;
 let {StyleResizable, StylePropable} = Mixins;
 
-
-let PageWithNav = React.createClass({
+const PageWithNav = React.createClass({
 
   contextTypes: {
     muiTheme: React.PropTypes.object,
     router: React.PropTypes.func,
   },
 
-  mixins: [StyleResizable, StylePropable, History],
+  mixins: [
+    StyleResizable,
+    StylePropable,
+    History,
+  ],
 
   propTypes: {
     children: React.PropTypes.node,

--- a/src/hoc/selectable-enhance.js
+++ b/src/hoc/selectable-enhance.js
@@ -77,7 +77,7 @@ export const SelectableContainerEnhance = (Component) => {
     },
 
     _extendChild(child, styles, selectedItemStyle) {
-      if (child.type.displayName === 'ListItem') {
+      if (child.type && child.type.displayName === 'ListItem') {
         let selected = this._isChildSelected(child, this.props);
         let selectedChildrenStyles = {};
         if (selected) {

--- a/src/left-nav.jsx
+++ b/src/left-nav.jsx
@@ -265,7 +265,7 @@ const LeftNav = React.createClass({
         transform: `translate3d(${x}px, 0, 0)`,
         transition: !this.state.swiping && Transitions.easeOut(),
         backgroundColor: theme.color,
-        overflow: 'hidden',
+        overflow: 'auto',
       },
       menu: {
         overflowY: 'auto',

--- a/src/mixins/style-resizable.js
+++ b/src/mixins/style-resizable.js
@@ -6,7 +6,6 @@ const Sizes = {
   LARGE: 3,
 };
 
-
 export default {
 
   statics: {
@@ -34,9 +33,14 @@ export default {
 
   _updateDeviceSize() {
     const width = window.innerWidth;
-    if (width >= 992) this.setState({deviceSize: Sizes.LARGE});
-    else if (width >= 768) this.setState({deviceSize: Sizes.MEDIUM});
-    else this.setState({deviceSize: Sizes.SMALL}); // width < 768
+
+    if (width >= 992) {
+      this.setState({deviceSize: Sizes.LARGE});
+    } else if (width >= 768) {
+      this.setState({deviceSize: Sizes.MEDIUM});
+    } else { // width < 768
+      this.setState({deviceSize: Sizes.SMALL});
+    }
   },
 
   _bindResize() {


### PR DESCRIPTION
Fix https://github.com/callemall/material-ui/issues/2616, and start adressing https://github.com/callemall/material-ui/issues/2435.

I think that we should get ride of the `PageWithNav` component.
Instead, I would use the `AppLeftNav` not only for the mobile view, but also for the desktop view with a `docked={true}` property.

![dec 29 2015 12 29](https://cloud.githubusercontent.com/assets/3165635/12033799/ea83163c-ae27-11e5-9337-644d0c3111c9.gif)