### PR TITLE
[Docs] Add footer paddingLeft for wide screen

### DIFF
--- a/docs/src/app/components/master.jsx
+++ b/docs/src/app/components/master.jsx
@@ -159,6 +159,7 @@ const Master = React.createClass({
         zIndex: styles.appBar.zIndex - 1,
       };
       styles.root.paddingLeft = 256;
+      styles.footer.paddingLeft = 256;
     }
 
     return (


### PR DESCRIPTION
I have forgotten to push this change in my previous PR.
Before:
![capture d ecran 2015-12-31 a 15 25 55](https://cloud.githubusercontent.com/assets/3165635/12065180/d4dab824-afd2-11e5-8aa5-6f9abf5f8243.png)

After:
![capture d ecran 2015-12-31 a 15 24 54](https://cloud.githubusercontent.com/assets/3165635/12065168/b773fa02-afd2-11e5-9929-639e350b81ef.png)
