### PR TITLE
[TableRow] fix row height in IE

### DIFF
--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -172,6 +172,7 @@ export default function getMuiTheme(baseTheme, muiTheme) {
       selectedColor: palette.borderColor,
       textColor: palette.textColor,
       borderColor: palette.borderColor,
+      height: 48,
     },
     tableRowColumn: {
       height: 48,

--- a/src/table/table-row.jsx
+++ b/src/table/table-row.jsx
@@ -94,8 +94,9 @@ const TableRow = React.createClass({
 
     let styles = {
       root: {
-        borderBottom: '1px solid ' + this.getTheme().borderColor,
-        color: this.getTheme().textColor,
+        borderBottom: '1px solid ' + theme.borderColor,
+        color: theme.textColor,
+        height: theme.height,
       },
       cell: {
         backgroundColor: cellBgColor,


### PR DESCRIPTION
This is an updated version of #1537 to work with latest branch.

Fix #2764

P.S. I don't have IE at hand so I didn't test how it looks. However, if #1537 was working this should be working, too.