### PR TITLE
[Babel] Adds a unit test that proves #2807 is fixed

### DIFF
--- a/test/es6-module-exports-spec.js
+++ b/test/es6-module-exports-spec.js
@@ -4,16 +4,30 @@ import TestUtils from 'react-addons-test-utils';
 const Divider = require('divider');
 const ActionAccessibility = require('svg-icons').ActionAccessibility;
 
-describe('require() style import of a component', () => {
-  it(`should not fail when rendering (Divider)`, () => {
+import ImportThemeManager from 'styles/theme-manager';
+const RequireThemeManager = require('styles/theme-manager');
+
+import ImportColorManipulator from 'utils/color-manipulator';
+const RequireColorManipulator = require('utils/color-manipulator');
+
+describe('require() style import of ', () => {
+  it(`Divider component should not fail when rendering`, () => {
     expect(() => {
       TestUtils.renderIntoDocument(<Divider />);
     }).to.not.throw(Error);
   });
 
-  it(`should not fail when rendering (ActionAccessibility)`, () => {
+  it(`ActionAccessibility component should not fail when rendering`, () => {
     expect(() => {
       TestUtils.renderIntoDocument(<ActionAccessibility />);
     }).to.not.throw(Error);
+  });
+
+  it(`ThemeManager should have same result as ES6 style import`, () => {
+    expect(RequireThemeManager).to.eql(ImportThemeManager);
+  });
+
+  it(`ColorManipulator should have same result as ES6 style import`, () => {
+    expect(RequireColorManipulator).to.eql(ImportColorManipulator);
   });
 });


### PR DESCRIPTION
This commit adds two tests that show that requiring and importing `ThemeManager` and `ColorManipulator` yield the same result. When running these tests in `0.14.1`, these two tests failed because all the utility functions were under a `default` key when imported using the require style syntax.

resolves #2807