### PR TITLE
[AutoComplete] Proxy focus/blur calls to refs.searchTextField

### DIFF
--- a/src/auto-complete.jsx
+++ b/src/auto-complete.jsx
@@ -374,6 +374,14 @@ const AutoComplete = React.createClass({
     }
   },
 
+  blur() {
+    this.refs.searchTextField.blur();
+  },
+
+  focus() {
+    this.refs.searchTextField.focus();
+  },
+
   render() {
     const {
       anchorOrigin,


### PR DESCRIPTION
Allows focusing/blurring auto-complete text input, nice for e.g. search
toggles.