### PR TITLE
[Docs] GridList - Fixed broken path in StarBorder import

### DIFF
--- a/docs/src/app/components/pages/components/GridList/ExampleSimple.jsx
+++ b/docs/src/app/components/pages/components/GridList/ExampleSimple.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import GridList from 'material-ui/lib/grid-list/grid-list';
 import GridTile from 'material-ui/lib/grid-list/grid-tile';
-import StarBorder from 'material-ui/svg-icons/toggle/star-border';
+import StarBorder from 'material-ui/lib/svg-icons/toggle/star-border';
 import IconButton from 'material-ui/lib/icon-button';
 
 const styles = {


### PR DESCRIPTION
## Current Behavior
The code in the _Simple Example_ in the [Grid List docs](http://www.material-ui.com/#/components/grid-list) had a small typo and was missing a `/lib` in an import statement (highlighted below):

<img width="643" alt="screen shot 2016-01-27 at 11 10 08 am" src="https://cloud.githubusercontent.com/assets/2514127/12619557/9053b114-c4e6-11e5-8c10-f2cac17795fb.png">

This points to a path that does not exist and causes an error if you copy/paste into your project. 
