### PR TITLE
[TextFieldLabel] Fix 2px position shift for TextFieldLabel

### DIFF
--- a/src/TextField/TextFieldLabel.jsx
+++ b/src/TextField/TextFieldLabel.jsx
@@ -71,7 +71,7 @@ const TextFieldLabel = (props) => {
       zIndex: 1, // Needed to display label above Chrome's autocomplete field background
       cursor: disabled ? 'default' : 'text',
       transform: shrink
-        ? 'perspective(1px) scale(0.75) translate3d(2px, -28px, 0)'
+        ? 'perspective(1px) scale(0.75) translate3d(0, -28px, 0)'
         : 'scale(1) translate3d(0, 0, 0)',
       transformOrigin: 'left top',
       pointerEvents: shrink ? 'none' : 'auto',


### PR DESCRIPTION
![shift](https://cloud.githubusercontent.com/assets/1949726/13321347/97563832-dbdf-11e5-9355-fa59f8952679.png)

Floating label is shifted 2px right, while there is no such shift in google MD guideline.