### PR TITLE
Revert "[TableRow] [TableRowColumn] Propagate events"

### DIFF
--- a/src/table/table-body.jsx
+++ b/src/table/table-body.jsx
@@ -210,7 +210,7 @@ const TableBody = React.createClass({
           children.push(child);
         });
 
-        return React.cloneElement(child, {...props, ...handlers, ...child.props}, children);
+        return React.cloneElement(child, {...props, ...handlers}, children);
       }
     });
   },

--- a/src/table/table-row.jsx
+++ b/src/table/table-row.jsx
@@ -234,7 +234,7 @@ const TableRow = React.createClass({
 
     const rowColumns = React.Children.map(this.props.children, (child, columnNumber) => {
       if (React.isValidElement(child)) {
-        return React.cloneElement(child, {...{
+        return React.cloneElement(child, {
           columnNumber: columnNumber,
           hoverable: this.props.hoverable,
           key: child.props.key || `${this.props.rowNumber}-${columnNumber}`,
@@ -242,7 +242,7 @@ const TableRow = React.createClass({
           onHover: this._onCellHover,
           onHoverExit: this._onCellHoverExit,
           style: Object.assign({}, styles.cell, child.props.style),
-        }, ...child.props});
+        });
       }
     });
 


### PR DESCRIPTION
Reverts callemall/material-ui#3492 due to regressions so we can take a fresh approach to the issue for `0.15.0`.