### PR TITLE
Should execute onDimiss callback after snackbar has closed

### DIFF
--- a/src/snackbar.jsx
+++ b/src/snackbar.jsx
@@ -300,16 +300,18 @@ const Snackbar = React.createClass({
     }
   },
 
+  _onDismiss() {
+    if (this.props.onDismiss) {
+      this.props.onDismiss();
+    }
+  },
+
   dismiss() {
     warning(false, 'dismiss has been deprecated in favor of explicitly setting the open property.');
 
     this.setState({
       open: false,
-    });
-
-    if (this.props.onDismiss) {
-      this.props.onDismiss();
-    }
+    }, this._onDismiss);
   },
 
   _setAutoHideTimer() {


### PR DESCRIPTION
This fix will ensure that the snackbar is actually closed and the state has been updated before executing the onDismiss callback property (if one is passed in). These is what the component parent probably expects to happen and should prevent any issues arising from the parent changing the props before the snackbar has closed.