### PR TITLE
[Core] Removes mergeAndPrefix(), refactor uses mergeStyles() and prepareStyles()

### DIFF
--- a/docs/src/app/components/full-width-section.jsx
+++ b/docs/src/app/components/full-width-section.jsx
@@ -62,7 +62,7 @@ const FullWidthSection = React.createClass({
       content =
         React.createElement(
           contentType,
-          {style: this.mergeAndPrefix(styles.content, contentStyle)},
+          {style: this.mergeStyles(styles.content, contentStyle)},
           this.props.children
         );
     } else {
@@ -71,7 +71,7 @@ const FullWidthSection = React.createClass({
 
     return (
       <ClearFix {...other}
-        style={this.mergeAndPrefix(
+        style={this.mergeStyles(
           styles.root,
           style,
           this.isDeviceSize(StyleResizable.statics.Sizes.SMALL) && styles.rootWhenSmall,

--- a/docs/src/app/components/pages/home-feature.jsx
+++ b/docs/src/app/components/pages/home-feature.jsx
@@ -78,7 +78,7 @@ let HomeFeature = React.createClass({
 
     if (this.isDeviceSize(StyleResizable.statics.Sizes.MEDIUM) ||
         this.isDeviceSize(StyleResizable.statics.Sizes.LARGE)) {
-      styles.root = this.mergeAndPrefix(
+      styles.root = this.mergeStyles(
         styles.root,
         styles.rootWhenMedium,
         this.props.firstChild && styles.rootWhenMediumAndFirstChild,
@@ -109,7 +109,7 @@ let HomeFeature = React.createClass({
         zDepth={this.state.zDepth}
         onMouseEnter={this._onMouseEnter}
         onMouseLeave={this._onMouseLeave}
-        style={this.mergeAndPrefix(
+        style={this.mergeStyles(
           styles.root,
           this.props.lastChild && styles.rootWhenLastChild)}>
         <h3 style={styles.heading}>{this.props.heading}</h3>

--- a/src/auto-complete.jsx
+++ b/src/auto-complete.jsx
@@ -305,15 +305,15 @@ const AutoComplete = React.createClass({
     };
 
     let textFieldProps = {
-      style: this.mergeAndPrefix(styles.input, style),
+      style: this.mergeStyles(styles.input, style),
       floatingLabelText: floatingLabelText,
       hintText: (!hintText && !floatingLabelText) ? '' : hintText,
       fullWidth: true,
       multiLine: false,
-      errorStyle: this.mergeAndPrefix(styles.error, errorStyle),
+      errorStyle: this.mergeStyles(styles.error, errorStyle),
     };
 
-    let mergedRootStyles = this.mergeAndPrefix(styles.root, style);
+    let mergedRootStyles = this.mergeStyles(styles.root, style);
     let mergedMenuStyles = this.mergeStyles(styles.menu, menuStyle);
 
     let requestsList = [];
@@ -352,7 +352,7 @@ const AutoComplete = React.createClass({
         onEscKeyDown={this._close}
         initiallyKeyboardFocused={false}
         onItemTouchTap={this._handleItemTouchTap}
-        listStyle={this.mergeAndPrefix(styles.list, listStyle)}
+        listStyle={this.mergeStyles(styles.list, listStyle)}
         style={mergedMenuStyles}>
         {
           requestsList.map((request, index) => {
@@ -392,7 +392,7 @@ const AutoComplete = React.createClass({
     }
 
     return (
-      <div style={mergedRootStyles}
+      <div style={this.prepareStyles(mergedRootStyles)}
         onKeyDown={this._handleKeyDown}>
         <div
           style={{

--- a/src/card/card-header.jsx
+++ b/src/card/card-header.jsx
@@ -98,10 +98,10 @@ const CardHeader = React.createClass({
 
   render() {
     let styles = this.getStyles();
-    let rootStyle = this.prepareStyles(styles.root, this.props.style);
-    let textStyle = this.prepareStyles(styles.text, this.props.textStyle);
-    let titleStyle = this.prepareStyles(styles.title, this.props.titleStyle);
-    let subtitleStyle = this.prepareStyles(styles.subtitle, this.props.subtitleStyle);
+    let rootStyle = this.mergeStyles(styles.root, this.props.style);
+    let textStyle = this.mergeStyles(styles.text, this.props.textStyle);
+    let titleStyle = this.mergeStyles(styles.title, this.props.titleStyle);
+    let subtitleStyle = this.mergeStyles(styles.subtitle, this.props.subtitleStyle);
 
     let avatar = this.props.avatar;
     if (React.isValidElement(this.props.avatar)) {
@@ -113,11 +113,11 @@ const CardHeader = React.createClass({
     }
 
     return (
-      <div {...this.props} style={rootStyle}>
+      <div {...this.props} style={this.prepareStyles(rootStyle)}>
         {avatar}
-        <div style={textStyle}>
-          <span style={titleStyle}>{this.props.title}</span>
-          <span style={subtitleStyle}>{this.props.subtitle}</span>
+        <div style={this.prepareStyles(textStyle)}>
+          <span style={this.prepareStyles(titleStyle)}>{this.props.title}</span>
+          <span style={this.prepareStyles(subtitleStyle)}>{this.props.subtitle}</span>
         </div>
         {this.props.children}
       </div>

--- a/src/card/card-media.jsx
+++ b/src/card/card-media.jsx
@@ -90,11 +90,11 @@ const CardMedia = React.createClass({
 
   render() {
     let styles = this.getStyles();
-    let rootStyle = this.prepareStyles(styles.root, this.props.style);
-    let mediaStyle = this.prepareStyles(styles.media, this.props.mediaStyle);
-    let overlayContainerStyle = this.prepareStyles(styles.overlayContainer, this.props.overlayContainerStyle);
-    let overlayContentStyle = this.prepareStyles(styles.overlayContent, this.props.overlayContentStyle);
-    let overlayStyle = this.prepareStyles(styles.overlay, this.props.overlayStyle);
+    let rootStyle = this.mergeStyles(styles.root, this.props.style);
+    let mediaStyle = this.mergeStyles(styles.media, this.props.mediaStyle);
+    let overlayContainerStyle = this.mergeStyles(styles.overlayContainer, this.props.overlayContainerStyle);
+    let overlayContentStyle = this.mergeStyles(styles.overlayContent, this.props.overlayContentStyle);
+    let overlayStyle = this.mergeStyles(styles.overlay, this.props.overlayStyle);
 
     let children = React.Children.map(this.props.children, (child) => {
       return React.cloneElement(child, {style: this.prepareStyles(styles.mediaChild, child.props.style)});
@@ -118,14 +118,14 @@ const CardMedia = React.createClass({
     });
 
     return (
-      <div {...this.props} style={rootStyle}>
-        <div style={mediaStyle}>
+      <div {...this.props} style={this.prepareStyles(rootStyle)}>
+        <div style={this.prepareStyles(mediaStyle)}>
           {children}
         </div>
         {(this.props.overlay) ?
-          <div style={overlayContainerStyle}>
-            <div style={overlayStyle}>
-              <div style={overlayContentStyle}>
+          <div style={this.prepareStyles(overlayContainerStyle)}>
+            <div style={this.prepareStyles(overlayStyle)}>
+              <div style={this.prepareStyles(overlayContentStyle)}>
                 {overlayChildren}
               </div>
             </div>

--- a/src/card/card-text.jsx
+++ b/src/card/card-text.jsx
@@ -62,10 +62,10 @@ const CardText = React.createClass({
 
   render() {
     let styles = this.getStyles();
-    let rootStyle = this.prepareStyles(styles.root, this.props.style);
+    let rootStyle = this.mergeStyles(styles.root, this.props.style);
 
     return (
-      <div {...this.props} style={rootStyle}>
+      <div {...this.props} style={this.prepareStyles(rootStyle)}>
         {this.props.children}
       </div>
     );

--- a/src/card/card-title.jsx
+++ b/src/card/card-title.jsx
@@ -87,16 +87,16 @@ const CardTitle = React.createClass({
 
   render() {
     const styles = this.getStyles();
-    const rootStyle = this.prepareStyles(styles.root, this.props.style);
-    const titleStyle = this.prepareStyles(styles.title, this.props.titleStyle);
-    const subtitleStyle = this.prepareStyles(styles.subtitle, this.props.subtitleStyle);
+    const rootStyle = this.mergeStyles(styles.root, this.props.style);
+    const titleStyle = this.mergeStyles(styles.title, this.props.titleStyle);
+    const subtitleStyle = this.mergeStyles(styles.subtitle, this.props.subtitleStyle);
 
     return (
-      <div {...this.props} style={rootStyle}>
-        <span style={titleStyle}>
+      <div {...this.props} style={this.prepareStyles(rootStyle)}>
+        <span style={this.prepareStyles(titleStyle)}>
           {this.props.title}
         </span>
-        <span style={subtitleStyle}>
+        <span style={this.prepareStyles(subtitleStyle)}>
           {this.props.subtitle}
         </span>
         {this.props.children}

--- a/src/enhanced-button.jsx
+++ b/src/enhanced-button.jsx
@@ -271,7 +271,7 @@ const EnhancedButton = React.createClass({
       ...other,
     } = this.props;
 
-    const mergedStyles = this.prepareStyles({
+    const mergedStyles = this.mergeStyles({
       border: 10,
       background: 'none',
       boxSizing: 'border-box',
@@ -297,7 +297,7 @@ const EnhancedButton = React.createClass({
 
     const buttonProps = {
       ...other,
-      style: mergedStyles,
+      style: this.prepareStyles(mergedStyles),
       disabled: disabled,
       onBlur: this._handleBlur,
       onFocus: this._handleFocus,

--- a/src/enhanced-switch.jsx
+++ b/src/enhanced-switch.jsx
@@ -343,8 +343,8 @@ const EnhancedSwitch = React.createClass({
     } = this.props;
 
     let styles = this.getStyles();
-    let wrapStyles = this.prepareStyles(styles.wrap, this.props.iconStyle);
-    let rippleStyle = this.prepareStyles(styles.ripple, this.props.rippleStyle);
+    let wrapStyles = this.mergeStyles(styles.wrap, this.props.iconStyle);
+    let rippleStyle = this.mergeStyles(styles.ripple, this.props.rippleStyle);
     let rippleColor = this.props.hasOwnProperty('rippleColor') ? this.props.rippleColor :
                       this.getTheme().primary1Color;
 
@@ -355,9 +355,9 @@ const EnhancedSwitch = React.createClass({
 
     let inputId = this.props.id || UniqueId.generate();
 
-    let labelStyle = this.prepareStyles(styles.label, this.props.labelStyle);
+    let labelStyle = this.mergeStyles(styles.label, this.props.labelStyle);
     let labelElement = this.props.label ? (
-      <label style={labelStyle} htmlFor={inputId}>
+      <label style={this.prepareStyles(labelStyle)} htmlFor={inputId}>
         {this.props.label}
       </label>
     ) : null;
@@ -418,12 +418,12 @@ const EnhancedSwitch = React.createClass({
     // If toggle component (indicated by whether the style includes thumb) manually lay out
     // elements in order to nest ripple elements
     let switchElement = !this.props.thumbStyle ? (
-      <div style={wrapStyles}>
+      <div style={this.prepareStyles(wrapStyles)}>
         {this.props.switchElement}
         {ripples}
       </div>
     ) : (
-      <div style={wrapStyles}>
+      <div style={this.prepareStyles(wrapStyles)}>
         <div style={this.prepareStyles(this.props.trackStyle)}/>
         <Paper style={this.props.thumbStyle} zDepth={1} circle={true}> {ripples} </Paper>
       </div>

--- a/src/font-icon.jsx
+++ b/src/font-icon.jsx
@@ -108,7 +108,7 @@ const FontIcon = React.createClass({
       this.state.muiTheme.rawTheme.palette.textColor;
     let onColor = hoverColor ? hoverColor : offColor;
 
-    let mergedStyles = this.prepareStyles({
+    let mergedStyles = this.mergeStyles({
       position: 'relative',
       fontSize: spacing.iconSize,
       display: 'inline-block',
@@ -123,7 +123,7 @@ const FontIcon = React.createClass({
         {...other}
         onMouseLeave={this._handleMouseLeave}
         onMouseEnter={this._handleMouseEnter}
-        style={mergedStyles} />
+        style={this.prepareStyles(mergedStyles)} />
     );
   },
 });

--- a/src/grid-list/grid-tile.jsx
+++ b/src/grid-list/grid-tile.jsx
@@ -220,7 +220,7 @@ const GridTile = React.createClass({
 
     const styles = this.getStyles();
 
-    const mergedRootStyles = this.prepareStyles(styles.root, style);
+    const mergedRootStyles = this.mergeStyles(styles.root, style);
 
     let titleBar = null;
 
@@ -259,7 +259,7 @@ const GridTile = React.createClass({
 
     const RootTag = rootClass;
     return (
-      <RootTag style={mergedRootStyles} {...other}>
+      <RootTag style={this.prepareStyles(mergedRootStyles)} {...other}>
         {newChildren}
         {titleBar}
       </RootTag>

--- a/src/ink-bar.jsx
+++ b/src/ink-bar.jsx
@@ -59,7 +59,7 @@ const InkBar = React.createClass({
     } = this.props;
 
     let colorStyle = color ? {backgroundColor: color} : undefined;
-    let styles = this.prepareStyles({
+    let styles = this.mergeStyles({
       left: left,
       width: width,
       bottom: 0,
@@ -72,7 +72,7 @@ const InkBar = React.createClass({
     }, this.props.style, colorStyle);
 
     return (
-      <div style={styles}>
+      <div style={this.prepareStyles(styles)}>
         &nbsp;
       </div>
     );

--- a/src/lists/list-item.jsx
+++ b/src/lists/list-item.jsx
@@ -254,14 +254,14 @@ const ListItem = React.createClass({
       style,
     } = this.props;
 
-    const mergedDivStyles = this.prepareStyles(
+    const mergedDivStyles = this.mergeStyles(
       styles.root,
       styles.innerDiv,
       innerDivStyle,
       style
     );
 
-    return React.createElement('div', {style: mergedDivStyles}, contentChildren);
+    return React.createElement('div', {style: this.prepareStyles(mergedDivStyles)}, contentChildren);
   },
 
   _createLabelElement(styles, contentChildren) {
@@ -270,7 +270,7 @@ const ListItem = React.createClass({
       style,
     } = this.props;
 
-    const mergedLabelStyles = this.prepareStyles(
+    const mergedLabelStyles = this.mergeStyles(
       styles.root,
       styles.innerDiv,
       innerDivStyle,
@@ -278,18 +278,18 @@ const ListItem = React.createClass({
       style
     );
 
-    return React.createElement('label', {style: mergedLabelStyles}, contentChildren);
+    return React.createElement('label', {style: this.prepareStyles(mergedLabelStyles)}, contentChildren);
   },
 
   _createTextElement(styles, data, key) {
     const isAnElement = React.isValidElement(data);
     const mergedStyles = isAnElement ?
-      this.prepareStyles(styles, data.props.style) : null;
+      this.mergeStyles(styles, data.props.style) : null;
 
     return isAnElement ? (
       React.cloneElement(data, {
         key: key,
-        style: mergedStyles,
+        style: this.prepareStyles(mergedStyles),
       })
     ) : (
       <div key={key} style={this.prepareStyles(styles)}>

--- a/src/lists/list.jsx
+++ b/src/lists/list.jsx
@@ -111,8 +111,8 @@ const List = React.createClass({
 
     let subheaderElement;
     if (subheader) {
-      const mergedSubheaderStyles = this.prepareStyles(styles.subheader, subheaderStyle);
-      subheaderElement = <div style={mergedSubheaderStyles}>{subheader}</div>;
+      const mergedSubheaderStyles = this.mergeStyles(styles.subheader, subheaderStyle);
+      subheaderElement = <div style={this.prepareStyles(mergedSubheaderStyles)}>{subheader}</div>;
     }
 
     return (

--- a/src/menu/menu.jsx
+++ b/src/menu/menu.jsx
@@ -159,7 +159,7 @@ const NestedMenuItem = React.createClass({
 
   render() {
     let styles = this.getStyles();
-    styles = this.prepareStyles(styles.root,
+    styles = this.mergeStyles(styles.root,
       (this.props.active && !this.props.disabled) && styles.rootWhenHovered, {
         position: 'relative',
       }, this.props.style);
@@ -178,7 +178,7 @@ const NestedMenuItem = React.createClass({
     return (
       <div
         ref="root"
-        style={styles}
+        style={this.prepareStyles(styles)}
         onMouseEnter={this._openNestedMenu}
         onMouseLeave={this._closeNestedMenu}
         onMouseOver={this._handleMouseOver}

--- a/src/menus/icon-menu.jsx
+++ b/src/menus/icon-menu.jsx
@@ -299,7 +299,7 @@ const IconMenu = React.createClass({
       },
     };
 
-    let mergedRootStyles = this.prepareStyles(styles.root, style);
+    let mergedRootStyles = this.mergeStyles(styles.root, style);
     let mergedMenuStyles = this.mergeStyles(styles.menu, menuStyle);
 
     let iconButton = React.cloneElement(iconButtonElement, {
@@ -333,7 +333,7 @@ const IconMenu = React.createClass({
         onMouseEnter={onMouseEnter}
         onMouseUp={onMouseUp}
         onTouchTap={onTouchTap}
-        style={mergedRootStyles}>
+        style={this.prepareStyles(mergedRootStyles)}>
         {iconButton}
         <Popover
           anchorOrigin={anchorOrigin}

--- a/src/menus/menu.jsx
+++ b/src/menus/menu.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import update from 'react-addons-update';
+import Controllable from '../mixins/controllable';
 import StylePropable from '../mixins/style-propable';
 import ClickAwayable from '../mixins/click-awayable';
 import AutoPrefix from '../styles/auto-prefix';
@@ -136,6 +137,7 @@ const Menu = React.createClass({
 
   mixins: [
     StylePropable,
+    Controllable,
     ClickAwayable,
   ],
 
@@ -147,7 +149,6 @@ const Menu = React.createClass({
       initiallyKeyboardFocused: false,
       maxHeight: null,
       multiple: false,
-      onChange: () => {},
       onEscKeyDown: () => {},
       onItemTouchTap: () => {},
       onKeyDown: () => {},
@@ -217,13 +218,6 @@ const Menu = React.createClass({
     this._setFocusIndex(-1, false);
   },
 
-  // Do not use outside of this component, it will be removed once valueLink is deprecated
-  getValueLink(props) {
-    return props.valueLink || {
-      value: props.value,
-      requestChange: props.onChange,
-    };
-  },
 
   setKeyboardFocused(keyboardFocused) {
     this.setState({
@@ -536,7 +530,7 @@ const Menu = React.createClass({
       },
     };
 
-    let mergedRootStyles = this.prepareStyles(styles.root, style);
+    let mergedRootStyles = this.mergeStyles(styles.root, style);
     let mergedListStyles = this.mergeStyles(styles.list, listStyle);
 
     const filteredChildren = this._getFilteredChildren(children);
@@ -565,7 +559,7 @@ const Menu = React.createClass({
           transitionDelay = cumulativeDelay;
         }
 
-        childrenContainerStyles = this.prepareStyles(styles.menuItemContainer, {
+        childrenContainerStyles = this.mergeStyles(styles.menuItemContainer, {
           transitionDelay: transitionDelay + 'ms',
         });
       }
@@ -577,7 +571,7 @@ const Menu = React.createClass({
       if (!childIsADivider && !childIsDisabled) menuItemIndex++;
 
       return animated ? (
-        <div style={childrenContainerStyles}>{clonedChild}</div>
+        <div style={this.prepareStyles(childrenContainerStyles)}>{clonedChild}</div>
       ) : clonedChild;
 
     });
@@ -585,7 +579,7 @@ const Menu = React.createClass({
     return (
       <div
         onKeyDown={this._handleKeyDown}
-        style={mergedRootStyles}>
+        style={this.prepareStyles(mergedRootStyles)}>
         <Paper
           ref="scrollContainer"
           style={styles.paper}

--- a/src/mixins/controllable.js
+++ b/src/mixins/controllable.js
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export default {
+
+  propTypes: {
+    onChange: React.PropTypes.func,
+    value: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.array,
+    ]),
+    valueLink: React.PropTypes.shape({
+      value: React.PropTypes.string.isRequired,
+      requestChange: React.PropTypes.func.isRequired,
+    }),
+  },
+
+  getDefaultProps() {
+    return {
+      onChange: () => {},
+    };
+  },
+
+  getValueLink(props) {
+    return props.valueLink || {
+      value: props.value,
+      requestChange: props.onChange,
+    };
+  },
+
+};

--- a/src/mixins/style-propable.js
+++ b/src/mixins/style-propable.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ImmutabilityHelper from '../utils/immutability-helper';
 import Styles from '../utils/styles';
+import warning from 'warning';
 
 // This mixin isn't necessary and will be removed
 
@@ -22,6 +23,8 @@ export default {
 
   //Moved this function to /utils/styles.js
   mergeAndPrefix() {
+    warning(false, 'Use of mergeAndPrefix() has been deprecated. ' +
+      'Please use mergeStyles() for merging styles, and then prepareStyles() for prefixing and ensuring direction.');
     return Styles.mergeAndPrefix.apply(this, arguments);
   },
 

--- a/src/overlay.jsx
+++ b/src/overlay.jsx
@@ -116,10 +116,10 @@ const Overlay = React.createClass({
       ...other,
     } = this.props;
 
-    const styles = this.prepareStyles(this.getStyles().root, style, show && this.getStyles().rootWhenShown);
+    const styles = this.mergeStyles(this.getStyles().root, style, show && this.getStyles().rootWhenShown);
 
     return (
-      <div {...other} style={styles} />
+      <div {...other} style={this.prepareStyles(styles)} />
     );
   },
 

--- a/src/ripples/circle-ripple.jsx
+++ b/src/ripples/circle-ripple.jsx
@@ -81,7 +81,7 @@ const CircleRipple = React.createClass({
       ...other,
     } = this.props;
 
-    const mergedStyles = this.mergeAndPrefix({
+    const mergedStyles = this.mergeStyles({
       position: 'absolute',
       top: 0,
       left: 0,
@@ -92,7 +92,7 @@ const CircleRipple = React.createClass({
     }, style);
 
     return (
-      <div {...other} style={mergedStyles} />
+      <div {...other} style={this.prepareStyles(mergedStyles)} />
     );
   },
 });

--- a/src/ripples/focus-ripple.jsx
+++ b/src/ripples/focus-ripple.jsx
@@ -57,7 +57,7 @@ const FocusRipple = React.createClass({
       opacity,
     } = props;
 
-    const innerStyles = this.mergeAndPrefix({
+    const innerStyles = this.mergeStyles({
       position: 'absolute',
       height: '100%',
       width: '100%',
@@ -67,7 +67,7 @@ const FocusRipple = React.createClass({
       transition: Transitions.easeOut(pulsateDuration + 'ms', 'transform', null, Transitions.easeInOutFunction),
     }, innerStyle);
 
-    return <div ref="innerCircle" style={innerStyles} />;
+    return <div ref="innerCircle" style={this.prepareStyles(innerStyles)} />;
   },
 
   _pulsate() {

--- a/src/ripples/touch-ripple.jsx
+++ b/src/ripples/touch-ripple.jsx
@@ -145,7 +145,7 @@ const TouchRipple = React.createClass({
 
     let rippleGroup;
     if (hasRipples) {
-      const mergedStyles = this.mergeAndPrefix({
+      const mergedStyles = this.mergeStyles({
         height: '100%',
         width: '100%',
         position: 'absolute',
@@ -155,7 +155,7 @@ const TouchRipple = React.createClass({
       }, style);
 
       rippleGroup = (
-        <ReactTransitionGroup style={mergedStyles}>
+        <ReactTransitionGroup style={this.prepareStyles(mergedStyles)}>
           {ripples}
         </ReactTransitionGroup>
       );

--- a/src/slider.jsx
+++ b/src/slider.jsx
@@ -5,7 +5,6 @@ import Transitions from './styles/transitions';
 import FocusRipple from './ripples/focus-ripple';
 import DefaultRawTheme from './styles/raw-themes/light-raw-theme';
 import ThemeManager from './styles/theme-manager';
-import AutoPrefix from './styles/auto-prefix';
 
 /**
   * Verifies min/max range.
@@ -289,7 +288,7 @@ const Slider = React.createClass({
         left: -this.getTheme().handleSize,
       },
     };
-    styles.filled = this.mergeAndPrefix(styles.filledAndRemaining, {
+    styles.filled = this.mergeStyles(styles.filledAndRemaining, {
       left: 0,
       backgroundColor: (this.props.disabled) ?
         this.getTheme().trackColor :
@@ -297,7 +296,7 @@ const Slider = React.createClass({
       marginRight: fillGutter,
       width: 'calc(' + (this.state.percent * 100) + '%' + calcDisabledSpacing + ')',
     });
-    styles.remaining = this.mergeAndPrefix(styles.filledAndRemaining, {
+    styles.remaining = this.mergeStyles(styles.filledAndRemaining, {
       right: 0,
       backgroundColor: this.getTheme().trackColor,
       marginLeft: fillGutter,
@@ -313,7 +312,11 @@ const Slider = React.createClass({
   // similar issues.
   _toggleSelection(value) {
     let body = document.getElementsByTagName('body')[0];
-    AutoPrefix.set(body.style, 'userSelect', value);
+    body.style['user-select'] = value;
+    body.style['-webkit-user-select'] = value;
+    body.style['-moz-user-select'] = value;
+    body.style['-ms-user-select'] = value;
+    body.style['-o-user-select'] = value;
   },
 
   _onHandleTouchStart(e) {
@@ -491,8 +494,8 @@ const Slider = React.createClass({
     if (percent > 1) percent = 1; else if (percent < 0) percent = 0;
 
     let styles = this.getStyles();
-    const sliderStyles = this.prepareStyles(styles.root, this.props.style);
-    const handleStyles = percent === 0 ? this.prepareStyles(
+    const sliderStyles = this.mergeStyles(styles.root, this.props.style);
+    const handleStyles = percent === 0 ? this.mergeStyles(
       styles.handle,
       styles.handleWhenPercentZero,
       this.state.active && styles.handleWhenActive,
@@ -500,7 +503,7 @@ const Slider = React.createClass({
       (this.state.hovered || this.state.focused) && !this.props.disabled
         && styles.handleWhenPercentZeroAndFocused,
       this.props.disabled && styles.handleWhenPercentZeroAndDisabled
-    ) : this.prepareStyles(
+    ) : this.mergeStyles(
       styles.handle,
       this.state.active && styles.handleWhenActive,
       this.state.focused && {outline: 'none'},
@@ -509,7 +512,7 @@ const Slider = React.createClass({
         left: (percent * 100) + '%',
       }
     );
-    let rippleStyle = this.mergeAndPrefix(
+    let rippleStyle = this.mergeStyles(
       styles.ripple,
       percent === 0 && styles.rippleWhenPercentZero
     );
@@ -526,7 +529,7 @@ const Slider = React.createClass({
         <FocusRipple
           ref="focusRipple"
           key="focusRipple"
-          style={rippleStyle}
+          style={this.mergeStyles(rippleStyle)}
           innerStyle={styles.rippleInner}
           show={rippleShowCondition}
           color={rippleColor}/>
@@ -546,7 +549,7 @@ const Slider = React.createClass({
       <div {...others } style={this.prepareStyles(this.props.style)}>
         <span>{this.props.description}</span>
         <span>{this.props.error}</span>
-        <div style={sliderStyles}
+        <div style={this.prepareStyles(sliderStyles)}
           onFocus={this._onFocus}
           onBlur={this._onBlur}
           onMouseDown={this._onMouseDown}
@@ -556,7 +559,7 @@ const Slider = React.createClass({
           <div ref="track" style={this.prepareStyles(styles.track)}>
             <div style={this.prepareStyles(styles.filled)}></div>
             <div style={this.prepareStyles(remainingStyles)}></div>
-            <div style={handleStyles} tabIndex={0} {...handleDragProps}>
+            <div style={this.prepareStyles(handleStyles)} tabIndex={0} {...handleDragProps}>
               {focusRipple}
             </div>
           </div>

--- a/src/svg-icon.jsx
+++ b/src/svg-icon.jsx
@@ -118,7 +118,7 @@ const SvgIcon = React.createClass({
       this.state.muiTheme.rawTheme.palette.textColor;
     const onColor = hoverColor ? hoverColor : offColor;
 
-    const mergedStyles = this.prepareStyles({
+    const mergedStyles = this.mergeStyles({
       display: 'inline-block',
       height: 24,
       width: 24,
@@ -138,7 +138,7 @@ const SvgIcon = React.createClass({
       <svg
         {...other}
         {...events}
-        style={mergedStyles}
+        style={this.prepareStyles(mergedStyles)}
         viewBox={viewBox}>
         {children}
       </svg>

--- a/src/table/table-footer.jsx
+++ b/src/table/table-footer.jsx
@@ -104,7 +104,7 @@ const TableFooter = React.createClass({
       displayBorder: false,
       key: 'f-' + rowNumber,
       rowNumber: rowNumber,
-      style: this.mergeAndPrefix(styles.cell, child.props.style),
+      style: this.mergeStyles(styles.cell, child.props.style),
     };
 
     let children = [this._getCheckboxPlaceholder(props)];

--- a/src/table/table-row.jsx
+++ b/src/table/table-row.jsx
@@ -197,7 +197,7 @@ const TableRow = React.createClass({
         columnNumber: columnNumber,
         hoverable: this.props.hoverable,
         key: child.props.key || key,
-        style: this.mergeAndPrefix(styles.cell, child.props.style),
+        style: this.mergeStyles(styles.cell, child.props.style),
         ...handlers,
       }
     );

--- a/src/table/table.jsx
+++ b/src/table/table.jsx
@@ -222,7 +222,7 @@ const Table = React.createClass({
         onRowHoverExit: this._onRowHoverExit,
         onRowSelection: this._onRowSelection,
         selectable: this.props.selectable,
-        style: this.mergeAndPrefix({height: this.props.height}, base.props.style),
+        style: this.mergeStyles({height: this.props.height}, base.props.style),
       }
     );
   },
@@ -305,7 +305,7 @@ const Table = React.createClass({
     // If we could not find a table-header and a table-body, do not attempt to display anything.
     if (!tBody && !tHead) return null;
 
-    let mergedTableStyle = this.prepareStyles(styles.root, style);
+    let mergedTableStyle = this.mergeStyles(styles.root, style);
     let headerTable;
     let footerTable;
     let inlineHeader;
@@ -327,7 +327,7 @@ const Table = React.createClass({
       if (fixedFooter) {
         footerTable = (
           <div style={this.prepareStyles(footerStyle)}>
-            <table className={className} style={mergedTableStyle}>
+            <table className={className} style={this.prepareStyles(mergedTableStyle)}>
               {tFoot}
             </table>
           </div>

--- a/src/tabs/tab.jsx
+++ b/src/tabs/tab.jsx
@@ -102,7 +102,7 @@ const Tab = React.createClass({
       ...other,
     } = this.props;
 
-    const styles = this.prepareStyles({
+    const styles = this.mergeStyles({
       display: 'table-cell',
       cursor: 'pointer',
       textAlign: 'center',
@@ -121,7 +121,7 @@ const Tab = React.createClass({
     return (
       <div
         {...other}
-        style={styles}
+        style={this.prepareStyles(styles)}
         onTouchTap={this._handleTouchTap}>
         {label}
       </div>

--- a/src/tabs/tabs.jsx
+++ b/src/tabs/tabs.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import TabTemplate from './tabTemplate';
 import InkBar from '../ink-bar';
 import StylePropable from '../mixins/style-propable';
+import Controllable from '../mixins/controllable';
 import DefaultRawTheme from '../styles/raw-themes/light-raw-theme';
 import ThemeManager from '../styles/theme-manager';
 import warning from 'warning';
@@ -79,12 +80,12 @@ const Tabs = React.createClass({
 
   mixins: [
     StylePropable,
+    Controllable,
   ],
 
   getDefaultProps() {
     return {
       initialSelectedIndex: 0,
-      onChange: () => {},
     };
   },
 
@@ -129,14 +130,6 @@ const Tabs = React.createClass({
 
   getTabCount() {
     return React.Children.count(this.props.children);
-  },
-
-  // Do not use outside of this component, it will be removed once valueLink is deprecated
-  getValueLink(props) {
-    return props.valueLink || {
-      value: props.value,
-      requestChange: props.onChange,
-    };
   },
 
   _getSelectedIndex(props) {

--- a/src/time-picker/time-picker-dialog.jsx
+++ b/src/time-picker/time-picker-dialog.jsx
@@ -129,8 +129,8 @@ const TimePickerDialog = React.createClass({
     return (
       <Dialog {...other}
         ref="dialogWindow"
-        style={this.mergeAndPrefix(styles.root)}
-        bodyStyle={this.mergeAndPrefix(styles.body)}
+        style={this.mergeStyles(styles.root)}
+        bodyStyle={styles.body}
         actions={actions}
         contentStyle={styles.dialogContent}
         repositionOnUpdate={false}

--- a/src/transition-groups/scale-in-child.jsx
+++ b/src/transition-groups/scale-in-child.jsx
@@ -116,7 +116,7 @@ const ScaleInChild = React.createClass({
       ...other,
     } = this.props;
 
-    const mergedRootStyles = this.prepareStyles({
+    const mergedRootStyles = this.mergeStyles({
       position: 'absolute',
       height: '100%',
       width: '100%',
@@ -126,7 +126,7 @@ const ScaleInChild = React.createClass({
     }, style);
 
     return (
-      <div {...other} style={mergedRootStyles}>
+      <div {...other} style={this.prepareStyles(mergedRootStyles)}>
         {children}
       </div>
     );

--- a/src/transition-groups/scale-in.jsx
+++ b/src/transition-groups/scale-in.jsx
@@ -71,7 +71,7 @@ const ScaleIn = React.createClass({
       ...other,
     } = this.props;
 
-    const mergedRootStyles = this.prepareStyles({
+    const mergedRootStyles = this.mergeStyles({
       position: 'relative',
       overflow: 'hidden',
       height: '100%',
@@ -93,7 +93,7 @@ const ScaleIn = React.createClass({
     return (
       <ReactTransitionGroup
         {...other}
-        style={mergedRootStyles}
+        style={this.prepareStyles(mergedRootStyles)}
         component="div">
         {newChildren}
       </ReactTransitionGroup>

--- a/src/transition-groups/slide-in-child.jsx
+++ b/src/transition-groups/slide-in-child.jsx
@@ -105,7 +105,7 @@ const SlideInChild = React.createClass({
       ...other,
     } = this.props;
 
-    let mergedRootStyles = this.prepareStyles({
+    let mergedRootStyles = this.mergeStyles({
       position: 'absolute',
       height: '100%',
       width: '100%',
@@ -115,7 +115,7 @@ const SlideInChild = React.createClass({
     }, style);
 
     return (
-      <div {...other} style={mergedRootStyles}>
+      <div {...other} style={this.prepareStyles(mergedRootStyles)}>
         {children}
       </div>
     );

--- a/src/transition-groups/slide-in.jsx
+++ b/src/transition-groups/slide-in.jsx
@@ -70,7 +70,7 @@ const SlideIn = React.createClass({
       ...other,
     } = this.props;
 
-    let mergedRootStyles = this.prepareStyles({
+    let mergedRootStyles = this.mergeStyles({
       position: 'relative',
       overflow: 'hidden',
       height: '100%',
@@ -92,7 +92,7 @@ const SlideIn = React.createClass({
     return (
       <ReactTransitionGroup
         {...other}
-        style={mergedRootStyles}
+        style={this.prepareStyles(mergedRootStyles)}
         component="div">
         {newChildren}
       </ReactTransitionGroup>

--- a/src/utils/styles.js
+++ b/src/utils/styles.js
@@ -6,102 +6,98 @@ const reTranslate = /((^|\s)translate(3d|X)?\()(\-?[\d]+)/;
 
 const reSkew = /((^|\s)skew(x|y)?\()\s*(\-?[\d]+)(deg|rad|grad)(,\s*(\-?[\d]+)(deg|rad|grad))?/;
 
+
+// This function ensures that `style` supports both ltr and rtl directions by checking
+//   `styleConstants` in `muiTheme` and replacing attribute keys if necessary.
+function ensureDirection(muiTheme, style) {
+  if (process.env.NODE_ENV !== 'production') {
+    warning(!style.didFlip, `You're calling ensureDirection() on the same style
+      object twice.`);
+
+    style = ImmutabilityHelper.merge({
+      didFlip: 'true',
+    }, style);
+  }
+
+  // Left to right is the default. No need to flip anything.
+  if (!muiTheme || !muiTheme.isRtl) return style;
+
+  const flippedAttributes = {
+    // Keys and their replacements.
+    right: 'left',
+    left: 'right',
+    marginRight: 'marginLeft',
+    marginLeft: 'marginRight',
+    paddingRight: 'paddingLeft',
+    paddingLeft: 'paddingRight',
+    borderRight: 'borderLeft',
+    borderLeft: 'borderRight',
+  };
+
+  let newStyle = {};
+
+  Object.keys(style).forEach(function(attribute) {
+    let value = style[attribute];
+    let key = attribute;
+
+    if (flippedAttributes.hasOwnProperty(attribute)) {
+      key = flippedAttributes[attribute];
+    }
+
+    switch (attribute) {
+      case 'float':
+      case 'textAlign':
+        if (value === 'right') {
+          value = 'left';
+        } else if (value === 'left') {
+          value = 'right';
+        }
+        break;
+
+      case 'direction':
+        if (value === 'ltr') {
+          value = 'rtl';
+        } else if (value === 'rtl') {
+          value = 'ltr';
+        }
+        break;
+
+      case 'transform':
+        let matches;
+        if ((matches = value.match(reTranslate))) {
+          value = value.replace(matches[0], matches[1] + (-parseFloat(matches[4])) );
+        }
+        if ((matches = value.match(reSkew))) {
+          value = value.replace(matches[0], matches[1] + (-parseFloat(matches[4])) + matches[5] +
+            matches[6] ? ',' + (-parseFloat(matches[7])) + matches[8] : ''
+          );
+        }
+        break;
+
+      case 'transformOrigin':
+        if (value.indexOf('right') > -1) {
+          value = value.replace('right', 'left');
+        } else if (value.indexOf('left') > -1) {
+          value = value.replace('left', 'right');
+        }
+        break;
+    }
+
+    newStyle[key] = value;
+  });
+
+  return newStyle;
+}
+
 export default {
 
   merge() {
     return ImmutabilityHelper.merge.apply(this, arguments);
   },
 
-  mergeAndPrefix() {
-    let mergedStyles = ImmutabilityHelper.merge.apply(this, arguments);
-    return AutoPrefix.all(mergedStyles);
-  },
-
-  // This function ensures that `style` supports both ltr and rtl directions by checking
-  //   `styleConstants` in `muiTheme` and replacing attribute keys if necessary.
-  ensureDirection(muiTheme, style) {
-    if (process.env.NODE_ENV !== 'production') {
-      warning(!style.didFlip, `You're calling ensureDirection() on the same style
-        object twice.`);
-
-      style = ImmutabilityHelper.merge({
-        didFlip: 'true',
-      }, style);
-    }
-
-    // Left to right is the default. No need to flip anything.
-    if (!muiTheme.isRtl) return style;
-
-    const flippedAttributes = {
-      // Keys and their replacements.
-      right: 'left',
-      left: 'right',
-      marginRight: 'marginLeft',
-      marginLeft: 'marginRight',
-      paddingRight: 'paddingLeft',
-      paddingLeft: 'paddingRight',
-      borderRight: 'borderLeft',
-      borderLeft: 'borderRight',
-    };
-
-    let newStyle = {};
-
-    Object.keys(style).forEach(function(attribute) {
-      let value = style[attribute];
-      let key = attribute;
-
-      if (flippedAttributes.hasOwnProperty(attribute)) {
-        key = flippedAttributes[attribute];
-      }
-
-      switch (attribute) {
-        case 'float':
-        case 'textAlign':
-          if (value === 'right') {
-            value = 'left';
-          } else if (value === 'left') {
-            value = 'right';
-          }
-          break;
-
-        case 'direction':
-          if (value === 'ltr') {
-            value = 'rtl';
-          } else if (value === 'rtl') {
-            value = 'ltr';
-          }
-          break;
-
-        case 'transform':
-          let matches;
-          if ((matches = value.match(reTranslate))) {
-            value = value.replace(matches[0], matches[1] + (-parseFloat(matches[4])) );
-          }
-          if ((matches = value.match(reSkew))) {
-            value = value.replace(matches[0], matches[1] + (-parseFloat(matches[4])) + matches[5] +
-              matches[6] ? ',' + (-parseFloat(matches[7])) + matches[8] : ''
-            );
-          }
-          break;
-
-        case 'transformOrigin':
-          if (value.indexOf('right') > -1) {
-            value = value.replace('right', 'left');
-          } else if (value.indexOf('left') > -1) {
-            value = value.replace('left', 'right');
-          }
-          break;
-      }
-
-      newStyle[key] = value;
-    });
-
-    return newStyle;
-  },
-
   prepareStyles(muiTheme, ...styles) {
     styles = styles.length > 1 ? ImmutabilityHelper.merge.apply(this, styles) : (styles[0] || {});
-    const flipped = this.ensureDirection(muiTheme, styles);
+    const flipped = ensureDirection(muiTheme, styles);
     return AutoPrefix.all(flipped);
   },
 };


### PR DESCRIPTION
This commit removes all instances of `mergeAndPrefix`. It also aims to use `mergeStyles` and `prepareStyles` in a more consistent manner. All uses of `mergeAndPrefix` were switched to `mergeStyles` OR `prepareStyles` depending on the following condition:
- If the computed style being is passed directly to a html tag's style attribute (ie. div, span, li, etc.) OR an externally managed component's style prop (such as `ReactTransitionGroup`), use `prepareStyles`
- If the computed style being passed to an internal component's style prop, or any related style props, use `mergeStyles`

This prevents any top level/parent components from prematurely preparing styles (styles should only be prepared when attaching to a DOM node).

I did searches across src and found places where that pattern were not followed and switched them as well.