### PR TITLE
[Examples] Remove stage-0 as it's not needed

### DIFF
--- a/examples/webpack-example/.babelrc
+++ b/examples/webpack-example/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "stage-1", "react"]
+  "presets": ["es2015", "react"]
 }

--- a/examples/webpack-example/package.json
+++ b/examples/webpack-example/package.json
@@ -17,7 +17,6 @@
     "babel-loader": "^6.2.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
-    "babel-preset-stage-0": "^6.3.13",
     "babel-runtime": "^6.3.19",
     "eslint": "^1.10.3",
     "eslint-loader": "^1.1.1",


### PR DESCRIPTION
Fix https://github.com/callemall/material-ui/issues/2792.
We were using `state-0` while using `stage-1`.
I think that it was only working due to the flattening behavior of npm 3 that npm 2 don't have.