### PR TITLE
[Menu] Fix _isChildSelected child not recognising first child

### DIFF
--- a/src/menus/menu.jsx
+++ b/src/menus/menu.jsx
@@ -401,7 +401,7 @@ const Menu = React.createClass({
     let childValue = child.props.value;
 
     return (multiple && menuValue.length && menuValue.indexOf(childValue) !== -1) ||
-      (!multiple && menuValue && menuValue === childValue);
+      (!multiple && menuValue === childValue);
   },
 
   _setFocusIndex(newIndex, isKeyboardFocused) {


### PR DESCRIPTION
Hey.  There's a bug propagating from the menu component that was messing with the styling of the first element in menus with the maxHeight property set ( see issue #3157 )  .  You can see it on the docs page for DropDownMenus: selecting the first item doesn't style it as if it's selected. 

This PR fixes that problem.