### PR TITLE
[eslint] Enforce @ignore before comment

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -108,10 +108,14 @@ rules:
   react/jsx-sort-props: 0
   react/no-set-state: 0
 
+  # Material-UI
+  material-ui/docgen-ignore-before-comment: 2
+
 parser: babel-eslint
 
 plugins:
   - react
+  - material-ui
 
 ecmaFeatures:
   jsx: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ build
 coverage
 
 # Exclude compiled files
-lib
+/lib
 icon-builder/js
 icon-builder/jsx
 

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "eslint": "~2.2.0",
     "eslint-loader": "^1.1.1",
     "eslint-plugin-react": "^4.0.0",
+    "eslint-plugin-material-ui": "./packages/eslint-plugin-material-ui",
     "glob": "^7.0.0",
     "in-publish": "^2.0.0",
     "isparta": "^4.0.0",

--- a/packages/eslint-plugin-material-ui/.gitignore
+++ b/packages/eslint-plugin-material-ui/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.idea

--- a/packages/eslint-plugin-material-ui/README.md
+++ b/packages/eslint-plugin-material-ui/README.md
@@ -1,0 +1,7 @@
+# eslint-plugin-material-ui
+
+Custom eslint rules for Material-UI
+
+## Supported Rules
+
+* docgen-ignore-before-comment

--- a/packages/eslint-plugin-material-ui/lib/index.js
+++ b/packages/eslint-plugin-material-ui/lib/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+// import all rules in lib/rules
+module.exports.rules = {
+  'docgen-ignore-before-comment': require('./rules/docgen-ignore-before-comment'),
+};
+
+// import processors
+module.exports.processors = {
+  // add your processors here
+};

--- a/packages/eslint-plugin-material-ui/lib/rules/docgen-ignore-before-comment.js
+++ b/packages/eslint-plugin-material-ui/lib/rules/docgen-ignore-before-comment.js
@@ -1,0 +1,20 @@
+module.exports = function(context) {
+  return {
+    BlockComment: function(node) {
+      const source = context.getSource(node);
+      /**
+        * The regex has 5 groups (mostly for readability) that match:
+        *   1. '/**',
+        *   2. One or more comment lines beginning with '*',
+        *   3. '* @ignore',
+        *   4. Any number of comment lines beginning with '*',
+        *   5. '* /' (without the space).
+        *
+        *   All lines can begin with any number of spaces.
+        */
+      if (source.match(/( *\/\*\*\n)( *\*.*\n)+( *\* @ignore\n)( *\*.*\n)*( *\*\/)/)) {
+        context.report(node, '@ignore should be at the beginning of a block comment.');
+      }
+    },
+  };
+};

--- a/packages/eslint-plugin-material-ui/package.json
+++ b/packages/eslint-plugin-material-ui/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "eslint-plugin-material-ui",
+  "version": "1.0.0",
+  "private": "true",
+  "description": "Custom eslint rules for Material-UI",
+  "repository": "https://github.com/callemall/material-ui/packages/eslint-plugin-material-ui",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "../../node_modules/mocha/bin/_mocha -- tests/lib/**/*.js",
+    "lint": "../../node_modules/eslint/bin/eslint.js --rulesdir ../.. --ext .js lib tests && echo \"eslint: no lint errors\""
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "license": "MIT"
+}

--- a/packages/eslint-plugin-material-ui/tests/lib/rules/docgen-ignore-before-comment.js
+++ b/packages/eslint-plugin-material-ui/tests/lib/rules/docgen-ignore-before-comment.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const rule = require('../../../lib/rules/docgen-ignore-before-comment');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester();
+ruleTester.run('ignore-before-comment', rule, {
+
+  valid: [
+    '\n/**\n * @ignore\n */\n',
+    '\n/**\n * @ignore\n * Comment.\n */\n',
+    '\n/**\n * @ignore\n * Multi-line\n * comment.\n */\n',
+    '\n  /**\n   * @ignore\n   * Indented\n   * multi-line\n   * comment.\n   */\n',
+  ],
+
+  invalid: [
+    {
+      code: '\n/**\n * Comment.\n * @ignore\n */\n',
+      errors: [{message: '@ignore should be at the beginning of a block comment.', type: 'Block'}],
+    },
+    {
+      code: '\n  /**\n   * Multi-line\n   * comment.\n   * @ignore\n   */\n',
+      errors: [{message: '@ignore should be at the beginning of a block comment.', type: 'Block'}],
+    },
+    {
+      code: '\n  /**\n   * Multi-line\n   * @ignore\n   * comment.\n   */\n',
+      errors: [{message: '@ignore should be at the beginning of a block comment.', type: 'Block'}],
+    },
+    {
+      code: '\n  /**\n   * Indented\n   * multi-line\n   * comment.\n   * @ignore\n   */\n',
+      errors: [{message: '@ignore should be at the beginning of a block comment.', type: 'Block'}],
+    },
+  ],
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / ~~docs demo~~, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Adds a custom eslint rule to enforce placing @ignore at the start of the comment block.

Resolves: https://github.com/callemall/material-ui/pull/3589#issuecomment-192878905