### PR TITLE
Fix regression caused by deprecating dismiss

### DIFF
--- a/src/snackbar.jsx
+++ b/src/snackbar.jsx
@@ -189,7 +189,7 @@ const Snackbar = React.createClass({
     if (this.props.open !== null && this.props.onRequestClose) {
       this.props.onRequestClose('clickaway');
     } else {
-      this.dismiss();
+      this.setState({open: false});
     }
   },
 
@@ -358,7 +358,7 @@ const Snackbar = React.createClass({
         if (this.props.open !== null && this.props.onRequestClose) {
           this.props.onRequestClose('timeout');
         } else {
-          this.dismiss();
+          this.setState({open: false});
         }
       }, autoHideDuration);
     }

--- a/src/snackbar.jsx
+++ b/src/snackbar.jsx
@@ -92,7 +92,7 @@ const Snackbar = React.createClass({
     /**
      * Fired when the `Snackbar` is requested to be closed by a click outside or when the time runs out.
      */
-    onRequestClose: React.PropTypes.func,
+    onRequestClose: React.PropTypes.func.isRequired,
 
     /**
      * Fired when the `Snackbar` is shown.


### PR DESCRIPTION
The Snackbar component now has declarative API. But the code had
some calls to the deprecated method dismiss.

Closes #2756

@oliviertassinari Take a look, thanks ^_^