### PR TITLE
Don't leak arguments, which causes V8 deopt.

### DIFF
--- a/src/mixins/style-propable.js
+++ b/src/mixins/style-propable.js
@@ -32,8 +32,8 @@ export default {
   // Never call this on the same style object twice. As a rule of thumb,
   // only call it when passing style attribute to html elements.
   // If you call it twice you'll get a warning anyway.
-  prepareStyles() {
+  prepareStyles(...args) {
     return Styles.prepareStyles.apply(Styles,
-      [(this.state && this.state.muiTheme) || this.context.muiTheme].concat([].slice.apply(arguments)));
+      [(this.state && this.state.muiTheme) || this.context.muiTheme].concat(args));
   },
 };

--- a/src/utils/immutability-helper.js
+++ b/src/utils/immutability-helper.js
@@ -8,11 +8,8 @@ function mergeSingle(objA, objB) {
 
 export default {
 
-  merge() {
-    const args = Array.prototype.slice.call(arguments, 0);
-    let base = args[0];
-
-    for (let i = 1; i < args.length; i++) {
+  merge(base, ...args) {
+    for (let i = 0; i < args.length; i++) {
       if (args[i]) {
         base = mergeSingle(base, args[i]);
       }


### PR DESCRIPTION
See https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#3-managing-arguments

Noticed while profiling in https://github.com/callemall/material-ui/issues/684#issuecomment-170414043