### PR TITLE
feat(calendar): add firstDayOfWeek and days abbreviations

### DIFF
--- a/docs/src/app/components/pages/components/DatePicker/ExampleInternational.jsx
+++ b/docs/src/app/components/pages/components/DatePicker/ExampleInternational.jsx
@@ -8,6 +8,7 @@ const DatePickerExampleInternational = () => (
     // Intl is supported by most modern browsers, see http://caniuse.com/#search=intl
     // for browsers that don't support it use this polyfill https://github.com/andyearnshaw/Intl.js
     wordings={{ok: 'OK', cancel: 'Annuler'}}
+    firstDayOfWeek={1}
     locale="fr"
   />
 );

--- a/docs/src/app/components/pages/components/DatePicker/Page.jsx
+++ b/docs/src/app/components/pages/components/DatePicker/Page.jsx
@@ -23,7 +23,7 @@ const descriptions = {
   ranged: 'This example allows you to set a date range, and to toggle `AutoOk`, and `disableYearSelection`.',
   controlled: 'Implements a controlled input, where the value is handled by state in the parent (example) component.',
   localised: 'Demonstrates a localised `DatePicker`, in this case in French. ' +
-  'Note that the buttons must be localised using the `wordings` property.',
+  'Note that the buttons must be localised using the `wordings` property and we set the `firstDayOfWeek` to Monday.',
 };
 
 if (!window.Intl) {

--- a/src/date-picker/calendar-month.jsx
+++ b/src/date-picker/calendar-month.jsx
@@ -8,6 +8,7 @@ const CalendarMonth = React.createClass({
   propTypes: {
     autoOk: React.PropTypes.bool,
     displayDate: React.PropTypes.object.isRequired,
+    firstDayOfWeek: React.PropTypes.number,
     maxDate: React.PropTypes.object,
     minDate: React.PropTypes.object,
     onDayTouchTap: React.PropTypes.func,
@@ -20,7 +21,7 @@ const CalendarMonth = React.createClass({
   },
 
   _getWeekElements() {
-    let weekArray = DateTime.getWeekArray(this.props.displayDate);
+    let weekArray = DateTime.getWeekArray(this.props.displayDate, this.props.firstDayOfWeek);
 
     return weekArray.map((week, i) => {
       return (

--- a/src/date-picker/calendar.jsx
+++ b/src/date-picker/calendar.jsx
@@ -13,11 +13,14 @@ import ClearFix from '../clearfix';
 import ThemeManager from '../styles/theme-manager';
 import DefaultRawTheme from '../styles/raw-themes/light-raw-theme';
 
+const daysArray = [...Array(7)];
+
 const Calendar = React.createClass({
 
   propTypes: {
     DateTimeFormat: React.PropTypes.func.isRequired,
     disableYearSelection: React.PropTypes.bool,
+    firstDayOfWeek: React.PropTypes.number,
     initialDate: React.PropTypes.object,
     locale: React.PropTypes.string.isRequired,
     maxDate: React.PropTypes.object,
@@ -243,7 +246,7 @@ const Calendar = React.createClass({
 
   render() {
     let yearCount = DateTime.yearDiff(this.props.maxDate, this.props.minDate) + 1;
-    let weekCount = DateTime.getWeekArray(this.state.displayDate).length;
+    let weekCount = DateTime.getWeekArray(this.state.displayDate, this.props.firstDayOfWeek).length;
     let toolbarInteractions = this._getToolbarInteractions();
     let isLandscape = this.props.mode === 'landscape';
     let styles = {
@@ -295,6 +298,7 @@ const Calendar = React.createClass({
     const {
       DateTimeFormat,
       locale,
+      firstDayOfWeek,
     } = this.props;
 
     return (
@@ -325,13 +329,11 @@ const Calendar = React.createClass({
               elementType="ul"
               style={styles.weekTitle}
             >
-              <li style={weekTitleDayStyle}>S</li>
-              <li style={weekTitleDayStyle}>M</li>
-              <li style={weekTitleDayStyle}>T</li>
-              <li style={weekTitleDayStyle}>W</li>
-              <li style={weekTitleDayStyle}>T</li>
-              <li style={weekTitleDayStyle}>F</li>
-              <li style={weekTitleDayStyle}>S</li>
+              {daysArray.map((e, i) => (
+                <li key={i} style={weekTitleDayStyle}>
+                  {DateTime.localizedWeekday(DateTimeFormat, locale, i, firstDayOfWeek)}
+                </li>
+              ))}
             </ClearFix>
             <SlideInTransitionGroup direction={this.state.transitionDirection}>
               <CalendarMonth
@@ -343,6 +345,7 @@ const Calendar = React.createClass({
                 minDate={this.props.minDate}
                 maxDate={this.props.maxDate}
                 shouldDisableDate={this.props.shouldDisableDate}
+                firstDayOfWeek={this.props.firstDayOfWeek}
               />
             </SlideInTransitionGroup>
           </div>

--- a/src/date-picker/date-picker-dialog.jsx
+++ b/src/date-picker/date-picker-dialog.jsx
@@ -18,6 +18,7 @@ const DatePickerDialog = React.createClass({
     autoOk: React.PropTypes.bool,
     container: React.PropTypes.oneOf(['dialog', 'inline']),
     disableYearSelection: React.PropTypes.bool,
+    firstDayOfWeek: React.PropTypes.number,
     initialDate: React.PropTypes.object,
     locale: React.PropTypes.string,
     maxDate: React.PropTypes.object,
@@ -151,6 +152,7 @@ const DatePickerDialog = React.createClass({
       onAccept,
       style,
       container,
+      firstDayOfWeek,
       ...other,
     } = this.props;
 
@@ -216,6 +218,7 @@ const DatePickerDialog = React.createClass({
       >
         <Calendar
           DateTimeFormat={DateTimeFormat}
+          firstDayOfWeek={firstDayOfWeek}
           locale={locale}
           ref="calendar"
           onDayTouchTap={this._onDayTouchTap}

--- a/src/date-picker/date-picker.jsx
+++ b/src/date-picker/date-picker.jsx
@@ -43,6 +43,13 @@ const DatePicker = React.createClass({
     disableYearSelection: React.PropTypes.bool,
 
     /**
+     * Used to change the first day of week. It drastically varies from
+     * Saturday to Monday (could even be Friday) between different locales.
+     * The allowed range is 0 (Sunday) to 6 (Saturday).
+     */
+    firstDayOfWeek: React.PropTypes.number,
+
+    /**
      * This function is called to format the date to display in the input box.
      * By default, date objects are formatted to MM/DD/YYYY.
      */
@@ -158,6 +165,7 @@ const DatePicker = React.createClass({
       autoOk: false,
       disableYearSelection: false,
       style: {},
+      firstDayOfWeek: 0,
     };
   },
 
@@ -283,6 +291,7 @@ const DatePicker = React.createClass({
       style,
       textFieldStyle,
       valueLink,
+      firstDayOfWeek,
       ...other,
     } = this.props;
 
@@ -312,6 +321,7 @@ const DatePicker = React.createClass({
           autoOk={autoOk}
           disableYearSelection={disableYearSelection}
           shouldDisableDate={this.props.shouldDisableDate}
+          firstDayOfWeek={firstDayOfWeek}
         />
       </div>
     );


### PR DESCRIPTION
This commit adds the ability to set the firstDayOfWeek for Europeans that often starts on monday rather than sunday, and to set a days abbreviations array for days first letter.

This part could be improved though, but don't really know how, feel free to tell me if you got an idea.

Related to #2099.