### PR TITLE
[RaisedButton] Fix backgroundColor property

### DIFF
--- a/src/raised-button.jsx
+++ b/src/raised-button.jsx
@@ -35,7 +35,7 @@ function getStyles(props, state) {
 
   const amount = (primary || secondary) ? 0.4 : 0.08;
 
-  let backgroundColor = raisedButton.color;
+  let backgroundColor = props.backgroundColor || raisedButton.color;
   let labelColor = raisedButton.textColor;
 
   if (disabled) {


### PR DESCRIPTION
The backgroundColor property currently does not have any effect on RaisedButton.

As documented RaisedButton should provide a backgroundColor property:
http://www.material-ui.com/v0.15.0-alpha.1/#/components/floating-action-button

Updating from 0.11.0 to 0.15.0-alpha.1 broke this behavior for me.
https://github.com/callemall/material-ui/commit/8587247caa02a3d82d1cf77f3b0b4d5ce4385abb seems to be the commit introducing the not working code.

The following patch makes RaidedButton use the property again, like seen in FloatingActionButton:
https://github.com/callemall/material-ui/blob/master/src/floating-action-button.jsx#L17