### PR TITLE
[eslint] Ignore coverage reports

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 src/svg-icons
+test/coverage


### PR DESCRIPTION
Running eslint after tests is currently broken locally because the coverage folders are not ignored. This fixes that.