### PR TITLE
toolbar-group.jsx firstChild s/left gap/right gap

### DIFF
--- a/src/toolbar/toolbar-group.jsx
+++ b/src/toolbar/toolbar-group.jsx
@@ -18,7 +18,7 @@ const ToolbarGroup = React.createClass({
 
     /**
      * Set this to true for if the `ToolbarGroup` is the first child of `Toolbar`
-     * to prevent setting the right gap.
+     * to prevent setting the left gap.
      */
     firstChild: React.PropTypes.bool,
 


### PR DESCRIPTION
Fix typo, `firstChild` should prevent setting of left gap rather than right gap