### PR TITLE
[Stepper] Simplify property name and update property docs

### DIFF
--- a/docs/src/app/components/pages/components/Stepper/HorizontalLinearStepper.jsx
+++ b/docs/src/app/components/pages/components/Stepper/HorizontalLinearStepper.jsx
@@ -82,8 +82,11 @@ const HorizontalStepper = React.createClass({
           <Step
             orderStepLabel="1"
             stepLabel="User account"
-            controlButtonsGroup={[
-              <RaisedButton key={0} label="Continue" primary={true}
+            actions={[
+              <RaisedButton
+                key={0}
+                label="Continue"
+                primary={true}
                 onClick={this.continue}
               />,
               <FlatButton key={1} label="Cancel" />,
@@ -96,8 +99,11 @@ const HorizontalStepper = React.createClass({
           <Step
             orderStepLabel="2"
             stepLabel="Event registration"
-            controlButtonsGroup={[
-              <RaisedButton key={0} label="Continue" primary={true}
+            actions={[
+              <RaisedButton
+                key={0}
+                label="Continue"
+                primary={true}
                 onClick={this.continue}
               />,
               <FlatButton key={1} label="Cancel" />,
@@ -111,8 +117,11 @@ const HorizontalStepper = React.createClass({
           <Step
             orderStepLabel="3"
             stepLabel="Payment"
-            controlButtonsGroup={[
-              <RaisedButton key={0} label="Finish" primary={true}
+            actions={[
+              <RaisedButton
+                key={0}
+                label="Finish"
+                primary={true}
                 onClick={this.continue}
               />,
               <FlatButton key={1} label="Cancel" />,

--- a/docs/src/app/components/pages/components/Stepper/HorizontalLinearStepper.jsx
+++ b/docs/src/app/components/pages/components/Stepper/HorizontalLinearStepper.jsx
@@ -11,30 +11,30 @@ import FlatButton from 'material-ui/lib/flat-button';
 const HorizontalStepper = React.createClass({
   getInitialState() {
     return {
-      activeStepIndex: -1,
-      lastActiveStepIndex: 0,
+      activeStep: -1,
+      lastActiveStep: 0,
     };
   },
 
-  selectStep(stepIndex) {
+  selectStep(currentStep) {
     const {
-      lastActiveStepIndex,
-      activeStepIndex,
+      lastActiveStep,
+      activeStep,
 
     } = this.state;
 
-    if (stepIndex > lastActiveStepIndex) {
+    if (currentStep > lastActiveStep) {
       return;
     }
 
     this.setState({
-      activeStepIndex: stepIndex,
-      lastActiveStepIndex: Math.max(lastActiveStepIndex, activeStepIndex),
+      activeStep: currentStep,
+      lastActiveStep: Math.max(lastActiveStep, activeStep),
     });
   },
 
-  updateCompletedSteps(stepIndex) {
-    return stepIndex < this.state.lastActiveStepIndex;
+  updateCompletedSteps(currentStep) {
+    return currentStep < this.state.lastActiveStep;
   },
 
   createIcon(step) {
@@ -51,13 +51,13 @@ const HorizontalStepper = React.createClass({
 
   continue() {
     const {
-      activeStepIndex,
-      lastActiveStepIndex,
+      activeStep,
+      lastActiveStep,
     } = this.state;
 
     this.setState({
-      activeStepIndex: activeStepIndex + 1,
-      lastActiveStepIndex: Math.max(lastActiveStepIndex, activeStepIndex + 1),
+      activeStep: activeStep + 1,
+      lastActiveStep: Math.max(lastActiveStep, activeStep + 1),
     });
   },
 
@@ -74,9 +74,9 @@ const HorizontalStepper = React.createClass({
         </div>
         <Stepper
           horizontal={true}
-          activeStepIndex={this.state.activeStepIndex}
+          activeStep={this.state.activeStep}
           onStepHeaderTouch={this.selectStep}
-          updateCompletedStatusOfStep={this.updateCompletedSteps}
+          updateCompletedStatus={this.updateCompletedSteps}
           createIcon={this.createIcon}
         >
           <Step

--- a/docs/src/app/components/pages/components/Stepper/VerticalLinearStepper.jsx
+++ b/docs/src/app/components/pages/components/Stepper/VerticalLinearStepper.jsx
@@ -11,41 +11,41 @@ import FlatButton from 'material-ui/lib/flat-button';
 const VerticalLinearStepper = React.createClass({
   getInitialState() {
     return {
-      activeStepIndex: -1,
-      lastActiveStepIndex: 0,
+      activeStep: -1,
+      lastActiveStep: 0,
     };
   },
 
-  selectStep(stepIndex) {
+  selectStep(currentStep) {
     const {
-      lastActiveStepIndex,
-      activeStepIndex,
+      lastActiveStep,
+      activeStep,
 
     } = this.state;
 
-    if (stepIndex > lastActiveStepIndex) {
+    if (currentStep > lastActiveStep) {
       return;
     }
 
     this.setState({
-      activeStepIndex: stepIndex,
-      lastActiveStepIndex: Math.max(lastActiveStepIndex, activeStepIndex),
+      activeStep: currentStep,
+      lastActiveStep: Math.max(lastActiveStep, activeStep),
     });
   },
 
-  updateCompletedSteps(stepIndex) {
-    return stepIndex < this.state.lastActiveStepIndex;
+  updateCompletedSteps(currentStep) {
+    return currentStep < this.state.lastActiveStep;
   },
 
   continue() {
     const {
-      activeStepIndex,
-      lastActiveStepIndex,
+      activeStep,
+      lastActiveStep,
     } = this.state;
 
     this.setState({
-      activeStepIndex: activeStepIndex + 1,
-      lastActiveStepIndex: Math.max(lastActiveStepIndex, activeStepIndex + 1),
+      activeStep: activeStep + 1,
+      lastActiveStep: Math.max(lastActiveStep, activeStep + 1),
     });
   },
 
@@ -73,9 +73,9 @@ const VerticalLinearStepper = React.createClass({
           Create an Ad Campaign
         </div>
         <Stepper
-          activeStepIndex={this.state.activeStepIndex}
+          activeStep={this.state.activeStep}
           onStepHeaderTouch={this.selectStep}
-          updateCompletedStatusOfStep={this.updateCompletedSteps}
+          updateCompletedStatus={this.updateCompletedSteps}
           createIcon={this.createIcon}
         >
           <Step

--- a/docs/src/app/components/pages/components/Stepper/VerticalLinearStepper.jsx
+++ b/docs/src/app/components/pages/components/Stepper/VerticalLinearStepper.jsx
@@ -8,6 +8,21 @@ import FontIcon from 'material-ui/lib/font-icon';
 import RaisedButton from 'material-ui/lib/raised-button';
 import FlatButton from 'material-ui/lib/flat-button';
 
+const styles = {
+  paper: {
+    width: 500,
+    margin: 'auto',
+  },
+  header: {
+    textAlign: 'center',
+    padding: 10,
+    fontSize: 20,
+  },
+  actionButton: {
+    marginRight: 8,
+  },
+};
+
 const VerticalLinearStepper = React.createClass({
   getInitialState() {
     return {
@@ -63,13 +78,8 @@ const VerticalLinearStepper = React.createClass({
 
   render() {
     return (
-      <Paper style={{width: 500, margin: 'auto'}}>
-        <div style={{
-          textAlign: 'center',
-          padding: 10,
-          fontSize: 20,
-        }}
-        >
+      <Paper style={styles.paper}>
+        <div style={styles.header}>
           Create an Ad Campaign
         </div>
         <Stepper
@@ -81,11 +91,18 @@ const VerticalLinearStepper = React.createClass({
           <Step
             orderStepLabel="1"
             stepLabel="Select campaign settings"
-            controlButtonsGroup={[
-              <RaisedButton key={0} label="Continue" primary={true}
+            actions={[
+              <RaisedButton
+                key={0}
+                label="Continue"
+                primary={true}
                 onClick={this.continue}
+                style={styles.actionButton}
               />,
-              <FlatButton key={1} label="Cancel" />,
+              <FlatButton
+                key={1}
+                label="Cancel"
+              />,
             ]}
           >
             <div>
@@ -95,11 +112,18 @@ const VerticalLinearStepper = React.createClass({
           <Step
             orderStepLabel="2"
             stepLabel="Create ad group"
-            controlButtonsGroup={[
-              <RaisedButton key={0} label="Continue" primary={true}
+            actions={[
+              <RaisedButton
+                key={0}
+                label="Continue"
+                primary={true}
                 onClick={this.continue}
+                style={styles.actionButton}
               />,
-              <FlatButton key={1} label="Cancel" />,
+              <FlatButton
+                key={1}
+                label="Cancel"
+              />,
             ]}
           >
             <div>
@@ -111,11 +135,18 @@ const VerticalLinearStepper = React.createClass({
           <Step
             orderStepLabel="3"
             stepLabel="Create an ad"
-            controlButtonsGroup={[
-              <RaisedButton key={0} label="Finish" primary={true}
+            actions={[
+              <RaisedButton
+                key={0}
+                label="Finish"
+                primary={true}
                 onClick={this.continue}
+                style={styles.actionButton}
               />,
-              <FlatButton key={1} label="Cancel" />,
+              <FlatButton
+                key={1}
+                label="Cancel"
+              />,
             ]}
           >
             <div style={{height: 50}}>

--- a/docs/src/app/components/pages/components/Stepper/VerticalLinearStepperWithOptionalStep.jsx
+++ b/docs/src/app/components/pages/components/Stepper/VerticalLinearStepperWithOptionalStep.jsx
@@ -10,9 +10,27 @@ import FlatButton from 'material-ui/lib/flat-button';
 import SeatIcon from 'material-ui/lib/svg-icons/action/event-seat';
 import PrintIcon from 'material-ui/lib/svg-icons/action/print';
 
-const iconStyle = {
-  width: 15,
-  height: 15,
+const styles = {
+  icon: {
+    width: 15,
+    height: 15,
+  },
+  paper: {
+    width: 500,
+    margin: 'auto',
+  },
+  header: {
+    textAlign: 'center',
+    padding: 10,
+    fontSize: 20,
+  },
+  actionButton: {
+    marginRight: 8,
+  },
+  stepLabelSecondary: {
+    fontSize: 10,
+    lineHeight: '5px',
+  },
 };
 
 const VerticalLinearStepper = React.createClass({
@@ -75,13 +93,8 @@ const VerticalLinearStepper = React.createClass({
 
   render() {
     return (
-      <Paper style={{width: 500, margin: 'auto'}}>
-        <div style={{
-          textAlign: 'center',
-          padding: 10,
-          fontSize: 20,
-        }}
-        >
+      <Paper style={styles.paper}>
+        <div style={styles.header}>
           Online check-in
         </div>
         <Stepper
@@ -97,52 +110,73 @@ const VerticalLinearStepper = React.createClass({
               </FontIcon>
             }
             stepLabel="Flight details"
-            controlButtonsGroup={[
-              <RaisedButton key={0} label="Continue" primary={true}
+            actions={[
+              <RaisedButton
+                key={0}
+                label="Continue"
+                primary={true}
                 onClick={this.continue}
+                style={styles.actionButton}
               />,
-              <FlatButton key={1} label="Cancel" />,
+              <FlatButton
+                key={1}
+                label="Cancel"
+              />,
             ]}
           >
             <div>
-              Please enter your booking reference, last name, and flight number.
+              Please enter your booking reference, and flight number.
             </div>
           </Step>
 
           <Step
-            orderStepLabel={<SeatIcon style={iconStyle} />}
+            orderStepLabel={<SeatIcon style={styles.icon} />}
             isCompleted={false}
             optional={true}
             stepLabel={
               <div>
                 <div>Seat selection</div>
-                <div style={{fontSize: 10, lineHeight: '5px'}}>optional</div>
+                <div style={styles.stepLabelSecondary}>optional</div>
               </div>
             }
             stepHeaderStyle={{
               alignItems: 'center',
             }}
-            controlButtonsGroup={[
-              <RaisedButton key={0} label="Continue" primary={true}
+            actions={[
+              <FlatButton
+                key={0}
+                label="Continue"
+                primary={true}
                 onClick={this.continue}
+                style={styles.actionButton}
               />,
-              <FlatButton key={1} label="Cancel" />,
+              <FlatButton
+                key={1}
+                label="Cancel"
+              />,
             ]}
           >
             <div>
-              If you wish to change your assigned seat, please select an alternative seat,
-              or click Finish below to skip this step.
+              If you wish to change your assigned seat, please select
+              an alternative seat, or click Finish below to skip this step.
             </div>
           </Step>
 
           <Step
-            orderStepLabel={<PrintIcon style={iconStyle} />}
+            orderStepLabel={<PrintIcon style={styles.icon} />}
             stepLabel="Boarding pass"
-            controlButtonsGroup={[
-              <RaisedButton key={0} label="Finish" primary={true}
+            actions={[
+              <RaisedButton
+                key={0}
+                label="Finish"
+                primary={true}
                 onClick={this.continue}
+                style={styles.actionButton}
               />,
-              <FlatButton key={1} label="Cancel" />,
+              <FlatButton
+                key={1}
+                label="Cancel"
+              />,
             ]}
           >
             <div>

--- a/docs/src/app/components/pages/components/Stepper/VerticalLinearStepperWithOptionalStep.jsx
+++ b/docs/src/app/components/pages/components/Stepper/VerticalLinearStepperWithOptionalStep.jsx
@@ -18,31 +18,31 @@ const iconStyle = {
 const VerticalLinearStepper = React.createClass({
   getInitialState() {
     return {
-      activeStepIndex: -1,
-      lastActiveStepIndex: 0,
+      activeStep: -1,
+      lastActiveStep: 0,
       statusSteps: [],
     };
   },
 
-  selectStep(stepIndex, step) {
+  selectStep(currentStep, step) {
     const {
-      lastActiveStepIndex,
-      activeStepIndex,
+      lastActiveStep,
+      activeStep,
 
     } = this.state;
 
-    if (stepIndex > lastActiveStepIndex && lastActiveStepIndex < step.props.previousStepOptionalIndex) {
+    if (currentStep > lastActiveStep && lastActiveStep < step.props.previousStepOptionalIndex) {
       return;
     }
 
     this.setState({
-      activeStepIndex: stepIndex,
-      lastActiveStepIndex: Math.max(lastActiveStepIndex, activeStepIndex),
+      activeStep: currentStep,
+      lastActiveStep: Math.max(lastActiveStep, activeStep),
     });
   },
 
-  updateCompletedSteps(stepIndex) {
-    return this.state.statusSteps[stepIndex];
+  updateCompletedSteps(currentStep) {
+    return this.state.statusSteps[currentStep];
   },
 
   createIcon(step) {
@@ -59,17 +59,17 @@ const VerticalLinearStepper = React.createClass({
 
   continue() {
     const {
-      activeStepIndex,
-      lastActiveStepIndex,
+      activeStep,
+      lastActiveStep,
       statusSteps,
     } = this.state;
 
-    statusSteps[activeStepIndex] = true;
+    statusSteps[activeStep] = true;
 
     this.setState({
-      activeStepIndex: activeStepIndex + 1,
+      activeStep: activeStep + 1,
       statusSteps: statusSteps,
-      lastActiveStepIndex: Math.max(lastActiveStepIndex, activeStepIndex + 1),
+      lastActiveStep: Math.max(lastActiveStep, activeStep + 1),
     });
   },
 
@@ -85,9 +85,9 @@ const VerticalLinearStepper = React.createClass({
           Online check-in
         </div>
         <Stepper
-          activeStepIndex={this.state.activeStepIndex}
+          activeStep={this.state.activeStep}
           onStepHeaderTouch={this.selectStep}
-          updateCompletedStatusOfStep={this.updateCompletedSteps}
+          updateCompletedStatus={this.updateCompletedSteps}
           createIcon={this.createIcon}
         >
           <Step

--- a/docs/src/app/components/pages/components/Stepper/VerticalNonLinearStepper.jsx
+++ b/docs/src/app/components/pages/components/Stepper/VerticalNonLinearStepper.jsx
@@ -11,19 +11,19 @@ import FlatButton from 'material-ui/lib/flat-button';
 const VerticalNonLinearStepper = React.createClass({
   getInitialState() {
     return {
-      activeStepIndex: -1,
+      activeStep: -1,
       statusSteps: [],
     };
   },
 
-  selectStep(stepIndex) {
+  selectStep(CurrentStep) {
     this.setState({
-      activeStepIndex: stepIndex,
+      activeStep: CurrentStep,
     });
   },
 
-  updateCompletedSteps(stepIndex) {
-    return this.state.statusSteps[stepIndex];
+  updateCompletedSteps(CurrentStep) {
+    return this.state.statusSteps[CurrentStep];
   },
 
   createIcon(step) {
@@ -40,14 +40,14 @@ const VerticalNonLinearStepper = React.createClass({
 
   continue() {
     const {
-      activeStepIndex,
+      activeStep,
       statusSteps,
     } = this.state;
 
-    statusSteps[activeStepIndex] = true;
+    statusSteps[activeStep] = true;
 
     this.setState({
-      activeStepIndex: activeStepIndex + 1,
+      activeStep: activeStep + 1,
       statusSteps: statusSteps,
     });
   },
@@ -64,9 +64,9 @@ const VerticalNonLinearStepper = React.createClass({
           Your interests
         </div>
         <Stepper
-          activeStepIndex={this.state.activeStepIndex}
+          activeStep={this.state.activeStep}
           onStepHeaderTouch={this.selectStep}
-          updateCompletedStatusOfStep={this.updateCompletedSteps}
+          updateCompletedStatus={this.updateCompletedSteps}
           createIcon={this.createIcon}
         >
           <Step

--- a/docs/src/app/components/pages/components/Stepper/VerticalNonLinearStepper.jsx
+++ b/docs/src/app/components/pages/components/Stepper/VerticalNonLinearStepper.jsx
@@ -8,6 +8,21 @@ import FontIcon from 'material-ui/lib/font-icon';
 import RaisedButton from 'material-ui/lib/raised-button';
 import FlatButton from 'material-ui/lib/flat-button';
 
+const styles = {
+  paper: {
+    width: 500,
+    margin: 'auto',
+  },
+  header: {
+    textAlign: 'center',
+    padding: 10,
+    fontSize: 20,
+  },
+  actionButton: {
+    marginRight: 8,
+  },
+};
+
 const VerticalNonLinearStepper = React.createClass({
   getInitialState() {
     return {
@@ -54,13 +69,8 @@ const VerticalNonLinearStepper = React.createClass({
 
   render() {
     return (
-      <Paper style={{width: 500, margin: 'auto'}}>
-        <div style={{
-          textAlign: 'center',
-          padding: 10,
-          fontSize: 20,
-        }}
-        >
+      <Paper style={styles.paper}>
+        <div style={styles.header}>
           Your interests
         </div>
         <Stepper
@@ -72,11 +82,18 @@ const VerticalNonLinearStepper = React.createClass({
           <Step
             orderStepLabel="1"
             stepLabel="Books"
-            controlButtonsGroup={[
-              <RaisedButton key={0} label="Finish" primary={true}
+            actions={[
+              <RaisedButton
+                key={0}
+                label="Finish"
+                primary={true}
                 onClick={this.continue}
+                style={styles.actionButton}
               />,
-              <FlatButton key={1} label="Cancel" />,
+              <FlatButton
+                key={1}
+                label="Cancel"
+              />,
             ]}
           >
             <div>
@@ -86,11 +103,18 @@ const VerticalNonLinearStepper = React.createClass({
           <Step
             orderStepLabel="2"
             stepLabel="Movies"
-            controlButtonsGroup={[
-              <RaisedButton key={0} label="Finish" primary={true}
+            actions={[
+              <RaisedButton
+                key={0}
+                label="Finish"
+                primary={true}
                 onClick={this.continue}
+                style={styles.actionButton}
               />,
-              <FlatButton key={1} label="Cancel" />,
+              <FlatButton
+                key={1}
+                label="Cancel"
+              />,
             ]}
           >
             <div style={{height: 50}}>
@@ -101,11 +125,18 @@ const VerticalNonLinearStepper = React.createClass({
           <Step
             orderStepLabel="3"
             stepLabel="Music"
-            controlButtonsGroup={[
-              <RaisedButton key={0} label="Finish" primary={true}
+            actions={[
+              <RaisedButton
+                key={0}
+                label="Finish"
+                primary={true}
                 onClick={this.continue}
+                style={styles.actionButton}
               />,
-              <FlatButton key={1} label="Cancel" />,
+              <FlatButton
+                key={1}
+                label="Cancel"
+              />,
             ]}
           >
             <div style={{height: 50}}>

--- a/src/Stepper/HorizontalStep.jsx
+++ b/src/Stepper/HorizontalStep.jsx
@@ -55,7 +55,7 @@ const HorizontalStep = React.createClass({
     onStepHeaderTouch: React.PropTypes.func,
 
     /**
-     * Override inline style of step header wrapper.
+     * Override inline-style of step header wrapper.
      */
     stepHeaderWrapperStyle: React.PropTypes.object,
 

--- a/src/Stepper/Stepper.jsx
+++ b/src/Stepper/Stepper.jsx
@@ -22,8 +22,8 @@ const Stepper = React.createClass({
     /**
      * Function used to set a suitable icon for the step, based on the current state of the step.
      *
-     * @param {node} Step Component which is being updated.
-     * @returns {node} - Icon which will be shown in the left avatar.
+     * @param {node} Step Component that is being updated.
+     * @returns {node} - Icon that will be shown for the step.
      */
     createIcon: PropTypes.func,
 
@@ -36,7 +36,7 @@ const Stepper = React.createClass({
      * Callback function fired when the step header is touched.
      *
      * @param {number} stepIndex - The index of step is being touched.
-     * @param {node} Step component which is being touched
+     * @param {node} Step component that is being touched.
      */
     onStepHeaderTouch: PropTypes.func,
 
@@ -51,11 +51,11 @@ const Stepper = React.createClass({
     style: PropTypes.object,
 
     /**
-     * Callback function fired on re-render to update the background of the left avatar.
+     * Callback function fired on re-render to set the background color of the icon.
      * If not passed, it will use the default theme.
      *
      * @param {node}  Step Component which is being updated.
-     * @returns {string} The background color of avatar.
+     * @returns {string} The background color of the icon.
      */
     updateAvatarBackgroundColor: PropTypes.func,
 
@@ -113,12 +113,12 @@ const Stepper = React.createClass({
 
     const childrenWrapperNode = this.refs.childrenWrapper;
     const containerWrapperNode = this.refs.containerWrapper;
-    const controlButtonsGroupNode = this.refs.controlButtonsGroup;
+    const actionsNode = this.refs.actions;
 
     if (containerWrapperNode.style.height === '0px' &&
       nextProps.activeStep > -1) {
       containerWrapperNode.style.height = `${(childrenWrapperNode.offsetHeight +
-        controlButtonsGroupNode.offsetHeight + 40)}px`;
+        actionsNode.offsetHeight + 40)}px`;
       childrenWrapperNode.style.transition = 'none';
     } else if (nextProps.activeStep > this.getTotalSteps() - 1) {
       containerWrapperNode.style.height = '0px';
@@ -205,12 +205,12 @@ const Stepper = React.createClass({
       hoveredHeaderStepIndex,
     } = this.state;
 
-    const setOfChildrens = [];
-    const setOfControlButtonsGroup = [];
+    const setOfChildren = [];
+    const setOfActions = [];
 
     const steps = React.Children.map(children, (step, index) => {
-      setOfChildrens.push(step.props.children);
-      setOfControlButtonsGroup.push(step.props.controlButtonsGroup);
+      setOfChildren.push(step.props.children);
+      setOfActions.push(step.props.actions);
 
       return React.cloneElement(step, {
         headerWidth: `${100 / this.getTotalSteps()}%`,
@@ -249,14 +249,14 @@ const Stepper = React.createClass({
         <div style={styles.container} ref="containerWrapper">
           <div style={styles.childrenWrapper} ref="childrenWrapper">
             <div style={{display: 'inline-flex'}}>
-              {setOfChildrens.map((children, index) =>
+              {setOfChildren.map((children, index) =>
                 <div style={{width: itemWidth}} key={index}>
                   {children}
                 </div>)}
             </div>
           </div>
-          <div style={{padding: 20, display: 'flex', justifyContent: 'flex-end'}} ref="controlButtonsGroup">
-            {setOfControlButtonsGroup[activeStep]}
+          <div style={{padding: 20, display: 'flex', justifyContent: 'flex-end'}} ref="actions">
+            {setOfActions[activeStep]}
           </div>
         </div>
       </div>

--- a/src/Stepper/Stepper.jsx
+++ b/src/Stepper/Stepper.jsx
@@ -4,37 +4,36 @@ import Paper from '../paper';
 
 const Stepper = React.createClass({
   propTypes: {
-
     /**
-     * The current active step index which passed by parent component.
+     * Set the active step.
      */
-    activeStepIndex: PropTypes.number,
+    activeStep: PropTypes.number,
 
     /**
-     * Children should be Step type.
+     * Should be two or more `HorizontalStep` or `VerticalStep`.
      */
     children: PropTypes.node,
 
-    /*
-     * Override inline-style of the content container.
+    /**
+     * Override the inline-style of the content container.
      */
     containerStyle: PropTypes.object,
 
     /**
-     * Function used to create suitable icon for step base on state of the step.
+     * Function used to set a suitable icon for the step, based on the current state of the step.
      *
-     * @param {node} Step component which is being updated .
-     * @returns {node} - which will be shown in the left avatar.
+     * @param {node} Step Component which is being updated.
+     * @returns {node} - Icon which will be shown in the left avatar.
      */
     createIcon: PropTypes.func,
 
     /**
-     * If true, it will be horizontal stepper.
+     * If true, it will be horizontal stepper. Should match the step type used for `children`.
      */
     horizontal: PropTypes.bool,
 
     /**
-     * Callback function that is fired when the header of step is touched.
+     * Callback function fired when the step header is touched.
      *
      * @param {number} stepIndex - The index of step is being touched.
      * @param {node} Step component which is being touched
@@ -42,34 +41,32 @@ const Stepper = React.createClass({
     onStepHeaderTouch: PropTypes.func,
 
     /**
-     * Overrie inline-style of the step header wrapper.
+     * Override the inline-style of the step header wrapper.
      */
     stepHeadersWrapperStyle: PropTypes.object,
 
     /**
-     * Override the inline-styles of the root element.
+     * Override the inline-style of the root element.
      */
     style: PropTypes.object,
 
     /**
-     * Callback function that is fired when re-render to update the background of left avatar.
-     If not passed, it will use default theme
+     * Callback function fired on re-render to update the background of the left avatar.
+     * If not passed, it will use the default theme.
      *
-     * @param {node}  Step component which is being updated
-     * @returns {string} the background color of avatar
+     * @param {node}  Step Component which is being updated.
+     * @returns {string} The background color of avatar.
      */
     updateAvatarBackgroundColor: PropTypes.func,
 
     /**
-     * Callback function that is fired  when re-render to update complete status of Step.
+     * Callback function fired on re-render to update the completed status of the step.
      *
-     * @param {number} stepIndex - The step is being updated.
-     * @param {node} Step component which is being updated
+     * @param {number} stepIndex - The step that is being updated.
+     * @param {node} Step Component that is being updated.
      * @returns {boolean} `true` if the step is completed.
      */
-    updateCompletedStatusOfStep: PropTypes.func,
-
-
+    updateCompletedStatus: PropTypes.func,
   },
 
   contextTypes: {
@@ -84,7 +81,7 @@ const Stepper = React.createClass({
 
   getDefaultProps() {
     return {
-      activeStepIndex: -1,
+      activeStep: -1,
       onStepHeaderTouch: () => {},
       updateAvatarBackgroundColor: () => null,
       style: {},
@@ -119,11 +116,11 @@ const Stepper = React.createClass({
     const controlButtonsGroupNode = this.refs.controlButtonsGroup;
 
     if (containerWrapperNode.style.height === '0px' &&
-      nextProps.activeStepIndex > -1) {
+      nextProps.activeStep > -1) {
       containerWrapperNode.style.height = `${(childrenWrapperNode.offsetHeight +
         controlButtonsGroupNode.offsetHeight + 40)}px`;
       childrenWrapperNode.style.transition = 'none';
-    } else if (nextProps.activeStepIndex > this.getTotalSteps() - 1) {
+    } else if (nextProps.activeStep > this.getTotalSteps() - 1) {
       containerWrapperNode.style.height = '0px';
     } else {
       childrenWrapperNode.style.transition = 'all 1s';
@@ -139,11 +136,11 @@ const Stepper = React.createClass({
       stepHeadersWrapperStyle,
       containerStyle,
       style,
-      activeStepIndex,
+      activeStep,
     } = this.props;
 
     const itemWidth = this.state.itemWidth;
-    const translateX = -activeStepIndex * itemWidth;
+    const translateX = -activeStep * itemWidth;
 
     const childrenWrapper = {
       transform: `translate3d(${translateX}px, 0px, 0px)`,
@@ -159,7 +156,7 @@ const Stepper = React.createClass({
     const wrapper = Object.assign({
       overflow: 'hidden',
     },
-      activeStepIndex > -1 && {
+      activeStep > -1 && {
         transition: 'all 0.5s',
       },
       style
@@ -200,8 +197,8 @@ const Stepper = React.createClass({
     const {
        children,
        onStepHeaderTouch,
-       activeStepIndex,
-       updateCompletedStatusOfStep,
+       activeStep,
+       updateCompletedStatus,
     } = this.props;
 
     const {
@@ -219,13 +216,13 @@ const Stepper = React.createClass({
         headerWidth: `${100 / this.getTotalSteps()}%`,
         key: index,
         stepIndex: index,
-        isActive: activeStepIndex === index,
+        isActive: activeStep === index,
         isStepHeaderHovered: hoveredHeaderStepIndex === index,
         onStepHeaderTouch: onStepHeaderTouch,
         onStepHeaderHover: this._handleHeaderStepHover,
         isLastStep: index === (this.getTotalSteps() - 1),
         isFirstStep: index === 0,
-        isCompleted: updateCompletedStatusOfStep(index, step),
+        isCompleted: updateCompletedStatus(index, step),
         previousStepOptionalIndex: this.findFurthestOptionalStep(index),
       });
     });
@@ -259,7 +256,7 @@ const Stepper = React.createClass({
             </div>
           </div>
           <div style={{padding: 20, display: 'flex', justifyContent: 'flex-end'}} ref="controlButtonsGroup">
-            {setOfControlButtonsGroup[activeStepIndex]}
+            {setOfControlButtonsGroup[activeStep]}
           </div>
         </div>
       </div>
@@ -271,8 +268,8 @@ const Stepper = React.createClass({
      style,
      children,
      onStepHeaderTouch,
-     activeStepIndex,
-     updateCompletedStatusOfStep,
+     activeStep,
+     updateCompletedStatus,
    } = this.props;
 
     const {
@@ -283,12 +280,12 @@ const Stepper = React.createClass({
       return React.cloneElement(step, {
         key: index,
         stepIndex: index,
-        isActive: activeStepIndex === index,
+        isActive: activeStep === index,
         isStepHeaderHovered: hoveredHeaderStepIndex === index,
         onStepHeaderTouch: onStepHeaderTouch,
         onStepHeaderHover: this._handleHeaderStepHover,
         isLastStep: index === (this.getTotalSteps() - 1),
-        isCompleted: updateCompletedStatusOfStep(index, step),
+        isCompleted: updateCompletedStatus(index, step),
         previousStepOptionalIndex: this.findFurthestOptionalStep(index),
       });
     });

--- a/src/Stepper/VerticalStep.jsx
+++ b/src/Stepper/VerticalStep.jsx
@@ -10,22 +10,22 @@ const Step = React.createClass({
     children: PropTypes.node,
 
     /**
-     * Override the inline-styles of div which contains all the children include control button groups.
+     * Override the inline-style of the div which contains all the children, including control button groups.
      */
     childrenWrapperStyle: PropTypes.object,
 
     /**
-     * Override the inline-styles of connector line.
+     * Override the inline-style of the connector line.
      */
     connectorLineStyle: PropTypes.object,
 
     /**
-     * An array of node for handling moving or canceling steps.
+     * An array of nodes for handling moving or canceling steps.
      */
     controlButtonsGroup: PropTypes.arrayOf(PropTypes.node),
 
     /**
-     * Override the inline-styles of div wrapper which contains control buttons group.
+     * Override the inline-style of the div which contains the control buttons group.
      */
     controlButtonsGroupWrapperStyle: PropTypes.object,
 
@@ -55,13 +55,13 @@ const Step = React.createClass({
 
     /**
      * @ignore
-     * Callback function that is fired when the header of step is hovered.
+     * Callback function fired when the header of step is hovered.
      */
     onStepHeaderHover: PropTypes.func,
 
     /**
      * @ignore
-     * Callback function that is fired when the header of step is touched.
+     * Callback function fired when the header of step is touched.
      */
     onStepHeaderTouch: PropTypes.func,
 
@@ -72,17 +72,17 @@ const Step = React.createClass({
     previousStepOptionalIndex: PropTypes.number,
 
     /**
-     * Override the inline-styles of step container which contains connector line and children.
+     * Override the inline-style of step container, which contains connector line and children.
      */
     stepContainerStyle: PropTypes.object,
 
     /**
-     * Override the inline-styles of step header view (not include left avatar).
+     * Override the inline-style of step header (not including left avatar).
      */
     stepHeaderStyle: PropTypes.object,
 
     /**
-     * Override the inline-styles of step header wrapper (include left avatar).
+     * Override the inline-style of step header wrapper, including left avatar.
      */
     stepHeaderWrapperStyle: PropTypes.object,
 
@@ -93,7 +93,7 @@ const Step = React.createClass({
     stepIndex: PropTypes.number,
 
     /**
-     * Customize the step label view.
+     * Customize the step label.
      */
     stepLabel: PropTypes.node,
   },
@@ -329,7 +329,7 @@ const Step = React.createClass({
           </TouchRipple>
         </div>
         <div style={styles.stepContainer} ref="containerWrapper">
-          {!isLastStep && <div style={styles.connectorLine} />}
+          {!isLastStep && <div style={styles.connectorLine}></div>}
           {<div style={styles.childrenWrapper} ref="childrenWrapper">
             <div>
               <div>

--- a/src/Stepper/VerticalStep.jsx
+++ b/src/Stepper/VerticalStep.jsx
@@ -7,6 +7,16 @@ import {getMuiTheme} from '../styles';
 
 const Step = React.createClass({
   propTypes: {
+    /**
+     * An array of nodes for handling moving or canceling steps.
+     */
+    actions: PropTypes.arrayOf(PropTypes.node),
+
+    /**
+     * Override the inline-style of the div which contains the actions.
+     */
+    actionsWrapperStyle: PropTypes.object,
+
     children: PropTypes.node,
 
     /**
@@ -18,16 +28,6 @@ const Step = React.createClass({
      * Override the inline-style of the connector line.
      */
     connectorLineStyle: PropTypes.object,
-
-    /**
-     * An array of nodes for handling moving or canceling steps.
-     */
-    controlButtonsGroup: PropTypes.arrayOf(PropTypes.node),
-
-    /**
-     * Override the inline-style of the div which contains the control buttons group.
-     */
-    controlButtonsGroupWrapperStyle: PropTypes.object,
 
     /**
      * @ignore
@@ -192,7 +192,7 @@ const Step = React.createClass({
       stepHeaderWrapperStyle,
       connectorLineStyle,
       stepContainerStyle,
-      controlButtonsGroupWrapperStyle,
+      actionsWrapperStyle,
       childrenWrapperStyle,
     } = this.props;
 
@@ -262,9 +262,9 @@ const Step = React.createClass({
       marginTop: -8,
     });
 
-    const controlButtonsGroupWrapper = Object.assign({
+    const actionsWrapper = Object.assign({
       marginTop: 16,
-    }, controlButtonsGroupWrapperStyle);
+    }, actionsWrapperStyle);
 
     const childrenWrapper = Object.assign({
       paddingLeft: 24,
@@ -292,7 +292,7 @@ const Step = React.createClass({
       stepHeaderWrapper: stepHeaderWrapper,
       stepContainer: stepContainer,
       connectorLine: connectorLine,
-      controlButtonsGroupWrapper: controlButtonsGroupWrapper,
+      actionsWrapper: actionsWrapper,
       childrenWrapper: childrenWrapper,
       stepHeader: stepHeader,
     };
@@ -302,7 +302,7 @@ const Step = React.createClass({
     const {
       children,
       stepLabel,
-      controlButtonsGroup,
+      actions,
       isLastStep,
     } = this.props;
 
@@ -335,8 +335,8 @@ const Step = React.createClass({
               <div>
                   {children}
               </div>
-              <div style={styles.controlButtonsGroupWrapper}>
-                  {controlButtonsGroup}
+              <div style={styles.actionsWrapper}>
+                  {actions}
               </div>
             </div>
           </div>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has ~~tests~~ / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

#### [Stepper] Simplify property name and update property docs

`Stepper.jsx`:
1. Change prop name `activeStepIndex` to `activeStep`
2. Change prop name `updateCompletedStatusOfStep` to `updateCompletedStatus` (This could probably be simpler still, but I'm lacking imagination!)
3. Update property docs

`HorizontalStep.jsx`
1. Tiny change to one prop docs comment.

`VerticalStep.jsx`
1. Various prop docs updates.
2. Correctly close a `<div />`

Examples:
1. Update to use changed prop names
2. Simplify state naming

#### [Stepper] Rename `controlButtonsGroup` to `actions`, further docs cleanup

Pretty much as it says:

1. Change the name for the action button prop to `actions` to match Dialog,
2, Use that prop name in the examples.
3. Fix the button spacing, and move styles to an object.
4. misc additional prop doc cleanup.

