### PR TITLE
[RaisedButton] Taking to account backgroundColor and labelColor props

### DIFF
--- a/src/raised-button.jsx
+++ b/src/raised-button.jsx
@@ -35,8 +35,8 @@ function getStyles(props, state) {
 
   const amount = (primary || secondary) ? 0.4 : 0.08;
 
-  let backgroundColor = raisedButton.color;
-  let labelColor = raisedButton.textColor;
+  let backgroundColor = props.backgroundColor || raisedButton.color;
+  let labelColor = props.labelColor || raisedButton.textColor;
 
   if (disabled) {
     backgroundColor = disabledBackgroundColor || raisedButton.disabledColor;


### PR DESCRIPTION
Currently backgroundColor and labelColor properties in RaisedButton  don't work. They're existing in propTypes but are not using while generating the styles for a RaisedButton element