### PR TITLE
[Tabs] Let customize the selected tab text color

### DIFF
--- a/src/tabs/tab.jsx
+++ b/src/tabs/tab.jsx
@@ -58,6 +58,11 @@ const Tab = React.createClass({
     selected: React.PropTypes.bool,
 
     /**
+    * This property is overriden by the Tabs component
+    */
+    selectedTextColor: React.PropTypes.string,
+
+    /**
      * Override the inline-styles of the root element.
      */
     style: React.PropTypes.object,
@@ -116,10 +121,13 @@ const Tab = React.createClass({
       value,
       width,
       icon,
+      selectedTextColor,
       ...other,
     } = this.props;
 
     const styles = getStyles(this.props, this.state);
+
+    if (selected && selectedTextColor) styles.color = selectedTextColor;
 
     let iconElement;
     if (icon && React.isValidElement(icon)) {

--- a/src/tabs/tabs.jsx
+++ b/src/tabs/tabs.jsx
@@ -64,6 +64,11 @@ const Tabs = React.createClass({
     onChange: React.PropTypes.func,
 
     /**
+     * Let customize the color of the text in the selected tab
+     */
+    selectedTextColor: React.PropTypes.string,
+
+    /**
      * Override the inline-styles of the root element.
      */
     style: React.PropTypes.object,
@@ -194,6 +199,7 @@ const Tabs = React.createClass({
       contentContainerStyle,
       initialSelectedIndex,
       inkBarStyle,
+      selectedTextColor,
       style,
       tabItemContainerStyle,
       tabTemplate,
@@ -231,6 +237,7 @@ const Tabs = React.createClass({
       return React.cloneElement(tab, {
         key: index,
         selected: this._getSelected(tab, index),
+        selectedTextColor: selectedTextColor,
         tabIndex: index,
         width: `${width}%`,
         onTouchTap: this._handleTabTouchTap,


### PR DESCRIPTION
Hello, 
I would want to change the text color of the selected tab. I don't see a more elegant way to do that out of the material-ui lib.

So, there is my pull request. It's very few code : 
1) I pass the prop selectedTextColor from <Tabs> to <Tab>
2) In the tab, if it's selected AND the prop selectedTextColor is set, I change the style propertie.
Any objections ?

Thanks,