### PR TITLE
[Docs] Added z-index to the input file

### DIFF
--- a/docs/src/app/components/pages/components/FlatButton/ExampleComplex.jsx
+++ b/docs/src/app/components/pages/components/FlatButton/ExampleComplex.jsx
@@ -13,6 +13,7 @@ const styles = {
     left: 0,
     width: '100%',
     opacity: 0,
+    zIndex: 1,
   },
 };
 


### PR DESCRIPTION
If z-index is not set you can't click the input and the file picker is not going to open.