### PR TITLE
[Docs] Fix TableRow that was displaying the Table PropType

### DIFF
--- a/docs/src/app/components/pages/components/Table/Page.jsx
+++ b/docs/src/app/components/pages/components/Table/Page.jsx
@@ -5,12 +5,12 @@ import MarkdownElement from '../../../MarkdownElement';
 
 import tableReadmeText from './README';
 import tableCode from '!raw!material-ui/lib/table/table';
-import tableRowCode from '!raw!material-ui/lib/table/table';
+import tableRowCode from '!raw!material-ui/lib/table/table-row';
+import tableRowColumnCode from '!raw!material-ui/lib/table/table-row-column';
+import tableHeaderCode from '!raw!material-ui/lib/table/table-header';
+import tableHeaderColumnCode from '!raw!material-ui/lib/table/table-header-column';
 import tableBodyCode from '!raw!material-ui/lib/table/table-body';
 import tableFooterCode from '!raw!material-ui/lib/table/table-footer';
-import tableHeaderColumnCode from '!raw!material-ui/lib/table/table-header-column';
-import tableHeaderCode from '!raw!material-ui/lib/table/table-header';
-import tableRowColumnCode from '!raw!material-ui/lib/table/table-row-column';
 import TableExampleSimple from './ExampleSimple';
 import tableExampleSimpleCode from '!raw!./ExampleSimple';
 import TableExampleComplex from './ExampleComplex';
@@ -39,12 +39,12 @@ const TablePage = () => (
       <TableExampleComplex />
     </CodeExample>
     <PropTypeDescription code={tableCode} header="### Table Properties" />
+    <PropTypeDescription code={tableRowCode} header="### TableRow Properties" />
+    <PropTypeDescription code={tableRowColumnCode} header="### TableRowColumn Properties" />
+    <PropTypeDescription code={tableHeaderCode} header="### TableHeader Properties" />
+    <PropTypeDescription code={tableHeaderColumnCode} header="### TableHeaderColumn Properties" />
     <PropTypeDescription code={tableBodyCode} header="### TableBody Properties" />
     <PropTypeDescription code={tableFooterCode} header="### TableFooter Properties" />
-    <PropTypeDescription code={tableHeaderColumnCode} header="### TableHeaderColumn Properties" />
-    <PropTypeDescription code={tableHeaderCode} header="### TableHeader Properties" />
-    <PropTypeDescription code={tableRowColumnCode} header="### TableRowColumn Properties" />
-    <PropTypeDescription code={tableRowCode} header="### TableRow Properties" />
   </div>
 );
 


### PR DESCRIPTION
https://github.com/callemall/material-ui/pull/3048 make me realize that the `TableRow Properties` table are the properties of the `Table` not `TableRow`. I have also changed the order of the components.