### PR TITLE
Adds a deprecation warning for drop-down-icon

### DIFF
--- a/src/drop-down-icon.jsx
+++ b/src/drop-down-icon.jsx
@@ -6,6 +6,7 @@ import FontIcon from './font-icon';
 import Menu from './menu/menu';
 import DefaultRawTheme from './styles/raw-themes/light-raw-theme';
 import ThemeManager from './styles/theme-manager';
+import warning from 'warning';
 
 const DropDownIcon = React.createClass({
 
@@ -42,6 +43,9 @@ const DropDownIcon = React.createClass({
   },
 
   getInitialState() {
+    warning(false, 'DropDownIcon has been deprecated and will be removed in an upcoming verion.' +
+      ' Please use IconMenu instead.');
+
     return {
       open: false,
       muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
@@ -52,13 +56,6 @@ const DropDownIcon = React.createClass({
     return {
       muiTheme: this.state.muiTheme,
     };
-  },
-
-  componentDidMount() {
-    // This component can be deprecated once ./menu/menu has been deprecated.
-    // if (process.env.NODE_ENV !== 'production') {
-    //   console.warn('DropDownIcon has been deprecated. Use IconMenu instead.');
-    // }
   },
 
   //to update theme inside state whenever a new theme is passed down


### PR DESCRIPTION
This component really should have had a deprecation warning from `0.14.0` when the old `./menu/menu` implementation was deprecated. This component is not used in any other components in src or docs. It also is not documented on the site. I think we should add this warning ASAP and plan for removal along with `./menu/menu` in our first `0.15.0` release candidate.