### PR TITLE
[FlatButton] Fix shared memory property modification

### DIFF
--- a/src/buttons/flat-button-label.jsx
+++ b/src/buttons/flat-button-label.jsx
@@ -66,7 +66,8 @@ const FlatButtonLabel = React.createClass({
 
     const mergedRootStyles = this.mergeStyles({
       position: 'relative',
-      padding: '0 ' + contextKeys.spacingDesktopGutterLess + 'px',
+      paddingLeft: contextKeys.spacingDesktopGutterLess,
+      paddingRight: contextKeys.spacingDesktopGutterLess,
     }, style);
 
     return (

--- a/src/flat-button.jsx
+++ b/src/flat-button.jsx
@@ -267,6 +267,7 @@ const FlatButton = React.createClass({
     }, style);
 
     let iconCloned;
+    const labelStyleIcon = {};
 
     if (icon) {
       iconCloned = React.cloneElement(icon, {
@@ -279,14 +280,14 @@ const FlatButton = React.createClass({
       });
 
       if (labelPosition === 'before') {
-        labelStyle.paddingRight = 8;
+        labelStyleIcon.paddingRight = 8;
       } else {
-        labelStyle.paddingLeft = 8;
+        labelStyleIcon.paddingLeft = 8;
       }
     }
 
     const labelElement = label ? (
-      <FlatButtonLabel label={label} style={labelStyle} />
+      <FlatButtonLabel label={label} style={mergeStyles(labelStyle, labelStyleIcon)} />
     ) : undefined;
 
     // Place label before or after children.


### PR DESCRIPTION
I was directly modifying the `labelStyle` property of the component. Properties are supposed to be immutable. React is using this property of properties to performs some optimization.
In our case, the `labelStyle` object is shared between different instance(element) of the same component.
As a result, the last example of the documentation was incorrect: **wrong padding**.