### PR TITLE
fix(#3586): avoid nested <noscript>

### DIFF
--- a/src/popover/popover.jsx
+++ b/src/popover/popover.jsx
@@ -380,7 +380,7 @@ const Popover = React.createClass({
 
   render() {
     return (
-      <noscript>
+      <div>
         <EventListener
           elementName="window"
           onScroll={this.handleScroll}
@@ -393,7 +393,7 @@ const Popover = React.createClass({
           useLayerForClickAway={this.props.useLayerForClickAway}
           render={this.renderLayer}
         />
-      </noscript>
+      </div>
     );
   },
 


### PR DESCRIPTION
Replace nested `<noscript>` with an empty `<div>`. Fixes https://github.com/callemall/material-ui/issues/3586.