### PR TITLE
Add swipeThreshold support to Left Nav

### DIFF
--- a/src/left-nav.jsx
+++ b/src/left-nav.jsx
@@ -164,6 +164,12 @@ const LeftNav = React.createClass({
     swipeAreaWidth: React.PropTypes.number,
 
     /**
+     * The number of pixels which the user needs to drag before the gesture is
+     * consider to be a swipe.
+     */
+    swipeThreshold: React.PropTypes.number,
+
+    /**
      * The width of the `LeftNav` in pixels. Defaults to using the values from theme.
      */
     width: React.PropTypes.number,
@@ -181,6 +187,7 @@ const LeftNav = React.createClass({
       open: null,
       openRight: false,
       swipeAreaWidth: 30,
+      swipeThreshold: 10,
       width: null,
     };
   },
@@ -511,7 +518,7 @@ const LeftNav = React.createClass({
       // If the user has moved his thumb ten pixels in either direction,
       // we can safely make an assumption about whether he was intending
       // to swipe or scroll.
-      const threshold = 10;
+      const threshold = this.props.swipeThreshold;
 
       if (dXAbs > threshold && dYAbs <= threshold) {
         this._swipeStartX = currentX;


### PR DESCRIPTION
The threshold for swiping the left nav away is currently hard-coded to 10 pixels.

We are using material-ui in our Cordova application. Swiping the nav is incredibly hard for us at the moment. The threshold is simply too high. Most of the gestures aren't being registered and to our users it feels "broken".

In order to reduce the threshold to 3px (which works much better for us), we need to expose it as a prop. This PR is to add this ability.

The PR doesn't include any changes to the documentation.