### PR TITLE
[Dialog] Update color for the docs full width example buttons

### DIFF
--- a/docs/src/app/components/pages/components/Dialog/ExampleCustomWidth.jsx
+++ b/docs/src/app/components/pages/components/Dialog/ExampleCustomWidth.jsx
@@ -33,7 +33,7 @@ export default class DialogExampleCustomWidth extends React.Component {
       />,
       <FlatButton
         label="Submit"
-        secondary={true}
+        primary={true}
         onTouchTap={this.handleClose}
       />,
     ];

--- a/docs/src/app/components/pages/components/Dialog/ExampleDialogDatePicker.jsx
+++ b/docs/src/app/components/pages/components/Dialog/ExampleDialogDatePicker.jsx
@@ -24,7 +24,7 @@ export default class DialogExampleDialogDatePicker extends React.Component {
     const actions = [
       <FlatButton
         label="Ok"
-        secondary={true}
+        primary={true}
         keyboardFocused={true}
         onTouchTap={this.handleClose}
       />,

--- a/docs/src/app/components/pages/components/Dialog/ExampleSimple.jsx
+++ b/docs/src/app/components/pages/components/Dialog/ExampleSimple.jsx
@@ -28,7 +28,7 @@ export default class DialogExampleSimple extends React.Component {
       />,
       <FlatButton
         label="Submit"
-        secondary={true}
+        primary={true}
         keyboardFocused={true}
         onTouchTap={this.handleClose}
       />,


### PR DESCRIPTION
This one is for @oliviertassinari RE https://github.com/callemall/material-ui/pull/3590/files#r54964518

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).
