### PR TITLE
[DropDownMenu] Fix openImmediately regression

### DIFF
--- a/docs/src/app/components/pages/components/DropDownMenu/ExampleOpenImmediate.jsx
+++ b/docs/src/app/components/pages/components/DropDownMenu/ExampleOpenImmediate.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import DropDownMenu from 'material-ui/lib/DropDownMenu';
+import MenuItem from 'material-ui/lib/menus/menu-item';
+
+export default class DropDownMenuOpenImmediateExample extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {value: 2};
+  }
+
+  handleChange = (event, index, value) => this.setState({value});
+
+  render() {
+    return (
+      <DropDownMenu value={this.state.value} onChange={this.handleChange} openImmediately={true}>
+        <MenuItem value={1} primaryText="Never"/>
+        <MenuItem value={2} primaryText="Every Night"/>
+        <MenuItem value={3} primaryText="Weeknights"/>
+        <MenuItem value={4} primaryText="Weekends"/>
+        <MenuItem value={5} primaryText="Weekly"/>
+      </DropDownMenu>
+    );
+  }
+}

--- a/docs/src/app/components/pages/components/DropDownMenu/Page.jsx
+++ b/docs/src/app/components/pages/components/DropDownMenu/Page.jsx
@@ -8,6 +8,8 @@ import MarkdownElement from '../../../MarkdownElement';
 import dropDownMenuReadmeText from './README';
 import DropDownMenuSimpleExample from './ExampleSimple';
 import dropDownMenuSimpleExampleCode from '!raw!./ExampleSimple';
+import DropDownMenuOpenImmediateExample from './ExampleOpenImmediate';
+import dropDownMenuOpenImmediateExampleCode from '!raw!./ExampleOpenImmediate';
 import DropDownMenuLongMenuExample from './ExampleLongMenu';
 import dropDownMenuLongMenuExampleCode from '!raw!./ExampleLongMenu';
 import DropDownMenuLabeledExample from './ExampleLabeled';
@@ -17,6 +19,7 @@ import dropDownMenuCode from '!raw!material-ui/lib/DropDownMenu/DropDownMenu';
 const descriptions = {
   simple: '`DropDownMenu` is implemented as a controlled component, with the current selection set through the ' +
   '`value` property.',
+  openImmediate: 'With `openImmediately` property set, the menu will open on mount.',
   long: 'With the `maxHeight` property set, the menu will be scrollable if the number of items causes the height ' +
   'to exceed this limit.',
   label: 'With a `label` applied to each `MenuItem`, `DropDownMenu` displays a complementary description ' +
@@ -33,6 +36,13 @@ const DropDownMenuPage = () => (
       code={dropDownMenuSimpleExampleCode}
     >
       <DropDownMenuSimpleExample />
+    </CodeExample>
+    <CodeExample
+      title="Open Immediate example"
+      description={descriptions.openImmediate}
+      code={dropDownMenuOpenImmediateExampleCode}
+    >
+      <DropDownMenuOpenImmediateExample />
     </CodeExample>
     <CodeExample
       title="Long example"

--- a/src/DropDownMenu/DropDownMenu.jsx
+++ b/src/DropDownMenu/DropDownMenu.jsx
@@ -107,7 +107,7 @@ const DropDownMenu = React.createClass({
 
   getInitialState() {
     return {
-      open: this.props.openImmediately,
+      open: false,
       muiTheme: this.context.muiTheme || getMuiTheme(),
     };
   },
@@ -120,6 +120,12 @@ const DropDownMenu = React.createClass({
 
   componentDidMount() {
     if (this.props.autoWidth) this._setWidth();
+    if (this.props.openImmediately) {
+      /*eslint-disable react/no-did-mount-set-state */
+      // Temorary fix to make openImmediately work with popover.
+      setTimeout(() => this.setState({open: true, anchorEl: this.refs.root}));
+      /*eslint-enable react/no-did-mount-set-state */
+    }
   },
 
   componentWillReceiveProps(nextProps, nextContext) {


### PR DESCRIPTION
Closes #2853

This is not a workaround as previously discussed. But rather an anti-pattern. For now we'll have to support this before we remove state entirely from our components and put them into wrappers.

I also added an example to the docs to avoid future regressions like this (this too is temporary :sweat_smile: )