### PR TITLE
[Popover]  Handle the touch event on touch enabled devices

### DIFF
--- a/docs/src/app/components/pages/components/Popover/ExampleAnimation.jsx
+++ b/docs/src/app/components/pages/components/Popover/ExampleAnimation.jsx
@@ -16,6 +16,8 @@ export default class PopoverExampleAnimation extends React.Component {
   }
 
   handleTouchTap = (event) => {
+    // This prevents ghost click.
+    event.preventDefault();
     this.setState({
       open: true,
       anchorEl: event.currentTarget,

--- a/docs/src/app/components/pages/components/Popover/ExampleConfigurable.jsx
+++ b/docs/src/app/components/pages/components/Popover/ExampleConfigurable.jsx
@@ -37,6 +37,8 @@ export default class PopoverExampleConfigurable extends React.Component {
   }
 
   handleTouchTap = (event) => {
+    // This prevents ghost click.
+    event.preventDefault();
     this.setState({
       open: true,
       anchorEl: event.currentTarget,

--- a/docs/src/app/components/pages/components/Popover/ExampleSimple.jsx
+++ b/docs/src/app/components/pages/components/Popover/ExampleSimple.jsx
@@ -15,6 +15,9 @@ export default class PopoverExampleSimple extends React.Component {
   }
 
   handleTouchTap = (event) => {
+    // This prevents ghost click.
+    event.preventDefault();
+
     this.setState({
       open: true,
       anchorEl: event.currentTarget,

--- a/docs/src/app/components/pages/components/Popover/NOTE.md
+++ b/docs/src/app/components/pages/components/Popover/NOTE.md
@@ -1,0 +1,3 @@
+## Note
+
+The `event.preventDefault();` in the examples above is to prevent an effect called [ghost click](http://ariatemplates.com/blog/2014/05/ghost-clicks-in-mobile-browsers/) that happens with touch-devices. It is recommended that you add that call whenever you handle a `TouchTap` event associated with closing/opening `Popover`.

--- a/docs/src/app/components/pages/components/Popover/Page.jsx
+++ b/docs/src/app/components/pages/components/Popover/Page.jsx
@@ -6,6 +6,7 @@ import PropTypeDescription from '../../../PropTypeDescription';
 import MarkdownElement from '../../../MarkdownElement';
 
 import popoverReadmeText from './README';
+import popoverNoteText from './NOTE';
 import popoverCode from '!raw!material-ui/lib/popover/popover';
 import PopoverExampleSimple from './ExampleSimple';
 import popoverExampleSimpleCode from '!raw!./ExampleSimple';
@@ -48,6 +49,7 @@ const PopoverPage = () => (
     >
       <PopoverExampleConfigurable />
     </CodeExample>
+    <MarkdownElement text={popoverNoteText} />
     <PropTypeDescription code={popoverCode} />
   </div>
 );


### PR DESCRIPTION
I set useLayerForClickAway to false in the default props of `popover.jsx` to avoid ghost click in the underlying div. To make this work I had to add a delay in the setTimeOut function in the `render-to-layer` component for the `useLayerForClickAway` property.

Delaying the adding of event listeners to the layer div in the `render-to-layer` component avoids ghost click event to be picked up by the component.

I tested it on chrome and it seems to work fine.

Fixes #3335.