### PR TITLE
[Dialog] Deprecate width

### DIFF
--- a/docs/src/app/components/pages/components/Dialog/ExampleCustomWidth.jsx
+++ b/docs/src/app/components/pages/components/Dialog/ExampleCustomWidth.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import Dialog from 'material-ui/lib/dialog';
+import FlatButton from 'material-ui/lib/flat-button';
+import RaisedButton from 'material-ui/lib/raised-button';
+
+const customContentStyle = {
+  width: '100%',
+  maxWidth: 'none',
+};
+
+export default class DialogExampleCustomWidth extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: false,
+    };
+  }
+
+  handleOpen = () => {
+    this.setState({open: true});
+  }
+
+  handleClose = () => {
+    this.setState({open: false});
+  }
+
+  render() {
+    const actions = [
+      <FlatButton
+        label="Cancel"
+        secondary={true}
+        onTouchTap={this.handleClose} />,
+      <FlatButton
+        label="Submit"
+        primary={true}
+        onTouchTap={this.handleClose} />,
+    ];
+
+    return (
+      <div>
+        <RaisedButton label="Dialog With Custom Width" onTouchTap={this.handleOpen} />
+        <Dialog
+          title="Dialog With Custom Width"
+          actions={actions}
+          modal={true}
+          contentStyle={customContentStyle}
+          open={this.state.open}
+        >
+          This dialog spans the entire width of the screen.
+        </Dialog>
+      </div>
+    );
+  }
+}

--- a/docs/src/app/components/pages/components/Dialog/Page.jsx
+++ b/docs/src/app/components/pages/components/Dialog/Page.jsx
@@ -5,19 +5,24 @@ import MarkdownElement from '../../../MarkdownElement';
 
 import dialogReadmeText from './README';
 import DialogExampleSimple from './ExampleSimple';
-import DialogExampleSimpleCode from '!raw!./ExampleSimple';
+import dialogExampleSimpleCode from '!raw!./ExampleSimple';
 import DialogExampleModal from './ExampleModal';
-import DialogExampleModalCode from '!raw!./ExampleModal';
+import dialogExampleModalCode from '!raw!./ExampleModal';
+import DialogExampleCustomWidth from './ExampleCustomWidth';
+import dialogExampleCustomWidthCode from '!raw!./ExampleCustomWidth';
 import dialogCode from '!raw!material-ui/lib/dialog';
 
 const DialogPage = () => (
   <div>
     <MarkdownElement text={dialogReadmeText} />
-    <CodeExample code={DialogExampleSimpleCode}>
+    <CodeExample code={dialogExampleSimpleCode}>
       <DialogExampleSimple />
     </CodeExample>
-    <CodeExample code={DialogExampleModalCode}>
+    <CodeExample code={dialogExampleModalCode}>
       <DialogExampleModal />
+    </CodeExample>
+    <CodeExample code={dialogExampleCustomWidthCode}>
+      <DialogExampleCustomWidth />
     </CodeExample>
     <PropTypeDescription code={dialogCode}/>
   </div>

--- a/src/dialog.jsx
+++ b/src/dialog.jsx
@@ -197,7 +197,7 @@ const DialogInline = React.createClass({
         WebkitTapHighlightColor: 'rgba(0,0,0,0)',
         transition: Transitions.easeOut(),
         position: 'relative',
-        width: width,
+        width: width || '75%',
         maxWidth: spacing.desktopKeylineIncrement * 12,
         margin: '0 auto',
         zIndex: muiTheme.zIndex.dialog,
@@ -578,7 +578,8 @@ const Dialog = React.createClass({
     /**
      * Changes the width of the `Dialog`.
      */
-    width: React.PropTypes.any,
+    width: deprecated(React.PropTypes.any,
+      'Use the contentStyle.'),
   },
 
   getDefaultProps() {
@@ -587,7 +588,6 @@ const Dialog = React.createClass({
       autoScrollBodyContent: false,
       modal: false,
       repositionOnUpdate: true,
-      width: '75%',
     };
   },
 


### PR DESCRIPTION
This seems to be a very common use-case. Specially for mobile applications where space is limited. So instead of having to look around for answers, users can refer to the documentations.

The width property was buggy and limited and it couldn't cover all use-cases. Instead of a prop for one use-case it's better to teach a pattern so everyone can implement what they need. This leads to a simpler and easier to maintain API.

Closes #2670

@oliviertassinari Is this a better approach? :grin: 