### PR TITLE
[MenuItem] Add flex property

### DIFF
--- a/src/menus/menu-item.jsx
+++ b/src/menus/menu-item.jsx
@@ -232,10 +232,16 @@ const MenuItem = React.createClass({
         paddingRight: sidePadding,
         paddingBottom: 0,
         paddingTop: 0,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignContent: 'space-between',
       },
 
       secondaryText: {
-        float: 'right',
+        order: 2,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
       },
 
       leftIconDesktop: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has ~~tests~~ / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

To avoid the secondary text over-lap, add flex property to the `MenuItem` component and assign order to the primary and secondary text.

Resolves #3531

