### PR TITLE
[TextField] Fix wrong label id

### DIFF
--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -231,7 +231,7 @@ const TextField = React.createClass({
     };
   },
 
-  componentDidMount() {
+  componentWillMount() {
     this._uniqueId = UniqueId.generate();
   },
 
@@ -424,7 +424,7 @@ const TextField = React.createClass({
 
     let styles = this.getStyles();
 
-    let inputId = id || this._uniqueId;
+    const inputId = id || this._uniqueId;
 
     let errorTextElement = this.state.errorText ? (
       <div style={this.prepareStyles(styles.error)}>{this.state.errorText}</div>
@@ -437,7 +437,6 @@ const TextField = React.createClass({
         htmlFor={inputId}
         shrink={this.state.hasValue || this.state.isFocused}
         disabled={disabled}
-        onTouchTap={this.focus}
       >
         {floatingLabelText}
       </TextFieldLabel>


### PR DESCRIPTION
The `inputId` is `undefined` during the first render.
That's breaking the selection of the `input` by the `label`.

@chrismcv is this solving https://github.com/callemall/material-ui/pull/3055 and https://github.com/callemall/material-ui/issues/3045? I would rather not depend on `pointerEvents` that is not supported by IE10: http://caniuse.com/#search=css%20pointer-events.