### PR TITLE
[RaisedButton] Don't override SvgIcon color prop

### DIFF
--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -377,7 +377,7 @@ class RaisedButton extends Component {
     );
 
     const iconCloned = icon && React.cloneElement(icon, {
-      color: styles.label.color,
+      color: icon.props.color || styles.label.color,
       style: styles.icon,
     });
 

--- a/src/RaisedButton/RaisedButton.spec.js
+++ b/src/RaisedButton/RaisedButton.spec.js
@@ -104,6 +104,17 @@ describe('<RaisedButton />', () => {
     );
   });
 
+  it('if an svg icon is provided, renders the icon with the correct color', () => {
+    const icon = <svg color="red" />;
+    const wrapper = shallowWithContext(
+      <RaisedButton icon={icon} />
+    );
+
+    const svgIcon = wrapper.find('svg');
+    assert.strictEqual(svgIcon.length, 1, 'should have an svg icon');
+    assert.strictEqual(svgIcon.node.props.color, 'red', 'should have color set as the prop');
+  });
+
   describe('propTypes', () => {
     let consoleStub;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

When passing an `SvgIcon` to a `RaisedButton` with a color property set, it renders the icon with the correct color (fixes #3745).

Since there wasn't a unit test file for `RaisedButton` component yet, I made one.