### PR TITLE
[Core] Remove babel-plugin-transform-decorators-legacy

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,6 @@
 {
   "presets": ["es2015", "stage-1", "react"],
   "plugins": [
-    "transform-decorators-legacy",
     "transform-dev-warning",
     "add-module-exports"
   ],

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "babel-eslint": "^5.0.0-beta6",
     "babel-loader": "^6.2.0",
     "babel-plugin-add-module-exports": "^0.1.2",
-    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-dev-warning": "^0.1.0",
     "babel-plugin-transform-react-constant-elements": "^6.3.13",
     "babel-plugin-transform-react-inline-elements": "^6.3.13",

--- a/test/theming-v12-spec.js
+++ b/test/theming-v12-spec.js
@@ -76,7 +76,7 @@ describe('Theming', () => {
     describe('using theme decorator, AppBar', () => {
 
       it('should display with passed down dark theme', () => {
-        let renderedAppbar = TestUtils.renderIntoDocument(<AppBarDarkUsingDecorator />);
+        let renderedAppbar = TestUtils.renderIntoDocument(<AppBarDarkTheme />);
         let appbarDivs = TestUtils.scryRenderedDOMComponentsWithTag(renderedAppbar, 'div');
         let firstDiv = appbarDivs[0];
 
@@ -84,7 +84,7 @@ describe('Theming', () => {
       });
 
       it('should display with passed down dark theme and overriden specific attribute', () => {
-        let renderedAppbar = TestUtils.renderIntoDocument(<AppBarDarkUsingDecoratorWithOverride />);
+        let renderedAppbar = TestUtils.renderIntoDocument(<AppBarDarkThemeOverride />);
         let appbarDivs = TestUtils.scryRenderedDOMComponentsWithTag(renderedAppbar, 'div');
         let firstDiv = appbarDivs[0];
 
@@ -166,27 +166,20 @@ const AppBarDarkUsingContextWithOverride = React.createClass({
   },
 });
 
-//react components used decorator-theme-passing texting
-let darkMuiTheme = getMuiTheme(DarkRawTheme);
 
-@ThemeDecorator(darkMuiTheme)
-class AppBarDarkUsingDecorator extends React.Component
-{
-  render() {
-    return (<AppBar />);
-  }
-}
+const darkMuiTheme = getMuiTheme(DarkRawTheme);
+const AppBarDarkTheme = ThemeDecorator(darkMuiTheme)(AppBar);
 
-let darkMuiThemeWithOverride = getMuiTheme(DarkRawTheme);
-darkMuiThemeWithOverride.appBar.textColor = Colors.deepPurpleA700;
+const AppBarTitle = () => (
+  <AppBar title="My AppBar" />
+);
 
-@ThemeDecorator(darkMuiThemeWithOverride)
-class AppBarDarkUsingDecoratorWithOverride extends React.Component
-{
-  render() {
-    return (<AppBar title="My AppBar"/>);
-  }
-}
+const darkMuiThemeWithOverride = getMuiTheme(DarkRawTheme, {
+  appBar: {
+    textColor: Colors.deepPurpleA700,
+  },
+});
+const AppBarDarkThemeOverride = ThemeDecorator(darkMuiThemeWithOverride)(AppBarTitle);
 
 //react component used to test whether or not theme updates down the hierarchy
 const ButtonToUpdateThemeWithAppBar = React.createClass({


### PR DESCRIPTION
As far as I know, that's no longer a candidate for the ES7 specification (removed from babel 6) and it's only used in one file.