### PR TITLE
[Tests] Add mocha grep passthrough for browser tests

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,3 +1,15 @@
+const argv = process.argv.slice(2);
+const opts = {
+  coverage: true,
+  grep: undefined,
+};
+
+argv.forEach((arg) => {
+  if (/^--grep=/.test(arg)) {
+    opts.grep = arg.replace('--grep=', '').trim();
+    opts.coverage = false; // disable if grepping
+  }
+});
 
 // Karma configuration
 module.exports = function(config) {
@@ -5,6 +17,11 @@ module.exports = function(config) {
     autoWatch: false,
     basePath: '../',
     browsers: ['PhantomJS'],
+    client: {
+      mocha: {
+        grep: opts.grep,
+      },
+    },
     colors: true,
     frameworks: ['mocha', 'chai-sinon'],
     files: [
@@ -22,27 +39,26 @@ module.exports = function(config) {
       'karma-mocha',
       'karma-sourcemap-loader',
       'karma-webpack',
-      'karma-coverage',
       'karma-mocha-reporter',
-    ],
+    ].concat(opts.coverage ? ['karma-coverage'] : []),
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
     logLevel: config.LOG_INFO,
     port: 9876,
     preprocessors: {
       'test/tests.webpack.js': ['webpack', 'sourcemap'],
     },
-    reporters: ['mocha', 'coverage'],
+    reporters: ['mocha'].concat(opts.coverage ? ['coverage'] : []),
     singleRun: false,
     webpack: {
       devtool: 'cheap-module-source-map',
       module: {
-        preLoaders: [
+        preLoaders: opts.coverage ? [
           {
             test: /\.(js|jsx)$/,
             loader: 'isparta',
             exclude: /(node_modules|test|svg-icons)/,
           },
-        ],
+        ] : [],
         loaders: [
           {
             test: /\.(js|jsx)$/,
@@ -71,7 +87,7 @@ module.exports = function(config) {
     webpackServer: {
       noInfo: true,
     },
-    coverageReporter: {
+    coverageReporter: opts.coverage ? {
       dir: 'test/coverage/browser',
       subdir: function(browser) {
         return browser.toLowerCase().split(/[ /-]/)[0];
@@ -84,6 +100,6 @@ module.exports = function(config) {
         {type: 'text-summary'},
         {type: 'html'},
       ],
-    },
+    } : {},
   });
 };

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -6,7 +6,11 @@ const argv = process.argv.slice(2);
 const opts = {};
 
 if (argv && argv.length > 0) {
-  opts.grep = argv[0];
+  let grep = argv[0];
+  if (/^--grep=/.test(grep)) {
+    grep = grep.replace('--grep=', '');
+  }
+  opts.grep = grep.trim();
 }
 
 const mocha = new Mocha(opts);


### PR DESCRIPTION
This enables passing the mocha grep argument to the browser tests. In order to avoid issues with the karma CLI, this requires the full `--grep=Component` rather than just passing the component after the test command, I wonder if we should update the unit test command to reflect this for consistency? (I can make it backwards compatible)

I'm parsing this argument manually and adding it to the karma config as the cli arg passthrough does not work. 

I've also disabled the coverage preprocessor and reporter in karma when using `grep=xxx` so that time is saved when building/rebuilding (no coverage instrumenting) if the user is just testing a single component rather than running the entire library coverage and they don't get the summary noise after each run.