### PR TITLE
[InkBar] remove &nbsp;

### DIFF
--- a/src/ink-bar.jsx
+++ b/src/ink-bar.jsx
@@ -71,9 +71,7 @@ const InkBar = React.createClass({
     }, this.props.style, colorStyle);
 
     return (
-      <div style={this.prepareStyles(styles)}>
-        &nbsp;
-      </div>
+      <div style={this.prepareStyles(styles)} />
     );
   },
 


### PR DESCRIPTION
This supposedly hidden character transform into 'Â' on Android.

Do you know why this nbsp was added? It works without on chrome desktop and android.