### PR TITLE
[Docs] Remove the usage of console

### DIFF
--- a/docs/.eslintrc
+++ b/docs/.eslintrc
@@ -1,2 +1,0 @@
-rules:
-  no-console: 0

--- a/docs/src/app/components/pages/components/AutoComplete/ExampleSimple.jsx
+++ b/docs/src/app/components/pages/components/AutoComplete/ExampleSimple.jsx
@@ -11,10 +11,6 @@ export default class AutoCompleteExampleSimple extends React.Component {
     };
   }
 
-  handleNewRequest = (t) => {
-    console.log(`New request: ${t}`);
-  };
-
   handleUpdateInput = (t) => {
     this.setState({
       dataSource: [t, t + t, t + t + t],
@@ -27,7 +23,6 @@ export default class AutoCompleteExampleSimple extends React.Component {
         hintText="Type c"
         dataSource={this.state.dataSource}
         onUpdateInput={this.handleUpdateInput}
-        onNewRequest={this.handleNewRequest}
       />
     );
   }


### PR DESCRIPTION
Using a console in the examples doesn't seem to be a good idea.
IMHO, this is adding unnecessary noise to the examples and not linked to anything visible on the screen. Isn't the purpose of our documentation, to see how it looks like?
I guess it was used to make sure the callback is called correctly, well, I would let this task to some unit test.