### PR TITLE
[Menu] zDepth was not getting passed on to List

### DIFF
--- a/src/menus/menu.jsx
+++ b/src/menus/menu.jsx
@@ -120,10 +120,7 @@ const Menu = React.createClass({
     width: PropTypes.stringOrNumber,
 
     /**
-     * Sets the width of the menu. If not specified,
-     * the menu width will be dictated by its children.
-     * The rendered width will always be a keyline increment
-     * (64px for desktop, 56px otherwise).
+     * The zDepth prop passed to the Paper element inside list.
      */
     zDepth: PropTypes.zDepth,
   },
@@ -569,6 +566,7 @@ const Menu = React.createClass({
             {...other}
             ref="list"
             style={mergedListStyles}
+            zDepth={zDepth}
           >
             {newChildren}
           </List>


### PR DESCRIPTION
I noticed zDepth was not getting passed to List (and hence down to Paper). However, even after fixing the code, I noticed zDepth still doesn't work. So this is just a starting point for a discussion.

Also fixed an inaccurate comment.

![title_here](https://cloud.githubusercontent.com/assets/12532733/13656736/686d24d8-e61e-11e5-9828-c16f82f04fce.png)
