### PR TITLE
[Progress] Added delay option to circular/linear progress

### DIFF
--- a/docs/src/app/components/pages/components/CircularProgress/ExampleDelayed.jsx
+++ b/docs/src/app/components/pages/components/CircularProgress/ExampleDelayed.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import RaisedButton from 'material-ui/lib/raised-button';
+import CircularProgress from 'material-ui/lib/circular-progress';
+
+export default class CircularProgressExampleDelayed extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      loading: false,
+    };
+  }
+
+  toggleOperation() {
+    this.setState({loading: !this.state.loading});
+  }
+
+  render() {
+    return (
+      <div>
+        <div>
+          <RaisedButton
+            style={{marginBottom: 16}}
+            primary
+            label={this.state.loading ? 'Cancel' : 'Load'}
+            onTouchTap={this.toggleOperation.bind(this)}
+          />
+        </div>
+        <div>
+          {this.state.loading ? <CircularProgress delay={2000} /> : ''}
+        </div>
+      </div>
+    );
+  }
+}

--- a/docs/src/app/components/pages/components/CircularProgress/Page.jsx
+++ b/docs/src/app/components/pages/components/CircularProgress/Page.jsx
@@ -9,11 +9,15 @@ import CircleProgressExampleSimple from './ExampleSimple';
 import circleProgressExampleSimpleCode from '!raw!./ExampleSimple';
 import CircleProgressExampleDeterminate from './ExampleDeterminate';
 import circleProgressExampleDeterminateCode from '!raw!./ExampleDeterminate';
+import CircleProgressExampleDelayed from './ExampleDelayed';
+import circleProgressExampleDelayedCode from '!raw!./ExampleDelayed';
 
 const descriptions = {
   indeterminate: 'By default, the indicator animates continuously.',
   determinate: 'In determinate mode, the indicator adjusts to show the percentage complete, ' +
   'as a ratio of `value`: `max-min`.',
+  delayed: 'You can also have the indicator wait a specified time before ' +
+           'displaying, to avoid showing it for very brief operations.',
 };
 
 const CircleProgressPage = () => (
@@ -32,6 +36,13 @@ const CircleProgressPage = () => (
       code={circleProgressExampleDeterminateCode}
     >
       <CircleProgressExampleDeterminate />
+    </CodeExample>
+    <CodeExample
+      title="Delayed progress"
+      description={descriptions.delayed}
+      code={circleProgressExampleDelayedCode}
+    >
+      <CircleProgressExampleDelayed />
     </CodeExample>
     <PropTypeDescription code={circleProgressCode}/>
   </div>

--- a/docs/src/app/components/pages/components/LinearProgress/ExampleDelayed.jsx
+++ b/docs/src/app/components/pages/components/LinearProgress/ExampleDelayed.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import RaisedButton from 'material-ui/lib/raised-button';
+import LinearProgress from 'material-ui/lib/linear-progress';
+
+export default class LinearProgressExampleDelayed extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      loading: false,
+    };
+  }
+
+  toggleOperation() {
+    this.setState({loading: !this.state.loading});
+  }
+
+  render() {
+    return (
+      <div>
+        <div>
+          <RaisedButton
+            style={{marginBottom: 16}}
+            primary
+            label={this.state.loading ? 'Cancel' : 'Load'}
+            onTouchTap={this.toggleOperation.bind(this)}
+          />
+        </div>
+        <div>
+          {this.state.loading ? <LinearProgress delay={2000} /> : ''}
+        </div>
+      </div>
+    );
+  }
+}

--- a/docs/src/app/components/pages/components/LinearProgress/Page.jsx
+++ b/docs/src/app/components/pages/components/LinearProgress/Page.jsx
@@ -9,11 +9,15 @@ import LinearProgressExampleSimple from './ExampleSimple';
 import linearProgressExampleSimpleCode from '!raw!./ExampleSimple';
 import LinearProgressExampleDeterminate from './ExampleDeterminate';
 import linearProgressExampleDeterminateCode from '!raw!./ExampleDeterminate';
