### PR TITLE
[AppBar] Put child between the title and the right icon

### DIFF
--- a/src/app-bar.jsx
+++ b/src/app-bar.jsx
@@ -328,8 +328,8 @@ const AppBar = React.createClass({
       >
         {menuElementLeft}
         {titleElement}
-        {menuElementRight}
         {children}
+        {menuElementRight}
       </Paper>
     );
   },


### PR DESCRIPTION
I currently tweak the style of the components I use in the app bar, but at least now they appear at the right position.

I'am not sure what is the right direction to make everything work perfectly without tweaking.

Should we support ToolbarGroup ?  (currently they do not go on the right or left as expected and I wasn't able to figure out why)