### PR TITLE
[ListItem] Add stopPropagation in touch ripple to avoid touch event bubbling

### DIFF
--- a/src/ripples/touch-ripple.jsx
+++ b/src/ripples/touch-ripple.jsx
@@ -119,6 +119,7 @@ const TouchRipple = React.createClass({
   },
 
   _handleTouchStart(event) {
+    event.stopPropagation();
     //If the user is swiping (not just tapping), save the position so we can
     //abort ripples if the user appears to be scrolling
     if (this.props.abortOnScroll && event.touches) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has ~~tests~~ / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Resolves: https://github.com/callemall/material-ui/issues/3556

The issue was bubbling up of the touch event from the `ListItem` icon.

![touch-issue](https://cloud.githubusercontent.com/assets/15271922/13514157/01b4a09c-e16c-11e5-816f-944b4ebe20dc.gif)

It was apparent during the diagnosis that , the bubbling of event was happening from the `EnhancedButton` of `IconButton` onto the `EnhancedButton` of the `ListItem`. And this was happening only because of touch and hence the `touch-ripple` was being called twice and hence the effect.

To solve this , all I had to do was add `event.stopPropagation()` in the event-handler of the touch-ripple component.

This prevents the touch event from bubbling up, as seen below:

![touch-solved](https://cloud.githubusercontent.com/assets/15271922/13514270/20fdad6c-e16d-11e5-99d2-f4bbec8703c6.gif)
