### PR TITLE
[DatePicker] Add startDate property

### DIFF
--- a/src/date-picker/date-picker.jsx
+++ b/src/date-picker/date-picker.jsx
@@ -35,6 +35,11 @@ const DatePicker = React.createClass({
     defaultDate: React.PropTypes.object,
 
     /**
+     * The date from which the picker will start.
+     */
+    startDate:  React.PropTypes.object,
+
+    /**
      * Disables the year selection in the date picker.
      */
     disableYearSelection: React.PropTypes.bool,
@@ -169,7 +174,7 @@ const DatePicker = React.createClass({
   getInitialState() {
     return {
       date: this._isControlled() ? this._getControlledDate() : this.props.defaultDate,
-      dialogDate: new Date(),
+      startDate: this.props.startDate || new Date(),
       muiTheme: this.context.muiTheme || getMuiTheme(),
     };
   },
@@ -208,7 +213,7 @@ const DatePicker = React.createClass({
    */
   openDialog() {
     this.setState({
-      dialogDate: this.getDate(),
+      startDate: this.getDate() || this.state.startDate,
     }, this.refs.dialogWindow.show);
   },
 
@@ -301,7 +306,7 @@ const DatePicker = React.createClass({
           locale={locale}
           wordings={wordings}
           mode={mode}
-          initialDate={this.state.dialogDate}
+          initialDate={this.state.startDate}
           onAccept={this._handleDialogAccept}
           onShow={onShow}
           onDismiss={onDismiss}


### PR DESCRIPTION
Continuation of #1628.

I renamed it to `startDate` it makes more sense. also I think this is a good feature to have, so I didn't close it.

@oliviertassinari See if this is alright.