### PR TITLE
[Ripple] Replace mergeStyles with Object.assign

### DIFF
--- a/src/ripples/focus-ripple.jsx
+++ b/src/ripples/focus-ripple.jsx
@@ -64,7 +64,7 @@ const FocusRipple = React.createClass({
       opacity,
     } = props;
 
-    const innerStyles = this.mergeStyles({
+    const innerStyles = Object.assign({
       position: 'absolute',
       height: '100%',
       width: '100%',


### PR DESCRIPTION
This removes a call of `mergeStyles()` that was missed in PR #3199

Found this during testing.