### PR TITLE
Webpack Example Babel 6 Upgrade

### DIFF
--- a/examples/webpack-example/.babelrc
+++ b/examples/webpack-example/.babelrc
@@ -1,4 +1,3 @@
 {
-  "breakConfig": true,
-  "stage": 1,
+  "presets": ["es2015", "stage-1", "react"]
 }

--- a/examples/webpack-example/package.json
+++ b/examples/webpack-example/package.json
@@ -12,23 +12,26 @@
   },
   "private": true,
   "devDependencies": {
-    "babel-core": "^5.8.21",
-    "babel-eslint": "^4.0.5",
-    "babel-loader": "^5.3.2",
-    "babel-runtime": "^5.8.25",
-    "eslint": "^1.1.0",
-    "eslint-loader": "^1.0.0",
-    "eslint-plugin-react": "^3.2.2",
-    "html-webpack-plugin": "^1.6.1",
-    "react-hot-loader": "^1.2.8",
+    "babel-core": "^6.3.26",
+    "babel-eslint": "^5.0.0-beta6",
+    "babel-loader": "^6.2.0",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
+    "babel-preset-stage-0": "^6.3.13",
+    "babel-runtime": "^6.3.19",
+    "eslint": "^1.10.3",
+    "eslint-loader": "^1.1.1",
+    "eslint-plugin-react": "^3.13.1",
+    "html-webpack-plugin": "^1.7.0",
+    "react-hot-loader": "^1.3.0",
     "transfer-webpack-plugin": "^0.1.4",
-    "webpack": "^1.11.0",
-    "webpack-dev-server": "^1.10.1"
+    "webpack": "^1.12.9",
+    "webpack-dev-server": "^1.14.0"
   },
   "dependencies": {
     "material-ui": "^0.14.0",
-    "react": "^0.14.0",
-    "react-dom":"^0.14.0",
+    "react": "^0.14.3",
+    "react-dom":"^0.14.3",
     "react-tap-event-plugin": "^0.2.1"
   }
 }

--- a/examples/webpack-example/webpack-dev-server.config.js
+++ b/examples/webpack-example/webpack-dev-server.config.js
@@ -54,7 +54,7 @@ var config = {
       {
         //React-hot loader and
         test: /\.(js|jsx)$/,  //All .js and .jsx files
-        loaders: ['react-hot','babel-loader?optional=runtime&stage=0'], //react-hot is like browser sync and babel loads jsx and es6-7
+        loaders: ['react-hot', 'babel'], //react-hot is like browser sync and babel loads jsx and es6-7
         exclude: [nodeModulesPath]
       }
     ]

--- a/examples/webpack-example/webpack-production.config.js
+++ b/examples/webpack-example/webpack-production.config.js
@@ -45,7 +45,7 @@ var config = {
     loaders: [
       {
         test: /\.(js|jsx)$/, //All .js and .jsx files
-        loader: 'babel-loader?optional=runtime&stage=0', //react-hot is like browser sync and babel loads jsx and es6-7
+        loaders: ['babel'], //react-hot is like browser sync and babel loads jsx and es6-7
         exclude: [nodeModulesPath]
       }
     ]


### PR DESCRIPTION
- Babel 6 upgrade 
- Added es2015, react & stage-0 presets 
- Configured .babelrc to utilize es2015, react & stage-1 
- Adjusted webpack dev-server & production config to reflect babel upgrade changes 
- Upgraded all other modules to most recent version 
- Start & Build tested ok