### PR TITLE
[RaisedButton] Fix alignment between text and icons

### DIFF
--- a/src/raised-button.jsx
+++ b/src/raised-button.jsx
@@ -66,6 +66,7 @@ function getStyles(props, state) {
     },
     label: {
       position: 'relative',
+      verticalAlign: 'middle',
       opacity: 1,
       fontSize: '14px',
       letterSpacing: 0,


### PR DESCRIPTION
Align text inside the button and also with the icon, if any.