### PR TITLE
[DatePicker] Fix date picker docs typo

### DIFF
--- a/src/date-picker/date-picker.jsx
+++ b/src/date-picker/date-picker.jsx
@@ -9,7 +9,7 @@ const DatePicker = React.createClass({
   propTypes: {
     /**
      * Constructor for time formatting.
-     * Follow this specificaction: ECMAScript Internationalization API 1.0 (ECMA-402).
+     * Follow this specification: ECMAScript Internationalization API 1.0 (ECMA-402).
      */
     DateTimeFormat: React.PropTypes.func,
 


### PR DESCRIPTION
Just fixing a typo on the docs for date picker 
`specificaction` -> `specification`