### PR TITLE
[Snackbar] Updated docs to give a warning to avoid unwanted hiding/sh…

### DIFF
--- a/src/snackbar.jsx
+++ b/src/snackbar.jsx
@@ -93,6 +93,10 @@ const Snackbar = React.createClass({
 
     /**
      * The message to be displayed.
+     *
+     * (Note: If the message is an element or array, and the `Snackbar` may re-render while it is still open,
+     * ensure that the same object remains as the `message` property if you want to avoid the `Snackbar` hiding and
+     * showing again)
      */
     message: React.PropTypes.node.isRequired,
 


### PR DESCRIPTION
I've added a bit of a warning to the `message` property documentation so that the unwanted behaviour of  a `Snackbar` hiding and showing again when the message is an `element` or `array` can be avoided.  As @oliviertassinari pointed out in #3186 , the onus should be on the user to ensure that the actual `message` object doesn't change if they don't want it to behave as if it didn't change, but I think some warning could be useful in avoiding `Snackbar` behaviour that appears to be a bug.