### PR TITLE
[DatePicker] add function signatures to docs

### DIFF
--- a/src/date-picker/date-picker.jsx
+++ b/src/date-picker/date-picker.jsx
@@ -63,7 +63,8 @@ const DatePicker = React.createClass({
      * This function is called to format the date displayed in the input box, and should return a string.
      * By default if no `locale` and `DateTimeFormat` is provided date objects are formatted to ISO 8601 YYYY-MM-DD.
      *
-     * @param {object} date `Date` object to be formatted.
+     * @param {object} date Date object to be formatted.
+     * @returns {any} The formatted date.
      */
     formatDate: React.PropTypes.func,
 
@@ -96,35 +97,43 @@ const DatePicker = React.createClass({
     okLabel: React.PropTypes.string,
 
     /**
-     * Callback function that is fired when the date value changes. Since there
-     * is no particular event associated with the change the first argument
-     * will always be null and the second argument will be the new Date instance.
+     * Callback function that is fired when the date value changes.
+     *
+     * @param {null} null Since there is no particular event associated with the change,
+     * the first argument will always be null.
+     * @param {object} date The new date.
      */
     onChange: React.PropTypes.func,
 
     /**
-     * Fired when the Date Picker dialog is dismissed.
+     * Callback function that is fired when the Date Picker's dialog is dismissed.
      */
     onDismiss: React.PropTypes.func,
 
     /**
-     * Fired when the Date Picker field gains focus.
+     * Callback function that is fired when the Date Picker's `TextField` gains focus.
+     *
+     * @param {object} event `focus` event targeting the `TextField`.
      */
     onFocus: React.PropTypes.func,
 
     /**
-     * Fired when the Date Picker dialog is shown.
+     * Callback function that is fired when the Date Picker's dialog is shown.
      */
     onShow: React.PropTypes.func,
 
     /**
-     * Called when touch tap event occurs on text-field.
+     * Callback function that is fired when a touch tap event occurs on the Date Picker's `TextField`.
+     *
+     * @param {object} event TouchTap event targeting the `TextField`.
      */
     onTouchTap: React.PropTypes.func,
 
     /**
-     * Called during render time of a given day. If this method returns
-     * false the day is disabled, otherwise it is displayed normally.
+     * Callback function used to determine if a day's entry should be disabled on the calendar.
+     *
+     * @param {object} day Date object of a day.
+     * @returns {boolean} Indicates whether the day should be disabled.
      */
     shouldDisableDate: React.PropTypes.func,
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Hey, a PR towards  #3096 .

I left the `DateTimeFormat` entry as it is because a signature for that seems beyond the scope of the docs.

I wasn't sure how to handle two situations:

- functions, like `onDismiss`, that take no arguments and aren't expected to return anything: how should their signature be represented? I just left them out.

- `null` arguments, like with `onChange`: how should they be represented? They have `undefined` type and require a name (null in this PR) with the current setup.

Anyway, let me know what you think.

