### PR TITLE
[Toolbar] Remove style-propable mixin

### DIFF
--- a/src/toolbar/toolbar-group.jsx
+++ b/src/toolbar/toolbar-group.jsx
@@ -1,7 +1,71 @@
 import React from 'react';
 import Colors from '../styles/colors';
-import StylePropable from '../mixins/style-propable';
 import getMuiTheme from '../styles/getMuiTheme';
+
+function getStyles(props, state) {
+  const {
+    firstChild,
+    float,
+    lastChild,
+  } = props;
+
+  const {
+    baseTheme,
+    button,
+    toolbar,
+  } = state.muiTheme;
+
+  const marginHorizontal = baseTheme.spacing.desktopGutter;
+  const marginVertical = (toolbar.height - button.height) / 2;
+
+  const styles = {
+    root: {
+      float,
+      position: 'relative',
+      marginLeft: firstChild ? -marginHorizontal : undefined,
+      marginRight: lastChild ? -marginHorizontal : undefined,
+    },
+    dropDownMenu: {
+      root: {
+        float: 'left',
+        color: Colors.lightBlack, // removes hover color change, we want to keep it
+        display: 'inline-block',
+        marginRight: baseTheme.spacing.desktopGutter,
+      },
+      controlBg: {
+        backgroundColor: toolbar.menuHoverColor,
+        borderRadius: 0,
+      },
+      underline: {
+        display: 'none',
+      },
+    },
+    button: {
+      float: 'left',
+      margin: marginVertical + 'px ' + marginHorizontal + 'px',
+      position: 'relative',
+    },
+    icon: {
+      root: {
+        float: 'left',
+        cursor: 'pointer',
+        color: toolbar.iconColor,
+        lineHeight: toolbar.height + 'px',
+        paddingLeft: baseTheme.spacing.desktopGutter,
+      },
+      hover: {
+        color: Colors.darkBlack,
+      },
+    },
+    span: {
+      float: 'left',
+      color: toolbar.iconColor,
+      lineHeight: toolbar.height + 'px',
+    },
+  };
+
+  return styles;
+}
 
 const ToolbarGroup = React.createClass({
   propTypes: {
@@ -42,12 +106,9 @@ const ToolbarGroup = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  //for passing default theme context to children
   childContextTypes: {
     muiTheme: React.PropTypes.object,
   },
-
-  mixins: [StylePropable],
 
   getDefaultProps() {
     return {
@@ -69,87 +130,20 @@ const ToolbarGroup = React.createClass({
     };
   },
 
-  //to update theme inside state whenever a new theme is passed down
-  //from the parent / owner using context
   componentWillReceiveProps(nextProps, nextContext) {
-    const newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
+    this.setState({
+      muiTheme: nextContext.muiTheme || this.state.muiTheme,
+    });
   },
 
-  getTheme() {
-    return this.state.muiTheme.toolbar;
+  _handleMouseEnterFontIcon: (style) => (e) => {
+    e.target.style.zIndex = style.hover.zIndex;
+    e.target.style.color = style.hover.color;
   },
 
-  getSpacing() {
-    return this.state.muiTheme.rawTheme.spacing;
-  },
-
-  getStyles() {
-    const {
-      firstChild,
-      float,
-      lastChild,
-    } = this.props;
-
-    const marginHorizontal = this.getSpacing().desktopGutter;
-    const marginVertical = (this.getTheme().height - this.state.muiTheme.button.height) / 2;
-    const styles = {
-      root: {
-        float,
-        position: 'relative',
-        marginLeft: firstChild ? -marginHorizontal : undefined,
-        marginRight: lastChild ? -marginHorizontal : undefined,
-      },
-      dropDownMenu: {
-        root: {
-          float: 'left',
-          color: Colors.lightBlack, // removes hover color change, we want to keep it
-          display: 'inline-block',
-          marginRight: this.getSpacing().desktopGutter,
-        },
-        controlBg: {
-          backgroundColor: this.getTheme().menuHoverColor,
-          borderRadius: 0,
-        },
-        underline: {
-          display: 'none',
-        },
-      },
-      button: {
-        float: 'left',
-        margin: marginVertical + 'px ' + marginHorizontal + 'px',
-        position: 'relative',
-      },
-      icon: {
-        root: {
-          float: 'left',
-          cursor: 'pointer',
-          color: this.getTheme().iconColor,
-          lineHeight: this.getTheme().height + 'px',
-          paddingLeft: this.getSpacing().desktopGutter,
-        },
-        hover: {
-          color: Colors.darkBlack,
-        },
-      },
-      span: {
-        float: 'left',
-        color: this.getTheme().iconColor,
-        lineHeight: this.getTheme().height + 'px',
-      },
-    };
-
-    return styles;
-  },
-
-  _handleMouseEnterFontIcon(e) {
-    e.target.style.zIndex = this.getStyles().icon.hover.zIndex;
-    e.target.style.color = this.getStyles().icon.hover.color;
-  },
-
-  _handleMouseLeaveFontIcon(e) {
+  _handleMouseLeaveFontIcon: (style) => (e) => {
     e.target.style.zIndex = 'auto';
-    e.target.style.color = this.getStyles().icon.root.color;
+    e.target.style.color = style.root.color;
   },
 
   render() {
@@ -160,7 +154,12 @@ const ToolbarGroup = React.createClass({
       ...other,
     } = this.props;
 
-    const styles = this.getStyles();
+    const {
+      prepareStyles,
+    } = this.state.muiTheme;
+
+    const styles = getStyles(this.props, this.state);
+
     const newChildren = React.Children.map(children, currentChild => {
       if (!currentChild) {
         return null;
@@ -171,25 +170,25 @@ const ToolbarGroup = React.createClass({
       switch (currentChild.type.displayName) {
         case 'DropDownMenu' :
           return React.cloneElement(currentChild, {
-            style: this.mergeStyles(styles.dropDownMenu.root, currentChild.props.style),
+            style: Object.assign({}, styles.dropDownMenu.root, currentChild.props.style),
             styleControlBg: styles.dropDownMenu.controlBg,
             styleUnderline: styles.dropDownMenu.underline,
           });
         case 'RaisedButton' :
         case 'FlatButton' :
           return React.cloneElement(currentChild, {
-            style: this.mergeStyles(styles.button, currentChild.props.style),
+            style: Object.assign({}, styles.button, currentChild.props.style),
           });
         case 'FontIcon' :
           return React.cloneElement(currentChild, {
-            style: this.mergeStyles(styles.icon.root, currentChild.props.style),
-            onMouseEnter: this._handleMouseEnterFontIcon,
-            onMouseLeave: this._handleMouseLeaveFontIcon,
+            style: Object.assign({}, styles.icon.root, currentChild.props.style),
+            onMouseEnter: this._handleMouseEnterFontIcon(styles.icon),
+            onMouseLeave: this._handleMouseLeaveFontIcon(styles.icon),
           });
         case 'ToolbarSeparator' :
         case 'ToolbarTitle' :
           return React.cloneElement(currentChild, {
-            style: this.mergeStyles(styles.span, currentChild.props.style),
+            style: Object.assign({}, styles.span, currentChild.props.style),
           });
         default:
           return currentChild;
@@ -197,7 +196,7 @@ const ToolbarGroup = React.createClass({
     }, this);
 
     return (
-      <div {...other} className={className} style={this.prepareStyles(styles.root, style)}>
+      <div {...other} className={className} style={prepareStyles(Object.assign({}, styles.root, style))}>
         {newChildren}
       </div>
     );

--- a/src/toolbar/toolbar-separator.jsx
+++ b/src/toolbar/toolbar-separator.jsx
@@ -1,6 +1,24 @@
 import React from 'react';
-import StylePropable from '../mixins/style-propable';
 import getMuiTheme from '../styles/getMuiTheme';
+
+function getStyles(props, state) {
+  const {
+    baseTheme,
+    toolbar,
+  } = state.muiTheme;
+
+  return {
+    root: {
+      backgroundColor: toolbar.separatorColor,
+      display: 'inline-block',
+      height: baseTheme.spacing.desktopGutterMore,
+      marginLeft: baseTheme.spacing.desktopGutter,
+      position: 'relative',
+      top: ((toolbar.height - baseTheme.spacing.desktopGutterMore) / 2),
+      width: 1,
+    },
+  };
+}
 
 const ToolbarSeparator = React.createClass({
 
@@ -20,12 +38,9 @@ const ToolbarSeparator = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  //for passing default theme context to children
   childContextTypes: {
     muiTheme: React.PropTypes.object,
   },
-
-  mixins: [StylePropable],
 
   getInitialState() {
     return {
@@ -39,47 +54,27 @@ const ToolbarSeparator = React.createClass({
     };
   },
 
-  //to update theme inside state whenever a new theme is passed down
-  //from the parent / owner using context
   componentWillReceiveProps(nextProps, nextContext) {
-    const newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
-  },
-
-  getTheme() {
-    return this.state.muiTheme.toolbar;
-  },
-
-  getSpacing() {
-    return this.state.muiTheme.rawTheme.spacing;
-  },
-
-  getStyles() {
-    return {
-      root: {
-        backgroundColor: this.getTheme().separatorColor,
-        display: 'inline-block',
-        height: this.getSpacing().desktopGutterMore,
-        marginLeft: this.getSpacing().desktopGutter,
-        position: 'relative',
-        top: ((this.getTheme().height - this.getSpacing().desktopGutterMore) / 2),
-        width: 1,
-      },
-    };
+    this.setState({
+      muiTheme: nextContext.muiTheme || this.state.muiTheme,
+    });
   },
 
   render() {
-
     const {
       className,
       style,
       ...other,
     } = this.props;
 
-    const styles = this.getStyles();
+    const {
+      prepareStyles,
+    } = this.state.muiTheme;
+
+    const styles = getStyles(this.props, this.state);
 
     return (
-      <span {...other} className={className} style={this.prepareStyles(styles.root, style)}/>
+      <span {...other} className={className} style={prepareStyles(Object.assign({}, styles.root, style))}/>
     );
   },
 

--- a/src/toolbar/toolbar-title.jsx
+++ b/src/toolbar/toolbar-title.jsx
@@ -1,6 +1,22 @@
 import React from 'react';
-import StylePropable from '../mixins/style-propable';
 import getMuiTheme from '../styles/getMuiTheme';
+
+function getStyles(props, state) {
+  const {
+    baseTheme,
+    toolbar,
+  } = state.muiTheme;
+
+  return {
+    root: {
+      paddingRight: baseTheme.spacing.desktopGutterLess,
+      lineHeight: toolbar.height + 'px',
+      fontSize: toolbar.titleFontSize + 'px',
+      display: 'inline-block',
+      position: 'relative',
+    },
+  };
+}
 
 const ToolbarTitle = React.createClass({
 
@@ -25,12 +41,9 @@ const ToolbarTitle = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  //for passing default theme context to children
   childContextTypes: {
     muiTheme: React.PropTypes.object,
   },
-
-  mixins: [StylePropable],
 
   getInitialState() {
     return {
@@ -44,31 +57,10 @@ const ToolbarTitle = React.createClass({
     };
   },
 
-  //to update theme inside state whenever a new theme is passed down
-  //from the parent / owner using context
   componentWillReceiveProps(nextProps, nextContext) {
-    const newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
-  },
-
-  getTheme() {
-    return this.state.muiTheme.toolbar;
-  },
-
-  getSpacing() {
-    return this.state.muiTheme.rawTheme.spacing;
-  },
-
-  getStyles() {
-    return {
-      root: {
-        paddingRight: this.getSpacing().desktopGutterLess,
-        lineHeight: this.getTheme().height + 'px',
-        fontSize: this.getTheme().titleFontSize + 'px',
-        display: 'inline-block',
-        position: 'relative',
-      },
-    };
+    this.setState({
+      muiTheme: nextContext.muiTheme || this.state.muiTheme,
+    });
   },
 
   render() {
@@ -79,10 +71,14 @@ const ToolbarTitle = React.createClass({
       ...other,
     } = this.props;
 
-    const styles = this.getStyles();
+    const {
+      prepareStyles,
+    } = this.state.muiTheme;
+
+    const styles = getStyles(this.props, this.state);
 
     return (
-      <span {...other} className={className} style={this.prepareStyles(styles.root, style)}>
+      <span {...other} className={className} style={prepareStyles(Object.assign({}, styles.root, style))}>
         {text}
       </span>
     );

--- a/src/toolbar/toolbar.jsx
+++ b/src/toolbar/toolbar.jsx
@@ -1,6 +1,27 @@
 import React from 'react';
-import StylePropable from '../mixins/style-propable';
 import getMuiTheme from '../styles/getMuiTheme';
+
+function getStyles(props, state) {
+  const {
+    noGutter,
+  } = props;
+
+  const {
+    baseTheme,
+    toolbar,
+  } = state.muiTheme;
+
+  return {
+    root: {
+      boxSizing: 'border-box',
+      WebkitTapHighlightColor: 'rgba(0,0,0,0)',
+      backgroundColor: toolbar.backgroundColor,
+      height: toolbar.height,
+      width: '100%',
+      padding: noGutter ? 0 : '0px ' + baseTheme.spacing.desktopGutter + 'px',
+    },
+  };
+}
 
 const Toolbar = React.createClass({
 
@@ -29,12 +50,10 @@ const Toolbar = React.createClass({
   contextTypes: {
     muiTheme: React.PropTypes.object,
   },
-  //for passing default theme context to children
+
   childContextTypes: {
     muiTheme: React.PropTypes.object,
   },
-
-  mixins: [StylePropable],
 
   getDefaultProps() {
     return {
@@ -54,32 +73,10 @@ const Toolbar = React.createClass({
     };
   },
 
-  //to update theme inside state whenever a new theme is passed down
-  //from the parent / owner using context
   componentWillReceiveProps(nextProps, nextContext) {
-    let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
-  },
-
-  getTheme() {
-    return this.state.muiTheme.toolbar;
-  },
-
-  getSpacing() {
-    return this.state.muiTheme.rawTheme.spacing;
-  },
-
-  getStyles() {
-    return {
-      root: {
-        boxSizing: 'border-box',
-        WebkitTapHighlightColor: 'rgba(0,0,0,0)',
-        backgroundColor: this.getTheme().backgroundColor,
-        height: this.getTheme().height,
-        width: '100%',
-        padding: this.props.noGutter ? 0 : '0px ' + this.getSpacing().desktopGutter + 'px',
-      },
-    };
+    this.setState({
+      muiTheme: nextContext.muiTheme || this.state.muiTheme,
+    });
   },
 
   render() {
@@ -90,15 +87,18 @@ const Toolbar = React.createClass({
       ...other,
     } = this.props;
 
-    const styles = this.getStyles();
+    const {
+      prepareStyles,
+    } = this.state.muiTheme;
+
+    const styles = getStyles(this.props, this.state);
 
     return (
-      <div {...other} className={className} style={this.prepareStyles(styles.root, style)}>
+      <div {...other} className={className} style={prepareStyles(Object.assign({}, styles.root, style))}>
         {children}
       </div>
     );
   },
-
 });
 
 export default Toolbar;


### PR DESCRIPTION
@oliviertassinari @alitaheri @mbrookes 

This isn't done, as I'm migrating the code, I wanted to get your feedback on this pattern of moving `getStyles()` outside of the class declaration (and changing the method signature to `getStyles(props, state)`.

I think this approach has the following benefits:

1. Reduces component surface API (and imperative methods) which is safer and allows us to move more towards functional components
2. Prevents leaky abstractions and [prevents developers from implementing custom styling and behavior from undocumented methods](https://github.com/callemall/material-ui/issues/684#issuecomment-170727507) (**Disclosure:** I am **not** trying to say anything bad about this developer :grin:. I perfectly understand what and why he was doing what he was doing, but I still think we should find a better way for material-ui to handle his use case and prevent developers from falling into the trap of using internal API)
2. Discourages the use of other instance methods to calculate style such `this.getTheme()` and `this.getSpacing()`
3. Forces us (and other contributors) to think of style as a function of `props` and `state` (and ideally in the future just a function of `props`)
4. It's more functional, predictable, and reusable (could open up interesting opportunities in the future like composition and more)

**Final note**: This PR was originally the start of migrating the toolbar components off of `style-propable`. After we decide, I'll rename the PR and finish that work.

Signed-off-by: Neil Gabbadon <neil.gabbadon@emikra.com>