### PR TITLE
Fixes missing build dependencies for browserify example

### DIFF
--- a/examples/browserify-gulp-example/package.json
+++ b/examples/browserify-gulp-example/package.json
@@ -11,6 +11,8 @@
   },
   "private": true,
   "devDependencies": {
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
     "babelify": "^7.2.0",
     "browser-sync": "^2.11.0",
     "browserify": "^12.0.1",


### PR DESCRIPTION
This commit adds missing babel presets needed for the bablel6 migrations.

resolves #2857