### PR TITLE
[Core] Deprecate style-propable mixin

### DIFF
--- a/src/mixins/style-propable.js
+++ b/src/mixins/style-propable.js
@@ -1,16 +1,18 @@
 import React from 'react';
-import {mergeStyles, mergeAndPrefix} from '../utils/styles';
+import warning from 'warning';
 
-/**
- * This mixin isn't necessary and will be removed soon. DO NOT USE!
- *
- * All internal components that use this mixin should be switched to the
- * `styleUtils` that this mixin now wraps. Notice the method signature of
- * the `prepareStyles()` function of this mixin is different than the method
- * signature of the `prepareStyles()` function in `styleUtils`.
- *
- * See `../utils/styles.js` for more details.
- */
+let hasWarned;
+const warn = () => {
+  warning(hasWarned, 'The \'material-ui/lib/mixins/style-propable.js\' mixin has been deprecated.' +
+    ' Please do not use this mixin as it will be removed in an upcoming release.');
+  hasWarned = true;
+};
+
+export const mergeStyles = (...args) => {
+  warn();
+  return Object.assign({}, ...args);
+};
+
 export default {
 
   propTypes: {
@@ -19,14 +21,17 @@ export default {
 
   mergeStyles,
 
-  mergeAndPrefix,
-
   prepareStyles(...args) {
+    warn();
     const {
       prepareStyles = (style) => (style),
     } = (this.state && this.state.muiTheme) || (this.context && this.context.muiTheme) ||
         (this.props && this.props.muiTheme) || {};
 
-    return prepareStyles(mergeStyles({}, ...args));
+    return prepareStyles(mergeStyles(...args));
+  },
+
+  componentWillMount() {
+    warn();
   },
 };

--- a/src/utils/styles.js
+++ b/src/utils/styles.js
@@ -1,23 +1,20 @@
-export const mergeStyles = (...args) => Object.assign({}, ...args);
+import warning from 'warning';
 
-/**
- * `prepareStyles` is used to merge multiple styles, make sure they are flipped
- * to rtl if needed, and then autoprefix them.
- *
- * Never call this on the same style object twice. As a rule of thumb, only
- * call it when passing style attribute to html elements.
- *
- * If this method detects you called it twice on the same style object, it
- * will produce a warning in the console.
- */
-export function prepareStyles(muiTheme, style = {}, ...styles) {
-  if (styles) {
-    //warning(false, 'Providing more than one style argument to prepareStyles has been deprecated. ' +
-    //  'Please pass a single style, such as the result from mergeStyles(...styles).');
-    style = mergeStyles(style, ...styles);
-  }
+let hasWarned;
+const warn = () => {
+  warning(hasWarned, 'The \'material-ui/lib/utils/styles.js\' utility module has been deprecated.' +
+    ' Please do not use this utility module as it will be removed in an upcoming release.');
+  hasWarned = true;
+};
 
-  return muiTheme.prepareStyles(style);
+export const mergeStyles = (...args) => {
+  warn();
+  return Object.assign({}, ...args);
+};
+
+export function prepareStyles(muiTheme, ...styles) {
+  warn();
+  return muiTheme.prepareStyles(...styles);
 }
 
 export default {


### PR DESCRIPTION
This should be merged after #3350.

This commit deprecates the `style-propable` mixin. It also removes the `utils/styles` utility file. 

**Note:** The export for the mixin was also removed from 'mixins/index.js' to avoid warning for all applications.