### PR TITLE
[Dialog] Fix overlay scroll when dialog element are in dialog

### DIFF
--- a/docs/src/app/components/pages/components/Dialog/ExampleDialogDatePicker.jsx
+++ b/docs/src/app/components/pages/components/Dialog/ExampleDialogDatePicker.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import Dialog from 'material-ui/lib/dialog';
+import FlatButton from 'material-ui/lib/flat-button';
+import RaisedButton from 'material-ui/lib/raised-button';
+import DatePicker from 'material-ui/lib/date-picker/date-picker';
+
+export default class DialogExampleDialogDatePicker extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: false,
+    };
+  }
+
+  handleOpen = () => {
+    this.setState({open: true});
+  };
+
+  handleClose = () => {
+    this.setState({open: false});
+  };
+
+  render() {
+    const actions = [
+      <FlatButton
+        label="Ok"
+        primary={true}
+        keyboardFocused={true}
+        onTouchTap={this.handleClose}
+      />,
+    ];
+
+    return (
+      <div>
+        <RaisedButton label="Dialog With Date Picker" onTouchTap={this.handleOpen} />
+        <Dialog
+          title="Dialog With Date Picker"
+          actions={actions}
+          modal={false}
+          open={this.state.open}
+          onRequestClose={this.handleClose}
+        >
+          Open a Date Picker dialog from within a dialog.
+          <DatePicker hintText="Date Picker" />
+        </Dialog>
+      </div>
+    );
+  }
+}

--- a/docs/src/app/components/pages/components/Dialog/Page.jsx
+++ b/docs/src/app/components/pages/components/Dialog/Page.jsx
@@ -10,6 +10,8 @@ import DialogExampleModal from './ExampleModal';
 import dialogExampleModalCode from '!raw!./ExampleModal';
 import DialogExampleCustomWidth from './ExampleCustomWidth';
 import dialogExampleCustomWidthCode from '!raw!./ExampleCustomWidth';
+import DialogExampleDialogDatePicker from './ExampleDialogDatePicker';
+import dialogExampleDialogDatePickerCode from '!raw!./ExampleDialogDatePicker';
 import dialogCode from '!raw!material-ui/lib/dialog';
 
 const descriptions = {
@@ -18,7 +20,7 @@ const descriptions = {
   'You can also close this dialog by clicking outside the dialog, or with the \'Esc\' key.',
   modal: 'A modal dialog can only be closed by selecting one of the actions.',
   styled: 'The dialog width has been set to occupy the full width of browser through the `contentStyle` property.',
-
+  nested: 'Dialogs can be nested. This example opens a Date Picker from within a Dialog.',
 };
 
 const DialogPage = () => (
@@ -44,6 +46,13 @@ const DialogPage = () => (
       code={dialogExampleCustomWidthCode}
     >
       <DialogExampleCustomWidth />
+    </CodeExample>
+    <CodeExample
+      title="Nested dialogs"
+      description={descriptions.nested}
+      code={dialogExampleDialogDatePickerCode}
+    >
+      <DialogExampleDialogDatePicker />
     </CodeExample>
     <PropTypeDescription code={dialogCode} />
   </div>

--- a/src/overlay.jsx
+++ b/src/overlay.jsx
@@ -34,7 +34,6 @@ const Overlay = React.createClass({
   },
 
   componentDidMount() {
-    this._originalBodyOverflow = document.getElementsByTagName('body')[0].style.overflow;
     if (this.props.show) {
       this._applyAutoLockScrolling(this.props);
     }
@@ -47,7 +46,9 @@ const Overlay = React.createClass({
   },
 
   componentWillUnmount() {
-    this._allowScrolling();
+    if (this.props.show === true) {
+      this._allowScrolling();
+    }
   },
 
   _originalBodyOverflow: '',
@@ -101,6 +102,8 @@ const Overlay = React.createClass({
 
   _preventScrolling() {
     const body = document.getElementsByTagName('body')[0];
+    this._originalBodyOverflow = body.style.overflow;
+
     body.style.overflow = 'hidden';
   },
 


### PR DESCRIPTION
Hi, I solved this issue https://github.com/callemall/material-ui/issues/2779

This way it prevent to set an ```overflow:hidden ``` on already empty overflow when ```_allowScrolling``` is called.   

It's not the best way because normaly the lifecycle events and components hiearchy  should prevent this but. 