### PR TITLE
[Core] Remove add-module-exports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,8 +2,7 @@
   "presets": ["es2015", "stage-1", "react"],
   "plugins": [
     ["transform-replace-object-assign", "simple-assign"],
-    "transform-dev-warning",
-    "add-module-exports"
+    "transform-dev-warning"
   ],
   "env": {
     "docs-production": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 ## HEAD
 
 ##### Breaking Changes
+- [Core] if you used Material-UI from npm in CommonJS environment, you need to add `.default` to your requires:
+
+```diff
+- var MUI = require('material-ui')
++ var MUI = require('material-ui').default
+```
+
+If you used ES modules, you’re already all good:
+```js
+import MUI from 'material-ui' // no changes here 😀
+```
+
 - [Styles] RaisedButton, FlatButton, and FloatingActionButton now properly use primary/secondary colors
 - [Menu] Remove Paper (#3559)
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "babel-core": "^6.3.21",
     "babel-eslint": "^5.0.0-beta6",
     "babel-loader": "^6.2.0",
-    "babel-plugin-add-module-exports": "^0.1.2",
     "babel-plugin-transform-dev-warning": "^0.1.0",
     "babel-plugin-transform-react-constant-elements": "^6.3.13",
     "babel-plugin-transform-react-inline-elements": "^6.3.13",

--- a/test/browser/es6-module-exports-spec.js
+++ b/test/browser/es6-module-exports-spec.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 
-const Divider = require('divider');
+const Divider = require('divider').default;
 const ActionAccessibility = require('svg-icons').ActionAccessibility;
 
 import ImportGetMuiTheme from 'styles/getMuiTheme';
-const RequireGetMuiTheme = require('styles/getMuiTheme');
+const RequireGetMuiTheme = require('styles/getMuiTheme').default;
 
 import ImportColorManipulator from 'utils/color-manipulator';
-const RequireColorManipulator = require('utils/color-manipulator');
+const RequireColorManipulator = require('utils/color-manipulator').default;
 
 describe('require() style import of ', () => {
   it('Divider component should not fail when rendering', () => {


### PR DESCRIPTION
Closes https://github.com/callemall/material-ui/issues/3594.
It's linked to https://github.com/callemall/material-ui/pull/2804.