### PR TITLE
[Timepicker] Redesign of 24hr format w.r.t material spec

### DIFF
--- a/src/TimePicker/ClockHours.js
+++ b/src/TimePicker/ClockHours.js
@@ -142,6 +142,9 @@ const ClockHours = React.createClass({
     value = value || 12;
     if (this.props.format === '24hr') {
       if (distance < 90) {
+        value %= 24;
+      }
+      else{
         value += 12;
         value %= 24;
       }
@@ -178,6 +181,7 @@ const ClockHours = React.createClass({
       const isSelected = this._getSelected() === hour;
       return (
         <ClockNumber
+          format={this.props.format}
           key={hour}
           style={style}
           isSelected={isSelected}
@@ -215,7 +219,7 @@ const ClockHours = React.createClass({
 
     return (
       <div ref="clock" style={prepareStyles(styles.root)} >
-        <ClockPointer hasSelected={true} value={hours} type="hour" />
+        <ClockPointer format={this.props.format} hasSelected={true} value={hours} type="hour" />
         {numbers}
         <div
           ref="mask" style={prepareStyles(styles.hitMask)} onTouchMove={this.handleTouchMove}

--- a/src/TimePicker/ClockNumber.js
+++ b/src/TimePicker/ClockNumber.js
@@ -4,6 +4,7 @@ import getMuiTheme from '../styles/getMuiTheme';
 const ClockNumber = React.createClass({
 
   propTypes: {
+    format: React.PropTypes.oneOf(['ampm', '24hr']),
     isSelected: React.PropTypes.bool,
     onSelected: React.PropTypes.func,
     type: React.PropTypes.oneOf(['hour', 'minute']),
@@ -57,7 +58,12 @@ const ClockNumber = React.createClass({
     let inner = false;
 
     if (this.props.type === 'hour') {
-      inner = pos < 1 || pos > 12;
+      if (this.props.format === '24hr') {
+       inner = pos < 13 && pos > 0;
+      }
+      else {
+        inner = pos < 1 && pos > 12;
+      }
       pos %= 12;
     } else {
       pos = pos / 5;

--- a/src/TimePicker/ClockPointer.js
+++ b/src/TimePicker/ClockPointer.js
@@ -11,7 +11,12 @@ function isInner(props) {
   if (props.type !== 'hour' ) {
     return false;
   }
-  return props.value < 1 || props.value > 12 ;
+  if (props.format === '24hr') {
+    return props.value < 13 && props.value > 0
+  }
+  else {
+    return props.value < 1 && props.value > 12 ;
+  }
 }
 
 function getStyles(props, state) {
@@ -61,6 +66,7 @@ function getStyles(props, state) {
 const ClockPointer = React.createClass({
 
   propTypes: {
+    format: React.PropTypes.oneOf(['ampm', '24hr']),
     hasSelected: React.PropTypes.bool,
     type: React.PropTypes.oneOf(['hour', 'minute']),
     value: React.PropTypes.number,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Closes callemall/material-ui#3766


- Reformat the layout of hours for the '24hr' format of the timepicker.
- The current design has the hours 1-12 on the outer circle which is
not in sync with the timepickers from android phones which follows
material design.
- Though the material design spec doesnot specify 24hr timepicker format,
it is only intuitive to have the first 12 hours on the inner circle and
the next 12 on the outer one.