### PR TITLE
Don't use for...of on table children.

### DIFF
--- a/src/table/table.jsx
+++ b/src/table/table.jsx
@@ -287,8 +287,8 @@ const Table = React.createClass({
     let tFoot;
     let tBody;
 
-    for (let child of children) {
-      if (!React.isValidElement(child)) continue;
+    React.Children.forEach(children, (child) => {
+      if (!React.isValidElement(child)) return;
 
       let displayName = child.type.displayName;
       if (displayName === 'TableBody') {
@@ -300,7 +300,7 @@ const Table = React.createClass({
       else if (displayName === 'TableFooter') {
         tFoot = this._createTableFooter(child);
       }
-    }
+    });
 
     // If we could not find a table-header and a table-body, do not attempt to display anything.
     if (!tBody && !tHead) return null;


### PR DESCRIPTION
We can't assume `children` is an array, as it is a single
element when only one child is passed.

Fixes #1531, #1972, #2058 and removes need for a Symbol
polyfill.