### PR TITLE
[Menu] Fix a regression apply the select style to all the MenuItem

### DIFF
--- a/src/menus/menu.jsx
+++ b/src/menus/menu.jsx
@@ -389,12 +389,14 @@ const Menu = React.createClass({
   },
 
   _isChildSelected(child, props) {
-    let multiple = props.multiple;
-    let menuValue = this.getValueLink(props).value;
-    let childValue = child.props.value;
+    const menuValue = this.getValueLink(props).value;
+    const childValue = child.props.value;
 
-    return (multiple && menuValue.length && menuValue.indexOf(childValue) !== -1) ||
-      (!multiple && menuValue === childValue);
+    if (props.multiple) {
+      return menuValue.length && menuValue.indexOf(childValue) !== -1;
+    } else {
+      return child.props.hasOwnProperty('value') && menuValue === childValue;
+    }
   },
 
   _setFocusIndex(newIndex, isKeyboardFocused) {


### PR DESCRIPTION
Fix a regression introduced by https://github.com/callemall/material-ui/pull/3165:
![capture d ecran 2016-02-08 a 18 15 54](https://cloud.githubusercontent.com/assets/3165635/12893185/034eeaa0-ce90-11e5-9153-1ba0a09b9dd7.png)
In some case `child.props.value` and `this.getValueLink(props).value` can be both undefined.