### PR TITLE
Fix invariant violation for ListDivider and MenuDivider

### DIFF
--- a/src/lists/list-divider.jsx
+++ b/src/lists/list-divider.jsx
@@ -6,6 +6,7 @@ const ListDivider = React.createClass({
 
   getInitialState() {
     warning(false, '<ListDivider /> has been deprecated. Please use the <Divider /> component.');
+    return null;
   },
 
   render() {

--- a/src/menus/menu-divider.jsx
+++ b/src/menus/menu-divider.jsx
@@ -14,6 +14,7 @@ const MenuDivider = React.createClass({
 
   getInitialState() {
     warning(false, '<MenuDivider /> has been deprecated. Please use the <Divider /> component.');
+    return null;
   },
 
   getStyles() {


### PR DESCRIPTION
Fixes callemall/material-ui#2687

When deprecating ListDivider and MenuDivider for Divider, the reimplementation of the deprecated components did not return an object or null in getInitialState() causing an error. This commit fixes that issue.