### PR TITLE
[Toolbar] toolbar-title overflow

### DIFF
--- a/src/toolbar/toolbar-title.jsx
+++ b/src/toolbar/toolbar-title.jsx
@@ -14,6 +14,10 @@ function getStyles(props, state) {
       fontSize: toolbar.titleFontSize,
       display: 'inline-block',
       position: 'relative',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      width: (props.text.length > 40) ? '200' : 'inherit',
     },
   };
 }


### PR DESCRIPTION
# Proposed Solution

The highlighted text in the below screenshot are the needed changes. The changes are to be included in the **toolbar-title.jsx** file:

<img width="554" alt="screen shot 2016-02-08 at 4 23 19 pm" src="https://cloud.githubusercontent.com/assets/15271922/12902058/6db44ee6-ce84-11e5-806e-0eb00b36f07a.png">

This leads to the following change:
 a)  When its a long string :
![screen shot 2016-02-08 at 5 26 42 pm](https://cloud.githubusercontent.com/assets/15271922/12902834/311e60fc-ce89-11e5-8314-58f9bf71714a.png)

b) when its a small string:
![screen shot 2016-02-08 at 5 28 27 pm](https://cloud.githubusercontent.com/assets/15271922/12902893/7c821944-ce89-11e5-94e4-833269fce105.png)


