### PR TITLE
[Docs] Add tooltip to docs examples code icon

### DIFF
--- a/docs/src/app/components/CodeExample/CodeBlock.jsx
+++ b/docs/src/app/components/CodeExample/CodeBlock.jsx
@@ -57,18 +57,18 @@ ${this.props.children}
     \`\`\``;
 
     const descriptionStyle = styles.description;
-    let codeStyle;
+    let codeStyle = StylePropable.mergeStyles(styles.markdown, styles.markdownRetracted);
+    let tooltip = 'Show source';
 
     if (this.state.expand) {
       codeStyle = styles.markdown;
-    } else {
-      codeStyle = StylePropable.mergeStyles(styles.markdown, styles.markdownRetracted);
+      tooltip = 'Hide source';
     }
 
     return (
       <div style={styles.root}>
         <div onTouchTap={this.handleTouchTap} style={styles.codeBlockTitle}>
-          <CodeBlockTitle title={this.props.title} />
+          <CodeBlockTitle title={this.props.title} tooltip={tooltip}/>
         </div>
         <MarkdownElement style={codeStyle} text={text} />
         <MarkdownElement style={descriptionStyle} text={this.props.description} />

--- a/docs/src/app/components/CodeExample/CodeBlockTitle.jsx
+++ b/docs/src/app/components/CodeExample/CodeBlockTitle.jsx
@@ -11,13 +11,16 @@ const CodeBlockTitle = (props) => (
       <ToolbarTitle text={props.title || 'Example'} />
     </ToolbarGroup>
     <ToolbarGroup float="right">
-      <IconButton touch={true}>
+      <IconButton touch={true} tooltip={props.tooltip}>
         <CodeIcon />
       </IconButton>
     </ToolbarGroup>
   </Toolbar>
 );
 
-CodeBlockTitle.propTypes = {title: React.PropTypes.string};
+CodeBlockTitle.propTypes = {
+  title: React.PropTypes.string,
+  tooltip: React.PropTypes.string,
+};
 
 export default CodeBlockTitle;


### PR DESCRIPTION
Realised we can simply use the icon button tooltip, rather than implementing the internal tooltip component for the entire title-bar. 