### PR TITLE
[TableBody] fix allRowsSelected prop change bug.

### DIFF
--- a/src/table/table-body.jsx
+++ b/src/table/table-body.jsx
@@ -85,10 +85,9 @@ const TableBody = React.createClass({
     let newState = {};
 
     if (this.props.allRowsSelected && !nextProps.allRowsSelected) {
-      const lastSelectedRow = this.state.selectedRows.length ?
-        this.state.selectedRows[this.state.selectedRows.length - 1] : undefined;
-
-      newState.selectedRows = [lastSelectedRow];
+      newState.selectedRows = this.state.selectedRows.length > 0
+        ? [this.state.selectedRows[this.state.selectedRows.length - 1]]
+        : [];
     } else {
       newState.selectedRows = this._calculatePreselectedRows(nextProps);
     }


### PR DESCRIPTION
Passing undefined to an array makes an array with the length of 1, not zero. This should be avoided since it can lead to undesired behavior.

Closes #2731

@oliviertassinari If you approve of this, please merge ^_^