### PR TITLE
Update editorconfig so it helps enforce the trailing whitespace eslint rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,6 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.js]
+trim_trailing_whitespace = true


### PR DESCRIPTION
This addition to `.editorconfig` means that the trailing whitespace is automatically stripped for those of us that use it, which helps satisfy the eslint rule below (it is enabled for this project):

```
no-trailing-spaces: 2
```