### PR TITLE
[Menu] zDepth - hide in docs, add warning, remove usages

### DIFF
--- a/docs/src/app/components/pages/components/Popover/ExampleAnimation.jsx
+++ b/docs/src/app/components/pages/components/Popover/ExampleAnimation.jsx
@@ -45,7 +45,7 @@ export default class PopoverExampleAnimation extends React.Component {
           onRequestClose={this.handleRequestClose}
           animation={PopoverAnimationFromTop}
         >
-          <Menu zDepth={0}>
+          <Menu>
             <MenuItem primaryText="Refresh" />
             <MenuItem primaryText="Help &amp; feedback" />
             <MenuItem primaryText="Settings" />

--- a/docs/src/app/components/pages/components/Popover/ExampleConfigurable.jsx
+++ b/docs/src/app/components/pages/components/Popover/ExampleConfigurable.jsx
@@ -157,7 +157,7 @@ export default class PopoverExampleConfigurable extends React.Component {
           targetOrigin={this.state.targetOrigin}
           onRequestClose={this.handleRequestClose}
         >
-          <Menu zDepth={0}>
+          <Menu>
             <MenuItem primaryText="Refresh" />
             <MenuItem primaryText="Help &amp; feedback" />
             <MenuItem primaryText="Settings" />

--- a/docs/src/app/components/pages/components/Popover/ExampleSimple.jsx
+++ b/docs/src/app/components/pages/components/Popover/ExampleSimple.jsx
@@ -44,7 +44,7 @@ export default class PopoverExampleSimple extends React.Component {
           targetOrigin={{horizontal: 'left', vertical: 'top'}}
           onRequestClose={this.handleRequestClose}
         >
-          <Menu zDepth={0}>
+          <Menu>
             <MenuItem primaryText="Refresh" />
             <MenuItem primaryText="Help &amp; feedback" />
             <MenuItem primaryText="Settings" />

--- a/src/auto-complete.jsx
+++ b/src/auto-complete.jsx
@@ -460,7 +460,6 @@ const AutoComplete = React.createClass({
         {...menuProps}
         ref="menu"
         autoWidth={false}
-        zDepth={0}
         disableAutoFocus={focusTextField}
         onEscKeyDown={this.close}
         initiallyKeyboardFocused={false}

--- a/src/menus/icon-menu.jsx
+++ b/src/menus/icon-menu.jsx
@@ -307,7 +307,6 @@ const IconMenu = React.createClass({
         initiallyKeyboardFocused={this.state.menuInitiallyKeyboardFocused}
         onEscKeyDown={this._handleMenuEscKeyDown}
         onItemTouchTap={this._handleItemTouchTap}
-        zDepth={0}
         style={mergedMenuStyles}
       >
         {this.props.children}

--- a/src/menus/menu.jsx
+++ b/src/menus/menu.jsx
@@ -9,6 +9,7 @@ import PropTypes from '../utils/prop-types';
 import List from '../lists/list';
 import getMuiTheme from '../styles/getMuiTheme';
 import deprecated from '../utils/deprecatedPropType';
+import warning from 'warning';
 
 const Menu = React.createClass({
 
@@ -120,10 +121,9 @@ const Menu = React.createClass({
     width: PropTypes.stringOrNumber,
 
     /**
-     * Sets the width of the menu. If not specified,
-     * the menu width will be dictated by its children.
-     * The rendered width will always be a keyline increment
-     * (64px for desktop, 56px otherwise).
+     * @ignore
+     * Menu no longer supports `zDepth`. Instead, wrap it in `Paper`
+     * or another component that provides zDepth.
      */
     zDepth: PropTypes.zDepth,
   },
@@ -149,7 +149,6 @@ const Menu = React.createClass({
       onItemTouchTap: () => {},
       onKeyDown: () => {},
       openDirection: 'bottom-left',
-      zDepth: 1,
     };
   },
 
@@ -463,6 +462,9 @@ const Menu = React.createClass({
       zDepth,
       ...other,
     } = this.props;
+
+    warning((typeof zDepth === 'undefined'), 'Menu no longer supports `zDepth`. Instead, wrap it in `Paper` ' +
+      'or another component that provides `zDepth`.');
 
     const {
       focusIndex,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has ~~tests~~ / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Paper was removed from `Menu` in #3559, but `zDepth` remained in the prop docs with its current (incorrect) description. This PR hides the prop, updates the (now internal) comment, adds a warning, and removes unneeded `zDepth={0}` usage from other components.

