### PR TITLE
[Snackbar] Added optional customMessageEqualityTester callback property

### DIFF
--- a/src/snackbar.jsx
+++ b/src/snackbar.jsx
@@ -92,6 +92,17 @@ const Snackbar = React.createClass({
     className: React.PropTypes.string,
 
     /**
+     * Callback used to test the equality of the current message against the next message. This is useful for when
+     * the message is a node type that requires more involved equality testing, such as an element, and the
+     * snackbar may be re-rendered while it's open, though the properties haven't changed. If it returns true,
+     * the messages will be considered equal by the snackbar component.
+     *
+     * @param {node} currentMessage - The current message
+     * @param {node} nextMessage - The next message
+     */
+    customMessageEqualityTester: React.PropTypes.func,
+
+    /**
      * The message to be displayed.
      */
     message: React.PropTypes.node.isRequired,
@@ -167,8 +178,16 @@ const Snackbar = React.createClass({
       muiTheme: nextContext.muiTheme || this.state.muiTheme,
     });
 
+    const messageDidChange = (() => {
+      if (this.props.customMessageEqualityTester) {
+        return !this.props.customMessageEqualityTester(this.props.message, nextProps.message);
+      } else {
+        return this.props.message !== nextProps.message;
+      }
+    })();
+
     if (this.state.open && nextProps.open === this.props.open &&
-        (nextProps.message !== this.props.message || nextProps.action !== this.props.action)) {
+        (messageDidChange || nextProps.action !== this.props.action)) {
       this.setState({
         open: false,
       });


### PR DESCRIPTION
The `Snackbar` can accept a callback which tests the equality of the current `props.message` and `nextProps.message` to determine if they should be considered equal, in scenarios where the message is node type that requires special equality testing, like an element.

Here's how it would be used to avoid the bug shown in #3186 

![example_with_custom_equality_tester_cropped](https://cloud.githubusercontent.com/assets/8320854/13199844/01ea83e0-d7ff-11e5-99a6-f33b3ad2749d.png)

Fixes #3186.