### PR TITLE
[AutoComplete] Support onFocus and onBlur events propagation

### DIFF
--- a/src/auto-complete.jsx
+++ b/src/auto-complete.jsx
@@ -293,6 +293,8 @@ const AutoComplete = React.createClass({
       menuProps,
       listStyle,
       targetOrigin,
+      onFocus,
+      onBlur,
       ...other,
     } = this.props;
 
@@ -429,17 +431,21 @@ const AutoComplete = React.createClass({
               let searchText = e.target.value;
               this._updateRequests(searchText);
             }}
-            onBlur={() => {
+            onBlur={(e) => {
               if (this.focusOnInput && open)
                 this.refs.searchTextField.focus();
+              else if (onBlur)
+                onBlur(e);
             }}
-            onFocus={() => {
+            onFocus={(e) => {
               if (!open && (this.props.triggerUpdateOnFocus
                 || this.props.updateWhenFocused //this line will be removed in the future
                 || this.requestsList > 0)) {
                 this._updateRequests(this.state.searchText);
               }
               this.focusOnInput = true;
+              if (onFocus)
+                onFocus(e);
             }}
 
             {...textFieldProps}

--- a/src/auto-complete.jsx
+++ b/src/auto-complete.jsx
@@ -85,6 +85,16 @@ const AutoComplete = React.createClass({
     menuStyle: React.PropTypes.object,
 
     /**
+     * Callback function that is fired when the textfield loses focus.
+     */
+    onBlur: React.PropTypes.func,
+
+    /**
+     * Callback function that is fired when the textfield gains focus.
+     */
+    onFocus: React.PropTypes.func,
+
+    /**
      * Gets called when list item is clicked or pressed enter.
      */
     onNewRequest: React.PropTypes.func,


### PR DESCRIPTION
It's required to use onFocus and onBlur events over AutoComplete component:
`<AutoComplete ... onFocus={this._handleInputFocus} onBlur={this._handleInputBlur} />`

These events are propagated to TextField from AutoComplete props but are overwritten by custom handlers. So we need to support them obviously.