### PR TITLE
[RaisedButton] backgroundColor prop was previously ignored

### DIFF
--- a/src/raised-button.jsx
+++ b/src/raised-button.jsx
@@ -45,6 +45,13 @@ function getStyles(props, state) {
   } else if (secondary) {
     backgroundColor = raisedButton.secondaryColor;
     labelColor = raisedButton.secondaryTextColor;
+  } else {
+    if (props.backgroundColor) {
+      backgroundColor = props.backgroundColor;
+    }
+    if (props.labelColor) {
+      labelColor = props.labelColor;
+    }
   }
 
   return {


### PR DESCRIPTION
Strange. This is documented, though it was apparently ignored in the code.