### PR TITLE
[Examples] Prevent eslint traversing configuration files

### DIFF
--- a/examples/webpack-example/.eslintrc
+++ b/examples/webpack-example/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true, // Don't traverse ancestor directories looking for .eslintrc[.*] files to merge.
   "env": {
     "es6": true,
     "browser": true,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

eslint has a "feature" in which it traverses ancestor directories
and merges any `.eslintrc[.*]` found with that in the current
dirctory.

This was causing the webpack example to attempt to use 
`eslint-plugin-material-ui`, which is not included in `package.json`.

This change prevents that behaviour.