### PR TITLE
[Babel] Completely remove transform-runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,7 +9,6 @@
     "docs-production": {
       "plugins": [
         "transform-react-remove-prop-types",
-        "transform-runtime",
         "transform-react-constant-elements",
         "transform-react-inline-elements"
       ]


### PR DESCRIPTION
I have forgotten this one in https://github.com/callemall/material-ui/pull/2867.