### PR TITLE
[CardActions] Allow to accept false as child

### DIFF
--- a/src/card/card-actions.jsx
+++ b/src/card/card-actions.jsx
@@ -61,9 +61,11 @@ const CardActions = React.createClass({
     let styles = this.getStyles();
 
     let children = React.Children.map(this.props.children, (child) => {
-      return React.cloneElement(child, {
-        style: this.mergeStyles({marginRight: 8}, child.props.style),
-      });
+      if (React.isValidElement(child)) {
+        return React.cloneElement(child, {
+          style: this.mergeStyles({marginRight: 8}, child.props.style),
+        });
+      }
     });
 
     return (


### PR DESCRIPTION
Hello, currently it is impossible to do something like this, because system crushes on `false` result:
```javascript
<CardActions>
  {pkg.enabled && this.renderButton()}
</CardActions>
```

