### PR TITLE
[EnhancedButton] fix enhanced buttons containing a link instead of a button

### DIFF
--- a/src/enhanced-button.jsx
+++ b/src/enhanced-button.jsx
@@ -284,7 +284,6 @@ const EnhancedButton = React.createClass({
       font: 'inherit',
       fontFamily: this.state.muiTheme.rawTheme.fontFamily,
       tapHighlightColor: Colors.transparent,
-      appearance: linkButton ? null : 'button',
       cursor: disabled ? 'default' : 'pointer',
       textDecoration: 'none',
       outline: 'none',


### PR DESCRIPTION
Remove `appearance: button` style from enhanced buttons to fix https://github.com/callemall/material-ui/issues/3129