### PR TITLE
[Core] Replace merge implementation in utils/styles with Object.assign

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": ["es2015", "stage-1", "react"],
   "plugins": [
+    ["transform-replace-object-assign", "simple-assign"],
     "transform-dev-warning",
     "add-module-exports"
   ],

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-addons-pure-render-mixin": "^0.14.0",
     "react-addons-transition-group": "^0.14.0",
     "react-addons-update": "^0.14.0",
+    "simple-assign": "^0.1.0",
     "warning": "^2.1.0"
   },
   "peerDependencies": {
@@ -55,6 +56,7 @@
     "babel-plugin-transform-react-constant-elements": "^6.3.13",
     "babel-plugin-transform-react-inline-elements": "^6.3.13",
     "babel-plugin-transform-react-remove-prop-types": "^0.1.0",
+    "babel-plugin-transform-replace-object-assign": "^0.2.1",
     "babel-polyfill": "^6.3.14",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",

--- a/src/utils/styles.js
+++ b/src/utils/styles.js
@@ -1,21 +1,7 @@
 import autoPrefix from '../styles/auto-prefix';
-import update from 'react-addons-update';
 import warning from 'warning';
 
-function mergeSingle(objA, objB) {
-  if (!objA) return objB;
-  if (!objB) return objA;
-  return update(objA, {$merge: objB});
-}
-
-export function mergeStyles(base, ...args) {
-  for (let i = 0; i < args.length; i++) {
-    if (args[i]) {
-      base = mergeSingle(base, args[i]);
-    }
-  }
-  return base;
-}
+export const mergeStyles = (...args) => Object.assign({}, ...args);
 
 /**
  * `mergeAndPrefix` is used to merge styles and autoprefix them. It has has been deprecated


### PR DESCRIPTION
This PR splits of the some of the work that was started in #2986 that switched our merge implementation to `Object.assign`.

The essence of this PR is to pave the way to start using `Object.assign` for merging styles instead of a merge utility method. The problem we ran into was that Chrome's `Object.assign` implementation currently has a bug in which the keys were not always ordered properly (which sometimes led to styling bugs because of the order style properties were defined). This PR includes a babel transformation step (that needs to be reviewed) that uses the same implementation as [babel-plugin-transform-object-assign](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-assign) from the babel repository, *except* it will not use the native `Object.assign` when found.

**Note:** This does not replace browser's `Object.assign`, it simply uses a different method (similar to a ponyfill).