### PR TITLE
[PropTypeDescription] Add support for multi-line function @param and …

### DIFF
--- a/docs/src/app/components/PropTypeDescription.jsx
+++ b/docs/src/app/components/PropTypeDescription.jsx
@@ -68,8 +68,15 @@ function generateDescription(required, description, type) {
   let signature = '';
 
   if (type.name === 'func' && parsed.tags.length > 0) {
-    // Split up the parsed objects into arguments and the returns parsed object. If there's no
-    // returns parsed object (i.e., one with title being 'returns'), make one of type 'void'.
+    // Remove new lines from tag descriptions to avoid markdown errors.
+    parsed.tags.forEach((tag) => {
+      if (tag.description) {
+        tag.description = tag.description.replace(/\n/g, ' ');
+      }
+    });
+
+    // Split up the parsed tags into 'arguments' and 'returns' parsed objects. If there's no
+    // 'returns' parsed object (i.e., one with title being 'returns'), make one of type 'void'.
     const parsedLength = parsed.tags.length;
     let parsedArgs = [];
     let parsedReturns;


### PR DESCRIPTION
Here's the `PropTypeDescription` changes that were initially part of #3550 .

If there are newlines in the tags' descriptions it messes up the output markdown.  This PR just removes the newlines from the descriptions of the function `@param` and `@returns` tags and adds a space.  I followed what was already done to address the same problem with the non-function descriptions.