### PR TITLE
[List] Fix issue with styling on list related components

### DIFF
--- a/src/lists/list-item.jsx
+++ b/src/lists/list-item.jsx
@@ -662,7 +662,7 @@ const ListItem = React.createClass({
               ref="enhancedButton"
               style={Object.assign({}, styles.root, style)}
             >
-              <div style={this.state.muiTheme.prepareStyles(styles.innerDiv, innerDivStyle)}>
+              <div style={this.state.muiTheme.prepareStyles(Object.assign(styles.innerDiv, innerDivStyle))}>
                 {contentChildren}
               </div>
             </EnhancedButton>


### PR DESCRIPTION
The issue currently shows extra padding around list items (for menus) on the docs site.