### PR TITLE
[TimePicker] fix issue where clock does not render in timepicker nested in dialog

### DIFF
--- a/src/time-picker/time-display.jsx
+++ b/src/time-picker/time-display.jsx
@@ -92,7 +92,6 @@ const TimeDisplay = React.createClass({
       root: {
         position: 'relative',
         width: 280,
-        height: '100%',
       },
 
       box: {


### PR DESCRIPTION
This PR fixes #1398

Having a TimePicker component in a Dialog component currently renders like this:

<img width="279" alt="issue" src="https://cloud.githubusercontent.com/assets/11324678/12995915/4c1aaf42-d0f9-11e5-9406-b333e56c5d87.png">

This PR resolves this issue so that it now renders like this:

<img width="278" alt="fix" src="https://cloud.githubusercontent.com/assets/11324678/12995942/6d09b3ec-d0f9-11e5-88ba-a01e87851b70.png">