### PR TITLE
[MenuItem][Table][Tabs] Hide internal properties in docs

### DIFF
--- a/src/Stepper/HorizontalStep.jsx
+++ b/src/Stepper/HorizontalStep.jsx
@@ -7,50 +7,50 @@ const HorizontalStep = React.createClass({
   propTypes: {
 
     /**
-     * The width of step header, unit is % which passed from Stepper.
      * @ignore
+     * The width of step header, unit is % which passed from Stepper.
      */
     headerWidth: React.PropTypes.string,
 
     /**
-     * If true, the step is active.
      * @ignore
+     * If true, the step is active.
      */
     isActive: React.PropTypes.bool,
 
     /**
-     * If true, the step is completed.
      * @ignore
+     * If true, the step is completed.
      */
     isCompleted: React.PropTypes.bool,
 
     /**
-     * If true, the step is the first step.
      * @ignore
+     * If true, the step is the first step.
      */
     isFirstStep: React.PropTypes.bool,
 
     /**
-     * If true, the step is the last step.
      * @ignore
+     * If true, the step is the last step.
      */
     isLastStep: React.PropTypes.bool,
 
     /**
-     * If true, the step header is hovered.
      * @ignore
+     * If true, the step header is hovered.
      */
     isStepHeaderHovered: React.PropTypes.bool,
 
     /**
-     * Callback function will be called when step header is hovered.
      * @ignore
+     * Callback function will be called when step header is hovered.
      */
     onStepHeaderHover: React.PropTypes.func,
 
     /**
-     * Call back function will be called when step header is touched.
      * @ignore
+     * Call back function will be called when step header is touched.
      */
     onStepHeaderTouch: React.PropTypes.func,
 
@@ -60,8 +60,8 @@ const HorizontalStep = React.createClass({
     stepHeaderWrapperStyle: React.PropTypes.object,
 
     /**
-     * The index of step in array of Steps.
      * @ignore
+     * The index of step in array of Steps.
      */
     stepIndex: React.PropTypes.number,
 

--- a/src/Stepper/VerticalStep.jsx
+++ b/src/Stepper/VerticalStep.jsx
@@ -30,44 +30,44 @@ const Step = React.createClass({
     controlButtonsGroupWrapperStyle: PropTypes.object,
 
     /**
-     * If true, the step is active.
      * @ignore
+     * If true, the step is active.
      */
     isActive: PropTypes.bool,
 
     /**
-     * If true, the step is completed.
      * @ignore
+     * If true, the step is completed.
      */
     isCompleted: PropTypes.bool,
 
     /**
-     * If true, the step is the last one.
      * @ignore
+     * If true, the step is the last one.
      */
     isLastStep: PropTypes.bool,
 
     /**
-     * If true, the header of step is hovered.
      * @ignore
+     * If true, the header of step is hovered.
      */
     isStepHeaderHovered: PropTypes.bool,
 
     /**
-     * Callback function that is fired when the header of step is hovered.
      * @ignore
+     * Callback function that is fired when the header of step is hovered.
      */
     onStepHeaderHover: PropTypes.func,
 
     /**
-     * Callback function that is fired when the header of step is touched.
      * @ignore
+     * Callback function that is fired when the header of step is touched.
      */
     onStepHeaderTouch: PropTypes.func,
 
     /**
-     * The index of the furthest optional step.
      * @ignore
+     * The index of the furthest optional step.
      */
     previousStepOptionalIndex: PropTypes.number,
 
@@ -87,8 +87,8 @@ const Step = React.createClass({
     stepHeaderWrapperStyle: PropTypes.object,
 
     /**
-     * The index of step in array of Steps.
      * @ignore
+     * The index of step in array of Steps.
      */
     stepIndex: PropTypes.number,
 

--- a/src/Subheader/Subheader.jsx
+++ b/src/Subheader/Subheader.jsx
@@ -13,8 +13,8 @@ const propTypes = {
   inset: React.PropTypes.bool,
 
   /**
-   * The material-ui theme applied to this component.
    * @ignore
+   * The material-ui theme applied to this component.
    */
   muiTheme: React.PropTypes.object.isRequired,
 

--- a/src/divider.jsx
+++ b/src/divider.jsx
@@ -13,8 +13,8 @@ const propTypes = {
   inset: React.PropTypes.bool,
 
   /**
-   * The material-ui theme applied to this component.
    * @ignore
+   * The material-ui theme applied to this component.
    */
   muiTheme: React.PropTypes.object.isRequired,
 

--- a/src/menus/menu-item.jsx
+++ b/src/menus/menu-item.jsx
@@ -25,6 +25,7 @@ const MenuItem = React.createClass({
     children: React.PropTypes.node,
 
     /**
+     * @ignore
      * Indicates if the menu should render with compact desktop styles.
      */
     desktop: React.PropTypes.bool,

--- a/src/table/table-body.jsx
+++ b/src/table/table-body.jsx
@@ -8,6 +8,7 @@ const TableBody = React.createClass({
 
   propTypes: {
     /**
+     * @ignore
      * Set to true to indicate that all rows should be selected.
      */
     allRowsSelected: React.PropTypes.bool,
@@ -34,6 +35,7 @@ const TableBody = React.createClass({
     displayRowCheckbox: React.PropTypes.bool,
 
     /**
+     * @ignore
      * If true, multiple table rows can be selected.
      * CTRL/CMD+Click and SHIFT+Click are valid actions.
      * The default value is false.
@@ -41,11 +43,13 @@ const TableBody = React.createClass({
     multiSelectable: React.PropTypes.bool,
 
     /**
+     * @ignore
      * Callback function for when a cell is clicked.
      */
     onCellClick: React.PropTypes.func,
 
     /**
+     * @ignore
      * Called when a table cell is hovered. rowNumber
      * is the row number of the hovered row and columnId
      * is the column number or the column key of the cell.
@@ -53,6 +57,7 @@ const TableBody = React.createClass({
     onCellHover: React.PropTypes.func,
 
     /**
+     * @ignore
      * Called when a table cell is no longer hovered.
      * rowNumber is the row number of the row and columnId
      * is the column number or the column key of the cell.
@@ -60,12 +65,14 @@ const TableBody = React.createClass({
     onCellHoverExit: React.PropTypes.func,
 
     /**
+     * @ignore
      * Called when a table row is hovered.
      * rowNumber is the row number of the hovered row.
      */
     onRowHover: React.PropTypes.func,
 
     /**
+     * @ignore
      * Called when a table row is no longer
      * hovered. rowNumber is the row number of the row
      * that is no longer hovered.
@@ -73,6 +80,7 @@ const TableBody = React.createClass({
     onRowHoverExit: React.PropTypes.func,
 
     /**
+     * @ignore
      * Called when a row is selected. selectedRows is an
      * array of all row selections. IF all rows have been selected,
      * the string "all" will be returned instead to indicate that
@@ -88,6 +96,7 @@ const TableBody = React.createClass({
     preScanRows: React.PropTypes.bool,
 
     /**
+     * @ignore
      * If true, table rows can be selected. If multiple
      * row selection is desired, enable multiSelectable.
      * The default value is true.

--- a/src/table/table-footer.jsx
+++ b/src/table/table-footer.jsx
@@ -22,6 +22,7 @@ const TableFooter = React.createClass({
 
   propTypes: {
     /**
+     * @ignore
      * Controls whether or not header rows should be adjusted
      * for a checkbox column. If the select all checkbox is true,
      * this property will not influence the number of columns.

--- a/src/table/table-header-column.jsx
+++ b/src/table/table-header-column.jsx
@@ -49,6 +49,7 @@ const TableHeaderColumn = React.createClass({
     key: React.PropTypes.string,
 
     /**
+     * @ignore
      * Callback function for click event.
      */
     onClick: React.PropTypes.func,

--- a/src/table/table-header.jsx
+++ b/src/table/table-header.jsx
@@ -52,11 +52,13 @@ const TableHeader = React.createClass({
     enableSelectAll: React.PropTypes.bool,
 
     /**
+     * @ignore
      * Callback when select all has been checked.
      */
     onSelectAll: React.PropTypes.func,
 
     /**
+     * @ignore
      * True when select all has been checked.
      */
     selectAllSelected: React.PropTypes.bool,

--- a/src/table/table-row-column.jsx
+++ b/src/table/table-row-column.jsx
@@ -37,12 +37,14 @@ const TableRowColumn = React.createClass({
     className: React.PropTypes.string,
 
     /**
+     * @ignore
      * Number to identify the header row. This property
      * is automatically populated when used with TableHeader.
      */
     columnNumber: React.PropTypes.number,
 
     /**
+     * @ignore
      * If true, this column responds to hover events.
      */
     hoverable: React.PropTypes.bool,
@@ -53,16 +55,19 @@ const TableRowColumn = React.createClass({
     key: React.PropTypes.string,
 
     /**
+     * @ignore
      * Callback function for click event.
      */
     onClick: React.PropTypes.func,
 
     /**
+     * @ignore
      * Callback function for hover event.
      */
     onHover: React.PropTypes.func,
 
     /**
+     * @ignore
      * Callback function for hover exit event.
      */
     onHoverExit: React.PropTypes.func,

--- a/src/table/table-row.jsx
+++ b/src/table/table-row.jsx
@@ -60,6 +60,7 @@ const TableRow = React.createClass({
     hovered: React.PropTypes.bool,
 
     /**
+     * @ignore
      * Called when a row cell is clicked.
      * rowNumber is the row number and columnId is
      * the column number or the column key.
@@ -67,6 +68,7 @@ const TableRow = React.createClass({
     onCellClick: React.PropTypes.func,
 
     /**
+     * @ignore
      * Called when a table cell is hovered.
      * rowNumber is the row number of the hovered row
      * and columnId is the column number or the column key of the cell.
@@ -74,6 +76,7 @@ const TableRow = React.createClass({
     onCellHover: React.PropTypes.func,
 
     /**
+     * @ignore
      * Called when a table cell is no longer hovered.
      * rowNumber is the row number of the row and columnId
      * is the column number or the column key of the cell.
@@ -81,17 +84,20 @@ const TableRow = React.createClass({
     onCellHoverExit: React.PropTypes.func,
 
     /**
+     * @ignore
      * Called when row is clicked.
      */
     onRowClick: React.PropTypes.func,
 
     /**
+     * @ignore
      * Called when a table row is hovered.
      * rowNumber is the row number of the hovered row.
      */
     onRowHover: React.PropTypes.func,
 
     /**
+     * @ignore
      * Called when a table row is no longer hovered.
      * rowNumber is the row number of the row that is no longer hovered.
      */

--- a/src/tabs/tab.jsx
+++ b/src/tabs/tab.jsx
@@ -47,11 +47,13 @@ const Tab = React.createClass({
     onActive: React.PropTypes.func,
 
     /**
+     * @ignore
      * This property is overriden by the Tabs component.
      */
     onTouchTap: React.PropTypes.func,
 
     /**
+     * @ignore
      * Defines if the current tab is selected or not.
      * The Tabs component is responsible for setting this property.
      */
@@ -69,6 +71,7 @@ const Tab = React.createClass({
     value: React.PropTypes.any,
 
     /**
+     * @ignore
      * This property is overriden by the Tabs component.
      */
     width: React.PropTypes.string,


### PR DESCRIPTION
- [x] PR has ~~tests~~ / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

A number of props that are controlled by a parent component are visible in the docs. This PR hides them.

Some of the table click / hover in particular cause confusion, as they appear to offer functionality that doesn't exist. While this should be fixed at some point (parent component should attach to a separate internal use callback prop), for now hiding them will reduce confusion.

The associated issue lists all the components that have been checked.
Closes #3588.