### PR TITLE
[Docs] Hide code examples by default

### DIFF
--- a/docs/src/app/components/CodeExample/CodeBlock.jsx
+++ b/docs/src/app/components/CodeExample/CodeBlock.jsx
@@ -2,10 +2,8 @@ import React from 'react';
 import MarkdownElement from '../MarkdownElement';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import StylePropable from 'material-ui/lib/mixins/style-propable';
-import FlatButton from 'material-ui/lib/flat-button';
 import Transitions from 'material-ui/lib/styles/transitions';
-
-const LINE_MAX = 7;
+import CodeBlockTitle from './CodeBlockTitle';
 
 const styles = {
   root: {
@@ -16,19 +14,29 @@ const styles = {
     overflow: 'auto',
     maxHeight: 1400,
     transition: Transitions.create('max-height', '800ms', '0ms', 'ease-in-out'),
+    marginTop: 0,
+    marginBottom: 0,
   },
   markdownRetracted: {
-    maxHeight: LINE_MAX * 18,
+    maxHeight: 0,
   },
-  expand: {
-    padding: 10,
-    textAlign: 'center',
+  description: {
+    background: '#ffffff',
+    overflow: 'auto',
+    padding: '10px 20px 0',
+    marginTop: 0,
+    marginBottom: 0,
+  },
+  codeBlockTitle: {
+    cursor: 'pointer',
   },
 };
 
 const CodeBlock = React.createClass({
   propTypes: {
     children: React.PropTypes.string,
+    description: React.PropTypes.string,
+    title: React.PropTypes.string,
   },
   mixins: [
     PureRenderMixin,
@@ -48,38 +56,22 @@ const CodeBlock = React.createClass({
 ${this.props.children}
     \`\`\``;
 
-    const lineNumber = (text.match(/\n/g) || []).length;
+    const descriptionStyle = styles.description;
+    let codeStyle;
 
-    let expand;
-    let style = styles.markdown;
-
-    if (lineNumber > LINE_MAX) {
-      let label;
-
-      if (this.state.expand) {
-        label = 'Retract the example';
-      } else {
-        style = StylePropable.mergeStyles(styles.markdown, styles.markdownRetracted);
-        label = 'Expand the example';
-      }
-
-      expand = (
-        <div
-          style={styles.expand}
-          onTouchTap={this.handleTouchTap}
-        >
-          <FlatButton label={label} />
-        </div>
-      );
+    if (this.state.expand) {
+      codeStyle = styles.markdown;
+    } else {
+      codeStyle = StylePropable.mergeStyles(styles.markdown, styles.markdownRetracted);
     }
 
     return (
       <div style={styles.root}>
-        <MarkdownElement
-          style={style}
-          text={text}
-        />
-        {expand}
+        <div onTouchTap={this.handleTouchTap} style={styles.codeBlockTitle}>
+          <CodeBlockTitle title={this.props.title} />
+        </div>
+        <MarkdownElement style={codeStyle} text={text} />
+        <MarkdownElement style={descriptionStyle} text={this.props.description} />
       </div>
     );
   },

--- a/docs/src/app/components/CodeExample/CodeBlockTitle.jsx
+++ b/docs/src/app/components/CodeExample/CodeBlockTitle.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import IconButton from 'material-ui/lib/icon-button';
+import CodeIcon from 'material-ui/lib/svg-icons/action/code';
+import Toolbar from 'material-ui/lib/toolbar/toolbar';
+import ToolbarGroup from 'material-ui/lib/toolbar/toolbar-group';
+import ToolbarTitle from 'material-ui/lib/toolbar/toolbar-title';
+
+const CodeBlockTitle = (props) => (
+  <Toolbar>
+    <ToolbarGroup float="left">
+      <ToolbarTitle text={props.title || 'Example'} />
+    </ToolbarGroup>
+    <ToolbarGroup float="right">
+      <IconButton touch={true}>
+        <CodeIcon />
+      </IconButton>
+    </ToolbarGroup>
+  </Toolbar>
+);
+
+CodeBlockTitle.propTypes = {title: React.PropTypes.string};
+
+export default CodeBlockTitle;

--- a/docs/src/app/components/CodeExample/index.jsx
+++ b/docs/src/app/components/CodeExample/index.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import CodeBlock from './CodeBlock';
 import ClearFix from 'material-ui/lib/clearfix';
 import Paper from 'material-ui/lib/paper';
-import Spacing from 'material-ui/lib/styles/spacing';
-import Typography from 'material-ui/lib/styles/typography';
 import ThemeManager from 'material-ui/lib/styles/theme-manager';
 import DefaultRawTheme from 'material-ui/lib/styles/raw-themes/light-raw-theme';
 
@@ -12,7 +10,9 @@ const CodeExample = React.createClass({
   propTypes: {
     children: React.PropTypes.node,
     code: React.PropTypes.string.isRequired,
+    description: React.PropTypes.string,
     layoutSideBySide: React.PropTypes.bool,
+    title: React.PropTypes.string,
   },
 
   contextTypes: {
@@ -50,7 +50,6 @@ const CodeExample = React.createClass({
     } = this.props;
 
     let palette = this.state.muiTheme.rawTheme.palette;
-    let borderColor = palette.borderColor;
     let canvasColor = palette.canvasColor;
 
     let styles = {
@@ -58,19 +57,9 @@ const CodeExample = React.createClass({
         backgroundColor: canvasColor,
         marginBottom: 32,
       },
-      exampleLabel: {
-        color: borderColor,
-        padding: 8,
-        marginBottom: 0,
-        fontSize: 14,
-        lineHeight: '20px',
-        letterSpacing: 0,
-        textTransform: 'uppercase',
-        fontWeight: Typography.fontWeightMedium,
-      },
       exampleBlock: {
         borderRadius: '0 0 2px 0',
-        padding: Spacing.desktopGutter,
+        padding: '14px 24px 24px',
         margin: 0,
         width: layoutSideBySide ? '45%' : null,
         float: layoutSideBySide ? 'right' : null,
@@ -79,8 +68,8 @@ const CodeExample = React.createClass({
 
     return (
       <Paper style={styles.root}>
+        <CodeBlock title={this.props.title} description={this.props.description}>{code}</CodeBlock>
         <ClearFix style={styles.exampleBlock}>{children}</ClearFix>
-        <CodeBlock style={styles.codeBlock}>{code}</CodeBlock>
       </Paper>
     );
   },

--- a/docs/src/app/components/pages/components/AppBar/Page.jsx
+++ b/docs/src/app/components/pages/components/AppBar/Page.jsx
@@ -6,6 +6,7 @@ import MarkdownElement from '../../../MarkdownElement';
 import appBarReadmeText from './README';
 import AppBarExampleIcon from './ExampleIcon';
 import appBarExampleIconCode from '!raw!./ExampleIcon';
+import appBarExampleIconDescription from './exampleIconDescription.md';
 import AppBarExampleIconButton from './ExampleIconButton';
 import appBarExampleIconButtonCode from '!raw!./ExampleIconButton';
 import AppBarExampleIconMenu from './ExampleIconMenu';
@@ -15,7 +16,11 @@ import appBarCode from '!raw!material-ui/lib/app-bar';
 const AppBarPage = () => (
   <div>
     <MarkdownElement text={appBarReadmeText} />
-    <CodeExample code={appBarExampleIconCode}>
+    <CodeExample
+      code={appBarExampleIconCode}
+      title="Simple Example"
+      description={appBarExampleIconDescription}
+    >
       <AppBarExampleIcon />
     </CodeExample>
     <CodeExample code={appBarExampleIconButtonCode}>
@@ -24,7 +29,7 @@ const AppBarPage = () => (
     <CodeExample code={appBarExampleIconMenuCode}>
       <AppBarExampleIconMenu />
     </CodeExample>
-    <PropTypeDescription code={appBarCode}/>
+    <PropTypeDescription code={appBarCode} />
   </div>
 );
 

--- a/docs/src/app/components/pages/components/AppBar/exampleIconDescription.md
+++ b/docs/src/app/components/pages/components/AppBar/exampleIconDescription.md
@@ -1,0 +1,1 @@
+A simple example of `AppBar` with an icon on the right hand side. By default, the left icon is a `hamburger-menu`.


### PR DESCRIPTION
To address #2888

`CodeBlock` now has a title-bar (which is an `AppBar`), and takes an optional `title` and `description` prop.

`title` defaults to "Example", and description is blank by default, so docs updates to add a title ad description can be dome in stages while still looking fine with the defaults.

The description can be markdown, either in a string in `SomeComponent/Page.jsx` or optionally in its own md file along side the relevant example code.