### PR TITLE
[TextField] Add shouldComponentUpdate function

### DIFF
--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import keycode from 'keycode';
+import shallowEqual from '../utils/shallow-equal';
 import ColorManipulator from '../utils/color-manipulator';
 import Transitions from '../styles/transitions';
 import deprecated from '../utils/deprecatedPropType';
@@ -354,6 +355,14 @@ const TextField = React.createClass({
     }
 
     if (newState) this.setState(newState);
+  },
+
+  shouldComponentUpdate(nextProps, nextState, nextContext) {
+    return (
+      !shallowEqual(this.props, nextProps) ||
+      !shallowEqual(this.state, nextState) ||
+      !shallowEqual(this.context, nextContext)
+    );
   },
 
   blur() {


### PR DESCRIPTION
This fixes #3394.

**edit:** FYI, this change is somewhat of a band-aid since it does not address the root cause in TextField. However, this is a non-breaking change and the upcoming refactor will remove much of the internal state from the core component anyways. This gets the fix in without needing that rework right now.

Right now, when a `TextField` is controlled from outside of a portal (for eg, from outside of a `Dialog`), typing will prevent a double render that happens due to the internal `setState` call and some weirdness related to `setState` execution with components added through the `ReactDOM` API (`render`, `unstable_renderSubtreeIntoContainer`).

However, that internal `setState` call does not change any props, state, or context. So it is breaking IME composition for no reason. This addition prevents that rerender so the component retains the IME composition event in progress.

- [ ] **I spent a couple of hours trying to get tests for this working (failing) in karma/PhantomJS but they kept passing (it's a weird one). I can have another go at getting the tests working if you want**
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

