### PR TITLE
[LeftNav] Allow width to take on number or string values.

### DIFF
--- a/src/left-nav.jsx
+++ b/src/left-nav.jsx
@@ -7,6 +7,7 @@ import Transitions from './styles/transitions';
 import Overlay from './overlay';
 import Paper from './paper';
 import getMuiTheme from './styles/getMuiTheme';
+import PropTypes from './utils/prop-types';
 
 let openNavEventHandler = null;
 
@@ -89,9 +90,9 @@ const LeftNav = React.createClass({
     swipeAreaWidth: React.PropTypes.number,
 
     /**
-     * The width of the `LeftNav` in pixels. Defaults to using the values from theme.
+     * The width of the `LeftNav`. Defaults to using the values from theme.
      */
-    width: React.PropTypes.number,
+    width: PropTypes.stringOrNumber,
   },
 
   contextTypes: {


### PR DESCRIPTION
I dynamically switch the menu to full screen on small size devices. Currently, giving '100%' works but just results in a PropType warning.

This PR removes that warning.