### PR TITLE
[FlatBotton] Fix alignment between text and icons

### DIFF
--- a/src/app-bar.jsx
+++ b/src/app-bar.jsx
@@ -55,7 +55,7 @@ function getStyles(props, state) {
     },
     flatButton: {
       color: appBar.textColor,
-      marginTop: (iconButtonSize - flatButtonSize) / 2 + 2,
+      marginTop: (iconButtonSize - flatButtonSize) / 2 + 1,
     },
   };
 

--- a/src/buttons/flat-button-label.jsx
+++ b/src/buttons/flat-button-label.jsx
@@ -11,6 +11,7 @@ function getStyles(props, state) {
       position: 'relative',
       paddingLeft: baseTheme.spacing.desktopGutterLess,
       paddingRight: baseTheme.spacing.desktopGutterLess,
+      verticalAlign: 'middle',
     },
   };
 }


### PR DESCRIPTION
Continue https://github.com/callemall/material-ui/pull/3364.

Align text inside the button and also with the icon, if any.