### PR TITLE
[CardTitle] remove `title` from injected node attributes (to avoid native tooltip)

### DIFF
--- a/src/card/card-title.jsx
+++ b/src/card/card-title.jsx
@@ -79,13 +79,19 @@ const CardTitle = React.createClass({
     const titleStyle = Object.assign({}, styles.title, this.props.titleStyle);
     const subtitleStyle = Object.assign({}, styles.subtitle, this.props.subtitleStyle);
 
+    const {
+      title,
+      subtitle,
+      ...other,
+    } = this.props;
+
     return (
-      <div {...this.props} style={prepareStyles(rootStyle)}>
+      <div {...other} style={prepareStyles(rootStyle)}>
         <span style={prepareStyles(titleStyle)}>
-          {this.props.title}
+          {title}
         </span>
         <span style={prepareStyles(subtitleStyle)}>
-          {this.props.subtitle}
+          {subtitle}
         </span>
         {this.props.children}
       </div>


### PR DESCRIPTION
- [ ] PR has tests / docs demo
- [x] PR is linted
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction"
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue

Fixes #2894.
