### PR TITLE
Patch Changelog to include the missing changes from #3495

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ from the code with the 0.16.0 release.
 - [IconMenu] Enable `useLayerForClickAway` (#3400)
 - [IconMenu] Support MenuItem nested menuItems (#3265)
 - [InkBar] remove `&nbsp;` (#3283)
+- [LeftNav] Add a configurable zDepth (#3495)
 - [LeftNav] Add iOS momentum scroll (#2946)
 - [List] Fix issue with styling on list related components (#3278)
 - [ListItem] Fix hardcoded `secondaryTextColor` (#3288)


### PR DESCRIPTION
This commit adds the #3495 to the 0.15.0-alpha.1 section that snuck into the 0.15.0-alpha.1 release. This happened because there was a delay between accepting the release preperation pull request and tagging the commit.

This one snuck into the release during this window.

@oliviertassinari Is this ok? if so merge :+1: 