### PR TITLE
extends child only when child existed in selectable-enhance

### DIFF
--- a/src/hoc/selectable-enhance.js
+++ b/src/hoc/selectable-enhance.js
@@ -55,7 +55,7 @@ export const SelectableContainerEnhance = (Component) => {
     },
 
     _extendChild(child, styles, selectedItemStyle) {
-      if (child.type && child.type.displayName === 'ListItem') {
+      if (child && child.type && child.type.displayName === 'ListItem') {
         let selected = this._isChildSelected(child, this.props);
         let selectedChildrenStyles = {};
         if (selected) {


### PR DESCRIPTION
extends child only when that child existed

In this scenario, second child of SelectableList is null, and SelectableList should be still render correctly.

````javascript

render: function() {
  const a = 'item';
  const b = null;

  return (
    <SelectableList>
      { a && <ListItem value={a}>{a}</ListItem> }
      { b && <ListItem value={b}>{b}</ListItem> }
    </SelectableList>
  );
}
````

