### PR TITLE
[RadioButton] add callback signatures to docs; improve other props

### DIFF
--- a/src/RadioButton/RadioButton.js
+++ b/src/RadioButton/RadioButton.js
@@ -64,23 +64,23 @@ const RadioButton = React.createClass({
     checked: React.PropTypes.bool,
 
     /**
-     * The icon element to show when radio button is checked.
+     * The icon element to show when the radio button is checked.
      */
     checkedIcon: React.PropTypes.element,
 
     /**
-     * Disabled if true.
+     * If true, the radio button is disabled.
      */
     disabled: React.PropTypes.bool,
 
     /**
-     * Overrides the inline-styles of the icon element.
+     * Override the inline-styles of the icon element.
      */
     iconStyle: React.PropTypes.object,
 
     /**
-    * Overrides the inline-styles of the input element.
-    */
+     * Override the inline-styles of the input element.
+     */
     inputStyle: React.PropTypes.object,
 
     /**
@@ -91,12 +91,19 @@ const RadioButton = React.createClass({
     labelPosition: React.PropTypes.oneOf(['left', 'right']),
 
     /**
-     * Overrides the inline-styles of the RadioButton element label.
+     * Override the inline-styles of the label element.
      */
     labelStyle: React.PropTypes.object,
 
     /**
-     * Callback function for checked event.
+     * @ignore
+     * Callback function fired when the radio button is checked. Note that this
+     * function will not be called if the radio button is part of a
+     * radio button group: in this case, use the `onChange` property of
+     * `RadioButtonGroup`.
+     *
+     * @param {object} event `change` event targeting the element.
+     * @param {string} value The element's `value`.
      */
     onCheck: React.PropTypes.func,
 
@@ -106,12 +113,12 @@ const RadioButton = React.createClass({
     style: React.PropTypes.object,
 
     /**
-     * The icon element to show when radio button is unchecked.
+     * The icon element to show when the radio button is unchecked.
      */
     uncheckedIcon: React.PropTypes.element,
 
     /**
-     * The value of our radio button component.
+     * The value of the radio button.
      */
     value: React.PropTypes.string,
   },

--- a/src/RadioButton/RadioButtonGroup.js
+++ b/src/RadioButton/RadioButtonGroup.js
@@ -12,34 +12,36 @@ const RadioButtonGroup = React.createClass({
     children: React.PropTypes.node,
 
     /**
-     * The css class name of the root element.
+     * The CSS class name of the root element.
      */
     className: React.PropTypes.string,
 
     /**
-     * Sets the default radio button to be the one whose
-     * value matches defaultSelected (case-sensitive).
-     * This will override any individual radio button with
-     * the defaultChecked or checked property stated.
+     * The `value` property (case-sensitive) of the radio button that will be
+     * selected by default. This takes precedence over the `checked` property
+     * of the `RadioButton` elements.
      */
     defaultSelected: React.PropTypes.string,
 
     /**
-     * Where the label will be placed for all radio buttons.
-     * This will override any labelPosition properties defined
-     * for an individual radio button.
+     * Where the label will be placed for all child radio buttons.
+     * This takes precedence over the `labelPosition` property of the
+     * `RadioButton` elements.
      */
     labelPosition: React.PropTypes.oneOf(['left', 'right']),
 
     /**
-     * The name that will be applied to all radio buttons inside it.
+     * The name that will be applied to all child radio buttons.
      */
     name: React.PropTypes.string.isRequired,
 
     /**
      * Callback function that is fired when a radio button has
-     * been clicked. Returns the event and the value of the radio
-     * button that has been selected.
+     * been checked.
+     *
+     * @param {object} event `change` event targeting the selected
+     * radio button.
+     * @param {string} value The `value` of the selected radio button.
      */
     onChange: React.PropTypes.func,
 
@@ -49,7 +51,7 @@ const RadioButtonGroup = React.createClass({
     style: React.PropTypes.object,
 
     /**
-     * The value of the currently selected radio button.
+     * The `value` of the currently selected radio button.
      */
     valueSelected: React.PropTypes.string,
   },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Hey, another one for #3096.  I noticed that the `onCheck` callback of `RadioButton` elements wasn't being called when they were part of a `RadioButtonGroup`, so I added a bit of warning for this behaviour.
