### PR TITLE
[Docs] Add an example on how to use Tabs inside an AppBar

### DIFF
--- a/docs/src/app/components/pages/components/AppBar/ExampleTabs.jsx
+++ b/docs/src/app/components/pages/components/AppBar/ExampleTabs.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import AppBar from 'material-ui/lib/app-bar';
+import Tabs from 'material-ui/lib/tabs/tabs';
+import Tab from 'material-ui/lib/tabs/tab';
+
+const styles = {
+  appBar: {
+    flexWrap: 'wrap',
+  },
+  tabs: {
+    width: '100%',
+  },
+};
+
+const AppBarExampleTabs = () => (
+  <AppBar
+    title="Title"
+    style={styles.appBar}
+    iconClassNameRight="muidocs-icon-navigation-expand-more"
+  >
+    <Tabs style={styles.tabs}>
+      <Tab label="ALL" />
+      <Tab label="CAMERA" />
+      <Tab label="RECENT" />
+    </Tabs>
+  </AppBar>
+);
+
+export default AppBarExampleTabs;

--- a/docs/src/app/components/pages/components/AppBar/Page.jsx
+++ b/docs/src/app/components/pages/components/AppBar/Page.jsx
@@ -10,6 +10,8 @@ import AppBarExampleIconButton from './ExampleIconButton';
 import appBarExampleIconButtonCode from '!raw!./ExampleIconButton';
 import AppBarExampleIconMenu from './ExampleIconMenu';
 import appBarExampleIconMenuCode from '!raw!./ExampleIconMenu';
+import AppBarExampleTabs from './ExampleTabs';
+import appBarExampleTabsCode from '!raw!./ExampleTabs';
 import appBarCode from '!raw!material-ui/lib/app-bar';
 
 const descriptions = {
@@ -17,6 +19,7 @@ const descriptions = {
   'By default, the left icon is a navigation-menu.',
   iconButton: '`IconButton` left, clickable title, and `FlatButton` right.',
   iconMenu: '`IconMenu` on the right.',
+  tabs: 'Use `Tabs` to organize content at a high level.',
 };
 
 const AppBarPage = () => (
@@ -42,6 +45,13 @@ const AppBarPage = () => (
       description={descriptions.iconMenu}
     >
       <AppBarExampleIconMenu />
+    </CodeExample>
+    <CodeExample
+      code={appBarExampleTabsCode}
+      title="Tabs"
+      description={descriptions.tabs}
+    >
+      <AppBarExampleTabs />
     </CodeExample>
     <PropTypeDescription code={appBarCode} />
   </div>


### PR DESCRIPTION
Here is the result:
![capture d ecran 2016-01-21 a 16 22 02](https://cloud.githubusercontent.com/assets/3165635/12484556/28cff7c6-c05b-11e5-8d2c-c590069d3f85.png)
This is also to illustrate what https://github.com/callemall/material-ui/pull/3004 would break. cc @cgestes.
We should address https://github.com/callemall/material-ui/pull/1817 at some point.