### PR TITLE
[TextField] Fix defaultValue behavior

### DIFF
--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -244,16 +244,13 @@ const TextField = React.createClass({
       nextProps = nextProps.children.props;
     }
 
-    let hasValueLinkProp = nextProps.hasOwnProperty('valueLink');
-    let hasValueProp = nextProps.hasOwnProperty('value');
-    let hasNewDefaultValue = nextProps.defaultValue !== this.props.defaultValue;
+    const hasValueLinkProp = nextProps.hasOwnProperty('valueLink');
+    const hasValueProp = nextProps.hasOwnProperty('value');
 
     if (hasValueLinkProp) {
       newState.hasValue = isValid(nextProps.valueLink.value);
     } else if (hasValueProp) {
       newState.hasValue = isValid(nextProps.value);
-    } else if (hasNewDefaultValue) {
-      newState.hasValue = isValid(nextProps.defaultValue);
     }
 
     if (newState) this.setState(newState);


### PR DESCRIPTION
From the React docs we can read:
> The defaultValue and defaultChecked props are only used during initial render.
If you need to update the value in a subsequent render, you will need to use a controlled component.

I think that the `<TextField />` component should behave in the same way as an `<input />`.
Hence this PR.