### PR TITLE
[Toolbar] toolbar-title overflow:  Set width in the example

### DIFF
--- a/docs/src/app/components/pages/components/Toolbar/ExampleSimple.jsx
+++ b/docs/src/app/components/pages/components/Toolbar/ExampleSimple.jsx
@@ -37,7 +37,7 @@ export default class ToolbarExamplesSimple extends React.Component {
           </DropDownMenu>
         </ToolbarGroup>
         <ToolbarGroup float="right">
-          <ToolbarTitle text="Options" />
+          <ToolbarTitle text="Options" style={{width: 90}} />
           <FontIcon className="muidocs-icon-custom-sort" />
           <IconMenu
             iconButtonElement={

--- a/src/toolbar/toolbar-title.jsx
+++ b/src/toolbar/toolbar-title.jsx
@@ -17,7 +17,6 @@ function getStyles(props, state) {
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
       overflow: 'hidden',
-      width: (props.text.length > 40) ? '200' : 'inherit',
     },
   };
 }


### PR DESCRIPTION
This references issue: https://github.com/callemall/material-ui/issues/3192

Previously submitted PR: https://github.com/callemall/material-ui/pull/3250

- Since the issue still persists even after the last PR was merged, I decided to change the fix a bit. All other css changes in `toolbar-title.jsx` remains the same except for the width attribute. 
- The earlier logic of having the width based on the number of characters within the component jsx code seemed dodgy. I decided to move the width attribute as a part of the inline style in the example code instead.
- This makes more sense to me since the use of toolbar might change based on the use-case and so does the title width which is dependent on the number of elements being present in a toolbar implementation.
- I have included a value of `width:150px` based on the implementation in the example page but I understand that it is still a magic constant and my suggestion would be to add a note in the docs mentioning the same like its done for the [popover ghost touch issue](https://github.com/callemall/material-ui/pull/3389) , as it is more of an implementation issue.

- I could add the note if needed. @alitaheri @newoga need you opinion about it.

- As you both know I have started work on redesign of the Toolbar component. This can work as a temporary fix till then. 

P.S: I created a new branch and proceeded the issue in a fresh manner hence the new branch.


