### PR TITLE
[TextField] Preparation for ES6 codemod

### DIFF
--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -300,12 +300,12 @@ const TextField = React.createClass({
   },
 
   getInitialState() {
-    const props = (this.props.children) ? this.props.children.props : this.props;
+    const propsLeaf = this.props.children ? this.props.children.props : this.props;
 
     return {
       isFocused: false,
       errorText: this.props.errorText,
-      hasValue: isValid(props.value) || isValid(props.defaultValue),
+      hasValue: isValid(propsLeaf.value) || isValid(propsLeaf.defaultValue),
       isClean: true,
       muiTheme: this.context.muiTheme || getMuiTheme(),
     };


### PR DESCRIPTION
I have tried to run the ES6 codemod as here https://github.com/callemall/material-ui/pull/3089 on the source code without any luck. The tool complains for some of our component coding style and some are broken. We need to fix all those issues so we can run the tool once for all.

That's the first step, the `props` variable name collide with `constructor(props, ...`.

