### PR TITLE
[TimePicker] Fix for displaying defaultTime on time-picker.

### DIFF
--- a/src/time-picker/time-picker.jsx
+++ b/src/time-picker/time-picker.jsx
@@ -114,7 +114,7 @@ const TimePicker = React.createClass({
 
   getInitialState() {
     return {
-      time: this._isControlled() ? this._getControlledTime() : this.props.defaultTime,
+      time: this._getControlledTime(),
       dialogTime: new Date(),
       muiTheme: this.context.muiTheme || getMuiTheme(),
     };
@@ -125,7 +125,7 @@ const TimePicker = React.createClass({
     if (nextContext.muiTheme) {
       newState.muiTheme = nextContext.muiTheme;
     }
-    newState.time = this._getControlledTime(nextProps);
+    newState.time = this._getControlledTime(nextProps) || this.state.time;
     this.setState(newState);
   },
 
@@ -186,14 +186,10 @@ const TimePicker = React.createClass({
     if (this.props.onTouchTap) this.props.onTouchTap(event);
   },
 
-  _isControlled() {
-    return this.props.value !== null;
-  },
-
   _getControlledTime(props = this.props) {
     let result = null;
-    if (DateTime.isDateObject(props.value)) {
-      result = props.value;
+    if (DateTime.isDateObject(props.defaultTime)) {
+      result = props.defaultTime;
     }
     return result;
   },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


Should work for both controlled and uncontrolled-component.
Removed the reference to props.value. It's a undocumented prop instead relying only on defaultTime.
I do however think value is a better prop-name. defaultTime seems like a 'start-up'-prop somehow.

Fixes #3452.