### PR TITLE
[CardHeader] handle wide titles: allow them to wrap

### DIFF
--- a/src/card/card-header.jsx
+++ b/src/card/card-header.jsx
@@ -7,15 +7,17 @@ function getStyles(props, state) {
 
   return {
     root: {
-      height: 72,
       padding: 16,
       fontWeight: card.fontWeight,
       boxSizing: 'border-box',
       position: 'relative',
+      whiteSpace: 'nowrap',
     },
     text: {
       display: 'inline-block',
       verticalAlign: 'top',
+      whiteSpace: 'normal',
+      paddingRight: '90px',
     },
     avatar: {
       marginRight: 16,


### PR DESCRIPTION
Before:

<img width="349" alt="capture d ecran 2016-02-26 21 53 26" src="https://cloud.githubusercontent.com/assets/160279/13370650/f34f42ba-dcd3-11e5-981c-863c1a7cd71f.png">

After:

<img width="351" alt="capture d ecran 2016-02-26 21 57 55" src="https://cloud.githubusercontent.com/assets/160279/13370654/020cfbbc-dcd4-11e5-842e-ddcb77d90c82.png">
