### PR TITLE
[Examples] : Changed the path for MuiThemeProvider

### DIFF
--- a/examples/browserify-gulp-example/src/app/Main.jsx
+++ b/examples/browserify-gulp-example/src/app/Main.jsx
@@ -9,7 +9,7 @@ import Dialog from 'material-ui/lib/dialog';
 import Colors from 'material-ui/lib/styles/colors';
 import FlatButton from 'material-ui/lib/flat-button';
 import getMuiTheme from 'material-ui/lib/styles/getMuiTheme';
-import MuiThemeProvider from 'material-ui/lib/styles/MuiThemeProvider';
+import MuiThemeProvider from 'material-ui/lib/MuiThemeProvider';
 
 const styles = {
   container: {


### PR DESCRIPTION
Changed the path from 
`import MuiThemeProvider from 'material-ui/lib/styles/MuiThemeProvider` to `import MuiThemeProvider from 'material-ui/lib/MuiThemeProvider` in `Main.jsx` of `browserify-gulp-example`

This fixed the issue and the example runs correctly now without any error.

Issue referenced: Cannot find module material-ui/lib/styles/MuiThemeProvider #3347