### PR TITLE
Add prevent default to stop triggering components under overlay

### DIFF
--- a/src/left-nav.jsx
+++ b/src/left-nav.jsx
@@ -401,7 +401,8 @@ const LeftNav = React.createClass({
     if (!this.props.docked) this._close('clickaway');
   },
 
-  _onOverlayTouchTap() {
+  _onOverlayTouchTap(event) {
+    event.preventDefault();
     this._close('clickaway');
   },
 


### PR DESCRIPTION
This fixes the issue when user clicks overlay to close Left Nav and accidentally triggers component under overlay (https://github.com/callemall/material-ui/issues/2689).