### PR TITLE
[TextField] Fix bad hint text show condition in edb8ad9c

### DIFF
--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -289,6 +289,7 @@ const TextField = React.createClass({
   getDefaultProps() {
     return {
       disabled: false,
+      floatingLabelFixed: false,
       multiLine: false,
       fullWidth: false,
       type: 'text',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

The hint text show condition resolves to `undefined` when `floatingLabelFixed` property is not passed, which result in the hint text being shown at the same time than the floating label.
