### PR TITLE
[Divider] Fixes code formatting conventions for Divider component

### DIFF
--- a/src/divider.jsx
+++ b/src/divider.jsx
@@ -4,14 +4,20 @@ import {mergeStyles, prepareStyles} from './utils/styles';
 
 const propTypes = {
   /**
-   * CSS class that will be added to the divider's root element
+   * The css class name of the root element.
    */
   className: React.PropTypes.string,
 
   /**
-   * If true, the divider will be indented 72px
+   * If true, the `Divider` will be indented `72px`.
    */
   inset: React.PropTypes.bool,
+
+  /**
+   * The material-ui theme applied to this component.
+   * @ignore
+   */
+  muiTheme: React.PropTypes.object.isRequired,
 
   /**
    * Override the inline-styles of the root element.
@@ -23,7 +29,14 @@ const defaultProps = {
   inset: false,
 };
 
-let Divider = ({inset, muiTheme, style, ...other}) => {
+let Divider = (props) => {
+  const {
+    inset,
+    muiTheme,
+    style,
+    ...other,
+  } = props;
+
   const styles = {
     root: {
       margin: 0,


### PR DESCRIPTION
This commit changes a few code formatting conventions, primarily as it relates where to destructure props, as we discussed when implementing the Subheader component.