### PR TITLE
[RaisedButton] fix the className does not set class to parent element 

### DIFF
--- a/src/raised-button.jsx
+++ b/src/raised-button.jsx
@@ -344,6 +344,7 @@ const RaisedButton = React.createClass({
   render() {
     let {
       children,
+      className,
       disabled,
       icon,
       label,
@@ -408,6 +409,7 @@ const RaisedButton = React.createClass({
 
     return (
       <Paper
+        className={this.props.className}
         style={this.mergeStyles(styles.root, this.props.style)}
         zDepth={this.state.zDepth}
       >


### PR DESCRIPTION
**Edit by** @alitaheri: This should be documented as a possible breaking change in the 0.15.0 release.

This PR is in reference  to the issue #3122 