### PR TITLE
[Popover] absolute positioning

### DIFF
--- a/src/dialog.jsx
+++ b/src/dialog.jsx
@@ -512,6 +512,37 @@ const Dialog = React.createClass({
     };
   },
 
+  getInitialState() {
+    return {
+      open: this.props.open,
+      closing: false,
+    };
+  },
+
+  componentWillReceiveProps(nextProps, nextContext) {
+    let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
+
+    if (nextProps.open !== this.state.open) {
+      if (nextProps.open) {
+        this.setState({
+          open: true,
+          closing: false,
+          muiTheme: newMuiTheme,
+        });
+      } else {
+        this.setState({closing: true});
+        this._timeout = setTimeout(() => {
+          if (this.isMounted()) {
+            this.setState({
+              open: false,
+              muiTheme: newMuiTheme,
+            });
+          }
+        }, 500);
+      }
+    }
+  },
+
   renderLayer() {
     return (
       <DialogInline {...this.props} />
@@ -520,7 +551,7 @@ const Dialog = React.createClass({
 
   render() {
     return (
-      <RenderToLayer render={this.renderLayer} open={true} useLayerForClickAway={false} />
+      <RenderToLayer render={this.renderLayer} open={this.state.open} useLayerForClickAway={false} />
     );
   },
 

--- a/src/popover/popover-animation-from-top.jsx
+++ b/src/popover/popover-animation-from-top.jsx
@@ -23,7 +23,7 @@ function getStyles(props, state) {
       opacity: open ? 1 : 0,
       transform: open ? 'scaleY(1)' : 'scaleY(0)',
       transformOrigin: `${horizontal} ${targetOrigin.vertical}`,
-      position: 'fixed',
+      position: 'absolute',
       zIndex: zIndex.popover,
       transition: Transitions.easeOut('450ms', ['transform', 'opacity']),
       maxHeight: '100%',

--- a/src/popover/popover-default-animation.jsx
+++ b/src/popover/popover-default-animation.jsx
@@ -23,7 +23,7 @@ function getStyles(props, state) {
       opacity: open ? 1 : 0,
       transform: open ? 'scale(1, 1)' : 'scale(0, 0)',
       transformOrigin: `${horizontal} ${targetOrigin.vertical}`,
-      position: 'fixed',
+      position: 'absolute',
       zIndex: zIndex.popover,
       transition: Transitions.easeOut('250ms', ['transform', 'opacity']),
       maxHeight: '100%',

--- a/src/popover/popover.jsx
+++ b/src/popover/popover.jsx
@@ -243,8 +243,8 @@ const Popover = React.createClass({
     const a = {
       top: rect.top,
       left: rect.left,
-      width: el.offsetWidth,
-      height: el.offsetHeight,
+      width: rect.width,
+      height: rect.height,
     };
 
     a.right = rect.right || a.left + a.width;


### PR DESCRIPTION
Hi, 
One thing that came up in our testing, was that when `Popover` contains a `TextField` or input, and when using Mobile Safari, (e.g. ipad) and the keyboard comes up, the fixed positioning causes the popover to lose its position, and become unusable.  Making it absolute should sort this, the downside is that render-to-layer needs to track its position manually via a throttled WindowListener.

Comments welcome.

Thanks, 
Chris

Fixes https://github.com/callemall/material-ui/issues/3482.