### PR TITLE
[CardHeader] remove `title` from injected node attributes (to avoid native tooltip)

### DIFF
--- a/src/card/card-header.jsx
+++ b/src/card/card-header.jsx
@@ -109,12 +109,18 @@ const CardHeader = React.createClass({
       avatar = <Avatar src={this.props.avatar} style={styles.avatar} />;
     }
 
+    const {
+      title,
+      subtitle,
+      ...other,
+    } = this.props;
+
     return (
-      <div {...this.props} style={prepareStyles(rootStyle)}>
+      <div {...other} style={prepareStyles(rootStyle)}>
         {avatar}
         <div style={prepareStyles(textStyle)}>
-          <span style={prepareStyles(titleStyle)}>{this.props.title}</span>
-          <span style={prepareStyles(subtitleStyle)}>{this.props.subtitle}</span>
+          <span style={prepareStyles(titleStyle)}>{title}</span>
+          <span style={prepareStyles(subtitleStyle)}>{subtitle}</span>
         </div>
         {this.props.children}
       </div>


### PR DESCRIPTION
- [ ] PR has tests / docs demo
- [x] PR is linted
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction"
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue (see https://github.com/callemall/material-ui/issues/2218)
