### PR TITLE
[Docs] Resolved issue where building docs would fail due to incorrect naming

### DIFF
--- a/docs/src/app/AppRoutes.jsx
+++ b/docs/src/app/AppRoutes.jsx
@@ -6,8 +6,8 @@ import {
 } from 'react-router';
 
 // Here we define all our material-ui ReactComponents.
-import Master from './components/Master';
-import Home from './components/pages/Home';
+import Master from './components/master';
+import Home from './components/pages/home';
 
 import Prerequisites from './components/pages/get-started/Prerequisites';
 import Installation from './components/pages/get-started/Installation';
@@ -15,8 +15,8 @@ import Usage from './components/pages/get-started/Usage';
 import Examples from './components/pages/get-started/Examples';
 import ServerRendering from './components/pages/get-started/ServerRendering';
 
-import Colors from './components/pages/customization/Colors';
-import Themes from './components/pages/customization/Themes';
+import Colors from './components/pages/customization/colors';
+import Themes from './components/pages/customization/themes';
 import InlineStyles from './components/pages/customization/InlineStyles';
 
 import AppBarPage from './components/pages/components/AppBar/Page';


### PR DESCRIPTION
Fixes this issue here.

ERROR in ./src/app/AppRoutes.jsx
Module not found: Error: Cannot resolve 'file' or 'directory' ./components/Master in /home/rosiet01/Documents/material-ui/docs/src/app
@ ./src/app/AppRoutes.jsx 15:14-44
ERROR in ./src/app/AppRoutes.jsx
Module not found: Error: Cannot resolve 'file' or 'directory' ./components/pages/Home in /home/rosiet01/Documents/material-ui/docs/src/app
@ ./src/app/AppRoutes.jsx 19:12-46
ERROR in ./src/app/AppRoutes.jsx
Module not found: Error: Cannot resolve 'file' or 'directory' ./components/pages/customization/Colors in /home/rosiet01/Documents/material-ui/docs/src/app
@ ./src/app/AppRoutes.jsx 43:14-64
ERROR in ./src/app/AppRoutes.jsx
Module not found: Error: Cannot resolve 'file' or 'directory' ./components/pages/customization/Themes in /home/rosiet01/Documents/material-ui/docs/src/app
@ ./src/app/AppRoutes.jsx 47:14-64
webpack: bundle is now VALID.