### PR TITLE
[PropTypeDescription] Adds @returns type and descriptions for functio…

### DIFF
--- a/docs/src/app/components/PropTypeDescription.jsx
+++ b/docs/src/app/components/PropTypeDescription.jsx
@@ -65,14 +65,30 @@ function generateDescription(required, description, type) {
   const jsDocText = parsed.description.replace(/\n\n/g, '<br>').replace(/\n/g, ' ');
 
   if (parsed.tags.some((tag) => tag.title === 'ignore')) return null;
-
   let signature = '';
 
   if (type.name === 'func' && parsed.tags.length > 0) {
+    // Split up the parsed objects into arguments and the returns parsed object. If there's no
+    // returns parsed object (i.e., one with title being 'returns'), make one of type 'void'.
+    const parsedLength = parsed.tags.length;
+    let parsedArgs = [];
+    let parsedReturns;
+
+    if (parsed.tags[parsedLength - 1].title === 'returns') {
+      parsedArgs = parsed.tags.slice(0, parsedLength - 1);
+      parsedReturns = parsed.tags[parsedLength - 1];
+    } else {
+      parsedArgs = parsed.tags;
+      parsedReturns = {type: {name: 'void'}};
+    }
+
     signature += '<br><br>**Signature:**<br>`function(';
-    signature += parsed.tags.map((tag) => `${tag.name}: ${tag.type.name}`).join(', ');
-    signature += ') => void`<br>';
-    signature += parsed.tags.map((tag) => `*${tag.name}:* ${tag.description}`).join('<br>');
+    signature += parsedArgs.map((tag) => `${tag.name}: ${tag.type.name}`).join(', ');
+    signature += `) => ${parsedReturns.type.name}` + '`<br>';
+    signature += parsedArgs.map((tag) => `*${tag.name}:* ${tag.description}`).join('<br>');
+    if (parsedReturns.description) {
+      signature += `<br> *returns* (${parsedReturns.type.name}): ${parsedReturns.description}`;
+    }
   }
 
   return `${deprecated} ${jsDocText}${signature}`;


### PR DESCRIPTION
Hey, this PR is to help with finishing #3096 

Some of the callback functions that need documentation have return values that should probably be documented. 

![code_description_included_cropped](https://cloud.githubusercontent.com/assets/8320854/13417780/df62d80a-df3c-11e5-87d6-e556971aa4c0.png)
![docs_description_included_cropped](https://cloud.githubusercontent.com/assets/8320854/13417781/e1400044-df3c-11e5-8839-da8b820d7c84.png)

When there's no `@returns` tag in the documentation, the function signature has a `void` return, exactly as it already works.  The description on the `@returns` tag is optional: 
![docs_no_description_cropped](https://cloud.githubusercontent.com/assets/8320854/13417876/be0b2ba2-df3d-11e5-9814-14dc811219ad.png)

