### PR TITLE
[TouchRipple] Abort on scroll

### DIFF
--- a/src/ripples/circle-ripple.jsx
+++ b/src/ripples/circle-ripple.jsx
@@ -7,6 +7,7 @@ import Transitions from '../styles/transitions';
 const CircleRipple = React.createClass({
 
   propTypes: {
+    aborted: React.PropTypes.bool,
     color: React.PropTypes.string,
 
     /**
@@ -29,7 +30,8 @@ const CircleRipple = React.createClass({
 
   getDefaultProps() {
     return {
-      opacity: 0.16,
+      opacity: 0.1,
+      aborted: false,
     };
   },
 
@@ -52,9 +54,11 @@ const CircleRipple = React.createClass({
   componentWillLeave(callback) {
     const style = ReactDOM.findDOMNode(this).style;
     style.opacity = 0;
+    //If the animation is aborted, remove from the DOM immediately
+    const removeAfter = this.props.aborted ? 0 : 2000;
     setTimeout(() => {
       if (this.isMounted()) callback();
-    }, 2000);
+    }, removeAfter);
   },
 
   _animate() {


### PR DESCRIPTION
Fixes #2165. This change causes touch-ripple to be cancelled by default if the user begins to scroll.

This is only my second PR to this project so feedback on code and PR process are extremely appreciated.

**How to verify PR**
1. Open the docs page in a mobile emulation mode, or on a mobile device
2. Tap the leftNav menu button
3. Scroll the menu. 
4. Observe that scrolling in this menu doesn't trigger ripples on the list-items (as prod does today), but tapping them (or holding etc) does cause the ripple.

1. Observe the same effect on buttons - tapping them works the same as today, but starting a scroll prevents a ripple from appearing.

**How it was implemented**
To do this, when a touch starts we add a touchmove listener, which aborts the animation if a scroll of more than 6px is detected in the first 300ms.

To abort the animation, the relevant ripple is replaced by a clone with `aborted` set to true which tells it to disappear immediately when `componentWillLeave` is called. `this.end()` is then called, removing the ripple from the `ReactTransitionGroup`, triggering `componentWillLeave`.

**Additional note**
Note that I reduced `touchRippleOpacity` on list-item to 0.1 as it felt a little too dark before, and since the ripple starts really dark and eases out quickly sometimes there would be a dark flash as the animation started before it aborted. Reducing the opacity is a visual improvement IMHO, and lessens this issue. For additional polish, in the future we may want to move from an ease out animation to one where the opacity starts lower and remains there for slightly longer before fading out, which would also help with this issue.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/callemall/material-ui/3407)
<!-- Reviewable:end -->
