### PR TITLE
[TableBody] Don't ignore the possible `selected` prop passed to the TableRow

### DIFF
--- a/src/table/table-body.jsx
+++ b/src/table/table-body.jsx
@@ -183,10 +183,11 @@ const TableBody = React.createClass({
 
     return React.Children.map(this.props.children, (child) => {
       if (React.isValidElement(child)) {
+        const {selected} = child.props;
         const props = {
           displayRowCheckbox: this.props.displayRowCheckbox,
           hoverable: this.props.showRowHover,
-          selected: this._isRowSelected(rowNumber),
+          selected: selected !== undefined ? selected : this._isRowSelected(rowNumber),
           striped: this.props.stripedRows && (rowNumber % 2 === 0),
           rowNumber: rowNumber++,
         };
@@ -212,7 +213,6 @@ const TableBody = React.createClass({
     const key = `${rowProps.rowNumber}-cb`;
     const checkbox = (
       <Checkbox
-        ref="rowSelectCB"
         name={key}
         value="selected"
         disabled={!this.props.selectable}


### PR DESCRIPTION
Currently the `selected` property of the TableRow is determined using a local selection state, with `_isRowSelected()`.

Now if we want to manage the `selected` state of the TableRow outside of the local state (in a redux global state), we expect this `selected` prop to be used, so it should not be overriden by the local state.

With this patch, the specified `selected` prop is used, if any, otherwise the local state is used to determine if the row is selected or not, just as before.