### PR TITLE
[Datepicker] Add a check to fetch current system date

### DIFF
--- a/src/date-picker/date-picker.jsx
+++ b/src/date-picker/date-picker.jsx
@@ -178,7 +178,6 @@ const DatePicker = React.createClass({
   getInitialState() {
     return {
       date: this._isControlled() ? this._getControlledDate() : this.props.defaultDate,
-      dialogDate: new Date(),
       muiTheme: this.context.muiTheme || getMuiTheme(),
     };
   },
@@ -212,9 +211,20 @@ const DatePicker = React.createClass({
    * Open the date-picker dialog programmatically from a parent.
    */
   openDialog() {
-    this.setState({
-      dialogDate: this.getDate(),
-    }, this.refs.dialogWindow.show);
+    /**
+     * if the date is not selected then set it to new date
+     * (get the current system date while doing so)
+     * else set it to the currently selected date
+     */
+    if (this.state.date !== undefined) {
+      this.setState({
+        dialogDate: this.getDate(),
+      }, this.refs.dialogWindow.show);
+    } else {
+      this.setState({
+        dialogDate: new Date(),
+      }, this.refs.dialogWindow.show);
+    }
   },
 
   /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has ~~tests~~ / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

The current issue #3545 deals with the date picker not picking up the updated system date when the dialog opens.  This happens because if the system date updates but the page is not refreshed then the date which the dialog box gets is the old system date as the system date is set in the getinitialState() of the date picker and is not updated on the system date change.
 
I observed that there is no check when the openDialog() to get the updated date, which  is what I added. I check if the Datepicker has a pre-existing selected date , if it does show that date on openDialog() else if the Datepicker is empty pick up the current system date (this will always pick up the updated date) and hence solves the problem.

Heres the example:
![datepicker](https://cloud.githubusercontent.com/assets/15271922/13678837/6ad1b066-e6b6-11e5-85b3-33d155b6abda.gif)

Fixes #3545.


