### PR TITLE
[FlatButton] Fix alignment between text and icons

### DIFF
--- a/src/buttons/flat-button-label.jsx
+++ b/src/buttons/flat-button-label.jsx
@@ -11,6 +11,7 @@ function getStyles(props, state) {
       position: 'relative',
       paddingLeft: baseTheme.spacing.desktopGutterLess,
       paddingRight: baseTheme.spacing.desktopGutterLess,
+      verticalAlign: 'middle',
     },
   };
 }


### PR DESCRIPTION
Align text inside the button and also with the icon, if any. For better explanation see #3366 