### PR TITLE
[LeftNav] : Added a z-index component to the AppLeftNav component of docs to enable toggle

### DIFF
--- a/docs/src/app/components/AppLeftNav.jsx
+++ b/docs/src/app/components/AppLeftNav.jsx
@@ -10,6 +10,7 @@ import {
   Spacing,
   Typography,
 } from 'material-ui/lib/styles';
+import zIndex from 'material-ui/lib/styles/zIndex';
 
 const SelectableList = SelectableContainerEnhance(List);
 
@@ -78,6 +79,7 @@ const AppLeftNav = React.createClass({
         docked={docked}
         open={open}
         onRequestChange={onRequestChangeLeftNav}
+        containerStyle={{zIndex: zIndex.leftNav - 100}}
       >
         <div style={prepareStyles(styles.logo)} onTouchTap={this.handleTouchTapHeader}>
           Material-UI


### PR DESCRIPTION
The leftNav examples in the doc website had the same z-index as the AppLeftNav component from the master page and hence were hidden behind the AppLeftNav during toggle.

Both the example leftNav and the AppLeftNav referred to the z-index component  from the styles and had the same value.

Adding a z-index component to the AppLeftNav and assigning it a value of the original zindex.leftNav -100, fixed the issue as it layers it below the leftNav.

This pull request references the issue:  The Left Nav toggle doesn't work. #3355. 