### PR TITLE
[BeforeAfterWrapper] Remove style-propable mixin

### DIFF
--- a/src/before-after-wrapper.jsx
+++ b/src/before-after-wrapper.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import StylePropable from './mixins/style-propable';
 import getMuiTheme from './styles/getMuiTheme';
 
 /**
@@ -56,12 +55,9 @@ const BeforeAfterWrapper = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  //for passing default theme context to children
   childContextTypes: {
     muiTheme: React.PropTypes.object,
   },
-
-  mixins: [StylePropable],
 
   getDefaultProps() {
     return {
@@ -83,11 +79,10 @@ const BeforeAfterWrapper = React.createClass({
     };
   },
 
-  //to update theme inside state whenever a new theme is passed down
-  //from the parent / owner using context
   componentWillReceiveProps(nextProps, nextContext) {
-    let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
+    this.setState({
+      muiTheme: nextContext.muiTheme || this.state.muiTheme,
+    });
   },
 
   render() {
@@ -99,6 +94,10 @@ const BeforeAfterWrapper = React.createClass({
       elementType,
       ...other,
     } = this.props;
+
+    const {
+      prepareStyles,
+    } = this.state.muiTheme;
 
     let beforeElement;
     let afterElement;
@@ -114,20 +113,20 @@ const BeforeAfterWrapper = React.createClass({
     if (this.props.beforeStyle) beforeElement =
       React.createElement(this.props.beforeElementType,
         {
-          style: this.prepareStyles(beforeStyle, this.props.beforeStyle),
+          style: prepareStyles(Object.assign(beforeStyle, this.props.beforeStyle)),
           key: '::before',
         });
     if (this.props.afterStyle) afterElement =
       React.createElement(this.props.afterElementType,
         {
-          style: this.prepareStyles(afterStyle, this.props.afterStyle),
+          style: prepareStyles(Object.assign(afterStyle, this.props.afterStyle)),
           key: '::after',
         });
 
     let children = [beforeElement, this.props.children, afterElement];
 
     let props = other;
-    props.style = this.prepareStyles(this.props.style);
+    props.style = prepareStyles(Object.assign({}, this.props.style));
 
     return React.createElement(this.props.elementType, props, children);
   },


### PR DESCRIPTION
I think it'd be cool if we could remove this component and `ClearFix` in `0.15.0`. We have so much to do though, maybe it'd be a nice bonus.