### PR TITLE
[DropDownMenu] Preliminary step toward virtualization

### DIFF
--- a/src/DropDownMenu/DropDownMenu.jsx
+++ b/src/DropDownMenu/DropDownMenu.jsx
@@ -239,18 +239,18 @@ const DropDownMenu = React.createClass({
     }
   },
 
-  _onMenuItemTouchTap(key, payload, event) {
-    this.props.onChange(event, key, payload);
-
-    this.setState({
-      open: false,
-    });
-  },
-
   handleRequestCloseMenu() {
     this.setState({
       open: false,
       anchorEl: null,
+    });
+  },
+
+  handleItemTouchTap(event, child, index) {
+    this.props.onChange(event, index, child.props.value);
+
+    this.setState({
+      open: false,
     });
   },
 
@@ -290,12 +290,6 @@ const DropDownMenu = React.createClass({
       }
     });
 
-    const menuItemElements = React.Children.map(children, (child, index) => {
-      return React.cloneElement(child, {
-        onTouchTap: this._onMenuItemTouchTap.bind(this, index, child.props.value),
-      });
-    });
-
     let popoverStyle;
     if (anchorEl && !autoWidth) {
       popoverStyle = {width: anchorEl.clientWidth};
@@ -331,8 +325,9 @@ const DropDownMenu = React.createClass({
             value={value}
             style={menuStyle}
             listStyle={listStyle}
+            onItemTouchTap={this.handleItemTouchTap}
           >
-            {menuItemElements}
+            {children}
           </Menu>
         </Popover>
       </div>

--- a/src/menus/menu.jsx
+++ b/src/menus/menu.jsx
@@ -237,7 +237,7 @@ const Menu = React.createClass({
     }
   },
 
-  _cloneMenuItem(child, childIndex, styles) {
+  _cloneMenuItem(child, childIndex, styles, index) {
     const {
       desktop,
       selectedMenuItemStyle,
@@ -263,7 +263,7 @@ const Menu = React.createClass({
       desktop: desktop,
       focusState: focusState,
       onTouchTap: (event) => {
-        this._handleMenuItemTouchTap(event, child);
+        this._handleMenuItemTouchTap(event, child, index);
         if (child.props.onTouchTap) child.props.onTouchTap(event);
       },
       ref: isFocused ? 'focusedMenuItem' : null,
@@ -356,7 +356,7 @@ const Menu = React.createClass({
     this.props.onKeyDown(event);
   },
 
-  _handleMenuItemTouchTap(event, item) {
+  _handleMenuItemTouchTap(event, item, index) {
     const children = this.props.children;
     const multiple = this.props.multiple;
     const valueLink = this.getValueLink(this.props);
@@ -367,17 +367,17 @@ const Menu = React.createClass({
     this._setFocusIndex(focusIndex, false);
 
     if (multiple) {
-      const index = menuValue.indexOf(itemValue);
-      const newMenuValue = index === -1 ?
+      const itemIndex = menuValue.indexOf(itemValue);
+      const newMenuValue = itemIndex === -1 ?
         update(menuValue, {$push: [itemValue]}) :
-        update(menuValue, {$splice: [[index, 1]]});
+        update(menuValue, {$splice: [[itemIndex, 1]]});
 
       valueLink.requestChange(event, newMenuValue);
     } else if (!multiple && itemValue !== menuValue) {
       valueLink.requestChange(event, itemValue);
     }
 
-    this.props.onItemTouchTap(event, item);
+    this.props.onItemTouchTap(event, item, index);
   },
 
   _incrementKeyboardFocusIndex(filteredChildren) {
@@ -531,7 +531,7 @@ const Menu = React.createClass({
     const cumulativeDelayIncrement = Math.ceil(150 / cascadeChildrenCount);
 
     let menuItemIndex = 0;
-    const newChildren = React.Children.map(filteredChildren, (child) => {
+    const newChildren = React.Children.map(filteredChildren, (child, index) => {
       const childIsADivider = child.type && child.type.displayName === 'Divider';
       const childIsDisabled = child.props.disabled;
       let childrenContainerStyles = {};
@@ -555,7 +555,7 @@ const Menu = React.createClass({
 
       const clonedChild = childIsADivider ? React.cloneElement(child, {style: styles.divider}) :
         childIsDisabled ? React.cloneElement(child, {desktop: desktop}) :
-        this._cloneMenuItem(child, menuItemIndex, styles);
+        this._cloneMenuItem(child, menuItemIndex, styles, index);
 
       if (!childIsADivider && !childIsDisabled) menuItemIndex++;
 


### PR DESCRIPTION
This is a preliminary step toward adding support for [react-virtualized](https://github.com/bvaughn/react-virtualized) and [react-list](https://github.com/orgsync/react-list).
We need to stop cloning children and doing heavy computation with them. cc @bvaughn.

Hopefully, that's already improving the performance of the rendering method (https://github.com/callemall/material-ui/issues/2787).
**Before** : 446 ms to open the `Long example`
![capture d ecran 2016-03-15 a 22 35 22](https://cloud.githubusercontent.com/assets/3165635/13795040/483a7d56-eaff-11e5-88ab-d0f5f55ab9bf.png)

**After** : 374 ms to open the `Long example`
![capture d ecran 2016-03-15 a 22 44 03](https://cloud.githubusercontent.com/assets/3165635/13795091/79e8a60c-eaff-11e5-9e57-1a0bd02244e2.png)