### PR TITLE
[Slider] Avoid selection when dragging

### DIFF
--- a/src/slider.jsx
+++ b/src/slider.jsx
@@ -307,6 +307,18 @@ const Slider = React.createClass({
   },
 
 
+  // Needed to prevent text selection when dragging the slider handler.
+  // In the future, we should consider use <input type="range"> to avoid
+  // similar issues.
+  _toggleSelection(value) {
+    let body = document.getElementsByTagName('body')[0];
+    body.style['user-select'] = value;
+    body.style['-webkit-user-select'] = value;
+    body.style['-moz-user-select'] = value;
+    body.style['-ms-user-select'] = value;
+    body.style['-o-user-select'] = value;
+  },
+
   _onHandleTouchStart(e) {
     if (document) {
       document.addEventListener('touchmove', this._dragTouchHandler, false);
@@ -321,6 +333,7 @@ const Slider = React.createClass({
     if (document) {
       document.addEventListener('mousemove', this._dragHandler, false);
       document.addEventListener('mouseup', this._dragEndHandler, false);
+      this._toggleSelection('none');
     }
     this._onDragStart(e);
   },
@@ -347,6 +360,7 @@ const Slider = React.createClass({
     if (document) {
       document.removeEventListener('mousemove', this._dragHandler, false);
       document.removeEventListener('mouseup', this._dragEndHandler, false);
+      this._toggleSelection('');
     }
 
     this._onDragStop(e);


### PR DESCRIPTION
When using *mouse events* and dragging to outside of the *slider container* the user will start to select text what will cause some undesired issues.

So to fix that I am using the *user-select* property. I add these property to the *body* element *onmousedown* disabling the selection and I remove it *onmouseup* enabling the selection again. This property is compatible with all the good browsers and with IE10, IE11 and Edge.

Text selection:
<img width="525" alt="screen shot 2016-01-07 at 18 09 00" src="https://cloud.githubusercontent.com/assets/4316501/12181792/8226c6e2-b56b-11e5-95e9-8cd4d63259ca.png">

Undesired behaviour: if you start to drag without unselect the text you will start to carry the text around with you:
<img width="515" alt="screen" src="https://cloud.githubusercontent.com/assets/4316501/12181805/93d7beb4-b56b-11e5-88b6-192d1eb77367.png">