### PR TITLE
Fix missing export from index.js

### DIFF
--- a/src/hoc/selectable-enhance.js
+++ b/src/hoc/selectable-enhance.js
@@ -124,3 +124,4 @@ export const SelectableContainerEnhance = (Component) => {
   return composed;
 };
 
+export default SelectableContainerEnhance;

--- a/src/index.js
+++ b/src/index.js
@@ -153,6 +153,7 @@ export const Icons = {
 };
 
 export default {
+  AppBar,
   AppCanvas,
   AutoComplete,
   Avatar,


### PR DESCRIPTION
AppBar was missing from the default export, which is a regression.

Closes #2736

@oliviertassinari Review and merge, thanks :+1: 