### PR TITLE
[FlatButton][RaisedButton] Fix the text align issue

### DIFF
--- a/docs/src/app/components/pages/components/RaisedButton/ExampleIcon.jsx
+++ b/docs/src/app/components/pages/components/RaisedButton/ExampleIcon.jsx
@@ -23,8 +23,8 @@ const RaisedButtonExampleIcon = () => (
       linkButton={true}
       href="https://github.com/callemall/material-ui"
       secondary={true}
-      style={style}
       icon={<FontIcon className="muidocs-icon-custom-github" />}
+      style={style}
     />
   </div>
 );

--- a/src/enhanced-button.jsx
+++ b/src/enhanced-button.jsx
@@ -296,7 +296,6 @@ const EnhancedButton = React.createClass({
       background: 'none',
       boxSizing: 'border-box',
       display: 'inline-block',
-      font: 'inherit',
       fontFamily: this.state.muiTheme.rawTheme.fontFamily,
       WebkitTapHighlightColor: enhancedButton.tapHighlightColor, // Remove mobile color flashing (deprecated)
       cursor: disabled ? 'default' : 'pointer',

--- a/src/flat-button.jsx
+++ b/src/flat-button.jsx
@@ -254,6 +254,8 @@ const FlatButton = React.createClass({
       minWidth: buttonMinWidth,
       padding: 0,
       margin: 0,
+      // That's the default value for a button but not a link
+      textAlign: 'center',
     }, style);
 
     let iconCloned;
@@ -267,7 +269,6 @@ const FlatButton = React.createClass({
           verticalAlign: 'middle',
           marginLeft: label && labelPosition !== 'before' ? 12 : 0,
           marginRight: label && labelPosition === 'before' ? 12 : 0,
-          display: label || !linkButton ? 'inline-block' : 'block',
         },
       });
 

--- a/src/raised-button.jsx
+++ b/src/raised-button.jsx
@@ -27,7 +27,6 @@ function getStyles(props, state) {
     icon,
     label,
     labelPosition,
-    linkButton,
     primary,
     secondary,
     style,
@@ -72,6 +71,8 @@ function getStyles(props, state) {
       borderRadius: 2,
       transition: Transitions.easeOut(),
       backgroundColor: backgroundColor,
+      // That's the default value for a button but not a link
+      textAlign: 'center',
     },
     label: {
       position: 'relative',
@@ -93,8 +94,6 @@ function getStyles(props, state) {
       verticalAlign: 'middle',
       marginLeft: label && labelPosition !== 'before' ? 12 : 0,
       marginRight: label && labelPosition === 'before' ? 12 : 0,
-      display: label || !linkButton ? 'inline-block' : 'block',
-      textAlign: label || !linkButton ? '' : 'center',
     },
     overlay: {
       backgroundColor: state.hovered && !disabled && ColorManipulator.fade(labelColor, amount),


### PR DESCRIPTION
#### The issue:
![blob](https://cloud.githubusercontent.com/assets/3165635/13862520/30971cb8-ec94-11e5-8757-68aaefbe7409.png)

@mbrookes The browser applies a `text-align: center` property to `<button />` component by default. However, when we provide a link to the last example, we are no longer using a `<button />` element, we use a `<a />`.

### The fix:
Explicitly use `text-align: center`.