### PR TITLE
[TimePicker] Reinstate #3030 - Add support for custom button labels

### DIFF
--- a/docs/src/app/components/pages/components/TimePicker/ExampleInternational.jsx
+++ b/docs/src/app/components/pages/components/TimePicker/ExampleInternational.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import TimePicker from 'material-ui/lib/time-picker/time-picker';
+
+const TimePickerInternational = () => (
+  <div>
+    <TimePicker
+      hintText="Custom Labels"
+      okLabel="确定"
+      cancelLabel="取消"
+    />
+  </div>
+);
+
+export default TimePickerInternational;

--- a/docs/src/app/components/pages/components/TimePicker/Page.jsx
+++ b/docs/src/app/components/pages/components/TimePicker/Page.jsx
@@ -18,7 +18,7 @@ const descriptions = {
   simple: 'Time Picker supports 12 hour and 24 hour formats. In 12 hour format the AM and PM indicators toggle the ' +
   'selected time period.',
   controlled: '`TimePicker` can be used as a controlled component.',
-  localised: 'The buttons can be localised using the `wordings` property.',
+  localised: 'The buttons can be localised using the `cancelLabel` and `okLabel` properties.',
 };
 
 const TimePickersPage = () => (

--- a/docs/src/app/components/pages/components/TimePicker/Page.jsx
+++ b/docs/src/app/components/pages/components/TimePicker/Page.jsx
@@ -11,11 +11,14 @@ import TimePickerExampleSimple from './ExampleSimple';
 import timePickerExampleSimpleCode from '!raw!./ExampleSimple';
 import TimePickerExampleComplex from './ExampleComplex';
 import timePickerExampleComplexCode from '!raw!./ExampleComplex';
+import TimePickerExampleInternational from './ExampleInternational';
+import timePickerExampleInternationalCode from '!raw!./ExampleInternational';
 
 const descriptions = {
   simple: 'Time Picker supports 12 hour and 24 hour formats. In 12 hour format the AM and PM indicators toggle the ' +
   'selected time period.',
   controlled: '`TimePicker` can be used as a controlled component.',
+  localised: 'The buttons can be localised using the `wordings` property.',
 };
 
 const TimePickersPage = () => (
@@ -35,6 +38,13 @@ const TimePickersPage = () => (
       code={timePickerExampleComplexCode}
     >
       <TimePickerExampleComplex />
+    </CodeExample>
+    <CodeExample
+      title="Localised example"
+      description={descriptions.localised}
+      code={timePickerExampleInternationalCode}
+    >
+      <TimePickerExampleInternational />
     </CodeExample>
     <PropTypeDescription code={timePickerCode} />
   </div>

--- a/src/time-picker/time-picker-dialog.jsx
+++ b/src/time-picker/time-picker-dialog.jsx
@@ -10,8 +10,10 @@ const TimePickerDialog = React.createClass({
 
   propTypes: {
     autoOk: React.PropTypes.bool,
+    cancelLabel: React.PropTypes.string,
     format: React.PropTypes.oneOf(['ampm', '24hr']),
     initialTime: React.PropTypes.object,
+    okLabel: React.PropTypes.string,
     onAccept: React.PropTypes.func,
     onDismiss: React.PropTypes.func,
     onShow: React.PropTypes.func,
@@ -23,6 +25,13 @@ const TimePickerDialog = React.createClass({
 
   childContextTypes: {
     muiTheme: React.PropTypes.object,
+  },
+
+  getDefaultProps() {
+    return {
+      okLabel: 'OK',
+      cancelLabel: 'Cancel',
+    };
   },
 
   getInitialState() {
@@ -85,6 +94,8 @@ const TimePickerDialog = React.createClass({
       onAccept,
       format,
       autoOk,
+      okLabel,
+      cancelLabel,
       ...other,
     } = this.props;
 
@@ -104,13 +115,13 @@ const TimePickerDialog = React.createClass({
     const actions = [
       <FlatButton
         key={0}
-        label="Cancel"
+        label={cancelLabel}
         secondary={true}
         onTouchTap={this.dismiss}
       />,
       <FlatButton
         key={1}
-        label="OK"
+        label={okLabel}
         secondary={true}
         onTouchTap={this._handleOKTouchTap}
       />,

--- a/src/time-picker/time-picker.jsx
+++ b/src/time-picker/time-picker.jsx
@@ -19,6 +19,11 @@ const TimePicker = React.createClass({
      */
     autoOk: React.PropTypes.bool,
 
+   /**
+    * Override the label of the 'Cancel' button.
+    */
+    cancelLabel: React.PropTypes.string,
+
     /**
      * This is the initial time value of the component.
      */
@@ -29,6 +34,11 @@ const TimePicker = React.createClass({
      * ampm (12hr) format or 24hr format.
      */
     format: React.PropTypes.oneOf(['ampm', '24hr']),
+
+    /**
+     * Override the label of the 'OK' button.
+     */
+    okLabel: React.PropTypes.string,
 
     /**
      * Callback function that is fired when the time
@@ -83,6 +93,7 @@ const TimePicker = React.createClass({
      * Sets the time for the Time Picker programmatically.
      */
     value: React.PropTypes.object,
+
   },
 
   contextTypes: {
@@ -96,6 +107,8 @@ const TimePicker = React.createClass({
       pedantic: false,
       autoOk: false,
       style: {},
+      okLabel: 'OK',
+      cancelLabel: 'Cancel',
     };
   },
 
@@ -188,14 +201,16 @@ const TimePicker = React.createClass({
   render() {
     const {
       autoOk,
+      cancelLabel,
       format,
+      okLabel,
       onFocus,
       onTouchTap,
       onShow,
       onDismiss,
+      pedantic,
       style,
       textFieldStyle,
-      pedantic,
       ...other,
     } = this.props;
 
@@ -223,6 +238,8 @@ const TimePicker = React.createClass({
           onShow={onShow}
           onDismiss={onDismiss}
           format={format}
+          okLabel={okLabel}
+          cancelLabel={cancelLabel}
           autoOk={autoOk}
         />
       </div>


### PR DESCRIPTION
Commits from #3030 were reverted prior to release of  0.14.4 to allow prop naming to be agreed.