### PR TITLE
[ToolbarGroup] Add support for the toggle switch within ToolbarGroup.

### DIFF
--- a/docs/src/app/components/pages/components/Toolbar/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/Toolbar/ExampleSimple.js
@@ -6,6 +6,7 @@ import NavigationExpandMoreIcon from 'material-ui/svg-icons/navigation/expand-mo
 import MenuItem from 'material-ui/MenuItem';
 import DropDownMenu from 'material-ui/DropDownMenu';
 import RaisedButton from 'material-ui/RaisedButton';
+import Toggle from 'material-ui/Toggle';
 import {Toolbar, ToolbarGroup, ToolbarSeparator, ToolbarTitle} from 'material-ui/Toolbar';
 
 export default class ToolbarExamplesSimple extends React.Component {
@@ -32,6 +33,7 @@ export default class ToolbarExamplesSimple extends React.Component {
             <MenuItem value={6} primaryText="Active Voice" />
             <MenuItem value={7} primaryText="Active Text" />
           </DropDownMenu>
+          <Toggle label="Advanced" />
         </ToolbarGroup>
         <ToolbarGroup>
           <ToolbarTitle text="Options" />

--- a/src/Toggle/Toggle.js
+++ b/src/Toggle/Toggle.js
@@ -14,7 +14,7 @@ function getStyles(props, state) {
     toggle,
   } = state.muiTheme;
 
-  const toggleSize = 20;
+  const toggleSize = toggle.height;
   const toggleTrackWidth = 36;
   const styles = {
     icon: {

--- a/src/Toolbar/ToolbarGroup.js
+++ b/src/Toolbar/ToolbarGroup.js
@@ -11,10 +11,12 @@ function getStyles(props, state) {
     baseTheme,
     button,
     toolbar,
+    toggle,
   } = state.muiTheme;
 
   const marginHorizontal = baseTheme.spacing.desktopGutter;
-  const marginVertical = (toolbar.height - button.height) / 2;
+  const marginVerticalButton = (toolbar.height - button.height) / 2;
+  const marginVerticalToggle = (toolbar.height - toggle.height) / 2;
 
   const styles = {
     root: {
@@ -40,8 +42,13 @@ function getStyles(props, state) {
       },
     },
     button: {
-      margin: `${marginVertical}px ${marginHorizontal}px`,
+      margin: `${marginVerticalButton}px ${marginHorizontal}px`,
       position: 'relative',
+    },
+    toggle: {
+      margin: `${marginVerticalToggle}px ${marginHorizontal}px`,
+      position: 'relative',
+      width: 'auto',
     },
     icon: {
       root: {
@@ -168,6 +175,10 @@ const ToolbarGroup = React.createClass({
             style: Object.assign({}, styles.dropDownMenu.root, currentChild.props.style),
             styleControlBg: styles.dropDownMenu.controlBg,
             styleUnderline: styles.dropDownMenu.underline,
+          });
+        case 'Toggle' :
+          return React.cloneElement(currentChild, {
+            style: Object.assign({}, styles.toggle, currentChild.props.style),
           });
         case 'RaisedButton' :
         case 'FlatButton' :

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -294,6 +294,7 @@ export default function getMuiTheme(muiTheme, ...more) {
       thumbOffColor: palette.accent2Color,
       thumbDisabledColor: palette.borderColor,
       thumbRequiredColor: palette.primary1Color,
+      height: 20,
       trackOnColor: ColorManipulator.fade(palette.primary1Color, 0.5),
       trackOffColor: palette.primary3Color,
       trackDisabledColor: palette.primary3Color,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
## Description
Previously, ToolbarGroup had no case for handling Toggle styling, which caused it to look extremely out place, forcing material-ui consumers to style the component manually.

These changes add a case for Toggle styling within a ToolbarGroup so that consumers by default get a consistent style applied to their Toolbar-embedded Toggles.

## Changes

1. Added reference to toggle height to getMuiTheme.js
2. Implemented this new reference into Toggle.js
3. Added a new switch case and style property for a Toggle added within a ToolbarGroup 
4. Added implementation example to Toolbar ExampleSimple.js


- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


Fixes #3787.