### PR TITLE
[TimePicker] Fix label for 12AM  as per material spec

### DIFF
--- a/src/TimePicker/ClockNumber.js
+++ b/src/TimePicker/ClockNumber.js
@@ -129,8 +129,10 @@ const ClockNumber = React.createClass({
 
     styles.root.transform = `translate(${x}px, ${y}px)`;
 
+    const clockNumber = this.props.value === 0 ? '00' : this.props.value;
+
     return (
-      <span style={prepareStyles(styles.root)}>{this.props.value}</span>
+      <span style={prepareStyles(styles.root)}>{clockNumber}</span>
     );
   },
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has ~~tests~~ / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

The current Timepicker component has a label of "0" for 12 AM. It should be "00" as per
the material spec.

Add a 0 in front of the value for the 12AM hour value.

Part of #3766.