+import LinearProgressExampleDelayed from './ExampleDelayed';
+import linearProgressExampleDelayedCode from '!raw!./ExampleDelayed';
 
 const descriptions = {
   indeterminate: 'By default, the indicator animates continuously.',
   determinate: 'In `determinate` mode, the indicator adjusts to show the percentage complete, ' +
   'as a ratio of `value`: `max-min`.',
+  delayed: 'You can also have the indicator wait a specified time before ' +
+           'displaying, to avoid showing it for very brief operations.',
 };
 
 const LinearProgressPage = () => (
@@ -32,6 +36,13 @@ const LinearProgressPage = () => (
       code={linearProgressExampleDeterminateCode}
     >
       <LinearProgressExampleDeterminate />
+    </CodeExample>
+    <CodeExample
+      title="Delayed progress"
+      description={descriptions.delayed}
+      code={linearProgressExampleDelayedCode}
+    >
+      <LinearProgressExampleDelayed />
     </CodeExample>
     <PropTypeDescription code={linearProgressCode}/>
   </div>

--- a/src/circular-progress.jsx
+++ b/src/circular-progress.jsx
@@ -15,6 +15,11 @@ const CircularProgress = React.createClass({
     color: React.PropTypes.string,
 
     /**
+     * Specify a delay (in ms) before showing, only works in indeterminate mode.
+     */
+    delay: React.PropTypes.number,
+
+    /**
      * Style for inner wrapper div.
      */
     innerStyle: React.PropTypes.object,
@@ -64,6 +69,7 @@ const CircularProgress = React.createClass({
 
   getDefaultProps() {
     return {
+      delay: 0,
       mode: 'indeterminate',
       value: 0,
       min: 0,
@@ -75,6 +81,7 @@ const CircularProgress = React.createClass({
   getInitialState() {
     return {
       muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
+      visible: this.props.delay === 0 || this.props.mode === 'determinate',
     };
   },
 
@@ -82,6 +89,14 @@ const CircularProgress = React.createClass({
     return {
       muiTheme: this.state.muiTheme,
     };
+  },
+
+  componentWillMount() {
+    if (this.props.delay > 0 && this.props.mode === 'indeterminate') {
+      this.delayTimer = setTimeout(() => {
+        this.setState({visible: true});
+      }, this.props.delay);
+    }
   },
 
   componentDidMount() {
@@ -102,6 +117,7 @@ const CircularProgress = React.createClass({
   componentWillUnmount() {
     clearTimeout(this.scalePathTimer);
     clearTimeout(this.rotateWrapperTimer);
+    clearTimeout(this.delayTimer);
   },
 
   _getRelativeValue() {
@@ -117,6 +133,7 @@ const CircularProgress = React.createClass({
 
   scalePathTimer: undefined,
   rotateWrapperTimer: undefined,
+  delayTimer: undefined,
 
   _scalePath(path, step) {
     if (this.props.mode !== 'indeterminate') return;
@@ -175,6 +192,7 @@ const CircularProgress = React.createClass({
         display: 'inline-block',
         width: size,
         height: size,
+        visibility: this.state.visible ? 'visible' : 'hidden',
       },
       wrapper: {
         width: size,

--- a/src/linear-progress.jsx
+++ b/src/linear-progress.jsx
@@ -14,6 +14,11 @@ const LinearProgress = React.createClass({
     color: React.PropTypes.string,
 
     /**
+     * Specify a delay (in ms) before showing, only works in indeterminate mode.
+     */
+    delay: React.PropTypes.number,
+
+    /**
      * The max value of progress, only works in determinate mode.
      */
     max: React.PropTypes.number,
@@ -55,6 +60,7 @@ const LinearProgress = React.createClass({
 
   getDefaultProps() {
     return {
+      delay: 0,
       mode: 'indeterminate',
       value: 0,
       min: 0,
@@ -65,6 +71,7 @@ const LinearProgress = React.createClass({
   getInitialState() {
     return {
       muiTheme: this.context.muiTheme ? this.context.muiTheme : ThemeManager.getMuiTheme(DefaultRawTheme),
+      visible: this.props.delay === 0 || this.props.mode === 'determinate',
     };
   },
 
@@ -72,6 +79,14 @@ const LinearProgress = React.createClass({
     return {
       muiTheme: this.state.muiTheme,
     };
+  },
+
+  componentWillMount() {
+    if (this.props.delay > 0 && this.props.mode === 'indeterminate') {
+      this.timers.delayTimer = setTimeout(() => {
+        this.setState({visible: true});
+      }, this.props.delay);
+    }
   },
 
   componentDidMount() {
@@ -101,11 +116,13 @@ const LinearProgress = React.createClass({
   componentWillUnmount() {
     clearTimeout(this.timers.bar1);
     clearTimeout(this.timers.bar2);
+    clearTimeout(this.timers.delayTimer);
   },
 
   timers: {
     bar1: undefined,
     bar2: undefined,
+    delayTimer: undefined,
   },
 
   _barUpdate(id, step, barElement, stepValues) {
@@ -146,6 +163,7 @@ const LinearProgress = React.createClass({
         borderRadius: 2,
         margin: 0,
         overflow: 'hidden',
+        visibility: this.state.visible ? 'visible' : 'hidden',
       },
       bar: {
         height: '100%',


### PR DESCRIPTION
Ok, 2nd attempt...

Some background on this:

Often times we use loading indicators like this to indicate that data is loading, or some other operation is being performed. This operation could be as brief as 200ms or several seconds, and so I think it's bad UX to always display the indicator immediately. IMO users should only see an indicator like this at a point in time when they might think to themselves, "Ok, this is taking some time - what's going on?"

I've added a delay prop to CircularProgress and LinearProgress, so that developers can now have these components wait a certain number of milliseconds before appearing (I recommend around 1500 to 2000 ms).

Please feel free to modify/improve!