### PR TITLE
[TextField] Fixed ie9-ie10 click focus problem

### DIFF
--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -304,7 +304,7 @@ const TextField = React.createClass({
         height: '100%',
         border: 'none',
         outline: 'none',
-        backgroundColor: 'transparent',
+        backgroundColor: 'rgba(0,0,0,0)',
         color: props.disabled ? disabledTextColor : textColor,
         font: 'inherit',
       },


### PR DESCRIPTION
When using a hint, clicking on the span containing the hint removes the focus from the input (IE9-10). Weirdly, changing the background-color to rgba fixes the problem.