### PR TITLE
[Doc] Divider - Fixes form example to use showUnderline prop instead of underlineStyle

### DIFF
--- a/docs/src/app/components/pages/components/Divider/ExampleForm.jsx
+++ b/docs/src/app/components/pages/components/Divider/ExampleForm.jsx
@@ -3,23 +3,19 @@ import Divider from 'material-ui/lib/divider';
 import Paper from 'material-ui/lib/paper';
 import TextField from 'material-ui/lib/text-field';
 
-const underlineStyle = {
-  display: 'none',
-};
-
 const style = {
   marginLeft: 20,
 };
 
 const DividerExampleForm = () => (
   <Paper zDepth={2}>
-    <TextField hintText="First name" underlineStyle={underlineStyle} style={style} />
+    <TextField hintText="First name" style={style} underlineShow={false} />
     <Divider />
-    <TextField hintText="Middle name" underlineStyle={underlineStyle} style={style} />
+    <TextField hintText="Middle name" style={style} underlineShow={false} />
     <Divider />
-    <TextField hintText="Last name" underlineStyle={underlineStyle} style={style} />
+    <TextField hintText="Last name" style={style} underlineShow={false} />
     <Divider />
-    <TextField hintText="Email address" underlineStyle={underlineStyle} style={style} />
+    <TextField hintText="Email address" style={style} underlineShow={false} />
     <Divider />
   </Paper>
 );


### PR DESCRIPTION
Forgot to update this example after implementing optional underline for TextField.