### PR TITLE
[LeftNav] Add iOS momentum scroll

### DIFF
--- a/src/left-nav.jsx
+++ b/src/left-nav.jsx
@@ -264,6 +264,7 @@ const LeftNav = React.createClass({
         transition: !this.state.swiping && Transitions.easeOut(null, 'transform', null),
         backgroundColor: theme.color,
         overflow: 'auto',
+        WebkitOverflowScrolling: 'touch', // iOS momentum scrolling
       },
       menu: {
         overflowY: 'auto',


### PR DESCRIPTION
It really bugged me that there was no touch scroll (momentum) on a few Material UI elements. Makes the interface feel a bit dated.