### PR TITLE
[Docs] Fix missing Object.assign on docs site

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,6 +8,7 @@
   "env": {
     "docs-production": {
       "plugins": [
+        ["transform-replace-object-assign", "simple-assign"],
         "transform-react-remove-prop-types",
         "transform-react-constant-elements",
         "transform-react-inline-elements"

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,7 +19,8 @@
     "android:setup-port": "adb reverse tcp:8081 tcp:8081"
   },
   "dependencies": {
-    "react-title-component": "^1.0.1"
+    "react-title-component": "^1.0.1",
+    "simple-assign": "^0.1.0"
   },
   "devDependencies": {
     "babel-eslint": "^5.0.0",

--- a/docs/src/.babelrc
+++ b/docs/src/.babelrc
@@ -1,11 +1,15 @@
 {
   "presets": ["react", "es2015", "stage-1"],
+  "plugins": [
+    ["transform-replace-object-assign", "simple-assign"]
+  ],
   "env": {
     "docs-production": {
       "plugins": [
         "transform-react-remove-prop-types",
         "transform-react-constant-elements",
-        "transform-react-inline-elements"
+        "transform-react-inline-elements",
+        ["transform-replace-object-assign", "simple-assign"]
       ]
     }
   }


### PR DESCRIPTION
@mbrookes Could you maybe gpr this when you get a chance and see if it fixes it for you?

I'm a little confused why we're specifying the following configuration in both `root/.babelrc` and `docs/src/.babelrc` (and an empty object in `docs/.babelrc`). It'd be nice to clean this up but this at least fixed the docs site on my Safari 8.

```json
"env": {
    "docs-production": {
      "plugins": [
        ["transform-replace-object-assign", "simple-assign"],
        "transform-react-remove-prop-types",
        "transform-react-constant-elements",
        "transform-react-inline-elements"
      ]
    }
  }
```