### PR TITLE
[TextField] Use name to generate the unique id

### DIFF
--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -321,7 +321,8 @@ const TextField = React.createClass({
     warning(name || hintText || floatingLabelText || id, `We don't have enough information
       to build a robust unique id for the TextField component. Please provide an id or a name.`);
 
-    const uniqueId = `${hintText}-${floatingLabelText}-${Math.floor(Math.random() * 0xFFFF)}`;
+    const uniqueId = `${name}-${hintText}-${floatingLabelText}-${
+      Math.floor(Math.random() * 0xFFFF)}`;
     this.uniqueId = uniqueId.replace(/[^A-Za-z0-9-]/gi, '');
   },
 


### PR DESCRIPTION
I have forgotten to use the `name` in this PR https://github.com/callemall/material-ui/pull/3538.

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).
