### PR TITLE
Fix timeout problem on rapid focus menu icon

### DIFF
--- a/src/menus/icon-menu.jsx
+++ b/src/menus/icon-menu.jsx
@@ -331,6 +331,7 @@ const IconMenu = React.createClass({
           targetOrigin={targetOrigin}
           open={open}
           anchorEl={anchorEl}
+          animated={false}
           childContextTypes={this.constructor.childContextTypes}
           useLayerForClickAway={useLayerForClickAway}
           onRequestClose={this.close}


### PR DESCRIPTION
Related fix: diabled animated on popover
https://github.com/callemall/material-ui/issues/3425
