### PR TITLE
Update DatePicker slide direction

### DIFF
--- a/src/date-picker/calendar.jsx
+++ b/src/date-picker/calendar.jsx
@@ -164,7 +164,10 @@ const Calendar = React.createClass({
   },
 
   _handleMonthChange(months) {
-    this.setState({displayDate: DateTime.addMonths(this.state.displayDate, months)});
+    this.setState({
+      transitionDirection: months >= 0 ? 'left' : 'right',
+      displayDate: DateTime.addMonths(this.state.displayDate, months),
+    });
   },
 
   _handleYearTouchTap(e, year) {


### PR DESCRIPTION
Hello,

Here's update, that makes calendar's datecells to slide right-to-left on "next month" and left-to-right on "prev month"