### PR TITLE
[Docs] Update required property indicator

### DIFF
--- a/docs/src/app/components/PropTypeDescription.jsx
+++ b/docs/src/app/components/PropTypeDescription.jsx
@@ -53,12 +53,10 @@ function generateDescription(required, description, type) {
   if (type.name === 'custom') {
     const deprecatedInfo = getDeprecatedInfo(type);
 
-    if (deprecatedInfo !== false) {
-      deprecated = `**DEPRECATED**. ${deprecatedInfo.explanation}<br><br>`;
+    if (deprecatedInfo) {
+      deprecated = `*Deprecated*. ${deprecatedInfo.explanation}<br><br>`;
     }
   }
-
-  const requirement = `${required ? '**required**' : '*optional*'}.`;
 
   const parsed = parseDoctrine(description);
 
@@ -75,7 +73,7 @@ function generateDescription(required, description, type) {
     signature += parsed.tags.map(tag => `*${tag.name}:* ${tag.description}`).join('<br>');
   }
 
-  return `${deprecated} ${requirement} ${jsDocText}${signature}`;
+  return `${deprecated} ${jsDocText}${signature}`;
 }
 
 const PropTypeDescription = React.createClass({
@@ -97,6 +95,8 @@ const PropTypeDescription = React.createClass({
       header,
     } = this.props;
 
+    let requiredProps = 0;
+
     let text = `${header}
 | Name | Type | Default | Description |
 |:-----|:-----|:-----|:-----|\n`;
@@ -112,14 +112,30 @@ const PropTypeDescription = React.createClass({
         defaultValue = prop.defaultValue.value.replace(/\n/g, '');
       }
 
+      if (prop.required) {
+        key = `<span style="color: #31a148">${key} \*</span>`;
+        requiredProps += 1;
+      }
+
+      if (prop.type.name === 'custom') {
+        if (getDeprecatedInfo(prop.type)) {
+          key = `~~${key}~~`;
+        }
+      }
+
       const description = generateDescription(prop.required, prop.description, prop.type);
 
       text += `| ${key} | ${generatePropType(prop.type)} | ${defaultValue} | ${description} |\n`;
     }
 
+    const requiredPropFootnote = (requiredProps === 1) ? '* required property' :
+      (requiredProps > 1) ? '* required properties' :
+        '';
+
     return (
       <div className="propTypeDescription">
         <MarkdownElement text={text} />
+        <div style={{fontSize: '90%', paddingLeft: '15px'}}>{requiredPropFootnote}</div>
       </div>
     );
   },

--- a/docs/src/app/components/prop-type-description.css
+++ b/docs/src/app/components/prop-type-description.css
@@ -21,18 +21,17 @@
 
 .propTypeDescription table td {
   color: #266d90;
-  font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
-  font-size: 90%;
+  font-size: 95%;
 }
 
 .propTypeDescription table td + td {
   color: #bf2a5c;
+  font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
+  font-size: 90%;
 }
 
 .propTypeDescription table td + td + td {
   color: #666;
-  font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
-  font-size: 90%;
 }
 
 .propTypeDescription table td + td + td + td {


### PR DESCRIPTION
Having spent so long staring at the docs :dizzy_face:, the optional/required indicator in front of the every prop description began to bother me (especially since most components don't even *have* required props), so I had a quick stab at visually simplifying it.

### Before:
<img width="782" alt="screen shot 2016-01-19 at 19 57 52" src="https://cloud.githubusercontent.com/assets/357702/12431049/309f9608-beeb-11e5-96df-d54f4d5a14cd.png">
 
### After:
<img width="714" alt="screen shot 2016-01-19 at 20 52 26" src="https://cloud.githubusercontent.com/assets/357702/12431655/90b49838-beee-11e5-920a-2f2ea20fdc70.png">

The message also pluralises. (`CircularProgress` has multiple required props to save you looking for an example to test against. :smile:)

Another possibility is to have the asterisk against the property name, rather than the description.

@alitaheri @newoga @oliviertassinari ?