### PR TITLE
[EnhancedButton] fix onKeyboardFocus being called with nullified event object

### DIFF
--- a/src/enhanced-button.jsx
+++ b/src/enhanced-button.jsx
@@ -229,6 +229,7 @@ const EnhancedButton = React.createClass({
   },
 
   _handleFocus(event) {
+    if (event) event.persist();
     if (!this.props.disabled && !this.props.disableKeyboardFocus) {
       //setTimeout is needed because the focus event fires first
       //Wait so that we can capture if this was a keyboard focus


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Hey, I was working on the docs for `FlatButton`, and I noticed that when I tabbed onto a button the `event` argument being passed to `onKeyboardFocus` isn't what it (presumably) should be:

~~~
SyntheticFocusEvent {dispatchConfig: null, dispatchMarker: null, nativeEvent: null, type: null, target: null…}
~~~

The problem is that in  the `_handleFocus` method of `EnhancedButton`, the `onKeyboardFocus` callback is being fired after a brief delay,
~~~
_handleFocus(event) {
    if (!this.props.disabled && !this.props.disableKeyboardFocus) {
      //setTimeout is needed because the focus event fires first
      //Wait so that we can capture if this was a keyboard focus
      //or touch focus
      this._focusTimeout = setTimeout(() => {
        if (tabPressed) {
          this.setKeyboardFocus(event);
        }
      }, 150);

      this.props.onFocus(event);
    }
  },
~~~

during which time React nullifies the event with it's `SyntheticEvent` pooling system.

This change makes it so the correct `focus` event is being passed to the `onKeyboardFocus` callback in `EnhancedButton`.

I tried for some time to get a test working for this PR, but I couldn't figure out how to replicate tabbing onto a button in a test with this component. 