### PR TITLE
[IconMenu] Support MenuItem nested menuItems

### DIFF
--- a/docs/src/app/components/pages/components/IconMenu/ExampleNested.jsx
+++ b/docs/src/app/components/pages/components/IconMenu/ExampleNested.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import IconMenu from 'material-ui/lib/menus/icon-menu';
+import MenuItem from 'material-ui/lib/menus/menu-item';
+import IconButton from 'material-ui/lib/icon-button';
+import Divider from 'material-ui/lib/divider';
+
+import Download from 'material-ui/lib/svg-icons/file/file-download';
+import ArrowDropRight from 'material-ui/lib/svg-icons/navigation-arrow-drop-right';
+import MoreVertIcon from 'material-ui/lib/svg-icons/navigation/more-vert';
+
+const IconMenuExampleNested = () => (
+  <div>
+    <IconMenu
+      iconButtonElement={<IconButton><MoreVertIcon/></IconButton>}
+      anchorOrigin={{horizontal: 'left', vertical: 'top'}}
+      targetOrigin={{horizontal: 'left', vertical: 'top'}}
+    >
+      <MenuItem
+        primaryText="Copy & Paste"
+        rightIcon={<ArrowDropRight />}
+        menuItems={[
+          <MenuItem primaryText="Cut" />,
+          <MenuItem primaryText="Copy" />,
+          <Divider />,
+          <MenuItem primaryText="Paste" />,
+        ]}
+      />
+
+      <MenuItem
+        primaryText="Case Tools"
+        rightIcon={<ArrowDropRight />}
+        menuItems={[
+          <MenuItem primaryText="UPPERCASE" />,
+          <MenuItem primaryText="lowercase" />,
+          <MenuItem primaryText="CamelCase" />,
+          <MenuItem primaryText="Propercase" />,
+        ]}
+      />
+      <Divider />
+      <MenuItem primaryText="Download" leftIcon={<Download />} />
+      <Divider />
+      <MenuItem value="Del" primaryText="Delete" />
+
+    </IconMenu>
+  </div>
+);
+
+export default IconMenuExampleNested;

--- a/docs/src/app/components/pages/components/IconMenu/Page.jsx
+++ b/docs/src/app/components/pages/components/IconMenu/Page.jsx
@@ -13,12 +13,15 @@ import IconMenuExampleControlled from './ExampleControlled';
 import iconMenuExampleControlledCode from '!raw!./ExampleControlled';
 import IconMenuExampleScrollable from './ExampleScrollable';
 import iconMenuExampleScrollableCode from '!raw!./ExampleScrollable';
+import IconMenuExampleNested from './ExampleNested';
+import iconMenuExampleNestedCode from '!raw!./ExampleNested';
 
 const descriptions = {
   simple: 'Simple Icon Menus demonstrating some of the layouts possible using the `anchorOrigin` and `' +
   'targetOrigin` properties.',
   controlled: 'Two controlled examples, the first allowing a single selection, the second multiple selections.',
   scrollable: 'The `maxHeight` property limits the height of the menu, above which it will be scrollable.',
+  nested: 'Example of nested menus within an IconMenu.',
 };
 
 const IconMenusPage = () => (
@@ -45,6 +48,13 @@ const IconMenusPage = () => (
       code={iconMenuExampleScrollableCode}
     >
       <IconMenuExampleScrollable />
+    </CodeExample>
+    <CodeExample
+      title="Nested Icon Menus"
+      description={descriptions.nested}
+      code={iconMenuExampleNestedCode}
+    >
+      <IconMenuExampleNested />
     </CodeExample>
     <PropTypeDescription code={iconMenuCode} />
   </div>

--- a/src/menus/icon-menu.jsx
+++ b/src/menus/icon-menu.jsx
@@ -116,6 +116,8 @@ const IconMenu = React.createClass({
     /**
      * Sets the delay in milliseconds before closing the
      * menu when an item is clicked.
+     * If set to 0 then the auto close functionality
+     * will be disabled.
      */
     touchTapCloseDelay: React.PropTypes.number,
   },
@@ -160,7 +162,6 @@ const IconMenu = React.createClass({
       open: false,
     };
   },
-
   getChildContext() {
     return {
       muiTheme: this.state.muiTheme,
@@ -228,10 +229,13 @@ const IconMenu = React.createClass({
   },
 
   _handleItemTouchTap(event, child) {
-    const isKeyboard = Events.isKeyboard(event);
-    this.timerCloseId = setTimeout(() => {
-      this.close(isKeyboard ? 'enter' : 'itemTap', isKeyboard);
-    }, this.props.touchTapCloseDelay);
+
+    if (this.props.touchTapCloseDelay !== 0 && !child.props.hasOwnProperty('menuItems')) {
+      const isKeyboard = Events.isKeyboard(event);
+      this.timerCloseId = setTimeout(() => {
+        this.close(isKeyboard ? 'enter' : 'itemTap', isKeyboard);
+      }, this.props.touchTapCloseDelay);
+    }
 
     this.props.onItemTouchTap(event, child);
   },


### PR DESCRIPTION
If nested `menuItem` is used in `MenuItem` they close instantaneously. 

This is an example of the bug. http://imgur.com/g4M32q4