### PR TITLE
[npm] Use files whitelist instead of npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-build
-coverage
-docs
-examples
-icon-builder
-test

--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
     "react-dom": "^0.14.0",
     "react-tap-event-plugin": "^0.2.0"
   },
+  "files": [
+    "lib",
+    "src"
+  ],
   "devDependencies": {
     "babel-cli": "^6.3.17",
     "babel-core": "^6.3.21",


### PR DESCRIPTION
Follow
 - https://github.com/gaearon/react-transform-catch-errors/commit/72b0976dc369f6c405a7f385073e4c8d36ab45a2
 - https://github.com/pouchdb/pouchdb/pull/4798