### PR TITLE
[Menu/DropDownMenu] safari select-field fix

### DIFF
--- a/src/menus/menu.jsx
+++ b/src/menus/menu.jsx
@@ -482,7 +482,7 @@ const Menu = React.createClass({
         bottom: !openDown ? 0 : null,
         left: !openLeft ? 0 : null,
         right: openLeft ? 0 : null,
-        transform: 'scaleX(0)',
+        transform: animated ? 'scaleX(0)' : null,
         transformOrigin: openLeft ? 'right' : 'left',
       },
 
@@ -506,7 +506,7 @@ const Menu = React.createClass({
 
       paper: {
         transition: animated ? Transitions.easeOut('500ms', ['transform', 'opacity']) : null,
-        transform: 'scaleY(0)',
+        transform: animated ? 'scaleY(0)' : null,
         transformOrigin: openDown ? 'top' : 'bottom',
         opacity: 0,
         maxHeight: maxHeight,


### PR DESCRIPTION
Hi, 
Just noticed in 0.14.4, on Safari, the dropdown-menu isn't rendering its contents, there is a `scaleX(0)` and `scaleY(0)` being applied.  I can't see where it came from, but as the popover controls the animation, I think it makes sense to disable the animation on the menu from the dropdown menu.  When I then did this, it was broken, so I've fixed that too.

Thanks,
Chris