### PR TITLE
[AutoComplete] Fix openOnFocus behavior

### DIFF
--- a/src/auto-complete.jsx
+++ b/src/auto-complete.jsx
@@ -390,6 +390,12 @@ const AutoComplete = React.createClass({
     }
   },
 
+  handlePopoverRequestClose() {
+    if (this.refs.searchTextField && !this.refs.searchTextField.state.isFocused) {
+      this.close();
+    }
+  },
+
   blur() {
     this.refs.searchTextField.blur();
   },
@@ -526,7 +532,7 @@ const AutoComplete = React.createClass({
           open={open}
           anchorEl={anchorEl}
           useLayerForClickAway={false}
-          onRequestClose={this.close}
+          onRequestClose={this.handlePopoverRequestClose}
           animated={animated}
         >
           {menu}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Resolves #3381

AutoComplete will now close the child Popover element when requested (e.g.after clicking away from the Popover) only when the child TextField is not in focus.
