### PR TITLE
[SelectField,TextField] Refactoring/Popover/Keyboard

### DIFF
--- a/docs/src/app/components/pages/components/SelectField/ExampleOpenOnMount.jsx
+++ b/docs/src/app/components/pages/components/SelectField/ExampleOpenOnMount.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import SelectField from 'material-ui/lib/select-field';
+import MenuItem from 'material-ui/lib/menus/menu-item';
+
+export default class SelectFieldExampleSimple extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: true,
+      value: 2,
+    };
+  }
+
+  handleChange = (event, index, value) => this.setState({value});
+
+  render() {
+    const {open} = this.state;
+    return (
+      <div>
+        <SelectField
+          open={open}
+          onRequestClose={() => this.setState({open: false})}
+          value={this.state.value}
+          onChange={this.handleChange}
+        >
+          <MenuItem value={1} primaryText="Never" />
+          <MenuItem value={2} primaryText="Every Night" />
+          <MenuItem value={3} primaryText="Weeknights" />
+          <MenuItem value={4} primaryText="Weekends" />
+          <MenuItem value={5} primaryText="Weekly" />
+        </SelectField>
+        <br />
+        <SelectField value={1} disabled={true}>
+          <MenuItem value={1} primaryText="Never" />
+          <MenuItem value={2} primaryText="Every Night" />
+        </SelectField>
+      </div>
+    );
+  }
+}

--- a/docs/src/app/components/pages/components/SelectField/Page.jsx
+++ b/docs/src/app/components/pages/components/SelectField/Page.jsx
@@ -14,6 +14,8 @@ import SelectFieldExampleCustomLabel from './ExampleCustomLabel';
 import selectFieldExampleCustomLabelCode from '!raw!./ExampleCustomLabel';
 import SelectFieldExampleFloatingLabel from './ExampleFloatingLabel';
 import selectFieldExampleFloatingLabelCode from '!raw!./ExampleFloatingLabel';
+import SelectFieldExampleOpenOnMount from './ExampleOpenOnMount';
+import selectFieldExampleOpenOnMountCode from '!raw!./ExampleOpenOnMount';
 import SelectFieldExampleError from './ExampleError';
 import selectFieldExampleErrorCode from '!raw!./ExampleError';
 import selectFieldCode from '!raw!material-ui/lib/SelectField/SelectField';
