### PR TITLE
[Style] Address server sider rendering issues

### DIFF
--- a/docs/src/app/app-routes.jsx
+++ b/docs/src/app/app-routes.jsx
@@ -13,6 +13,7 @@ import Prerequisites from './components/pages/get-started/Prerequisites';
 import Installation from './components/pages/get-started/Installation';
 import Usage from './components/pages/get-started/Usage';
 import Examples from './components/pages/get-started/Examples';
+import ServerRendering from './components/pages/get-started/ServerRendering';
 
 import Colors from './components/pages/customization/colors';
 import Themes from './components/pages/customization/themes';
@@ -77,6 +78,7 @@ const AppRoutes = (
       <Route path="installation" component={Installation} />
       <Route path="usage" component={Usage} />
       <Route path="examples" component={Examples} />
+      <Route path="server-rendering" component={ServerRendering} />
     </Route>
     <Redirect from="customization" to="/customization/themes" />
     <Route path="customization">

--- a/docs/src/app/components/app-left-nav.jsx
+++ b/docs/src/app/components/app-left-nav.jsx
@@ -93,6 +93,7 @@ const AppLeftNav = React.createClass({
               <ListItem primaryText="Installation" value="/get-started/installation" />,
               <ListItem primaryText="Usage" value="/get-started/usage" />,
               <ListItem primaryText="Examples" value="/get-started/examples" />,
+              <ListItem primaryText="Server Rendering" value="/get-started/server-rendering" />,
             ]}
           />
           <ListItem

--- a/docs/src/app/components/pages/get-started/ServerRendering.jsx
+++ b/docs/src/app/components/pages/get-started/ServerRendering.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import MarkdownElement from '../../MarkdownElement';
+import serverRenderingText from './serverRendering.md';
+
+const ServerRendering = () => (
+  <MarkdownElement text={serverRenderingText} />
+);
+
+export default ServerRendering;

--- a/docs/src/app/components/pages/get-started/serverRendering.md
+++ b/docs/src/app/components/pages/get-started/serverRendering.md
@@ -1,0 +1,55 @@
+## Server Rendering
+
+When using Material UI with server rendering, we must use the same environment for the server and the client.
+This has two technical implications.
+
+### Autoprefixer
+
+First, Material UI has to use the same user agent for the auto prefixer.
+On the client side, the default value is `navigator.userAgent`.
+But on the server side, the `navigator` is `undefined`. You need to provide it to Material UI.
+
+The `userAgent` can take one of the following values:
+- a regular user agent like
+`Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.82 Safari/537.36`
+- `'all'` to prefix for all user agents
+- `false` to disable the prefixer
+
+We rely on the [muiTheme](/#/customization/themes) context to spread the user agent to all of our component.
+For instance, you can provide it like this:
+
+```js
+import getMuiTheme from 'material-ui/lib/styles/getMuiTheme';
+import themeDecorator from 'material-ui/lib/styles/theme-decorator';
+import colors from 'material-ui/lib/styles/colors';
+
+const muiTheme = getMuiTheme({
+  palette: {
+    primary1Color: colors.green500,
+    primary2Color: colors.green700,
+    primary3Color: colors.green100,
+  },
+}, {
+  avatar: {
+    borderColor: null,
+  },
+  userAgent: req.headers['user-agent'],
+});
+
+class Main extends React.Component {
+  render() {
+    return (
+      <div>Hello world</div>
+    );
+  }
+}
+
+export default themeDecorator(muiTheme)(Main)
+```
+
+### process.env.NODE_ENV
+
+You also need to use the same `process.env.NODE_ENV` value for the client side and server side.
+Otherwise, the checksums won't match.
+In order to make sure our style transformations are only applied once,
+we add an additional property to each style when `process.env.NODE_ENV !== 'production'`.

--- a/src/auto-complete.jsx
+++ b/src/auto-complete.jsx
@@ -440,7 +440,7 @@ const AutoComplete = React.createClass({
           useLayerForClickAway={false}
           onRequestClose={this._close}
         >
-            {menu}
+          {menu}
         </Popover>
       </div>
     );

--- a/src/before-after-wrapper.jsx
+++ b/src/before-after-wrapper.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import StylePropable from './mixins/style-propable';
-import AutoPrefix from './styles/auto-prefix';
 import DefaultRawTheme from './styles/raw-themes/light-raw-theme';
 import ThemeManager from './styles/theme-manager';
 
@@ -105,8 +104,13 @@ const BeforeAfterWrapper = React.createClass({
     let beforeElement;
     let afterElement;
 
-    beforeStyle = AutoPrefix.all({boxSizing: 'border-box'});
-    afterStyle = AutoPrefix.all({boxSizing: 'border-box'});
+    beforeStyle = {
+      boxSizing: 'border-box',
+    };
+
+    afterStyle = {
+      boxSizing: 'border-box',
+    };
 
     if (this.props.beforeStyle) beforeElement =
       React.createElement(this.props.beforeElementType,

--- a/src/circular-progress.jsx
+++ b/src/circular-progress.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import StylePropable from './mixins/style-propable';
-import AutoPrefix from './styles/auto-prefix';
+import autoPrefix from './styles/auto-prefix';
 import Transitions from './styles/transitions';
 import DefaultRawTheme from './styles/raw-themes/light-raw-theme';
 import ThemeManager from './styles/theme-manager';
@@ -144,13 +144,13 @@ const CircularProgress = React.createClass({
   _rotateWrapper(wrapper) {
     if (this.props.mode !== 'indeterminate') return;
 
-    AutoPrefix.set(wrapper.style, 'transform', 'rotate(0deg)');
-    AutoPrefix.set(wrapper.style, 'transitionDuration', '0ms');
+    autoPrefix.set(wrapper.style, 'transform', 'rotate(0deg)', this.state.muiTheme);
+    autoPrefix.set(wrapper.style, 'transitionDuration', '0ms', this.state.muiTheme);
 
     setTimeout(() => {
-      AutoPrefix.set(wrapper.style, 'transform', 'rotate(1800deg)');
-      AutoPrefix.set(wrapper.style, 'transitionDuration', '10s');
-      AutoPrefix.set(wrapper.style, 'transitionTimingFunction', 'linear');
+      autoPrefix.set(wrapper.style, 'transform', 'rotate(1800deg)', this.state.muiTheme);
+      autoPrefix.set(wrapper.style, 'transitionDuration', '10s', this.state.muiTheme);
+      autoPrefix.set(wrapper.style, 'transitionTimingFunction', 'linear', this.state.muiTheme);
     }, 50);
 
     this.rotateWrapperTimer = setTimeout(() => this._rotateWrapper(wrapper), 10050);
@@ -197,7 +197,7 @@ const CircularProgress = React.createClass({
       },
     };
 
-    AutoPrefix.set(styles.wrapper, 'transitionTimingFunction', 'linear');
+    autoPrefix.set(styles.wrapper, 'transitionTimingFunction', 'linear', this.state.muiTheme);
 
     if (this.props.mode === 'determinate') {
       let relVal = this._getRelativeValue();

--- a/src/enhanced-button.jsx
+++ b/src/enhanced-button.jsx
@@ -176,6 +176,7 @@ const EnhancedButton = React.createClass({
     const focusRipple = isKeyboardFocused && !disabled && !disableFocusRipple && !disableKeyboardFocus ? (
       <FocusRipple
         color={focusRippleColor}
+        muiTheme={this.state.muiTheme}
         opacity={focusRippleOpacity}
         show={isKeyboardFocused}
       />
@@ -186,6 +187,7 @@ const EnhancedButton = React.createClass({
       <TouchRipple
         centerRipple={centerRipple}
         color={touchRippleColor}
+        muiTheme={this.state.muiTheme}
         opacity={touchRippleOpacity}
       >
         {children}

--- a/src/enhanced-switch.jsx
+++ b/src/enhanced-switch.jsx
@@ -397,6 +397,7 @@ const EnhancedSwitch = React.createClass({
         key="touchRipple"
         style={rippleStyle}
         color={rippleColor}
+        muiTheme={this.state.muiTheme}
         centerRipple={true}
       />
     );
@@ -406,6 +407,7 @@ const EnhancedSwitch = React.createClass({
         key="focusRipple"
         innerStyle={rippleStyle}
         color={rippleColor}
+        muiTheme={this.state.muiTheme}
         show={this.state.isKeyboardFocused}
       />
     );

--- a/src/left-nav.jsx
+++ b/src/left-nav.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import KeyCode from './utils/key-code';
 import StylePropable from './mixins/style-propable';
-import AutoPrefix from './styles/auto-prefix';
+import autoPrefix from './styles/auto-prefix';
 import Transitions from './styles/transitions';
 import WindowListenable from './mixins/window-listenable';
 import Overlay from './overlay';
@@ -413,7 +413,7 @@ const LeftNav = React.createClass({
     const leftNav = ReactDOM.findDOMNode(this.refs.clickAwayableElement);
     const transformCSS = 'translate3d(' + (this._getTranslateMultiplier() * translateX) + 'px, 0, 0)';
     this.refs.overlay.setOpacity(1 - translateX / this._getMaxTranslateX());
-    AutoPrefix.set(leftNav.style, 'transform', transformCSS);
+    autoPrefix.set(leftNav.style, 'transform', transformCSS, this.state.muiTheme);
   },
 
   _getTranslateX(currentX) {

--- a/src/menus/menu.jsx
+++ b/src/menus/menu.jsx
@@ -4,7 +4,7 @@ import update from 'react-addons-update';
 import Controllable from '../mixins/controllable';
 import StylePropable from '../mixins/style-propable';
 import ClickAwayable from '../mixins/click-awayable';
-import AutoPrefix from '../styles/auto-prefix';
+import autoPrefix from '../styles/auto-prefix';
 import Transitions from '../styles/transitions';
 import KeyCode from '../utils/key-code';
 import PropTypes from '../utils/prop-types';
@@ -206,7 +206,7 @@ const Menu = React.createClass({
     rootStyle.transition = Transitions.easeOut('250ms', ['opacity', 'transform']);
     rootStyle.transform = 'translate3d(0,-8px,0)';
     rootStyle.opacity = 0;
-    rootStyle = AutoPrefix.all(rootStyle);
+    rootStyle = autoPrefix.all(rootStyle);
     setTimeout(() => {
       if (this.isMounted()) callback();
     }, 250);
@@ -240,8 +240,8 @@ const Menu = React.createClass({
     let scrollContainerStyle = ReactDOM.findDOMNode(this.refs.scrollContainer).style;
     let menuContainers = ReactDOM.findDOMNode(this.refs.list).childNodes;
 
-    AutoPrefix.set(rootStyle, 'transform', 'scaleX(1)');
-    AutoPrefix.set(scrollContainerStyle, 'transform', 'scaleY(1)');
+    autoPrefix.set(rootStyle, 'transform', 'scaleX(1)');
+    autoPrefix.set(scrollContainerStyle, 'transform', 'scaleY(1)');
     scrollContainerStyle.opacity = 1;
 
     for (let i = 0; i < menuContainers.length; ++i) {

--- a/src/menus/menu.jsx
+++ b/src/menus/menu.jsx
@@ -206,7 +206,7 @@ const Menu = React.createClass({
     rootStyle.transition = Transitions.easeOut('250ms', ['opacity', 'transform']);
     rootStyle.transform = 'translate3d(0,-8px,0)';
     rootStyle.opacity = 0;
-    rootStyle = autoPrefix.all(rootStyle);
+    rootStyle = autoPrefix.all(rootStyle, this.state.muiTheme);
     setTimeout(() => {
       if (this.isMounted()) callback();
     }, 250);
@@ -240,8 +240,8 @@ const Menu = React.createClass({
     let scrollContainerStyle = ReactDOM.findDOMNode(this.refs.scrollContainer).style;
     let menuContainers = ReactDOM.findDOMNode(this.refs.list).childNodes;
 
-    autoPrefix.set(rootStyle, 'transform', 'scaleX(1)');
-    autoPrefix.set(scrollContainerStyle, 'transform', 'scaleY(1)');
+    autoPrefix.set(rootStyle, 'transform', 'scaleX(1)', this.state.muiTheme);
+    autoPrefix.set(scrollContainerStyle, 'transform', 'scaleY(1)', this.state.muiTheme);
     scrollContainerStyle.opacity = 1;
 
     for (let i = 0; i < menuContainers.length; ++i) {

--- a/src/menus/menu.jsx
+++ b/src/menus/menu.jsx
@@ -197,21 +197,6 @@ const Menu = React.createClass({
     if (this.props.autoWidth) this._setWidth();
   },
 
-  componentDidEnter() {
-    this._animateOpen();
-  },
-
-  componentWillLeave(callback) {
-    let rootStyle = ReactDOM.findDOMNode(this).style;
-    rootStyle.transition = Transitions.easeOut('250ms', ['opacity', 'transform']);
-    rootStyle.transform = 'translate3d(0,-8px,0)';
-    rootStyle.opacity = 0;
-    rootStyle = autoPrefix.all(rootStyle, this.state.muiTheme);
-    setTimeout(() => {
-      if (this.isMounted()) callback();
-    }, 250);
-  },
-
   componentClickAway(e) {
     if (e.defaultPrevented)
       return;

--- a/src/mixins/style-propable.js
+++ b/src/mixins/style-propable.js
@@ -22,6 +22,8 @@ export default {
   mergeAndPrefix,
 
   prepareStyles(...args) {
-    return prepare((this.state && this.state.muiTheme) || this.context.muiTheme, ...args);
+    return prepare((this.state && this.state.muiTheme) ||
+      this.context.muiTheme ||
+      (this.props && this.props.muiTheme), ...args);
   },
 };

--- a/src/refresh-indicator.jsx
+++ b/src/refresh-indicator.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import StylePropable from './mixins/style-propable';
-import AutoPrefix from './styles/auto-prefix';
+import autoPrefix from './styles/auto-prefix';
 import Transitions from './styles/transitions';
 import Paper from './paper';
 import DefaultRawTheme from './styles/raw-themes/light-raw-theme';
@@ -309,9 +309,9 @@ const RefreshIndicator = React.createClass({
       transitionDuration = '850ms';
     }
 
-    AutoPrefix.set(path.style, 'strokeDasharray', strokeDasharray);
-    AutoPrefix.set(path.style, 'strokeDashoffset', strokeDashoffset);
-    AutoPrefix.set(path.style, 'transitionDuration', transitionDuration);
+    autoPrefix.set(path.style, 'strokeDasharray', strokeDasharray);
+    autoPrefix.set(path.style, 'strokeDashoffset', strokeDashoffset);
+    autoPrefix.set(path.style, 'transitionDuration', transitionDuration);
 
     this.scalePathTimer = setTimeout(() => this._scalePath(path, currStep + 1), currStep ? 750 : 250);
   },
@@ -319,21 +319,17 @@ const RefreshIndicator = React.createClass({
   _rotateWrapper(wrapper) {
     if (this.props.status !== 'loading') return;
 
-    AutoPrefix.set(wrapper.style, 'transform', null);
-    AutoPrefix.set(wrapper.style, 'transform', 'rotate(0deg)');
-    AutoPrefix.set(wrapper.style, 'transitionDuration', '0ms');
+    autoPrefix.set(wrapper.style, 'transform', null);
+    autoPrefix.set(wrapper.style, 'transform', 'rotate(0deg)');
+    autoPrefix.set(wrapper.style, 'transitionDuration', '0ms');
 
     this.rotateWrapperSecondTimer = setTimeout(() => {
-      AutoPrefix.set(wrapper.style, 'transform', 'rotate(1800deg)');
-      AutoPrefix.set(wrapper.style, 'transitionDuration', '10s');
-      AutoPrefix.set(wrapper.style, 'transitionTimingFunction', 'linear');
+      autoPrefix.set(wrapper.style, 'transform', 'rotate(1800deg)');
+      autoPrefix.set(wrapper.style, 'transitionDuration', '10s');
+      autoPrefix.set(wrapper.style, 'transitionTimingFunction', 'linear');
     }, 50);
 
     this.rotateWrapperTimer = setTimeout(() => this._rotateWrapper(wrapper), 10050);
-  },
-
-  prefixed(key) {
-    return AutoPrefix.single(key);
   },
 
   render() {

--- a/src/refresh-indicator.jsx
+++ b/src/refresh-indicator.jsx
@@ -309,9 +309,9 @@ const RefreshIndicator = React.createClass({
       transitionDuration = '850ms';
     }
 
-    autoPrefix.set(path.style, 'strokeDasharray', strokeDasharray);
-    autoPrefix.set(path.style, 'strokeDashoffset', strokeDashoffset);
-    autoPrefix.set(path.style, 'transitionDuration', transitionDuration);
+    autoPrefix.set(path.style, 'strokeDasharray', strokeDasharray, this.state.muiTheme);
+    autoPrefix.set(path.style, 'strokeDashoffset', strokeDashoffset, this.state.muiTheme);
+    autoPrefix.set(path.style, 'transitionDuration', transitionDuration, this.state.muiTheme);
 
     this.scalePathTimer = setTimeout(() => this._scalePath(path, currStep + 1), currStep ? 750 : 250);
   },
@@ -319,14 +319,14 @@ const RefreshIndicator = React.createClass({
   _rotateWrapper(wrapper) {
     if (this.props.status !== 'loading') return;
 
-    autoPrefix.set(wrapper.style, 'transform', null);
-    autoPrefix.set(wrapper.style, 'transform', 'rotate(0deg)');
-    autoPrefix.set(wrapper.style, 'transitionDuration', '0ms');
+    autoPrefix.set(wrapper.style, 'transform', null, this.state.muiTheme);
+    autoPrefix.set(wrapper.style, 'transform', 'rotate(0deg)', this.state.muiTheme);
+    autoPrefix.set(wrapper.style, 'transitionDuration', '0ms', this.state.muiTheme);
 
     this.rotateWrapperSecondTimer = setTimeout(() => {
-      autoPrefix.set(wrapper.style, 'transform', 'rotate(1800deg)');
-      autoPrefix.set(wrapper.style, 'transitionDuration', '10s');
-      autoPrefix.set(wrapper.style, 'transitionTimingFunction', 'linear');
+      autoPrefix.set(wrapper.style, 'transform', 'rotate(1800deg)', this.state.muiTheme);
+      autoPrefix.set(wrapper.style, 'transitionDuration', '10s', this.state.muiTheme);
+      autoPrefix.set(wrapper.style, 'transitionTimingFunction', 'linear', this.state.muiTheme);
     }, 50);
 
     this.rotateWrapperTimer = setTimeout(() => this._rotateWrapper(wrapper), 10050);

--- a/src/ripples/circle-ripple.jsx
+++ b/src/ripples/circle-ripple.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import StylePropable from '../mixins/style-propable';
-import AutoPrefix from '../styles/auto-prefix';
+import autoPrefix from '../styles/auto-prefix';
 import Transitions from '../styles/transitions';
 import Colors from '../styles/colors';
 
@@ -60,14 +60,14 @@ const CircleRipple = React.createClass({
       Transitions.easeOut('2s', 'opacity') + ',' +
       Transitions.easeOut('1s', 'transform')
     );
-    AutoPrefix.set(style, 'transition', transitionValue);
-    AutoPrefix.set(style, 'transform', 'scale(1)');
+    autoPrefix.set(style, 'transition', transitionValue);
+    autoPrefix.set(style, 'transform', 'scale(1)');
   },
 
   _initializeAnimation(callback) {
     let style = ReactDOM.findDOMNode(this).style;
     style.opacity = this.props.opacity;
-    AutoPrefix.set(style, 'transform', 'scale(0)');
+    autoPrefix.set(style, 'transform', 'scale(0)');
     setTimeout(() => {
       if (this.isMounted()) callback();
     }, 0);

--- a/src/ripples/circle-ripple.jsx
+++ b/src/ripples/circle-ripple.jsx
@@ -10,6 +10,12 @@ const CircleRipple = React.createClass({
 
   propTypes: {
     color: React.PropTypes.string,
+
+    /**
+     * The material-ui theme applied to this component.
+     */
+    muiTheme: React.PropTypes.object.isRequired,
+
     opacity: React.PropTypes.number,
 
     /**
@@ -60,14 +66,14 @@ const CircleRipple = React.createClass({
       Transitions.easeOut('2s', 'opacity') + ',' +
       Transitions.easeOut('1s', 'transform')
     );
-    autoPrefix.set(style, 'transition', transitionValue);
-    autoPrefix.set(style, 'transform', 'scale(1)');
+    autoPrefix.set(style, 'transition', transitionValue, this.props.muiTheme);
+    autoPrefix.set(style, 'transform', 'scale(1)', this.props.muiTheme);
   },
 
   _initializeAnimation(callback) {
     let style = ReactDOM.findDOMNode(this).style;
     style.opacity = this.props.opacity;
-    autoPrefix.set(style, 'transform', 'scale(0)');
+    autoPrefix.set(style, 'transform', 'scale(0)', this.props.muiTheme);
     setTimeout(() => {
       if (this.isMounted()) callback();
     }, 0);

--- a/src/ripples/focus-ripple.jsx
+++ b/src/ripples/focus-ripple.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import StylePropable from '../mixins/style-propable';
-import AutoPrefix from '../styles/auto-prefix';
+import autoPrefix from '../styles/auto-prefix';
 import Colors from '../styles/colors';
 import Transitions from '../styles/transitions';
 import ScaleInTransitionGroup from '../transition-groups/scale-in';
@@ -85,7 +85,7 @@ const FocusRipple = React.createClass({
     nextScale = currentScale === startScale ?
       endScale : startScale;
 
-    AutoPrefix.set(innerCircle.style, 'transform', nextScale);
+    autoPrefix.set(innerCircle.style, 'transform', nextScale);
     this._timeout = setTimeout(this._pulsate, pulsateDuration);
   },
 

--- a/src/ripples/focus-ripple.jsx
+++ b/src/ripples/focus-ripple.jsx
@@ -14,6 +14,12 @@ const FocusRipple = React.createClass({
   propTypes: {
     color: React.PropTypes.string,
     innerStyle: React.PropTypes.object,
+
+    /**
+     * The material-ui theme applied to this component.
+     */
+    muiTheme: React.PropTypes.object.isRequired,
+
     opacity: React.PropTypes.number,
     show: React.PropTypes.bool,
 
@@ -85,7 +91,7 @@ const FocusRipple = React.createClass({
     nextScale = currentScale === startScale ?
       endScale : startScale;
 
-    autoPrefix.set(innerCircle.style, 'transform', nextScale);
+    autoPrefix.set(innerCircle.style, 'transform', nextScale, this.props.muiTheme);
     this._timeout = setTimeout(this._pulsate, pulsateDuration);
   },
 

--- a/src/ripples/touch-ripple.jsx
+++ b/src/ripples/touch-ripple.jsx
@@ -22,6 +22,12 @@ const TouchRipple = React.createClass({
     centerRipple: React.PropTypes.bool,
     children: React.PropTypes.node,
     color: React.PropTypes.string,
+
+    /**
+     * The material-ui theme applied to this component.
+     */
+    muiTheme: React.PropTypes.object.isRequired,
+
     opacity: React.PropTypes.number,
 
     /**
@@ -64,6 +70,7 @@ const TouchRipple = React.createClass({
     ripples = push(ripples, (
       <CircleRipple
         key={this.state.nextKey}
+        muiTheme={this.props.muiTheme}
         style={!this.props.centerRipple ? this._getRippleStyle(e) : {}}
         color={this.props.color}
         opacity={this.props.opacity}

--- a/src/slider.jsx
+++ b/src/slider.jsx
@@ -536,6 +536,7 @@ const Slider = React.createClass({
           style={this.mergeStyles(rippleStyle)}
           innerStyle={styles.rippleInner}
           show={rippleShowCondition}
+          muiTheme={this.state.muiTheme}
           color={rippleColor}
         />
       );

--- a/src/styles/auto-prefix.js
+++ b/src/styles/auto-prefix.js
@@ -49,23 +49,19 @@ export default {
     }
   },
 
-  all(style, muiTheme) {
+  all(style) {
     if (!style) {
       return {};
     }
 
-    if (muiTheme) {
-      return muiTheme.prefix(style);
+    warning(false, `Material UI: all() is no longer used, it will be removed. Do not use it`);
+
+    const prefixer = getPrefixer();
+
+    if (prefixer) {
+      return prefixer.prefix(style);
     } else {
-      warning(false, `Material UI: you need to provide the muiTheme to the autoPrefix.all()`);
-
-      const prefixer = getPrefixer();
-
-      if (prefixer) {
-        return prefixer.prefix(style);
-      } else {
-        return InlineStylePrefixer.prefixAll(style);
-      }
+      return InlineStylePrefixer.prefixAll(style);
     }
   },
 

--- a/src/styles/auto-prefix.js
+++ b/src/styles/auto-prefix.js
@@ -5,18 +5,19 @@ const prefixers = {};
 
 let hasWarnedAboutNavigator = false;
 
-function getPrefixer() {
-  // Server-side renderer needs to supply user agent
-  if (typeof navigator === 'undefined' && !hasWarnedAboutNavigator) {
-    warning(false, `Material-UI expects the global navigator.userAgent to be defined
-      for server-side rendering. Set this property when receiving the request headers.`);
+function getPrefixer(userAgent) {
+  if (typeof navigator !== 'undefined') {
+    userAgent = navigator.userAgent;
+  }
+
+  if (userAgent === null && !hasWarnedAboutNavigator) {
+    warning(false, `Material-UI: userAgent should be supplied in the muiTheme context
+      for server-side rendering.`);
 
     hasWarnedAboutNavigator = true;
 
     return null;
   }
-
-  const userAgent = navigator.userAgent;
 
   // Get prefixing instance for this user agent
   let prefixer = prefixers[userAgent];
@@ -34,38 +35,60 @@ function getPrefixer() {
 export default {
 
   getPrefixer() {
-    warning(false, `getPrefixer() is private to this lib. Do not use it.`);
+    warning(false, `Material UI: getPrefixer() is private to this lib. Do not use it.`);
     return getPrefixer();
   },
 
-  all(style) {
+  getTransform(userAgent) {
+    const prefixer = getPrefixer(userAgent);
+
+    if (prefixer) {
+      return prefixer.prefix;
+    } else {
+      return InlineStylePrefixer.prefixAll;
+    }
+  },
+
+  all(style, muiTheme) {
     if (!style) {
       return {};
     }
 
-    const prefixer = getPrefixer();
-
-    if (prefixer) {
-      return prefixer.prefix(style);
+    if (muiTheme) {
+      return muiTheme.prefix(style);
     } else {
-      return InlineStylePrefixer.prefixAll(style);
+      warning(false, `Material UI: you need to provide the muiTheme to the autoPrefix.all()`);
+
+      const prefixer = getPrefixer();
+
+      if (prefixer) {
+        return prefixer.prefix(style);
+      } else {
+        return InlineStylePrefixer.prefixAll(style);
+      }
     }
   },
 
-  set(style, key, value) {
+  set(style, key, value, muiTheme) {
     style[key] = value;
 
-    const prefixer = getPrefixer();
-
-    if (prefixer) {
-      style = prefixer.prefix(style);
+    if (muiTheme) {
+      style = muiTheme.prefix(style);
     } else {
-      style = InlineStylePrefixer.prefixAll(style);
+      warning(false, `Material UI: you need to provide the muiTheme to the autoPrefix.set()`);
+
+      const prefixer = getPrefixer();
+
+      if (prefixer) {
+        style = prefixer.prefix(style);
+      } else {
+        style = InlineStylePrefixer.prefixAll(style);
+      }
     }
   },
 
   getPrefix(key) {
-    warning(false, `getPrefix() is no longer used, it will be removed. Do not use it`);
+    warning(false, `Material UI: getPrefix() is no longer used, it will be removed. Do not use it`);
 
     let style = {};
     style[key] = true;

--- a/src/styles/auto-prefix.js
+++ b/src/styles/auto-prefix.js
@@ -3,28 +3,39 @@ import warning from 'warning';
 
 const prefixers = {};
 
+let hasWarnedAboutNavigator = false;
+
+function getPrefixer() {
+  // Server-side renderer needs to supply user agent
+  if (typeof navigator === 'undefined' && !hasWarnedAboutNavigator) {
+    warning(false, `Material-UI expects the global navigator.userAgent to be defined
+      for server-side rendering. Set this property when receiving the request headers.`);
+
+    hasWarnedAboutNavigator = true;
+
+    return null;
+  }
+
+  const userAgent = navigator.userAgent;
+
+  // Get prefixing instance for this user agent
+  let prefixer = prefixers[userAgent];
+  // None found, create a new instance
+  if (!prefixer) {
+    prefixer = new InlineStylePrefixer({
+      userAgent: userAgent,
+    });
+    prefixers[userAgent] = prefixer;
+  }
+
+  return prefixer;
+}
+
 export default {
 
   getPrefixer() {
-    // Server-side renderer needs to supply user agent
-    if (typeof navigator === 'undefined') {
-      warning(false, `Material-UI expects the global navigator.userAgent to be defined
-        for server-side rendering. Set this property when receiving the request headers.`);
-
-      return null;
-    }
-
-    const userAgent = navigator.userAgent;
-
-    // Get prefixing instance for this user agent
-    let prefixer = prefixers[userAgent];
-    // None found, create a new instance
-    if (!prefixer) {
-      prefixer = new InlineStylePrefixer({userAgent: userAgent});
-      prefixers[userAgent] = prefixer;
-    }
-
-    return prefixer;
+    warning(false, `getPrefixer() is private to this lib. Do not use it.`);
+    return getPrefixer();
   },
 
   all(style) {
@@ -32,7 +43,7 @@ export default {
       return {};
     }
 
-    const prefixer = this.getPrefixer();
+    const prefixer = getPrefixer();
 
     if (prefixer) {
       return prefixer.prefix(style);
@@ -44,7 +55,7 @@ export default {
   set(style, key, value) {
     style[key] = value;
 
-    const prefixer = this.getPrefixer();
+    const prefixer = getPrefixer();
 
     if (prefixer) {
       style = prefixer.prefix(style);
@@ -54,10 +65,12 @@ export default {
   },
 
   getPrefix(key) {
+    warning(false, `getPrefix() is no longer used, it will be removed. Do not use it`);
+
     let style = {};
     style[key] = true;
 
-    const prefixer = this.getPrefixer();
+    const prefixer = getPrefixer();
     let prefixes;
 
     if (prefixer) {

--- a/src/styles/auto-prefix.js
+++ b/src/styles/auto-prefix.js
@@ -3,50 +3,56 @@ import warning from 'warning';
 
 const prefixers = {};
 
-let hasWarnedAboutNavigator = false;
-
-function getPrefixer(userAgent) {
-  if (typeof navigator !== 'undefined') {
-    userAgent = navigator.userAgent;
-  }
-
-  if (userAgent === null && !hasWarnedAboutNavigator) {
-    warning(false, `Material-UI: userAgent should be supplied in the muiTheme context
-      for server-side rendering.`);
-
-    hasWarnedAboutNavigator = true;
-
-    return null;
-  }
-
-  // Get prefixing instance for this user agent
-  let prefixer = prefixers[userAgent];
-  // None found, create a new instance
-  if (!prefixer) {
-    prefixer = new InlineStylePrefixer({
-      userAgent: userAgent,
-    });
-    prefixers[userAgent] = prefixer;
-  }
-
-  return prefixer;
-}
+let hasWarnedAboutUserAgent = false;
 
 export default {
 
-  getPrefixer() {
-    warning(false, `Material UI: getPrefixer() is private to this lib. Do not use it.`);
-    return getPrefixer();
+  getTransform(userAgent) {
+    if (userAgent === undefined && typeof navigator !== 'undefined') {
+      userAgent = navigator.userAgent;
+    }
+
+    if (userAgent === undefined && !hasWarnedAboutUserAgent) {
+      warning(false, `Material UI: userAgent should be supplied in the muiTheme context
+        for server-side rendering.`);
+
+      hasWarnedAboutUserAgent = true;
+    }
+
+    if (userAgent === false) { // Disabled autoprefixer
+      return (style) => style;
+    } else if (userAgent === 'all' || userAgent === undefined) { // Prefix for all user agent
+      return InlineStylePrefixer.prefixAll;
+    } else {
+      const prefixer = new InlineStylePrefixer({
+        userAgent: userAgent,
+      });
+
+      return prefixer.prefix;
+    }
   },
 
-  getTransform(userAgent) {
-    const prefixer = getPrefixer(userAgent);
+  getPrefixer() {
+    warning(false, `Material UI: getPrefixer() is no longer used. Do not use it.`);
 
-    if (prefixer) {
-      return prefixer.prefix;
-    } else {
-      return InlineStylePrefixer.prefixAll;
+    if (typeof navigator === 'undefined') {
+      warning(false, `Material UI expects the global navigator.userAgent to be defined
+        for server-side rendering. Set this property when receiving the request headers.`);
+
+      return null;
     }
+
+    const userAgent = navigator.userAgent;
+
+    // Get prefixing instance for this user agent
+    let prefixer = prefixers[userAgent];
+    // None found, create a new instance
+    if (!prefixer) {
+      prefixer = new InlineStylePrefixer({userAgent: userAgent});
+      prefixers[userAgent] = prefixer;
+    }
+
+    return prefixer;
   },
 
   all(style) {
@@ -56,7 +62,7 @@ export default {
 
     warning(false, `Material UI: all() is no longer used, it will be removed. Do not use it`);
 
-    const prefixer = getPrefixer();
+    const prefixer = this.getPrefixer();
 
     if (prefixer) {
       return prefixer.prefix(style);
@@ -73,7 +79,7 @@ export default {
     } else {
       warning(false, `Material UI: you need to provide the muiTheme to the autoPrefix.set()`);
 
-      const prefixer = getPrefixer();
+      const prefixer = this.getPrefixer();
 
       if (prefixer) {
         style = prefixer.prefix(style);
@@ -89,7 +95,7 @@ export default {
     let style = {};
     style[key] = true;
 
-    const prefixer = getPrefixer();
+    const prefixer = this.getPrefixer();
     let prefixes;
 
     if (prefixer) {

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -20,7 +20,7 @@ export default function getMuiTheme(baseTheme, muiTheme) {
 
   muiTheme = merge({
     isRtl: false,
-    userAgent: null,
+    userAgent: undefined,
     zIndex,
     baseTheme,
     rawTheme: baseTheme, // To provide backward compatibility.

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -1,6 +1,7 @@
 import merge from 'lodash.merge';
 import Colors from './colors';
 import ColorManipulator from '../utils/color-manipulator';
+import autoPrefix from './auto-prefix';
 import lightBaseTheme from './baseThemes/lightBaseTheme';
 import zIndex from './zIndex';
 
@@ -12,10 +13,14 @@ import zIndex from './zIndex';
  */
 export default function getMuiTheme(baseTheme, muiTheme) {
   baseTheme = merge({}, lightBaseTheme, baseTheme);
-  const {palette, spacing} = baseTheme;
+  const {
+    palette,
+    spacing,
+  } = baseTheme;
 
-  return merge({
+  muiTheme = merge({
     isRtl: false,
+    userAgent: null,
     zIndex,
     baseTheme,
     rawTheme: baseTheme, // To provide backward compatibility.
@@ -224,4 +229,8 @@ export default function getMuiTheme(baseTheme, muiTheme) {
       borderColor: palette.borderColor,
     },
   }, muiTheme);
+
+  muiTheme.prefix = autoPrefix.getTransform(muiTheme.userAgent);
+
+  return muiTheme;
 }

--- a/src/transition-groups/scale-in-child.jsx
+++ b/src/transition-groups/scale-in-child.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import StylePropable from '../mixins/style-propable';
-import AutoPrefix from '../styles/auto-prefix';
+import autoPrefix from '../styles/auto-prefix';
 import Transitions from '../styles/transitions';
 import DefaultRawTheme from '../styles/raw-themes/light-raw-theme';
 import ThemeManager from '../styles/theme-manager';
@@ -83,7 +83,7 @@ const ScaleInChild = React.createClass({
     let style = ReactDOM.findDOMNode(this).style;
 
     style.opacity = '0';
-    AutoPrefix.set(style, 'transform', 'scale(' + this.props.minScale + ')');
+    autoPrefix.set(style, 'transform', 'scale(' + this.props.minScale + ')');
 
     setTimeout(() => {
       if (this.isMounted()) callback();
@@ -94,14 +94,14 @@ const ScaleInChild = React.createClass({
     let style = ReactDOM.findDOMNode(this).style;
 
     style.opacity = '1';
-    AutoPrefix.set(style, 'transform', 'scale(' + this.props.maxScale + ')');
+    autoPrefix.set(style, 'transform', 'scale(' + this.props.maxScale + ')');
   },
 
   _initializeAnimation(callback) {
     let style = ReactDOM.findDOMNode(this).style;
 
     style.opacity = '0';
-    AutoPrefix.set(style, 'transform', 'scale(0)');
+    autoPrefix.set(style, 'transform', 'scale(0)');
 
     setTimeout(() => {
       if (this.isMounted()) callback();

--- a/src/transition-groups/scale-in-child.jsx
+++ b/src/transition-groups/scale-in-child.jsx
@@ -83,7 +83,7 @@ const ScaleInChild = React.createClass({
     let style = ReactDOM.findDOMNode(this).style;
 
     style.opacity = '0';
-    autoPrefix.set(style, 'transform', 'scale(' + this.props.minScale + ')');
+    autoPrefix.set(style, 'transform', 'scale(' + this.props.minScale + ')', this.state.muiTheme);
 
     setTimeout(() => {
       if (this.isMounted()) callback();
@@ -94,14 +94,14 @@ const ScaleInChild = React.createClass({
     let style = ReactDOM.findDOMNode(this).style;
 
     style.opacity = '1';
-    autoPrefix.set(style, 'transform', 'scale(' + this.props.maxScale + ')');
+    autoPrefix.set(style, 'transform', 'scale(' + this.props.maxScale + ')', this.state.muiTheme);
   },
 
   _initializeAnimation(callback) {
     let style = ReactDOM.findDOMNode(this).style;
 
     style.opacity = '0';
-    autoPrefix.set(style, 'transform', 'scale(0)');
+    autoPrefix.set(style, 'transform', 'scale(0)', this.state.muiTheme);
 
     setTimeout(() => {
       if (this.isMounted()) callback();

--- a/src/transition-groups/slide-in-child.jsx
+++ b/src/transition-groups/slide-in-child.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import StylePropable from '../mixins/style-propable';
-import AutoPrefix from '../styles/auto-prefix';
+import autoPrefix from '../styles/auto-prefix';
 import Transitions from '../styles/transitions';
 import DefaultRawTheme from '../styles/raw-themes/light-raw-theme';
 import ThemeManager from '../styles/theme-manager';
@@ -67,7 +67,7 @@ const SlideInChild = React.createClass({
       this.props.direction === 'down' ? '-100%' : '0';
 
     style.opacity = '0';
-    AutoPrefix.set(style, 'transform', 'translate3d(' + x + ',' + y + ',0)');
+    autoPrefix.set(style, 'transform', 'translate3d(' + x + ',' + y + ',0)');
 
     setTimeout(() => {
       if (this.isMounted()) callback();
@@ -77,7 +77,7 @@ const SlideInChild = React.createClass({
   componentDidEnter() {
     let style = ReactDOM.findDOMNode(this).style;
     style.opacity = '1';
-    AutoPrefix.set(style, 'transform', 'translate3d(0,0,0)');
+    autoPrefix.set(style, 'transform', 'translate3d(0,0,0)');
   },
 
   componentWillLeave(callback) {
@@ -89,7 +89,7 @@ const SlideInChild = React.createClass({
       direction === 'down' ? '100%' : '0';
 
     style.opacity = '0';
-    AutoPrefix.set(style, 'transform', 'translate3d(' + x + ',' + y + ',0)');
+    autoPrefix.set(style, 'transform', 'translate3d(' + x + ',' + y + ',0)');
 
     setTimeout(() => {
       if (this.isMounted()) callback();

--- a/src/transition-groups/slide-in-child.jsx
+++ b/src/transition-groups/slide-in-child.jsx
@@ -67,7 +67,7 @@ const SlideInChild = React.createClass({
       this.props.direction === 'down' ? '-100%' : '0';
 
     style.opacity = '0';
-    autoPrefix.set(style, 'transform', 'translate3d(' + x + ',' + y + ',0)');
+    autoPrefix.set(style, 'transform', 'translate3d(' + x + ',' + y + ',0)', this.state.muiTheme);
 
     setTimeout(() => {
       if (this.isMounted()) callback();
@@ -77,7 +77,7 @@ const SlideInChild = React.createClass({
   componentDidEnter() {
     let style = ReactDOM.findDOMNode(this).style;
     style.opacity = '1';
-    autoPrefix.set(style, 'transform', 'translate3d(0,0,0)');
+    autoPrefix.set(style, 'transform', 'translate3d(0,0,0)', this.state.muiTheme);
   },
 
   componentWillLeave(callback) {
@@ -89,7 +89,7 @@ const SlideInChild = React.createClass({
       direction === 'down' ? '100%' : '0';
 
     style.opacity = '0';
-    autoPrefix.set(style, 'transform', 'translate3d(' + x + ',' + y + ',0)');
+    autoPrefix.set(style, 'transform', 'translate3d(' + x + ',' + y + ',0)', this.state.muiTheme);
 
     setTimeout(() => {
       if (this.isMounted()) callback();

--- a/src/utils/styles.js
+++ b/src/utils/styles.js
@@ -134,7 +134,7 @@ export function prepareStyles(muiTheme, style = {}, ...styles) {
   }
 
   const flipped = ensureDirection(muiTheme, style);
-  return autoPrefix.all(flipped);
+  return muiTheme.prefix(flipped);
 }
 
 export default {

--- a/src/utils/styles.js
+++ b/src/utils/styles.js
@@ -1,4 +1,4 @@
-import AutoPrefix from '../styles/auto-prefix';
+import autoPrefix from '../styles/auto-prefix';
 import update from 'react-addons-update';
 import warning from 'warning';
 
@@ -113,7 +113,7 @@ export function mergeStyles(base, ...args) {
 export function mergeAndPrefix(...args) {
   warning(false, 'Use of mergeAndPrefix() has been deprecated. ' +
     'Please use mergeStyles() for merging styles, and then prepareStyles() for prefixing and ensuring direction.');
-  return AutoPrefix.all(mergeStyles(...args));
+  return autoPrefix.all(mergeStyles(...args));
 }
 
 /**
@@ -134,7 +134,7 @@ export function prepareStyles(muiTheme, style = {}, ...styles) {
   }
 
   const flipped = ensureDirection(muiTheme, style);
-  return AutoPrefix.all(flipped);
+  return autoPrefix.all(flipped);
 }
 
 export default {


### PR DESCRIPTION
This PR introduce many changes.
- This prevent to be flooded by the warnings when using Material UI fo SSR.
```
Warning: Material UI: userAgent should be supplied in the muiTheme context
        for server-side rendering.
Warning: Material UI: userAgent should be supplied in the muiTheme context
        for server-side rendering.
Warning: Material UI: userAgent should be supplied in the muiTheme context
        for server-side rendering.
Warning: Material UI: userAgent should be supplied in the muiTheme context
        for server-side rendering.
Warning: Material UI: userAgent should be supplied in the muiTheme context
        for server-side rendering.
```
- The prefixer transform is moved to the context.
- We can now provide a `userAgent` variable to the `muiTheme`. We can use the following values:
 - a regular user agent like `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.82 Safari/537.36`
 - `'all'` to prefix for all user agents
 - `false` to disable the prefixer
- Deprecate the usage of `autoPrefixer.all()`
- Deprecate the usage of `autoPrefixer.getPrefixer()`
- Deprecate the usage of `autoPrefixer.getPrefix()`

Fix https://github.com/callemall/material-ui/issues/2530, https://github.com/callemall/material-ui/issues/2336 and https://github.com/callemall/material-ui/issues/2316.