### PR TITLE
[Table] Remove style-propable mixin

### DIFF
--- a/src/table/table-body.jsx
+++ b/src/table/table-body.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Checkbox from '../checkbox';
 import TableRowColumn from './table-row-column';
 import ClickAwayable from '../mixins/click-awayable';
-import StylePropable from '../mixins/style-propable';
 import getMuiTheme from '../styles/getMuiTheme';
 
 const TableBody = React.createClass({
@@ -118,14 +117,12 @@ const TableBody = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  //for passing default theme context to children
   childContextTypes: {
     muiTheme: React.PropTypes.object,
   },
 
   mixins: [
     ClickAwayable,
-    StylePropable,
   ],
 
   getDefaultProps() {
@@ -153,13 +150,10 @@ const TableBody = React.createClass({
     };
   },
 
-  //to update theme inside state whenever a new theme is passed down
-  //from the parent / owner using context
   componentWillReceiveProps(nextProps, nextContext) {
-    let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
-
-    let newState = {};
+    const newState = {
+      muiTheme: nextContext.muiTheme || this.state.muiTheme,
+    };
 
     if (this.props.allRowsSelected && !nextProps.allRowsSelected) {
       newState.selectedRows = this.state.selectedRows.length > 0
@@ -417,10 +411,15 @@ const TableBody = React.createClass({
       style,
       ...other,
     } = this.props;
+
+    const {
+      prepareStyles,
+    } = this.state.muiTheme;
+
     let rows = this._createRows();
 
     return (
-      <tbody className={className} style={this.prepareStyles(style)}>
+      <tbody className={className} style={prepareStyles(Object.assign({}, style))}>
         {rows}
       </tbody>
     );

--- a/src/table/table-header-column.jsx
+++ b/src/table/table-header-column.jsx
@@ -1,7 +1,31 @@
 import React from 'react';
-import StylePropable from '../mixins/style-propable';
 import Tooltip from '../tooltip';
 import getMuiTheme from '../styles/getMuiTheme';
+
+function getStyles(props, state) {
+  const {
+    tableHeaderColumn,
+  } = state.muiTheme;
+
+  return {
+    root: {
+      fontWeight: 'normal',
+      fontSize: 12,
+      paddingLeft: tableHeaderColumn.spacing,
+      paddingRight: tableHeaderColumn.spacing,
+      height: tableHeaderColumn.height,
+      textAlign: 'left',
+      whiteSpace: 'nowrap',
+      textOverflow: 'ellipsis',
+      color: tableHeaderColumn.textColor,
+      position: 'relative',
+    },
+    tooltip: {
+      boxSizing: 'border-box',
+      marginTop: tableHeaderColumn.height / 2,
+    },
+  };
+}
 
 const TableHeaderColumn = React.createClass({
 
@@ -50,12 +74,9 @@ const TableHeaderColumn = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  //for passing default theme context to children
   childContextTypes: {
     muiTheme: React.PropTypes.object,
   },
-
-  mixins: [StylePropable],
 
   getInitialState() {
     return {
@@ -70,39 +91,10 @@ const TableHeaderColumn = React.createClass({
     };
   },
 
-  //to update theme inside state whenever a new theme is passed down
-  //from the parent / owner using context
   componentWillReceiveProps(nextProps, nextContext) {
-    let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
-  },
-
-  getTheme() {
-    return this.state.muiTheme.tableHeaderColumn;
-  },
-
-  getStyles() {
-    let theme = this.getTheme();
-    let styles = {
-      root: {
-        fontWeight: 'normal',
-        fontSize: 12,
-        paddingLeft: theme.spacing,
-        paddingRight: theme.spacing,
-        height: theme.height,
-        textAlign: 'left',
-        whiteSpace: 'nowrap',
-        textOverflow: 'ellipsis',
-        color: this.getTheme().textColor,
-        position: 'relative',
-      },
-      tooltip: {
-        boxSizing: 'border-box',
-        marginTop: theme.height / 2,
-      },
-    };
-
-    return styles;
+    this.setState({
+      muiTheme: nextContext.muiTheme || this.state.muiTheme,
+    });
   },
 
   _onMouseEnter() {
@@ -118,13 +110,8 @@ const TableHeaderColumn = React.createClass({
   },
 
   render() {
-    let styles = this.getStyles();
-    let handlers = {
-      onMouseEnter: this._onMouseEnter,
-      onMouseLeave: this._onMouseLeave,
-      onClick: this._onClick,
-    };
     let {
+      children,
       className,
       columnNumber,
       onClick,
@@ -133,12 +120,24 @@ const TableHeaderColumn = React.createClass({
       tooltipStyle,
       ...other,
     } = this.props;
+
+    const {
+      prepareStyles,
+    } = this.state.muiTheme;
+
+    const styles = getStyles(this.props, this.state);
+    let handlers = {
+      onMouseEnter: this._onMouseEnter,
+      onMouseLeave: this._onMouseLeave,
+      onClick: this._onClick,
+    };
+
     if (this.props.tooltip !== undefined) {
       tooltip = (
         <Tooltip
           label={this.props.tooltip}
           show={this.state.hovered}
-          style={this.mergeStyles(styles.tooltip, tooltipStyle)}
+          style={Object.assign(styles.tooltip, tooltipStyle)}
         />
       );
     }
@@ -147,12 +146,12 @@ const TableHeaderColumn = React.createClass({
       <th
         key={this.props.key}
         className={className}
-        style={this.prepareStyles(styles.root, style)}
+        style={prepareStyles(Object.assign(styles.root, style))}
         {...handlers}
         {...other}
       >
         {tooltip}
-        {this.props.children}
+        {children}
       </th>
     );
   },

--- a/src/table/table-header.jsx
+++ b/src/table/table-header.jsx
@@ -1,8 +1,19 @@
 import React from 'react';
 import Checkbox from '../checkbox';
-import StylePropable from '../mixins/style-propable';
 import TableHeaderColumn from './table-header-column';
 import getMuiTheme from '../styles/getMuiTheme';
+
+function getStyles(props, state) {
+  const {
+    tableHeader,
+  } = state.muiTheme;
+
+  return {
+    root: {
+      borderBottom: `1px solid ${tableHeader.borderColor}`,
+    },
+  };
+}
 
 const TableHeader = React.createClass({
 
@@ -60,14 +71,9 @@ const TableHeader = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  //for passing default theme context to children
   childContextTypes: {
     muiTheme: React.PropTypes.object,
   },
-
-  mixins: [
-    StylePropable,
-  ],
 
   getDefaultProps() {
     return {
@@ -90,25 +96,10 @@ const TableHeader = React.createClass({
     };
   },
 
-  //to update theme inside state whenever a new theme is passed down
-  //from the parent / owner using context
   componentWillReceiveProps(nextProps, nextContext) {
-    let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
-  },
-
-  getTheme() {
-    return this.state.muiTheme.tableHeader;
-  },
-
-  getStyles() {
-    let styles = {
-      root: {
-        borderBottom: '1px solid ' + this.getTheme().borderColor,
-      },
-    };
-
-    return styles;
+    this.setState({
+      muiTheme: nextContext.muiTheme || this.state.muiTheme,
+    });
   },
 
   _createSuperHeaderRows() {
@@ -202,11 +193,18 @@ const TableHeader = React.createClass({
       style,
       ...other,
     } = this.props;
+
+    const {
+      prepareStyles,
+    } = this.state.muiTheme;
+
+    const styles = getStyles(this.props, this.state);
+
     let superHeaderRows = this._createSuperHeaderRows();
     let baseHeaderRow = this._createBaseHeaderRow();
 
     return (
-      <thead className={className} style={this.prepareStyles(this.getStyles().root, style)}>
+      <thead className={className} style={prepareStyles(Object.assign(styles.root, style))}>
         {superHeaderRows}
         {baseHeaderRow}
       </thead>

--- a/src/table/table-row-column.jsx
+++ b/src/table/table-row-column.jsx
@@ -1,6 +1,30 @@
 import React from 'react';
-import StylePropable from '../mixins/style-propable';
 import getMuiTheme from '../styles/getMuiTheme';
+
+function getStyles(props, state) {
+  const {
+    tableRowColumn,
+  } = state.muiTheme;
+
+  let styles = {
+    root: {
+      paddingLeft: tableRowColumn.spacing,
+      paddingRight: tableRowColumn.spacing,
+      height: tableRowColumn.height,
+      textAlign: 'left',
+      fontSize: 13,
+      overflow: 'hidden',
+      whiteSpace: 'nowrap',
+      textOverflow: 'ellipsis',
+    },
+  };
+
+  if (React.Children.count(props.children) === 1 && !isNaN(props.children)) {
+    styles.textAlign = 'right';
+  }
+
+  return styles;
+}
 
 const TableRowColumn = React.createClass({
 
@@ -53,14 +77,9 @@ const TableRowColumn = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  //for passing default theme context to children
   childContextTypes: {
     muiTheme: React.PropTypes.object,
   },
-
-  mixins: [
-    StylePropable,
-  ],
 
   getDefaultProps() {
     return {
@@ -81,37 +100,10 @@ const TableRowColumn = React.createClass({
     };
   },
 
-  //to update theme inside state whenever a new theme is passed down
-  //from the parent / owner using context
   componentWillReceiveProps(nextProps, nextContext) {
-    let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
-  },
-
-  getTheme() {
-    return this.state.muiTheme.tableRowColumn;
-  },
-
-  getStyles() {
-    let theme = this.getTheme();
-    let styles = {
-      root: {
-        paddingLeft: theme.spacing,
-        paddingRight: theme.spacing,
-        height: theme.height,
-        textAlign: 'left',
-        fontSize: 13,
-        overflow: 'hidden',
-        whiteSpace: 'nowrap',
-        textOverflow: 'ellipsis',
-      },
-    };
-
-    if (React.Children.count(this.props.children) === 1 && !isNaN(this.props.children)) {
-      styles.textAlign = 'right';
-    }
-
-    return styles;
+    this.setState({
+      muiTheme: nextContext.muiTheme || this.state.muiTheme,
+    });
   },
 
   _onClick(e) {
@@ -134,6 +126,7 @@ const TableRowColumn = React.createClass({
 
   render() {
     let {
+      children,
       className,
       columnNumber,
       hoverable,
@@ -143,7 +136,13 @@ const TableRowColumn = React.createClass({
       style,
       ...other,
     } = this.props;
-    let styles = this.getStyles();
+
+    const {
+      prepareStyles,
+    } = this.state.muiTheme;
+
+    const styles = getStyles(this.props, this.state);
+
     let handlers = {
       onClick: this._onClick,
       onMouseEnter: this._onMouseEnter,
@@ -154,11 +153,11 @@ const TableRowColumn = React.createClass({
       <td
         key={this.props.key}
         className={className}
-        style={this.prepareStyles(styles.root, style)}
+        style={prepareStyles(Object.assign(styles.root, style))}
         {...handlers}
         {...other}
       >
-        {this.props.children}
+        {children}
       </td>
     );
   },

--- a/src/table/table-row.jsx
+++ b/src/table/table-row.jsx
@@ -1,6 +1,31 @@
 import React from 'react';
-import StylePropable from '../mixins/style-propable';
 import getMuiTheme from '../styles/getMuiTheme';
+
+function getStyles(props, state) {
+  const {
+    tableRow,
+  } = state.muiTheme;
+
+  let cellBgColor = 'inherit';
+  if (props.hovered || state.hovered) {
+    cellBgColor = tableRow.hoverColor;
+  } else if (props.selected) {
+    cellBgColor = tableRow.selectedColor;
+  } else if (props.striped) {
+    cellBgColor = tableRow.stripeColor;
+  }
+
+  return {
+    root: {
+      borderBottom: props.displayBorder && `1px solid ${tableRow.borderColor}`,
+      color: tableRow.textColor,
+      height: tableRow.height,
+    },
+    cell: {
+      backgroundColor: cellBgColor,
+    },
+  };
+}
 
 const TableRow = React.createClass({
 
@@ -106,14 +131,9 @@ const TableRow = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  //for passing default theme context to children
   childContextTypes: {
     muiTheme: React.PropTypes.object,
   },
-
-  mixins: [
-    StylePropable,
-  ],
 
   getDefaultProps() {
     return {
@@ -139,74 +159,10 @@ const TableRow = React.createClass({
     };
   },
 
-  //to update theme inside state whenever a new theme is passed down
-  //from the parent / owner using context
   componentWillReceiveProps(nextProps, nextContext) {
-    let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
-  },
-
-  getTheme() {
-    return this.state.muiTheme.tableRow;
-  },
-
-  getStyles() {
-    let theme = this.getTheme();
-    let cellBgColor = 'inherit';
-    if (this.props.hovered || this.state.hovered) {
-      cellBgColor = theme.hoverColor;
-    } else if (this.props.selected) {
-      cellBgColor = theme.selectedColor;
-    } else if (this.props.striped) {
-      cellBgColor = theme.stripeColor;
-    }
-
-    let styles = {
-      root: {
-        borderBottom: '1px solid ' + theme.borderColor,
-        color: theme.textColor,
-        height: theme.height,
-      },
-      cell: {
-        backgroundColor: cellBgColor,
-      },
-    };
-
-    if (!this.props.displayBorder) {
-      styles.root.borderBottom = '';
-    }
-
-    return styles;
-  },
-
-  _createColumns() {
-    let columnNumber = 1;
-    return React.Children.map(this.props.children, (child) => {
-      if (React.isValidElement(child)) {
-        return this._createColumn(child, columnNumber++);
-      }
+    this.setState({
+      muiTheme: nextContext.muiTheme || this.state.muiTheme,
     });
-  },
-
-  _createColumn(child, columnNumber) {
-    let key = this.props.rowNumber + '-' + columnNumber;
-    let styles = this.getStyles();
-    const handlers = {
-      onClick: this._onCellClick,
-      onHover: this._onCellHover,
-      onHoverExit: this._onCellHoverExit,
-    };
-
-    return React.cloneElement(
-      child,
-      {
-        columnNumber: columnNumber,
-        hoverable: this.props.hoverable,
-        key: child.props.key || key,
-        style: this.mergeStyles(styles.cell, child.props.style),
-        ...handlers,
-      }
-    );
   },
 
   _onRowClick(e) {
@@ -261,12 +217,31 @@ const TableRow = React.createClass({
       style,
       ...other,
     } = this.props;
-    let rowColumns = this._createColumns();
+
+    const {
+      prepareStyles,
+    } = this.state.muiTheme;
+
+    const styles = getStyles(this.props, this.state);
+
+    const rowColumns = React.Children.map(this.props.children, (child, columnNumber) => {
+      if (React.isValidElement(child)) {
+        return React.cloneElement(child, {
+          columnNumber: columnNumber,
+          hoverable: this.props.hoverable,
+          key: child.props.key || `${this.props.rowNumber}-${columnNumber}`,
+          onClick: this._onCellClick,
+          onHover: this._onCellHover,
+          onHoverExit: this._onCellHoverExit,
+          style: Object.assign({}, styles.cell, child.props.style),
+        });
+      }
+    });
 
     return (
       <tr
         className={className}
-        style={this.prepareStyles(this.getStyles().root, style)}
+        style={prepareStyles(Object.assign(styles.root, style))}
         {...other}
       >
         {rowColumns}


### PR DESCRIPTION
This one was tough. A few of these components I refactored a good bit because there were loops in which we were recomputing the same style from `getStyles()` for each item. I've changed it so `getStyles()` only gets called once in each render which should help performance.