### PR TITLE
[AppBar] Render children before MenuElementRight

### DIFF
--- a/src/app-bar.jsx
+++ b/src/app-bar.jsx
@@ -328,8 +328,8 @@ const AppBar = React.createClass({
       >
         {menuElementLeft}
         {titleElement}
-        {menuElementRight}
         {children}
+        {menuElementRight}
       </Paper>
     );
   },


### PR DESCRIPTION
{children} should render before {menuElementRight}
