### PR TITLE
[ES6] Apply jscodeshift to use classes

### DIFF
--- a/docs/src/app/components/CodeExample/index.jsx
+++ b/docs/src/app/components/CodeExample/index.jsx
@@ -3,19 +3,18 @@ import CodeBlock from './CodeBlock';
 import ClearFix from 'material-ui/lib/clearfix';
 import Paper from 'material-ui/lib/paper';
 
-const CodeExample = React.createClass({
-
-  propTypes: {
+class CodeExample extends React.Component {
+  static propTypes = {
     children: React.PropTypes.node,
     code: React.PropTypes.string.isRequired,
     description: React.PropTypes.string,
     layoutSideBySide: React.PropTypes.bool,
     title: React.PropTypes.string,
-  },
+  };
 
-  contextTypes: {
+  static contextTypes = {
     muiTheme: React.PropTypes.object,
-  },
+  };
 
   render() {
 
@@ -48,7 +47,7 @@ const CodeExample = React.createClass({
         <ClearFix style={styles.exampleBlock}>{children}</ClearFix>
       </Paper>
     );
-  },
-});
+  }
+}
 
 export default CodeExample;

--- a/docs/src/app/components/pages/customization/inline-styles.jsx
+++ b/docs/src/app/components/pages/customization/inline-styles.jsx
@@ -5,8 +5,7 @@ import CodeExample from '../../CodeExample';
 const {Typography} = Styles;
 
 
-const InlineStyles = React.createClass({
-
+class InlineStyles extends React.Component {
   getStyles() {
     return {
       headline: {
@@ -28,7 +27,7 @@ const InlineStyles = React.createClass({
         color: Typography.textDarkBlack,
       },
     };
-  },
+  }
 
   render() {
     let codeOverrideStyles =
@@ -125,8 +124,7 @@ const InlineStyles = React.createClass({
         </p>
       </div>
     );
-  },
-
-});
+  }
+}
 
 export default InlineStyles;

--- a/src/date-picker/date-picker-inline.jsx
+++ b/src/date-picker/date-picker-inline.jsx
@@ -19,9 +19,8 @@ const styles = {
   },
 };
 
-const DatePickerInline = React.createClass({
-
-  propTypes: {
+class DatePickerInline extends React.Component {
+  static propTypes = {
     actions: React.PropTypes.node,
     children: React.PropTypes.node,
     open: React.PropTypes.bool,
@@ -30,13 +29,11 @@ const DatePickerInline = React.createClass({
      * Override the inline-styles of the root element.
      */
     style: React.PropTypes.object,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      open: false,
-    };
-  },
+  static defaultProps = {
+    open: false,
+  };
 
   render() {
     const {
@@ -63,8 +60,7 @@ const DatePickerInline = React.createClass({
         </div>
       </div>
     );
-  },
-
-});
+  }
+}
 
 export default DatePickerInline;

--- a/src/lists/nested-list.jsx
+++ b/src/lists/nested-list.jsx
@@ -2,10 +2,8 @@ import React from 'react';
 import {mergeStyles} from '../utils/styles';
 import List from './list';
 
-
-const NestedList = React.createClass({
-
-  propTypes: {
+class NestedList extends React.Component {
+  static propTypes = {
     children: React.PropTypes.node,
     nestedLevel: React.PropTypes.number,
     open: React.PropTypes.bool,
@@ -14,14 +12,12 @@ const NestedList = React.createClass({
      * Override the inline-styles of the root element.
      */
     style: React.PropTypes.object,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      nestedLevel: 1,
-      open: false,
-    };
-  },
+  static defaultProps = {
+    nestedLevel: 1,
+    open: false,
+  };
 
   render() {
 
@@ -51,8 +47,7 @@ const NestedList = React.createClass({
         }
       </List>
     );
-  },
-
-});
+  }
+}
 
 export default NestedList;

--- a/src/tabs/tabTemplate.jsx
+++ b/src/tabs/tabTemplate.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-const TabTemplate = React.createClass({
-  propTypes: {
+class TabTemplate extends React.Component {
+  static propTypes = {
     children: React.PropTypes.node,
     selected: React.PropTypes.bool,
-  },
+  };
 
   render() {
     const styles = {
@@ -25,7 +25,7 @@ const TabTemplate = React.createClass({
         {this.props.children}
       </div>
     );
-  },
-});
+  }
+}
 
 export default TabTemplate;


### PR DESCRIPTION
We need to remove the `mixins` to convert more components.
I have also left the components that need binding of methods.
I'm using:
- https://github.com/reactjs/react-codemod/blob/master/transforms/class.js
- https://github.com/zertosh/class-props-codemod/blob/master/class-props-codemod.js

That's a small step. But we need to start slowly. Thanks @cpojer for the script!