### PR TITLE
[Core] Temporarily add estraverse-fb missing dependency

### DIFF
--- a/examples/webpack-example/package.json
+++ b/examples/webpack-example/package.json
@@ -21,6 +21,7 @@
     "eslint": "^2.2.0",
     "eslint-loader": "^1.1.1",
     "eslint-plugin-react": "^4.0.0",
+    "estraverse-fb": "^1.3.1",
     "html-webpack-plugin": "^2.7.2",
     "react-hot-loader": "^1.3.0",
     "transfer-webpack-plugin": "^0.1.4",


### PR DESCRIPTION
After a first run of npm install in the ``webpack-example`` folder I had this error while running ``npm start``:

```
 50% 4/6 build modulesError: Cannot find module 'estraverse-fb'
```

Here is a fix.