@@ -69,6 +71,14 @@ const SelectFieldPage = () => (
       code={selectFieldExampleErrorCode}
     >
       <SelectFieldExampleError />
+    </CodeExample>
+
+    <CodeExample
+      title="Open on mount"
+      description={descriptions.errorText}
+      code={selectFieldExampleOpenOnMountCode}
+    >
+      <SelectFieldExampleOpenOnMount />
     </CodeExample>
     <PropTypeDescription code={selectFieldCode} />
   </div>

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "homepage": "http://material-ui.com/",
   "dependencies": {
     "inline-style-prefixer": "^1.0.1",
-    "keycode": "^2.1.0",
+    "keycode": "^2.1.1",
     "lodash.flowright": "^3.2.1",
     "lodash.merge": "^4.1.0",
     "lodash.throttle": "^4.0.0",

--- a/src/SelectField/SelectField.jsx
+++ b/src/SelectField/SelectField.jsx
@@ -170,7 +170,7 @@ const SelectField = React.createClass({
 
   componentDidMount() {
     if (this.props.open) {
-      /* eslint-disable */
+      /* eslint react/no-did-mount-set-state: 0 */
       /* because we're using ref for popover anchorEl  */
       this.setState({open: true});
     }

--- a/src/SelectField/SelectField.jsx
+++ b/src/SelectField/SelectField.jsx
@@ -168,7 +168,7 @@ const SelectField = React.createClass({
     };
   },
 
-  componentDidMount() {
+  componentWillMount() {
     if (this.props.open) {
       /* eslint react/no-did-mount-set-state: 0 */
       /* because we're using ref for popover anchorEl  */
@@ -279,8 +279,6 @@ const SelectField = React.createClass({
         displayValue = child.props.label || child.props.primaryText;
       }
     });
-    /* eslint-disable */
-    console.log(open)
     const selecter = (
       <SelectFieldLabel
         disabled={disabled}

--- a/src/SelectField/SelectField.jsx
+++ b/src/SelectField/SelectField.jsx
@@ -1,23 +1,10 @@
 import React from 'react';
-import TextField from '../text-field';
-import DropDownMenu from '../DropDownMenu';
+import ReactDom from 'react-dom';
+import TextFieldDecorator from '../TextField/TextFieldDecorator';
+import SelectFieldMenu from './SelectFieldMenu';
+import SelectFieldLabel from './SelectFieldLabel';
 import getMuiTheme from '../styles/getMuiTheme';
-
-function getStyles(props) {
-  return {
-    label: {
-      paddingLeft: 0,
-      top: props.floatingLabelText ? 6 : -4,
-    },
-    icon: {
-      right: 0,
-      top: props.floatingLabelText ? 22 : 14,
-    },
-    hideDropDownUnderline: {
-      borderTop: 'none',
-    },
-  };
-}
+import keycode from 'keycode';
 
 const SelectField = React.createClass({
 
@@ -83,6 +70,11 @@ const SelectField = React.createClass({
     iconStyle: React.PropTypes.object,
 
     /**
+     * The id prop for the text field.
+     */
+    id: React.PropTypes.string,
+
+    /**
      * Overrides the styles of label when the `SelectField` is inactive.
      */
     labelStyle: React.PropTypes.object,
@@ -103,6 +95,15 @@ const SelectField = React.createClass({
     onFocus: React.PropTypes.func,
 
     /**
+     * Callback function that is fired when the `SelectField` is closed.
+     */
+    onRequestClose: React.PropTypes.func,
+
+    /**
+     * Property controlling whether the `SelectField` is open.  Use to open `DropDown` on mount.
+     */
+    open: React.PropTypes.bool,
+    /**
      * The style object to use to override the `DropDownMenu`.
      */
     selectFieldRoot: React.PropTypes.object, // Must be changed!
@@ -111,6 +112,8 @@ const SelectField = React.createClass({
      * Override the inline-styles of the root element.
      */
     style: React.PropTypes.object,
+
+    tabIndex: React.PropTypes.number,
 
     /**
      * Override the inline-styles of the underline element when disabled.
@@ -146,12 +149,16 @@ const SelectField = React.createClass({
       autoWidth: false,
       disabled: false,
       fullWidth: false,
+      id: 'select',
+      open: false,
+      tabIndex: 0,
     };
   },
 
   getInitialState() {
     return {
       muiTheme: this.context.muiTheme || getMuiTheme(),
+      open: false,
     };
   },
 
@@ -161,70 +168,172 @@ const SelectField = React.createClass({
     };
   },
 
+  componentDidMount() {
+    if (this.props.open) {
+      /* eslint-disable */
+      /* because we're using ref for popover anchorEl  */
+      this.setState({open: true});
+    }
+  },
+
   componentWillReceiveProps(nextProps, nextContext) {
     this.setState({
       muiTheme: nextContext.muiTheme || this.state.muiTheme,
+      open: nextProps.open,
     });
+  },
+
+  componentWillUnmount() {
+    this.label = null;
+  },
+
+  handleMenuRequestClose() {
+    this.setState({
+      open: false,
+      isFocused: true,
+    }, () => this.label.focus());
+    const {onRequestClose} = this.props;
+    return onRequestClose ? onRequestClose() : null;
+  },
+
+  handleTouchTap() {
+    if (this.props.disabled)
+      return;
+
+    this.setState({
+      open: true,
+      isFocused: false,
+    });
+  },
+
+  onFocus() {
+    if (this.props.disabled)
+      return;
+    this.setState({isFocused: true});
+    const {onFocus} = this.props;
+    return onFocus ? onFocus() : null;
+  },
+
+  onBlur() {
+    const {onBlur} = this.props;
+    this.setState({isFocused: false});
+    return onBlur ? onBlur() : null;
+  },
+
+  handleKeyDown(event) {
+    switch (keycode(event)) {
+      case 'enter':
+      case 'space':
+      case 'down':
+        event.preventDefault();
+        if (!this.props.disabled) {
+          this.setState({
+            open: !this.state.open,
+            anchorEl: this.refs.root,
+          });
+        }
+    }
   },
 
   render() {
     const {
       autoWidth,
       children,
-      style,
-      labelStyle,
+      disabled,
+      errorStyle,
+      errorText,
+      floatingLabelStyle,
+      floatingLabelText,
+      fullWidth,
+      hintStyle,
+      hintText,
       iconStyle,
+      id,
+      labelStyle,
+      onBlur,
+      onChange,
+      selectFieldRoot,
+      style,
+      tabIndex,
       underlineDisabledStyle,
       underlineFocusStyle,
       underlineStyle,
-      errorStyle,
-      selectFieldRoot,
-      disabled,
-      floatingLabelText,
-      floatingLabelStyle,
-      hintStyle,
-      hintText,
-      fullWidth,
-      errorText,
-      onFocus,
-      onBlur,
-      onChange,
       value,
       ...other,
     } = this.props;
 
-    const styles = getStyles(this.props, this.state);
+    const {
+      isFocused,
+    } = this.state;
+
+    const {open, muiTheme} = this.state;
+    const errorStylePrepared = Object.assign({}, errorStyle, {position: 'absolute', bottom: -10});
+    const floatingLabelStylePrepared = Object.assign({}, floatingLabelStyle, {cursor: 'pointer'});
+                                                                           // ^^^^^^^^^^^^^^^^^
+                                                                           // current implementation
+                                                                           // doesn't do this, but should
+    let displayValue = '';
+    React.Children.forEach(children, (child) => {
+      if (value === child.props.value) {
+        // This will need to be improved (in case primaryText is a node)
+        displayValue = child.props.label || child.props.primaryText;
+      }
+    });
+    /* eslint-disable */
+    console.log(open)
+    const selecter = (
+      <SelectFieldLabel
+        disabled={disabled}
+        muiTheme={muiTheme}
+        onBlur={this.onBlur}
+        onFocus={this.onFocus}
+        onKeyDown={this.handleKeyDown}
+        onTouchTap={this.handleTouchTap}
+        ref={(c) => this.label = ReactDom.findDOMNode(c)}
+        style={labelStyle}
+        value={displayValue}
+      />
+    );
+
+    const menu = (
+      <SelectFieldMenu
+        {...other}
+        anchorEl={this.label}
+        autoWidth={autoWidth}
+        floatingLabelText={floatingLabelText}
+        onChange={onChange}
+        onRequestClose={this.handleMenuRequestClose}
+        open={open}
+        value={value}
+      >
+        {children}
+      </SelectFieldMenu>
+    );
 
     return (
-      <TextField
-        style={style}
+      <TextFieldDecorator
+        disabled={disabled}
+        errorStyle={errorStylePrepared}
+        errorText={errorText}
+        floatingLabelStyle={floatingLabelStylePrepared}
         floatingLabelText={floatingLabelText}
-        floatingLabelStyle={floatingLabelStyle}
+        fullWidth={fullWidth}
+        hasValue={true}
+        height={24}
         hintStyle={hintStyle}
         hintText={(!hintText && !floatingLabelText) ? ' ' : hintText}
-        fullWidth={fullWidth}
-        errorText={errorText}
-        underlineStyle={underlineStyle}
-        errorStyle={errorStyle}
-        onFocus={onFocus}
-        onBlur={onBlur}
+        id={id}
+        isFocused={isFocused}
+        muiTheme={muiTheme}
+        style={style}
+        tabIndex={tabIndex}
         underlineDisabledStyle={underlineDisabledStyle}
         underlineFocusStyle={underlineFocusStyle}
+        underlineStyle={underlineStyle}
       >
-        <DropDownMenu
-          disabled={disabled}
-          style={selectFieldRoot}
-          labelStyle={Object.assign(styles.label, labelStyle)}
-          iconStyle={Object.assign(styles.icon, iconStyle)}
-          underlineStyle={styles.hideDropDownUnderline}
-          autoWidth={autoWidth}
-          value={value}
-          onChange={onChange}
-          {...other}
-        >
-          {children}
-        </DropDownMenu>
-      </TextField>
+        {selecter}
+        {menu}
+      </TextFieldDecorator>
     );
   },
 });

--- a/src/SelectField/SelectFieldLabel.jsx
+++ b/src/SelectField/SelectFieldLabel.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import DropDownArrow from '../svg-icons/navigation/arrow-drop-down';
+
+const getStyles = (props) => {
+  const {
+    disabled,
+    style,
+  } = props;
+
+  const {palette, dropDownMenu} = props.muiTheme;
+  const {accentColor} = dropDownMenu;
+  const {marginTop} = style || {};
+
+  return {
+    label: {
+      color: disabled ? palette.disabledColor : palette.textColor,
+      cursor: disabled ? 'not-allowed' : 'pointer',
+      opacity: 1,
+      position: 'absolute',
+      paddingTop: (marginTop || 0) + 12, // just like magic
+      width: '100%',
+      height: '100%',
+      outline: 'none',
+    },
+    icon: {
+      fill: accentColor,
+      position: 'absolute',
+      right: 0,
+      top: 14,
+    },
+  };
+};
+
+                        // this can't be stateless
+                        // as we want to call focus on it
+                        // react-warpgate may help
+const SelectFieldLabel = React.createClass({
+  propTypes: {
+    iconStyle: React.PropTypes.object,
+    labelStyle: React.PropTypes.object,
+    muiTheme: React.PropTypes.object,
+    onBlur: React.PropTypes.func.isRequired,
+    onFocus: React.PropTypes.func.isRequired,
+    onTouchTap: React.PropTypes.func.isRequired,
+    value: React.PropTypes.any,
+  },
+
+  render() {
+    const {
+      iconStyle,
+      labelStyle,
+      muiTheme,
+      value,
+      ...other,
+    } = this.props;
+    const styles = getStyles(this.props);
+    const {prepareStyles} = muiTheme;
+
+    return (
+      <label
+        tabIndex={0}
+        {...other}
+        style={prepareStyles(styles.label, labelStyle)}
+      >
+        {value}
+        <DropDownArrow style={Object.assign({}, styles.icon, iconStyle)} />
+      </label>
+    );
+  },
+});
+
+export default SelectFieldLabel;

--- a/src/SelectField/SelectFieldMenu.jsx
+++ b/src/SelectField/SelectFieldMenu.jsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import Popover from '../popover/popover';
+import PopoverAnimationFromTop from '../popover/popover-animation-from-top';
+import Menu from '../menus/menu';
+import keycode from 'keycode';
+
+const anchorOrigin = {
+  vertical: 'top',
+  horizontal: 'left',
+};
+
+const SelectFieldMenu = React.createClass({
+  // The nested styles for drop-down-menu are modified by toolbar and possibly
+  // other user components, so it will give full access to its js styles rather
+  // than just the parent.
+  propTypes: {
+    anchorEl: React.PropTypes.object,
+    /**
+     * The width will automatically be set according to the items inside the menu.
+     * To control this width in css instead, set this prop to false.
+     */
+    autoWidth: React.PropTypes.bool,
+
+    /**
+     * The `MenuItem`s to populate the `Menu` with. If the `MenuItems` have the
+     * prop `label` that value will be used to render the representation of that
+     * item within the field.
+     */
+    children: React.PropTypes.node,
+
+    /**
+     * The css class name of the root element.
+     */
+    className: React.PropTypes.string,
+
+    /**
+     * Disables the menu.
+     */
+    disabled: React.PropTypes.bool,
+
+    /**
+     * Overrides the styles of icon element.
+     */
+    iconStyle: React.PropTypes.object,
+
+    /**
+     * Overrides the styles of label when the `DropDownMenu` is inactive.
+     */
+    labelStyle: React.PropTypes.object,
+
+    /**
+     * The style object to use to override underlying list style.
+     */
+    listStyle: React.PropTypes.object,
+
+    /**
+     * The maximum height of the `Menu` when it is displayed.
+     */
+    maxHeight: React.PropTypes.number,
+
+    /**
+     * Overrides the styles of `Menu` when the `DropDownMenu` is displayed.
+     */
+    menuStyle: React.PropTypes.object,
+
+    /**
+     * Fired when a menu item is clicked that is not the one currently selected.
+     */
+    onChange: React.PropTypes.func,
+
+    /**
+     * This is a callback that fires when the menu
+     * thinks it should close. (e.g. clickAway or selection made)
+     *
+     * @param {string} reason Determines what triggered this request.
+     */
+    onRequestClose: React.PropTypes.func.isRequired,
+    /**
+     * Set to true to have the `SelectFieldMenu` open.
+     */
+    open: React.PropTypes.bool,
+
+    /**
+     * Override the inline-styles of the root element.
+     */
+    style: React.PropTypes.object,
+
+    /**
+     * Overrides the inline-styles of the underline.
+     */
+    underlineStyle: React.PropTypes.object,
+
+    /**
+     * The value that is currently selected.
+     */
+    value: React.PropTypes.any,
+  },
+
+  onChange(event, value) {
+    this.props.onChange(event, null, value);
+                            // ^^^^ index - can we just ignore this?
+    this.props.onRequestClose();
+  },
+
+  onKeyDown(event) {
+    switch (keycode(event)) {
+      case 'tab' : this.props.onRequestClose();
+    }
+  },
+
+  render() {
+    const {
+      autoWidth,
+      anchorEl,
+      children,
+      listStyle,
+      menuStyle,
+      maxHeight,
+      open,
+      style,
+      //selectFieldRoot,
+      //fullWidth,
+      onRequestClose,
+      value,
+      ...other,
+    } = this.props;
+
+    let popoverStyle;
+    if (anchorEl && !autoWidth) {
+      popoverStyle = {width: anchorEl.clientWidth};
+    }
+    return (
+      <Popover
+        anchorOrigin={anchorOrigin}
+        anchorEl={anchorEl}
+        style={popoverStyle}
+        animation={PopoverAnimationFromTop}
+        open={open}
+        onRequestClose={this.props.onRequestClose}
+      >
+        <Menu
+          maxHeight={maxHeight}
+          desktop={true}
+          onChange={this.onChange}
+          onEscKeyDown={this.props.onRequestClose}
+          onKeyDown={this.onKeyDown}
+          style={menuStyle}
+          listStyle={listStyle}
+          value={value}
+        >
+          {open ? children : null}
+          {/* this hack is needed because of `componentDidUpdate`
+              on list-item.jsx as it
+              re-focusses the list-item during unmount */}
+        </Menu>
+      </Popover>
+    );
+  },
+});
+
+export default SelectFieldMenu;

--- a/src/TextField/TextFieldDecorator.jsx
+++ b/src/TextField/TextFieldDecorator.jsx
@@ -1,0 +1,293 @@
+import React from 'react';
+import ColorManipulator from '../utils/color-manipulator';
+import Transitions from '../styles/transitions';
+import TextFieldHint from './TextFieldHint';
+import TextFieldLabel from './TextFieldLabel';
+import TextFieldUnderline from './TextFieldUnderline';
+
+const getStyles = (props) => {
+  const {
+    disabled,
+    errorStyle,
+    errorText,
+    floatingLabelText,
+    fullWidth,
+    height,
+    hasValue,
+    isFocused,
+    muiTheme,
+    multiLine,
+  } = props;
+
+  const {
+    baseTheme,
+    textField: {
+      floatingLabelColor,
+      focusColor,
+      disabledTextColor,
+      backgroundColor,
+      hintColor,
+      errorColor,
+    },
+  } = muiTheme;
+
+  const styles = {
+    root: {
+      verticalAlign: 'top',
+      fontSize: 16,
+      lineHeight: '24px',
+      width: fullWidth ? '100%' : 256,
+      height: height + (floatingLabelText ? 48 : 24),
+      display: 'inline-block',
+      position: 'relative',
+      backgroundColor: backgroundColor,
+      fontFamily: baseTheme.fontFamily,
+      transition: Transitions.easeOut('200ms', 'height'),
+      marginTop: multiLine ? 8 : 0, // can't explain why this is needed
+                                    // floatingLabel + error example requires
+                                    // to match vertical spacing on docs site
+    },
+    error: {
+      position: 'relative',
+      bottom: 1,
+      fontSize: 12,
+      lineHeight: '12px',
+      color: errorColor,
+      transition: Transitions.easeOut(),
+    },
+    floatingLabel: {
+      color: hintColor,
+      pointerEvents: 'none',
+    },
+    floatingLabelWrapper: {
+      height: height + (floatingLabelText ? 48 : 24),
+      paddingTop: props.floatingLabelText ? 26 : 0,
+      boxSizing: 'border-box',
+    },
+  };
+
+  Object.assign(styles.error, errorStyle);
+
+
+  if (isFocused) {
+    styles.floatingLabel.color = focusColor;
+  }
+
+  if (hasValue) {
+    styles.floatingLabel.color = ColorManipulator.fade(disabled ? disabledTextColor : floatingLabelColor, 0.5);
+  }
+
+  if (errorText) {
+    if (isFocused) {
+      styles.floatingLabel.color = styles.error.color;
+    }
+  }
+
+  return styles;
+};
+
+const defaultProps = {
+  disabled: false,
+  multiLine: false,
+  fullWidth: false,
+  type: 'text',
+  underlineShow: true,
+};
+
+const propTypes = {
+  children: React.PropTypes.node,
+
+  /**
+   * The css class name of the root element.
+   */
+  className: React.PropTypes.string,
+
+  /**
+   * The text string to use for the default value.
+   */
+  defaultValue: React.PropTypes.any,
+
+  /**
+   * Disables the text field if set to true.
+   */
+  disabled: React.PropTypes.bool,
+
+  /**
+   * The style object to use to override error styles.
+   */
+  errorStyle: React.PropTypes.object,
+
+  /**
+   * The error content to display.
+   */
+  errorText: React.PropTypes.node,
+
+  /**
+   * The style object to use to override floating label styles.
+   */
+  floatingLabelStyle: React.PropTypes.object,
+
+  /**
+   * The content to use for the floating label element.
+   */
+  floatingLabelText: React.PropTypes.node,
+
+  /**
+   * If true, the field receives the property width 100%.
+   */
+  fullWidth: React.PropTypes.bool,
+
+  /**
+   * The height of the control being decorated
+   */
+  height: React.PropTypes.number,
+
+  /**
+   * Override the inline-styles of the TextField's hint text element.
+   */
+  hintStyle: React.PropTypes.object,
+
+  /**
+   * The hint content to display.
+   */
+  hintText: React.PropTypes.node,
+  /**
+   * The decorator should appear like it has a value
+   */
+  hasValue: React.PropTypes.bool,
+
+  /**
+   * The id prop for the text field.
+   */
+  id: React.PropTypes.string.isRequired,
+
+  /**
+   * The decorator should appear focussed (e.g blue underline)
+   */
+  isFocused: React.PropTypes.bool,
+
+  /**
+   * Override the inline-styles of the TextField's input element.
+   * When multiLine is false: define the style of the input element.
+   * When multiLine is true: define the style of the container of the textarea.
+   */
+  inputStyle: React.PropTypes.object,
+
+
+  muiTheme: React.PropTypes.object,
+
+  /**
+   * Name applied to the input.
+   */
+  name: React.PropTypes.string,
+
+  /**
+   * Override the inline-styles of the root element.
+   */
+  style: React.PropTypes.object,
+
+  /**
+   * Override the inline-styles of the
+   * TextField's underline element when disabled.
+   */
+  underlineDisabledStyle: React.PropTypes.object,
+
+  /**
+   * Override the inline-styles of the TextField's
+   * underline element when focussed.
+   */
+  underlineFocusStyle: React.PropTypes.object,
+
+  /**
+   * If true, shows the underline for the text field.
+   */
+  underlineShow: React.PropTypes.bool,
+
+  /**
+   * Override the inline-styles of the TextField's underline element.
+   */
+  underlineStyle: React.PropTypes.object,
+};
+
+const TextFieldDecorator = (props) => {
+  const {
+    children,
+    className,
+    disabled,
+    errorStyle,
+    errorText,
+    floatingLabelStyle,
+    floatingLabelText,
+    hasValue,
+    hintText,
+    hintStyle,
+    id,
+    isFocused,
+    muiTheme,
+    style,
+    underlineDisabledStyle,
+    underlineFocusStyle,
+    underlineShow,
+    underlineStyle,
+    ...other,
+  } = props;
+
+  const {
+    prepareStyles,
+  } = muiTheme;
+
+  const styles = getStyles(props);
+  const errorTextElement = errorText ? (
+    <div style={prepareStyles(styles.error)}>{errorText}</div>
+  ) : null;
+
+  const floatingLabelTextElement = floatingLabelText && (
+    <TextFieldLabel
+      disabled={disabled}
+      htmlFor={id}
+      muiTheme={muiTheme}
+      shrink={hasValue || isFocused}
+      style={Object.assign(styles.floatingLabel, floatingLabelStyle)}
+    >
+      {floatingLabelText}
+    </TextFieldLabel>
+  );
+
+
+  return (
+    <div className={className} style={prepareStyles(Object.assign(styles.root, style))}>
+      {floatingLabelTextElement}
+      {hintText ?
+        <TextFieldHint
+          muiTheme={muiTheme}
+          show={!(hasValue || (floatingLabelText && !isFocused))}
+          style={hintStyle}
+          text={hintText}
+        /> :
+        null
+      }
+      <div style={styles.floatingLabelWrapper}>
+        {children}
+        {errorTextElement}
+      </div>
+      {underlineShow ?
+        <TextFieldUnderline
+          disabled={disabled}
+          disabledStyle={underlineDisabledStyle}
+          error={!!errorText}
+          errorStyle={errorStyle}
+          focus={isFocused}
+          focusStyle={underlineFocusStyle}
+          muiTheme={muiTheme}
+          style={underlineStyle}
+        /> :
+        null
+      }
+    </div>
+  );
+};
+
+TextFieldDecorator.propTypes = propTypes;
+TextFieldDecorator.defaultProps = defaultProps;
+
+export default TextFieldDecorator;

--- a/src/date-picker/date-picker-inline.jsx
+++ b/src/date-picker/date-picker-inline.jsx
@@ -29,7 +29,7 @@ class DatePickerInline extends React.Component {
 
   state = {
     anchorEl: null,
-  }
+  };
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.open) {

--- a/src/menus/menu.jsx
+++ b/src/menus/menu.jsx
@@ -341,14 +341,6 @@ const Menu = React.createClass({
       case 'esc':
         this.props.onEscKeyDown(event);
         break;
-      case 'tab':
-        event.preventDefault();
-        if (event.shiftKey) {
-          this._decrementKeyboardFocusIndex();
-        } else {
-          this._incrementKeyboardFocusIndex(filteredChildren);
-        }
-        break;
       case 'up':
         event.preventDefault();
         this._decrementKeyboardFocusIndex();


### PR DESCRIPTION
This PR does several things...

1. `<SelectField />` no longer uses dropdown menu
2. Introduces `<TextFieldDecorator />` which is used to wrap an input element e.g. `TextInput` or `SelectInput` with `floatingLabel`, `errorText`, "animated underline of focus".  (This one is quite a useful change moving forward.  I'm not sure about the naming (as decorator has ES7 implications), so any thoughts welcome...)
 - I think this should lead to `<TextField />` and `<TextFieldMultiline />` in due course.
3, Adds keyboard support to `SelectField` (https://github.com/callemall/material-ui/pull/3583)
4. Adds on mount `open` support to`SelectField` superceding https://github.com/callemall/material-ui/pull/3403/files
5. Removes "tab" support for toggling through menu-items because this seemed silly.
6. Has a number of "magic numbers" to keep pixel precision with the current material-ui select-field and text-field demo pages... I think there is room to get rid of these, but that can be a next PR.

----
- [ ] **This PR has no tests.  It doesn't change behaviour, but what it is changing is covered by no tests.**
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


