### PR TITLE
[IconButton] Fixed tooltip ripple size for IE

### DIFF
--- a/src/icon-button.jsx
+++ b/src/icon-button.jsx
@@ -17,6 +17,7 @@ function getStyles(props, state) {
     root: {
       position: 'relative',
       boxSizing: 'border-box',
+      overflow: 'visible',
       transition: Transitions.easeOut(),
       padding: baseTheme.spacing.iconSize / 2,
       width: baseTheme.spacing.iconSize * 2,

--- a/src/tooltip.jsx
+++ b/src/tooltip.jsx
@@ -136,10 +136,10 @@ const Tooltip = React.createClass({
 
   _setRippleSize() {
     const ripple = this.refs.ripple;
-    const tooltip = window.getComputedStyle(this.refs.tooltip);
-    let tooltipWidth = parseInt(tooltip.getPropertyValue('width'), 10) /
+    const tooltip = this.refs.tooltip;
+    let tooltipWidth = parseInt(tooltip.offsetWidth, 10) /
       (this.props.horizontalPosition === 'center' ? 2 : 1);
-    let tooltipHeight = parseInt(tooltip.getPropertyValue('height'), 10);
+    let tooltipHeight = parseInt(tooltip.offsetHeight, 10);
 
     let rippleDiameter = Math.ceil((Math.sqrt(Math.pow(tooltipHeight, 2) +
                                     Math.pow(tooltipWidth, 2) ) * 2));


### PR DESCRIPTION
![ie-ripple-issue](https://cloud.githubusercontent.com/assets/7115401/12521441/b2018b28-c118-11e5-89b5-7e10df9174e3.png)

Issue was caused by `window.getComputedStyle` not getting the right width in IE (For some reason). `offsetWidth` is giving the right width across browsers.