### PR TITLE
Upgrade inline-style-prefixer to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "http://material-ui.com/",
   "dependencies": {
-    "inline-style-prefixer": "^0.5.2",
+    "inline-style-prefixer": "^0.6.6",
     "lodash.merge": "^3.3.2",
     "lodash.throttle": "~3.0.4",
     "react-addons-create-fragment": "^0.14.0",

--- a/src/styles/auto-prefix.js
+++ b/src/styles/auto-prefix.js
@@ -20,7 +20,7 @@ export default {
     let prefixer = prefixers[userAgent];
     // None found, create a new instance
     if (!prefixer) {
-      prefixer = new InlineStylePrefixer(userAgent);
+      prefixer = new InlineStylePrefixer({userAgent: userAgent});
       prefixers[userAgent] = prefixer;
     }
 


### PR DESCRIPTION
This PR upgrades the inline-style-prefixer to the latest version which contains some desirable fixes/enhancements.  To do so the call to the inline-style-prefixer constructor needed to be updated to accept the userAgent string via an options argument .  Also, some components are specifying style properties with "null" or "undefined" values which the new version doesn't like.  As a workaround I added a utility method in auto-prefix to remove any properties with null values.  I view this new `removeNulls` method as a interim solution while you figure out the long term game plan for inline style prefixing (i.e. Radium, React-look, CSS modules, etc.) and fix any nulls at their source.