### PR TITLE
[AutoPrefix] Change getTrasform() to return the prefixer object

### DIFF
--- a/src/styles/auto-prefix.js
+++ b/src/styles/auto-prefix.js
@@ -1,5 +1,4 @@
 import InlineStylePrefixer from 'inline-style-prefixer';
-import update from 'react-addons-update';
 import warning from 'warning';
 
 const prefixers = {};

--- a/src/styles/auto-prefix.js
+++ b/src/styles/auto-prefix.js
@@ -1,4 +1,5 @@
 import InlineStylePrefixer from 'inline-style-prefixer';
+import update from 'react-addons-update';
 import warning from 'warning';
 
 const prefixers = {};
@@ -28,7 +29,7 @@ export default {
         userAgent: userAgent,
       });
 
-      return prefixer.prefix;
+      return prefixer;
     }
   },
 
@@ -72,21 +73,25 @@ export default {
   },
 
   set(style, key, value, muiTheme) {
-    style[key] = value;
+    let newStyle;
 
     if (muiTheme) {
-      style = muiTheme.prefix(style);
+      newStyle = muiTheme.prefixer.prefix({[key]: value});
     } else {
       warning(false, `Material-UI: you need to provide the muiTheme to the autoPrefix.set()`);
 
       const prefixer = this.getPrefixer();
 
       if (prefixer) {
-        style = prefixer.prefix(style);
+        newStyle = prefixer.prefix(style);
       } else {
-        style = InlineStylePrefixer.prefixAll(style);
+        newStyle = InlineStylePrefixer.prefixAll(style);
       }
     }
+
+    Object.keys(newStyle).forEach(function(newKey) {
+      style[newKey] = newStyle[newKey];
+    });
   },
 
   getPrefix(key) {

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -240,7 +240,7 @@ export default function getMuiTheme(baseTheme, muiTheme) {
     },
   }, muiTheme);
 
-  muiTheme.prefix = autoPrefix.getTransform(muiTheme.userAgent);
+  muiTheme.prefixer = autoPrefix.getTransform(muiTheme.userAgent);
 
   return muiTheme;
 }

--- a/src/utils/styles.js
+++ b/src/utils/styles.js
@@ -134,7 +134,7 @@ export function prepareStyles(muiTheme, style = {}, ...styles) {
   }
 
   const flipped = ensureDirection(muiTheme, style);
-  return muiTheme.prefix(flipped);
+  return muiTheme.prefixer.prefix(flipped);
 }
 
 export default {


### PR DESCRIPTION
I believe there are three problems with the AutoPrefix module:

1. The *getTransform()* method is returning the *prefix()* method from the *Prefixer* class. This will not work since [inline-style-prefixer](https://github.com/rofrischmann/inline-style-prefixer/blob/master/modules/Prefixer.js) has statements like this one: 

        if (!this._hasPropsRequiringPrefix) {
          return styles
        }
When one calls *muiTheme.prefix()* he is actually setting the *this* keyword to the *muiTheme* object (so, *this._hasPropsRequiringPrefix* would be undefined). This is a big problem because it means that none of the styles transformations being called with *set()* is working.

2. The *set()* method has the signature: *set(style, key, value, muiTheme)*. Then, inside of it there are some piece of code like this:

        style = muiTheme.prefix(style);
This will not work because it is being passed a reference to the style object, so when you assign a new value to it we are actually loosing the reference to the original object and not changing anything at all in the caller.

3. As a setter the set function should not pass the entire style object to the prefix method, because inside of [its code](https://github.com/rofrischmann/inline-style-prefixer/blob/master/modules/Prefixer.js) it has:

        Object.keys(styles).forEach(property => {...}
So *prefix()* will iterate though all the style properties.

Obs: in the *all()* method inside the AutoPrefix module there are statements returning the object created by *InlineStylePrefixerInstance.prefix()*. That approach would not work for the set method because material-ui has statements like this one:

    let style = ReactDOM.findDOMNode(this).style;

The style object returned by a DOM element is actually a [CSSStyleDeclaration](https://drafts.csswg.org/cssom/#the-cssstyledeclaration-interface) and not a conventional Javascript object so one definetelly can not override it with the return object from *InlineStylePrefixerInstance.prefix()*.