### PR TITLE
[Core] Implements warning for 'react-tap-event-plugin' if not registered

### DIFF
--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -4,6 +4,7 @@ import ColorManipulator from '../utils/color-manipulator';
 import autoPrefix from './auto-prefix';
 import lightBaseTheme from './baseThemes/lightBaseTheme';
 import zIndex from './zIndex';
+import checkTapEventPlugin from '../utils/checkTapEventPlugin';
 
 /**
  * Get the MUI theme corresponding to a base theme.
@@ -12,6 +13,8 @@ import zIndex from './zIndex';
  * theme will be deeply merged with the second argument.
  */
 export default function getMuiTheme(baseTheme, muiTheme) {
+  if (process.env.NODE_ENV !== 'production') checkTapEventPlugin();
+
   baseTheme = merge({}, lightBaseTheme, baseTheme);
   const {
     palette,

--- a/src/utils/checkTapEventPlugin.js
+++ b/src/utils/checkTapEventPlugin.js
@@ -1,0 +1,17 @@
+import EventPluginRegistry from 'react/lib/EventPluginRegistry';
+import warning from 'warning';
+
+export default function checkTapEventPlugin() {
+  if (EventPluginRegistry && EventPluginRegistry.eventNameDispatchConfigs) {
+    warning(EventPluginRegistry.eventNameDispatchConfigs.touchTap,
+      `
+      The 'react-tap-event-plugin' has not been registered!
+
+      Material-UI requires that you load 'react-tap-event-plugin' and call 'injectTapEventPlugin()' for
+      components receive touch events and work properly.
+
+      See https://github.com/zilverline/react-tap-event-plugin for more details.
+      `
+    );
+  }
+}


### PR DESCRIPTION
Closes #2553.

This check should help a lot of new material-ui developers catch the infamous "forgot to call `injectTapEventPlugin()`" issue.

Probably related to a number of issues.

<img width="763" alt="check-tap-event-plugin" src="https://cloud.githubusercontent.com/assets/344018/12607873/26ad8dba-c4a6-11e5-8880-4e247d07512b.png">
