### PR TITLE
[AutoComplete] focus first item when cursor down key pressed

### DIFF
--- a/src/auto-complete.jsx
+++ b/src/auto-complete.jsx
@@ -172,6 +172,7 @@ const AutoComplete = React.createClass({
 
   componentWillMount() {
     this.focusOnInput = false;
+    this.focusOnKeyDown = false;
     this.requestsList = [];
   },
 
@@ -200,6 +201,7 @@ const AutoComplete = React.createClass({
   },
 
   close() {
+    this.focusOnKeyDown = false;
     this.setState({
       open: false,
       anchorEl: null,
@@ -278,6 +280,7 @@ const AutoComplete = React.createClass({
         if (this.focusOnInput && this.state.open) {
           event.preventDefault();
           this.focusOnInput = false;
+          this.focusOnKeyDown = true;
           this.open();
         }
         break;
@@ -376,7 +379,7 @@ const AutoComplete = React.createClass({
         key="dropDownMenu"
         autoWidth={false}
         onEscKeyDown={this.close}
-        initiallyKeyboardFocused={false}
+        keyboardFocused={this.focusOnKeyDown}
         onItemTouchTap={this.handleItemTouchTap}
         listStyle={this.mergeStyles(styles.list, listStyle)}
         style={this.mergeStyles(styles.menu, menuStyle)}

--- a/src/menus/menu.jsx
+++ b/src/menus/menu.jsx
@@ -44,6 +44,11 @@ const Menu = React.createClass({
     initiallyKeyboardFocused: React.PropTypes.bool,
 
     /**
+     * True if this item should be focused by the keyboard.
+     */
+    keyboardFocused: React.PropTypes.bool,
+
+    /**
      * The style object to use to override underlying list style.
      */
     listStyle: React.PropTypes.object,
@@ -184,6 +189,7 @@ const Menu = React.createClass({
       focusIndex: selectedIndex >= 0 ? selectedIndex : 0,
       keyWidth: nextProps.desktop ? 64 : 56,
       muiTheme: nextContext.muiTheme || this.state.muiTheme,
+      isKeyboardFocused: nextProps.keyboardFocused || this.state.isKeyboardFocused,
     });
   },
 


### PR DESCRIPTION
`Autocomplete` does not focus first item when press down arrow key (#2596). This PR solves it by using a new property `keyboardFocused` on `Menu` component.

Closes #2596.

