### PR TITLE
Revert "[TableBody] Don't ignore the possible `selected` prop passed to the TableRow"

### DIFF
--- a/src/table/table-body.jsx
+++ b/src/table/table-body.jsx
@@ -191,11 +191,10 @@ const TableBody = React.createClass({
 
     return React.Children.map(this.props.children, (child) => {
       if (React.isValidElement(child)) {
-        const {selected} = child.props;
         const props = {
           displayRowCheckbox: this.props.displayRowCheckbox,
           hoverable: this.props.showRowHover,
-          selected: selected !== undefined ? selected : this._isRowSelected(rowNumber),
+          selected: this._isRowSelected(rowNumber),
           striped: this.props.stripedRows && (rowNumber % 2 === 0),
           rowNumber: rowNumber++,
         };
@@ -221,6 +220,7 @@ const TableBody = React.createClass({
     const key = `${rowProps.rowNumber}-cb`;
     const checkbox = (
       <Checkbox
+        ref="rowSelectCB"
         name={key}
         value="selected"
         disabled={!this.props.selectable}


### PR DESCRIPTION
Reverts callemall/material-ui#3505 due to regressions so we can take a fresh approach to the issue for `0.15.0`.