### PR TITLE
[Core] Implements prepareStyles as composition of functions in muiTheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "homepage": "http://material-ui.com/",
   "dependencies": {
     "inline-style-prefixer": "^0.6.6",
+    "lodash.flowright": "^3.2.1",
     "lodash.merge": "^3.3.2",
     "lodash.throttle": "~3.0.4",
     "react-addons-create-fragment": "^0.14.0",

--- a/src/mixins/style-propable.js
+++ b/src/mixins/style-propable.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {mergeStyles, mergeAndPrefix, prepareStyles as prepare} from '../utils/styles';
+import {mergeStyles, mergeAndPrefix} from '../utils/styles';
 
 /**
  * This mixin isn't necessary and will be removed soon. DO NOT USE!
@@ -22,8 +22,11 @@ export default {
   mergeAndPrefix,
 
   prepareStyles(...args) {
-    return prepare((this.state && this.state.muiTheme) ||
-      this.context.muiTheme ||
-      (this.props && this.props.muiTheme), ...args);
+    const {
+      prepareStyles = (style) => (style),
+    } = (this.state && this.state.muiTheme) || (this.context && this.context.muiTheme) ||
+        (this.props && this.props.muiTheme) || {};
+
+    return prepareStyles(mergeStyles({}, ...args));
   },
 };

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -4,6 +4,8 @@ import ColorManipulator from '../utils/color-manipulator';
 import autoPrefix from './auto-prefix';
 import lightBaseTheme from './baseThemes/lightBaseTheme';
 import zIndex from './zIndex';
+import {autoprefixer, callOnce, rtl} from './transformers';
+import compose from 'lodash.flowright';
 
 /**
  * Get the MUI theme corresponding to a base theme.
@@ -240,7 +242,9 @@ export default function getMuiTheme(baseTheme, muiTheme) {
     },
   }, muiTheme);
 
+  const transformers = [autoprefixer, rtl, callOnce].map(t => t(muiTheme)).filter(t => t);
   muiTheme.prefix = autoPrefix.getTransform(muiTheme.userAgent);
+  muiTheme.prepareStyles = compose(...transformers);
 
   return muiTheme;
 }

--- a/src/styles/transformers/autoprefixer.js
+++ b/src/styles/transformers/autoprefixer.js
@@ -1,0 +1,5 @@
+export default function(muiTheme) {
+  if (muiTheme.userAgent !== false) {
+    return (style) => muiTheme.prefix(style);
+  }
+}

--- a/src/styles/transformers/callOnce.js
+++ b/src/styles/transformers/callOnce.js
@@ -1,0 +1,15 @@
+import warning from 'warning';
+
+const CALLED_ONCE = 'muiPrepared';
+
+export default function callOnce() {
+  if (process.env.NODE_ENV !== 'production') {
+    return (style) => {
+      if (style[CALLED_ONCE]) {
+        warning(false, 'You cannot call prepareStyles() on the same style object more than once.');
+      }
+      style[CALLED_ONCE] = true;
+      return style;
+    };
+  }
+}

--- a/src/styles/transformers/index.js
+++ b/src/styles/transformers/index.js
@@ -1,0 +1,9 @@
+import autoprefixer from './autoprefixer';
+import callOnce from './callOnce';
+import rtl from './rtl';
+
+export {
+  autoprefixer,
+  callOnce,
+  rtl,
+};

--- a/src/styles/transformers/rtl.js
+++ b/src/styles/transformers/rtl.js
@@ -1,0 +1,81 @@
+const reTranslate = /((^|\s)translate(3d|X)?\()(\-?[\d]+)/;
+const reSkew = /((^|\s)skew(x|y)?\()\s*(\-?[\d]+)(deg|rad|grad)(,\s*(\-?[\d]+)(deg|rad|grad))?/;
+
+/**
+ * This function ensures that `style` supports both ltr and rtl directions by
+ * checking `styleConstants` in `muiTheme` and replacing attribute keys if
+ * necessary.
+ */
+export default function rtl(muiTheme) {
+  if (muiTheme.isRtl) {
+    return (style) => {
+      const flippedAttributes = {
+        // Keys and their replacements.
+        right: 'left',
+        left: 'right',
+        marginRight: 'marginLeft',
+        marginLeft: 'marginRight',
+        paddingRight: 'paddingLeft',
+        paddingLeft: 'paddingRight',
+        borderRight: 'borderLeft',
+        borderLeft: 'borderRight',
+      };
+
+      let newStyle = {};
+
+      Object.keys(style).forEach(function(attribute) {
+        let value = style[attribute];
+        let key = attribute;
+
+        if (flippedAttributes.hasOwnProperty(attribute)) {
+          key = flippedAttributes[attribute];
+        }
+
+        switch (attribute) {
+          case 'float':
+          case 'textAlign':
+            if (value === 'right') {
+              value = 'left';
+            } else if (value === 'left') {
+              value = 'right';
+            }
+            break;
+
+          case 'direction':
+            if (value === 'ltr') {
+              value = 'rtl';
+            } else if (value === 'rtl') {
+              value = 'ltr';
+            }
+            break;
+
+          case 'transform':
+            let matches;
+            if ((matches = value.match(reTranslate))) {
+              value = value.replace(matches[0], matches[1] + (-parseFloat(matches[4])) );
+            }
+            if ((matches = value.match(reSkew))) {
+              value = value.replace(matches[0], matches[1] + (-parseFloat(matches[4])) + matches[5] +
+                matches[6] ? ',' + (-parseFloat(matches[7])) + matches[8] : ''
+              );
+            }
+            break;
+
+          case 'transformOrigin':
+            if (value.indexOf('right') > -1) {
+              value = value.replace('right', 'left');
+            } else if (value.indexOf('left') > -1) {
+              value = value.replace('left', 'right');
+            }
+            break;
+        }
+
+        newStyle[key] = value;
+      });
+
+      return newStyle;
+    };
+  }
+}
+
+


### PR DESCRIPTION
This commit implements the `prepareStyles` function as a composition of functions that can be configured in `muiTheme`. It switches the `./mixin/style-propable.js` implementation to use the `prepareStyles` stored in context.

@oliviertassinari @alitaheri 
This is an initial implementation of the approach of storing `prepareStyles` in context. I cleaned up the code a bit, however like I said, I don't think we should document this until we've confirmed we're happy and the API is final (I already have some ideas of how to improve it, but it shouldn't have any real immediate benefit). It's also very well possible this will all go away when we adopt a new styling framework.

**Note**: One minor difference I made is that the `getMuiTheme` function actually checks the computed theme for `isRtl` before composing the functions. If it's false, it doesn't even bother including the `ensureDirections()` (renamed to `rtl()`) method. **Edit:** It now does this for the `autoprefixer()` method based on the `userAgent` property

~~Right now, the list of transformers can be overridden by adding the following property to the muiTheme.  The following configuration would essentially disable the default behavior of always autoprefixing and calling `rtl()` when `isRtl` is equal to `true`.~~ Removed customizing of transformers in this PR, other approaches have since been implemented.

**Remaining tasks:**
- [x] Move implementation of "double call warning" out of `rtl()` into something that runs before all style transformations are executed. **Done**
- [x] ~~Change `rtl()` implementation to not care is `isRtl`~~ **No longer necessary**

**Future PR:**
- Convert components not using `./mixins/style-propable.js` to get `prepareStyles()` from context, not from importing it from `./utils/style.js`.
- Deprecate and/or remove `./utils/style.js`
