### PR TITLE
[eslint] Enforce arrow-parens

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@ rules:
   # Errors
   array-bracket-spacing: [2, never]
   arrow-spacing: 2
+  arrow-parens: 2
   block-spacing: [2, always]
   brace-style: 2
   comma-dangle: [2, always-multiline]

--- a/docs/src/app/components/PropTypeDescription.jsx
+++ b/docs/src/app/components/PropTypeDescription.jsx
@@ -39,7 +39,7 @@ function generatePropType(type) {
       return type.raw;
 
     case 'enum':
-      const values = type.value.map(v => v.value).join('<br>&nbsp;');
+      const values = type.value.map((v) => v.value).join('<br>&nbsp;');
       return `enum:<br>&nbsp;${values}<br>`;
 
     default:
@@ -64,15 +64,15 @@ function generateDescription(required, description, type) {
   // must be eliminated to prevent markdown mayhem.
   const jsDocText = parsed.description.replace(/\n\n/g, '<br>').replace(/\n/g, ' ');
 
-  if (parsed.tags.some(tag => tag.title === 'ignore')) return null;
+  if (parsed.tags.some((tag) => tag.title === 'ignore')) return null;
 
   let signature = '';
 
   if (type.name === 'func' && parsed.tags.length > 0) {
     signature += '<br><br>**Signature:**<br>`function(';
-    signature += parsed.tags.map(tag => `${tag.name}: ${tag.type.name}`).join(', ');
+    signature += parsed.tags.map((tag) => `${tag.name}: ${tag.type.name}`).join(', ');
     signature += ') => void`<br>';
-    signature += parsed.tags.map(tag => `*${tag.name}:* ${tag.description}`).join('<br>');
+    signature += parsed.tags.map((tag) => `*${tag.name}:* ${tag.description}`).join('<br>');
   }
 
   return `${deprecated} ${jsDocText}${signature}`;

--- a/docs/src/app/components/pages/components/GridList/ExampleComplex.jsx
+++ b/docs/src/app/components/pages/components/GridList/ExampleComplex.jsx
@@ -71,7 +71,7 @@ const GridListExampleComplex = () => (
       padding={1}
       style={styles.gridList}
     >
-      {tilesData.map(tile => (
+      {tilesData.map((tile) => (
         <GridTile
           key={tile.img}
           title={tile.title}

--- a/docs/src/app/components/pages/components/GridList/ExampleSimple.jsx
+++ b/docs/src/app/components/pages/components/GridList/ExampleSimple.jsx
@@ -70,7 +70,7 @@ const GridListExampleSimple = () => (
       style={styles.gridList}
     >
       <Subheader>December</Subheader>
-      {tilesData.map(tile => (
+      {tilesData.map((tile) => (
         <GridTile
           key={tile.img}
           title={tile.title}

--- a/docs/src/app/components/pages/components/LeftNav/ExampleUndocked.jsx
+++ b/docs/src/app/components/pages/components/LeftNav/ExampleUndocked.jsx
@@ -25,7 +25,7 @@ export default class LeftNavUndockedExample extends React.Component {
           docked={false}
           width={200}
           open={this.state.open}
-          onRequestChange={open => this.setState({open})}
+          onRequestChange={(open) => this.setState({open})}
         >
           <MenuItem onTouchTap={this.handleClose}>Menu Item</MenuItem>
           <MenuItem onTouchTap={this.handleClose}>Menu Item 2</MenuItem>

--- a/src/DropDownMenu/DropDownMenu.jsx
+++ b/src/DropDownMenu/DropDownMenu.jsx
@@ -262,7 +262,7 @@ const DropDownMenu = React.createClass({
     const styles = this.getStyles();
 
     let displayValue = '';
-    React.Children.forEach(children, child => {
+    React.Children.forEach(children, (child) => {
       if (value === child.props.value) {
         // This will need to be improved (in case primaryText is a node)
         displayValue = child.props.label || child.props.primaryText;

--- a/src/menus/menu.jsx
+++ b/src/menus/menu.jsx
@@ -217,7 +217,7 @@ const Menu = React.createClass({
 
   _getFilteredChildren(children) {
     const filteredChildren = [];
-    React.Children.forEach(children, child => {
+    React.Children.forEach(children, (child) => {
       if (child) {
         filteredChildren.push(child);
       }
@@ -299,7 +299,7 @@ const Menu = React.createClass({
 
     //Count all the children that will fit inside the
     //max menu height
-    filteredChildren.forEach(child => {
+    filteredChildren.forEach((child) => {
       if (currentHeight < maxHeight) {
         let childIsADivider = child.type && child.type.displayName === 'Divider';
 
@@ -313,7 +313,7 @@ const Menu = React.createClass({
 
   _getMenuItemCount(filteredChildren) {
     let menuItemCount = 0;
-    filteredChildren.forEach(child => {
+    filteredChildren.forEach((child) => {
       let childIsADivider = child.type && child.type.displayName === 'Divider';
       let childIsDisabled = child.props.disabled;
       if (!childIsADivider && !childIsDisabled) menuItemCount++;
@@ -325,7 +325,7 @@ const Menu = React.createClass({
     let selectedIndex = -1;
     let menuItemIndex = 0;
 
-    filteredChildren.forEach(child => {
+    filteredChildren.forEach((child) => {
       let childIsADivider = child.type && child.type.displayName === 'Divider';
 
       if (this._isChildSelected(child, props)) selectedIndex = menuItemIndex;
@@ -529,7 +529,7 @@ const Menu = React.createClass({
     let cumulativeDelayIncrement = Math.ceil(150 / cascadeChildrenCount);
 
     let menuItemIndex = 0;
-    let newChildren = React.Children.map(filteredChildren, child => {
+    let newChildren = React.Children.map(filteredChildren, (child) => {
       let childIsADivider = child.type && child.type.displayName === 'Divider';
       let childIsDisabled = child.props.disabled;
       let childrenContainerStyles = {};

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -121,7 +121,7 @@ export default function getMuiTheme(baseTheme, muiTheme) {
         [10, 30, 0.19, 6, 10, 0.23],
         [14, 45, 0.25, 10, 18, 0.22],
         [19, 60, 0.30, 15, 20, 0.22],
-      ].map(d => (
+      ].map((d) => (
         `0 ${d[0]}px ${d[1]}px ${ColorManipulator.fade(palette.shadowColor, d[2])},
          0 ${d[3]}px ${d[4]}px ${ColorManipulator.fade(palette.shadowColor, d[5])}`
       )),
@@ -241,7 +241,8 @@ export default function getMuiTheme(baseTheme, muiTheme) {
     },
   }, muiTheme);
 
-  const transformers = [autoprefixer, rtl, callOnce].map(t => t(muiTheme)).filter(t => t);
+  const transformers = [autoprefixer, rtl, callOnce].map((t) => t(muiTheme))
+    .filter((t) => t);
   muiTheme.prepareStyles = compose(...transformers);
 
   return muiTheme;

--- a/src/toolbar/toolbar-group.jsx
+++ b/src/toolbar/toolbar-group.jsx
@@ -160,7 +160,7 @@ const ToolbarGroup = React.createClass({
 
     const styles = getStyles(this.props, this.state);
 
-    const newChildren = React.Children.map(children, currentChild => {
+    const newChildren = React.Children.map(children, (currentChild) => {
       if (!currentChild) {
         return null;
       }

--- a/src/utils/date-time.js
+++ b/src/utils/date-time.js
@@ -93,7 +93,7 @@ export default {
       dayArray.push(new Date(d.getFullYear(), d.getMonth(), i));
     }
 
-    const addWeek = week => {
+    const addWeek = (week) => {
       const emptyDays = 7 - week.length;
       for (let i = 0; i < emptyDays; ++i) {
         week[weekArray.length ? 'push' : 'unshift'](null);
@@ -101,7 +101,7 @@ export default {
       weekArray.push(week);
     };
 
-    dayArray.forEach(day => {
+    dayArray.forEach((day) => {
       if (week.length > 0 && day.getDay() === firstDayOfWeek) {
         addWeek(week);
         week = [];


### PR DESCRIPTION
It reduces the cost of adding a new argument.
And it prevents the incorrect use of arrow functions in conditionals:
```js
if (a => b) {
}
```

http://eslint.org/docs/rules/arrow-parens.html
https://github.com/airbnb/javascript#arrow-functions