### PR TITLE
[Progress] Remove style propable mixin

### DIFF
--- a/src/linear-progress.jsx
+++ b/src/linear-progress.jsx
@@ -1,8 +1,71 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
-import StylePropable from './mixins/style-propable';
 import Transitions from './styles/transitions';
 import getMuiTheme from './styles/getMuiTheme';
+
+function getRelativeValue(value, min, max) {
+  const clampedValue = Math.min(Math.max(min, value), max);
+  const rangeValue = max - min;
+  const relValue = Math.round(clampedValue / rangeValue * 10000) / 10000;
+  return relValue * 100;
+}
+
+function getStyles(props, state) {
+  const {
+    max,
+    min,
+    value,
+  } = props;
+
+  const {
+    baseTheme: {
+      palette,
+    },
+  } = state.muiTheme;
+
+  const styles = {
+    root: {
+      position: 'relative',
+      height: 4,
+      display: 'block',
+      width: '100%',
+      backgroundColor: palette.primary3Color,
+      borderRadius: 2,
+      margin: 0,
+      overflow: 'hidden',
+    },
+    bar: {
+      height: '100%',
+    },
+    barFragment1: {},
+    barFragment2: {},
+  };
+
+  if (props.mode === 'indeterminate') {
+    styles.barFragment1 = {
+      position: 'absolute',
+      backgroundColor: props.color || palette.primary1Color,
+      top: 0,
+      left: 0,
+      bottom: 0,
+      transition: Transitions.create('all', '840ms', null, 'cubic-bezier(0.650, 0.815, 0.735, 0.395)'),
+    };
+
+    styles.barFragment2 = {
+      position: 'absolute',
+      backgroundColor: props.color || palette.primary1Color,
+      top: 0,
+      left: 0,
+      bottom: 0,
+      transition: Transitions.create('all', '840ms', null, 'cubic-bezier(0.165, 0.840, 0.440, 1.000)'),
+    };
+  } else {
+    styles.bar.backgroundColor = props.color || palette.primary1Color;
+    styles.bar.transition = Transitions.create('width', '.3s', null, 'linear');
+    styles.bar.width = `${getRelativeValue(value, min, max)}%`;
+  }
+
+  return styles;
+}
 
 const LinearProgress = React.createClass({
   propTypes: {
@@ -43,14 +106,9 @@ const LinearProgress = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  //for passing default theme context to children
   childContextTypes: {
     muiTheme: React.PropTypes.object,
   },
-
-  mixins: [
-    StylePropable,
-  ],
 
   getDefaultProps() {
     return {
@@ -74,27 +132,23 @@ const LinearProgress = React.createClass({
   },
 
   componentDidMount() {
-    let bar1 = ReactDOM.findDOMNode(this.refs.bar1);
-    let bar2 = ReactDOM.findDOMNode(this.refs.bar2);
-
-    this.timers.bar1 = this._barUpdate('bar1', 0, bar1, [
+    this.timers.bar1 = this._barUpdate('bar1', 0, this.refs.bar1, [
       [-35, 100],
       [100, -90],
     ]);
 
     this.timers.bar2 = setTimeout(() => {
-      this._barUpdate('bar2', 0, bar2, [
+      this._barUpdate('bar2', 0, this.refs.bar2, [
         [-200, 100],
         [107, -8],
       ]);
     }, 850);
   },
 
-  //to update theme inside state whenever a new theme is passed down
-  //from the parent / owner using context
   componentWillReceiveProps(nextProps, nextContext) {
-    let newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
+    this.setState({
+      muiTheme: nextContext.muiTheme || this.state.muiTheme,
+    });
   },
 
   componentWillUnmount() {
@@ -130,80 +184,23 @@ const LinearProgress = React.createClass({
     this.timers[id] = setTimeout(() => this._barUpdate(id, step + 1, barElement, stepValues), 420);
   },
 
-  getTheme() {
-    return this.state.muiTheme.rawTheme.palette;
-  },
-
-  getStyles() {
-    let styles = {
-      root: {
-        position: 'relative',
-        height: 4,
-        display: 'block',
-        width: '100%',
-        backgroundColor: this.getTheme().primary3Color,
-        borderRadius: 2,
-        margin: 0,
-        overflow: 'hidden',
-      },
-      bar: {
-        height: '100%',
-      },
-      barFragment1: {},
-      barFragment2: {},
-    };
-
-    if (this.props.mode === 'indeterminate') {
-      styles.barFragment1 = {
-        position: 'absolute',
-        backgroundColor: this.props.color || this.getTheme().primary1Color,
-        top: 0,
-        left: 0,
-        bottom: 0,
-        transition: Transitions.create('all', '840ms', null, 'cubic-bezier(0.650, 0.815, 0.735, 0.395)'),
-      };
-
-      styles.barFragment2 = {
-        position: 'absolute',
-        backgroundColor: this.props.color || this.getTheme().primary1Color,
-        top: 0,
-        left: 0,
-        bottom: 0,
-        transition: Transitions.create('all', '840ms', null, 'cubic-bezier(0.165, 0.840, 0.440, 1.000)'),
-      };
-    } else {
-      styles.bar.backgroundColor = this.props.color || this.getTheme().primary1Color;
-      styles.bar.transition = Transitions.create('width', '.3s', null, 'linear');
-      styles.bar.width = `${this._getRelativeValue()}%`;
-    }
-
-    return styles;
-  },
-
-  _getRelativeValue() {
-    let value = this.props.value;
-    let min = this.props.min;
-    let max = this.props.max;
-
-    let clampedValue = Math.min(Math.max(min, value), max);
-    let rangeValue = max - min;
-    let relValue = Math.round(clampedValue / rangeValue * 10000) / 10000;
-    return relValue * 100;
-  },
-
   render() {
     let {
       style,
       ...other,
     } = this.props;
 
-    let styles = this.getStyles();
+    const {
+      prepareStyles,
+    } = this.state.muiTheme;
+
+    const styles = getStyles(this.props, this.state);
 
     return (
-      <div {...other} style={this.prepareStyles(styles.root, style)}>
-        <div style={this.prepareStyles(styles.bar)}>
-          <div ref="bar1" style={this.prepareStyles(styles.barFragment1)}></div>
-          <div ref="bar2" style={this.prepareStyles(styles.barFragment2)}></div>
+      <div {...other} style={prepareStyles(Object.assign(styles.root, style))}>
+        <div style={prepareStyles(styles.bar)}>
+          <div ref="bar1" style={prepareStyles(styles.barFragment1)}></div>
+          <div ref="bar2" style={prepareStyles(styles.barFragment2)}></div>
         </div>
       </div>
     );


### PR DESCRIPTION
These components could use some refactoring. I started some of it, but `refresh-indicator` in particular could be improved a lot. There is some common logic that's duplicated such as the `getRelativeValue()` function. Maybe one day we can consider making a single `<Progress />` component that can have different prop or child implementations.