### PR TITLE
[tests] Temporary fix for non test exit on failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "gulp eslint:src && gulp eslint:docs && gulp eslint:test",
     "prebuild": "rimraf lib",
     "prepublish": "npm run build",
-    "test": "npm run test:unit:coverage && npm run test:browser && npm run coverage:combine",
+    "test": "npm run test:unit && npm run test:browser && npm run test:unit:coverage && npm run coverage:combine",
     "test:browser": "npm run test:browser:base -- --single-run",
     "test:browser:watch": "npm run test:browser:base -- --auto-watch",
     "test:browser:base": "karma start test/karma.conf.js",


### PR DESCRIPTION
This is a temporary fix to solve the problem of travis reporting a pass when a unit test is actually failing: [screenshot](https://cloud.githubusercontent.com/assets/4420103/13379600/05aa0fb0-ddf8-11e5-8407-bd87828f47f8.png), [build showing problem](https://travis-ci.org/callemall/material-ui/builds/112395709)

This appears to be a [regression](https://github.com/douglasduteil/isparta/issues/106) in isparta that was [previously solved](https://github.com/douglasduteil/isparta/issues/48).

I need to look into it as I've encountered the issue in another setup (private repo, we are using the same temporary fix for the CI server), but until then, this temporary fix will ensure that the tests exit on a failure by running the unit tests without coverage, and then with coverage prior to combining the coverage results.

The time impact is minimal as the unit tests run pretty quickly anyways. The alternative would be to just remove the coverage until the isparta issue is figured out.
