### PR TITLE
[DatePicker] Remove window-listenable mixin

### DIFF
--- a/src/date-picker/calendar.jsx
+++ b/src/date-picker/calendar.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import WindowListenable from '../mixins/window-listenable';
+import EventListener from 'react-event-listener';
 import DateTime from '../utils/date-time';
 import KeyCode from '../utils/key-code';
 import Transitions from '../styles/transitions';
@@ -36,10 +36,6 @@ const Calendar = React.createClass({
   childContextTypes: {
     muiTheme: React.PropTypes.object,
   },
-
-  mixins: [
-    WindowListenable,
-  ],
 
   getDefaultProps() {
     return {
@@ -79,10 +75,6 @@ const Calendar = React.createClass({
     }
 
     this.setState({muiTheme});
-  },
-
-  windowListeners: {
-    keydown: '_handleWindowKeyDown',
   },
 
   _yearSelector() {
@@ -303,6 +295,10 @@ const Calendar = React.createClass({
 
     return (
       <ClearFix style={styles.root}>
+        <EventListener
+          elementName="window"
+          onKeyDown={this._handleWindowKeyDown}
+        />
         <DateDisplay
           DateTimeFormat={DateTimeFormat}
           locale={locale}

--- a/src/date-picker/date-picker-dialog.jsx
+++ b/src/date-picker/date-picker-dialog.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ContextPure from '../mixins/context-pure';
-import WindowListenable from '../mixins/window-listenable';
+import EventListener from 'react-event-listener';
 import KeyCode from '../utils/key-code';
 import Calendar from './calendar';
 import Dialog from '../dialog';
@@ -43,7 +43,6 @@ const DatePickerDialog = React.createClass({
   },
 
   mixins: [
-    WindowListenable,
     ContextPure,
   ],
 
@@ -90,10 +89,6 @@ const DatePickerDialog = React.createClass({
     this.setState({
       muiTheme: nextContext.muiTheme || this.state.muiTheme,
     });
-  },
-
-  windowListeners: {
-    keyup: '_handleWindowKeyUp',
   },
 
   show() {
@@ -211,6 +206,10 @@ const DatePickerDialog = React.createClass({
         open={this.state.open}
         onRequestClose={this.dismiss}
       >
+        <EventListener
+          elementName="window"
+          onKeyUp={this._handleWindowKeyUp}
+        />
         <Calendar
           DateTimeFormat={DateTimeFormat}
           firstDayOfWeek={firstDayOfWeek}

--- a/src/date-picker/date-picker.jsx
+++ b/src/date-picker/date-picker.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import WindowListenable from '../mixins/window-listenable';
 import DateTime from '../utils/date-time';
 import DatePickerDialog from './date-picker-dialog';
 import TextField from '../text-field';
@@ -148,10 +147,6 @@ const DatePicker = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  mixins: [
-    WindowListenable,
-  ],
-
   getDefaultProps() {
     return {
       formatDate: DateTime.format,
@@ -190,10 +185,6 @@ const DatePicker = React.createClass({
         });
       }
     }
-  },
-
-  windowListeners: {
-    keyup: '_handleWindowKeyUp',
   },
 
   getDate() {
@@ -238,10 +229,6 @@ const DatePicker = React.createClass({
       setTimeout(() => {
         this.openDialog();
       }, 0);
-  },
-
-  _handleWindowKeyUp() {
-    //TO DO: open the dialog if input has focus
   },
 
   _isControlled() {


### PR DESCRIPTION
This is the last set of components for #3305.

Take note of the `date-picker.jsx` component. It had the mixin tied into an unimplemented method. I just removed them for now, but if you think we should implement it now, I can add the EventListener and take a stab. I'm not sure if I quite understand what it was trying to accomplish though.