### PR TITLE
[Core] Temporarily revert eslint version to ~2.2.0

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -27,7 +27,7 @@
     "babel-eslint": "^5.0.0",
     "css-loader": "^0.23.0",
     "doctrine": "^1.1.0",
-    "eslint": "^2.2.0",
+    "eslint": "~2.2.0",
     "eslint-plugin-react": "^4.0.0",
     "highlight.js": "^9.0.0",
     "history": "^2.0.0",

--- a/examples/webpack-example/package.json
+++ b/examples/webpack-example/package.json
@@ -18,7 +18,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-runtime": "^6.3.19",
-    "eslint": "^2.2.0",
+    "eslint": "~2.2.0",
     "eslint-loader": "^1.1.1",
     "eslint-plugin-react": "^4.0.0",
     "html-webpack-plugin": "^2.7.2",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "chai": "^3.2.0",
     "codecov": "^1.0.1",
     "enzyme": "^2.0.0",
-    "eslint": "^2.2.0",
+    "eslint": "~2.2.0",
     "eslint-loader": "^1.1.1",
     "eslint-plugin-react": "^4.0.0",
     "glob": "^7.0.0",


### PR DESCRIPTION
@oliviertassinari @mbrookes 

This addresses the `eslint`+`estraverse` issue (https://github.com/eslint/eslint/issues/5476).

We can bump the version once a solid conclusion has been reached.