### PR TITLE
[Core] Remove default theme handling from components

### DIFF
--- a/docs/src/app/app.js
+++ b/docs/src/app/app.js
@@ -1,9 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {
-  Router,
-  useRouterHistory,
-} from 'react-router';
+import {Router, useRouterHistory} from 'react-router';
 import AppRoutes from './AppRoutes';
 import injectTapEventPlugin from 'react-tap-event-plugin';
 import {createHashHistory} from 'history';

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -1,19 +1,18 @@
 import React from 'react';
 import IconButton from '../IconButton';
 import NavigationMenu from '../svg-icons/navigation/menu';
-import getMuiTheme from '../styles/getMuiTheme';
 import Paper from '../Paper';
 import propTypes from '../utils/propTypes';
 import warning from 'warning';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     appBar,
     button: {
       iconButtonSize,
     },
     zIndex,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   const flatButtonSize = 36;
 
@@ -156,27 +155,11 @@ const AppBar = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       showMenuIconButton: true,
       title: '',
       zDepth: 1,
-    };
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
     };
   },
 
@@ -186,12 +169,6 @@ const AppBar = React.createClass({
 
     warning(!this.props.iconElementRight || !this.props.iconClassNameRight, `Properties iconElementRight
       and iconClassNameRight cannot be simultaneously defined. Please use one or the other.`);
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   handleTouchTapLeftIconButton(event) {
@@ -229,11 +206,8 @@ const AppBar = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.context);
 
     let menuElementLeft;
     let menuElementRight;

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -152,7 +152,7 @@ const AppBar = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -207,7 +207,7 @@ const AppBar = React.createClass({
     } = this.props;
 
     const {prepareStyles} = this.context.muiTheme;
-    const styles = getStyles(this.context);
+    const styles = getStyles(this.props, this.context);
 
     let menuElementLeft;
     let menuElementRight;

--- a/src/AppBar/AppBar.spec.js
+++ b/src/AppBar/AppBar.spec.js
@@ -4,11 +4,15 @@ import sinon from 'sinon';
 import {shallow} from 'enzyme';
 import {assert} from 'chai';
 import AppBar from './AppBar';
+import getMuiTheme from '../styles/getMuiTheme';
 
 describe('<AppBar />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
   it('renders children by default', () => {
     const testChildren = <div className="unique">Hello World</div>;
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <AppBar>{testChildren}</AppBar>
     );
 
@@ -16,7 +20,7 @@ describe('<AppBar />', () => {
   });
 
   it('renders className', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <AppBar className="testClassName" />
     );
 
@@ -25,7 +29,7 @@ describe('<AppBar />', () => {
 
   it('renders iconClassNameLeft', () => {
     const iconClassName = 'muidocs-icon-navigation-expand-more';
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <AppBar iconClassNameLeft={iconClassName} />
     );
 
@@ -35,7 +39,7 @@ describe('<AppBar />', () => {
 
   it('renders iconClassNameRight', () => {
     const iconClassName = 'muidocs-icon-navigation-expand-more';
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <AppBar iconClassNameRight={iconClassName} />
     );
 
@@ -46,7 +50,7 @@ describe('<AppBar />', () => {
   it('renders iconClassNameLeft and iconClassNameRight', () => {
     const iconClassNameLeft = 'muidocs-icon-action-home';
     const iconClassNameRight = 'muidocs-icon-navigation-expand-more';
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <AppBar iconClassNameLeft={iconClassNameLeft} iconClassNameRight={iconClassNameRight} />
     );
 
@@ -57,7 +61,7 @@ describe('<AppBar />', () => {
   });
 
   it('renders iconElementLeft', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <AppBar iconElementLeft={<span className="icon" />} />
     );
 
@@ -65,7 +69,7 @@ describe('<AppBar />', () => {
   });
 
   it('renders iconElementRight', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <AppBar iconElementRight={<span className="icon" />} />
     );
 
@@ -75,7 +79,7 @@ describe('<AppBar />', () => {
   it('call onLeftIconButtonTouchTap callback', () => {
     const onLeftIconButtonTouchTap = sinon.spy();
     const iconClassNameLeft = 'muidocs-icon-action-home';
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <AppBar
         iconClassNameLeft={iconClassNameLeft}
         onLeftIconButtonTouchTap={onLeftIconButtonTouchTap}
@@ -90,7 +94,7 @@ describe('<AppBar />', () => {
   it('call onRightIconButtonTouchTap callback', () => {
     const onRightIconButtonTouchTap = sinon.spy();
     const iconClassNameRight = 'muidocs-icon-action-home';
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <AppBar
         iconClassNameRight={iconClassNameRight}
         onRightIconButtonTouchTap={onRightIconButtonTouchTap}
@@ -104,7 +108,7 @@ describe('<AppBar />', () => {
 
   it('call onTitleTouchTap callback', () => {
     const onTitleTouchTap = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <AppBar
         title="Title"
         onTitleTouchTap={onTitleTouchTap}
@@ -117,7 +121,7 @@ describe('<AppBar />', () => {
   });
 
   it('hide menu icon when showMenuIconButton is false', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <AppBar
         title="Title"
         showMenuIconButton={false}
@@ -131,7 +135,7 @@ describe('<AppBar />', () => {
     const style = {
       backgroundColor: 'red',
     };
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <AppBar title="Title" style={style} />
     );
 
@@ -140,7 +144,7 @@ describe('<AppBar />', () => {
   });
 
   it('renders title', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <AppBar title="Title" />
     );
 
@@ -151,7 +155,7 @@ describe('<AppBar />', () => {
     const titleStyle = {
       backgroundColor: 'red',
     };
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <AppBar title="Title" titleStyle={titleStyle} />
     );
 
@@ -161,7 +165,7 @@ describe('<AppBar />', () => {
   });
 
   it('renders zDepth to paper component', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <AppBar title="Title" zDepth={2} />
     );
 

--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -188,7 +188,7 @@ const AutoComplete = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -7,18 +7,12 @@ import MenuItem from '../MenuItem';
 import Divider from '../Divider';
 import Popover from '../Popover/Popover';
 import propTypes from '../utils/propTypes';
-import getMuiTheme from '../styles/getMuiTheme';
 import warning from 'warning';
 import deprecated from '../utils/deprecatedPropType';
 
-function getStyles(props, state) {
-  const {
-    anchorEl,
-  } = state;
-
-  const {
-    fullWidth,
-  } = props;
+function getStyles(props, context) {
+  const {anchorEl} = context;
+  const {fullWidth} = props;
 
   const styles = {
     root: {
@@ -197,10 +191,6 @@ const AutoComplete = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       anchorOrigin: {
@@ -229,14 +219,7 @@ const AutoComplete = React.createClass({
       searchText: this.props.searchText,
       open: this.props.open,
       anchorEl: null,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
       focusTextField: true,
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
     };
   },
 
@@ -419,12 +402,10 @@ const AutoComplete = React.createClass({
       anchorEl,
       searchText,
       focusTextField,
-      muiTheme: {
-        prepareStyles,
-      },
     } = this.state;
 
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     const requestsList = [];
 

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     backgroundColor,
     color,
@@ -9,9 +8,7 @@ function getStyles(props, state) {
     src,
   } = props;
 
-  const {
-    avatar,
-  } = state.muiTheme;
+  const {avatar} = context.muiTheme;
 
   const styles = {
     root: {
@@ -91,32 +88,10 @@ const Avatar = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       size: 40,
     };
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   render() {
@@ -128,11 +103,8 @@ const Avatar = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     if (src) {
       return (

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -85,7 +85,7 @@ const Avatar = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/Avatar/Avatar.spec.js
+++ b/src/Avatar/Avatar.spec.js
@@ -3,12 +3,15 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import {assert} from 'chai';
 import Avatar from './Avatar';
+import getMuiTheme from '../styles/getMuiTheme';
 
 describe('<Avatar />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
   const testChildren = <div className="unique">Hello World</div>;
 
   it('renders children by default', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Avatar>{testChildren}</Avatar>
     );
 
@@ -17,7 +20,7 @@ describe('<Avatar />', () => {
 
   it('renders children and an icon if passed in', () => {
     const icon = <div className="testIcon" />;
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Avatar icon={icon}>{testChildren}</Avatar>
     );
 
@@ -27,7 +30,7 @@ describe('<Avatar />', () => {
   });
 
   it('only renders an image when the src prop is set', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Avatar src="face.jpg">{testChildren}</Avatar>
     );
 

--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -1,15 +1,8 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
-  const {
-    primary,
-    secondary,
-  } = props;
-
-  const {
-    badge,
-  } = state.muiTheme;
+function getStyles(props, context) {
+  const {primary, secondary} = props;
+  const {badge} = context.muiTheme;
 
   let badgeBackgroundColor;
   let badgeTextColor;
@@ -97,33 +90,11 @@ const Badge = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       primary: false,
       secondary: false,
     };
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   render() {
@@ -135,11 +106,8 @@ const Badge = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     return (
       <div {...other} style={prepareStyles(Object.assign({}, styles.root, style))}>

--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -87,7 +87,7 @@ const Badge = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/Badge/Badge.spec.js
+++ b/src/Badge/Badge.spec.js
@@ -2,15 +2,17 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import {assert} from 'chai';
-import getMuiTheme from '../styles/getMuiTheme';
 import Badge from './Badge';
+import getMuiTheme from '../styles/getMuiTheme';
 
 describe('<Badge />', () => {
-  const badgeTheme = getMuiTheme().badge;
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+  const badgeTheme = muiTheme.badge;
   const testChildren = <div className="unique">Hello World</div>;
 
   it('renders children and badgeContent', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Badge badgeContent={10}>{testChildren}</Badge>
     );
 
@@ -22,7 +24,7 @@ describe('<Badge />', () => {
     const badgeStyle = {
       backgroundColor: 'red',
     };
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Badge badgeContent={10} badgeStyle={badgeStyle}>{testChildren}</Badge>
     );
 
@@ -32,7 +34,7 @@ describe('<Badge />', () => {
   });
 
   it('renders children by default', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Badge>{testChildren}</Badge>
     );
 
@@ -40,7 +42,7 @@ describe('<Badge />', () => {
   });
 
   it('renders children and className', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Badge className="testClassName">{testChildren}</Badge>
     );
 
@@ -49,7 +51,7 @@ describe('<Badge />', () => {
   });
 
   it('renders children and have primary styles', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Badge badgeContent={10} primary={true}>{testChildren}</Badge>
     );
 
@@ -61,7 +63,7 @@ describe('<Badge />', () => {
   });
 
   it('renders children and have secondary styles', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Badge badgeContent={10} secondary={true}>{testChildren}</Badge>
     );
 
@@ -76,7 +78,7 @@ describe('<Badge />', () => {
     const style = {
       backgroundColor: 'red',
     };
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Badge style={style}>{testChildren}</Badge>
     );
 

--- a/src/Card/CardActions.js
+++ b/src/Card/CardActions.js
@@ -42,7 +42,7 @@ const CardActions = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   render() {

--- a/src/Card/CardActions.js
+++ b/src/Card/CardActions.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
 function getStyles() {
   return {
@@ -46,34 +45,9 @@ const CardActions = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-  },
-
   render() {
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     const children = React.Children.map(this.props.children, (child) => {
       if (React.isValidElement(child)) {

--- a/src/Card/CardExpandable.js
+++ b/src/Card/CardExpandable.js
@@ -2,7 +2,6 @@ import React from 'react';
 import OpenIcon from '../svg-icons/hardware/keyboard-arrow-up';
 import CloseIcon from '../svg-icons/hardware/keyboard-arrow-down';
 import IconButton from '../IconButton';
-import getMuiTheme from '../styles/getMuiTheme';
 
 function getStyles() {
   return {
@@ -21,10 +20,6 @@ const CardExpandable = React.createClass({
   propTypes: {
     expanded: React.PropTypes.bool,
     onExpanding: React.PropTypes.func.isRequired,
-
-    /**
-     * Override the inline-styles of the root element.
-     */
     style: React.PropTypes.object,
   },
 
@@ -32,30 +27,8 @@ const CardExpandable = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-  },
-
   render() {
-    const styles = getStyles(this.props, this.state);
+    const styles = getStyles(this.props, this.context);
 
     return (
       <IconButton

--- a/src/Card/CardExpandable.js
+++ b/src/Card/CardExpandable.js
@@ -24,7 +24,7 @@ const CardExpandable = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   render() {

--- a/src/Card/CardHeader.js
+++ b/src/Card/CardHeader.js
@@ -104,7 +104,7 @@ const CardHeader = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/Card/CardHeader.js
+++ b/src/Card/CardHeader.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import Avatar from '../Avatar';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
-  const {card} = state.muiTheme;
+function getStyles(props, context) {
+  const {card} = context.muiTheme;
 
   return {
     root: {
@@ -108,40 +107,15 @@ const CardHeader = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       avatar: null,
     };
   },
 
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-  },
-
   render() {
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
     const rootStyle = Object.assign(styles.root, this.props.style);
     const textStyle = Object.assign(styles.text, this.props.textStyle);
     const titleStyle = Object.assign(styles.title, this.props.titleStyle);

--- a/src/Card/CardMedia.js
+++ b/src/Card/CardMedia.js
@@ -1,9 +1,8 @@
 import React from 'react';
 
 function getStyles(props, context) {
-  const {
-    cardMedia,
- } = context.muiTheme;
+  const {cardMedia} = context.muiTheme;
+
   return {
     root: {
       position: 'relative',

--- a/src/Card/CardMedia.js
+++ b/src/Card/CardMedia.js
@@ -87,7 +87,7 @@ const CardMedia = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   render() {

--- a/src/Card/CardMedia.js
+++ b/src/Card/CardMedia.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     cardMedia,
- } = state.muiTheme;
+ } = context.muiTheme;
   return {
     root: {
       position: 'relative',
@@ -91,42 +90,17 @@ const CardMedia = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-  },
-
   render() {
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
     const rootStyle = Object.assign(styles.root, this.props.style);
     const mediaStyle = Object.assign(styles.media, this.props.mediaStyle);
     const overlayContainerStyle = Object.assign(styles.overlayContainer, this.props.overlayContainerStyle);
     const overlayContentStyle = Object.assign(styles.overlayContent, this.props.overlayContentStyle);
     const overlayStyle = Object.assign(styles.overlay, this.props.overlayStyle);
-    const titleColor = this.state.muiTheme.cardMedia.titleColor;
-    const subtitleColor = this.state.muiTheme.cardMedia.subtitleColor;
-    const color = this.state.muiTheme.cardMedia.color;
+    const titleColor = this.context.muiTheme.cardMedia.titleColor;
+    const subtitleColor = this.context.muiTheme.cardMedia.subtitleColor;
+    const color = this.context.muiTheme.cardMedia.color;
 
     const children = React.Children.map(this.props.children, (child) => {
       return React.cloneElement(child, {

--- a/src/Card/CardText.js
+++ b/src/Card/CardText.js
@@ -1,9 +1,7 @@
 import React from 'react';
 
 function getStyles(props, context) {
-  const {
-    cardText,
-  } = context.muiTheme;
+  const {cardText} = context.muiTheme;
 
   return {
     root: {

--- a/src/Card/CardText.js
+++ b/src/Card/CardText.js
@@ -44,7 +44,7 @@ const CardText = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   render() {

--- a/src/Card/CardText.js
+++ b/src/Card/CardText.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     cardText,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   return {
     root: {
@@ -48,34 +47,9 @@ const CardText = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-  },
-
   render() {
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
     const rootStyle = Object.assign(styles.root, this.props.style);
 
     return (

--- a/src/Card/CardTitle.js
+++ b/src/Card/CardTitle.js
@@ -82,7 +82,7 @@ const CardTitle = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   render() {

--- a/src/Card/CardTitle.js
+++ b/src/Card/CardTitle.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
-  const {card} = state.muiTheme;
+function getStyles(props, context) {
+  const {card} = context.muiTheme;
 
   return {
     root: {
@@ -86,34 +85,9 @@ const CardTitle = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-  },
-
   render() {
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
     const rootStyle = Object.assign({}, styles.root, this.props.style);
     const titleStyle = Object.assign({}, styles.title, this.props.titleStyle);
     const subtitleStyle = Object.assign({}, styles.subtitle, this.props.subtitleStyle);

--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -6,10 +6,7 @@ import CheckboxChecked from '../svg-icons/toggle/check-box';
 import deprecated from '../utils/deprecatedPropType';
 
 function getStyles(props, context) {
-  const {
-    checkbox,
-  } = context.muiTheme;
-
+  const {checkbox} = context.muiTheme;
   const checkboxSize = 24;
 
   return {

--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -3,13 +3,12 @@ import EnhancedSwitch from '../internal/EnhancedSwitch';
 import transitions from '../styles/transitions';
 import CheckboxOutline from '../svg-icons/toggle/check-box-outline-blank';
 import CheckboxChecked from '../svg-icons/toggle/check-box';
-import getMuiTheme from '../styles/getMuiTheme';
 import deprecated from '../utils/deprecatedPropType';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     checkbox,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   const checkboxSize = 24;
 
@@ -137,10 +136,6 @@ const Checkbox = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       defaultChecked: false,
@@ -156,19 +151,11 @@ const Checkbox = React.createClass({
         this.props.defaultChecked ||
         (this.props.valueLink && this.props.valueLink.value) ||
         false,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
     };
   },
 
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
+  componentWillReceiveProps(nextProps) {
     this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
       switched: this.props.checked !== nextProps.checked ?
         nextProps.checked :
         this.state.switched,
@@ -200,7 +187,7 @@ const Checkbox = React.createClass({
       unCheckedIcon,
       ...other,
     } = this.props;
-    const styles = getStyles(this.props, this.state);
+    const styles = getStyles(this.props, this.context);
     const boxStyles =
       Object.assign(
         styles.box,

--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -133,7 +133,7 @@ const Checkbox = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/CircularProgress/CircularProgress.js
+++ b/src/CircularProgress/CircularProgress.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import autoPrefix from '../utils/autoPrefix';
 import transitions from '../styles/transitions';
-import getMuiTheme from '../styles/getMuiTheme';
 
 function getRelativeValue(value, min, max) {
   const clampedValue = Math.min(Math.max(min, value), max);
@@ -10,7 +9,7 @@ function getRelativeValue(value, min, max) {
   return relValue * 100;
 }
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     max,
     min,
@@ -18,12 +17,7 @@ function getStyles(props, state) {
     value,
   } = props;
 
-  const {
-    baseTheme: {
-      palette,
-    },
-  } = state.muiTheme;
-
+  const {baseTheme: {palette}} = context.muiTheme;
   const zoom = size * 1.4 ;
   const baseSize = 50;
   let margin = Math.round( ((50 * zoom) - 50) / 2 );
@@ -118,10 +112,6 @@ const CircularProgress = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       mode: 'indeterminate',
@@ -132,27 +122,9 @@ const CircularProgress = React.createClass({
     };
   },
 
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
   componentDidMount() {
     this._scalePath(this.refs.path);
     this._rotateWrapper(this.refs.wrapper);
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   componentWillUnmount() {
@@ -186,13 +158,13 @@ const CircularProgress = React.createClass({
   _rotateWrapper(wrapper) {
     if (this.props.mode !== 'indeterminate') return;
 
-    autoPrefix.set(wrapper.style, 'transform', 'rotate(0deg)', this.state.muiTheme);
-    autoPrefix.set(wrapper.style, 'transitionDuration', '0ms', this.state.muiTheme);
+    autoPrefix.set(wrapper.style, 'transform', 'rotate(0deg)');
+    autoPrefix.set(wrapper.style, 'transitionDuration', '0ms');
 
     setTimeout(() => {
-      autoPrefix.set(wrapper.style, 'transform', 'rotate(1800deg)', this.state.muiTheme);
-      autoPrefix.set(wrapper.style, 'transitionDuration', '10s', this.state.muiTheme);
-      autoPrefix.set(wrapper.style, 'transitionTimingFunction', 'linear', this.state.muiTheme);
+      autoPrefix.set(wrapper.style, 'transform', 'rotate(1800deg)');
+      autoPrefix.set(wrapper.style, 'transitionDuration', '10s');
+      autoPrefix.set(wrapper.style, 'transitionTimingFunction', 'linear');
     }, 50);
 
     this.rotateWrapperTimer = setTimeout(() => this._rotateWrapper(wrapper), 10050);
@@ -206,11 +178,8 @@ const CircularProgress = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     return (
       <div {...other} style={prepareStyles(Object.assign(styles.root, style))} >

--- a/src/CircularProgress/CircularProgress.js
+++ b/src/CircularProgress/CircularProgress.js
@@ -109,7 +109,7 @@ const CircularProgress = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/DatePicker/Calendar.js
+++ b/src/DatePicker/Calendar.js
@@ -9,7 +9,6 @@ import CalendarToolbar from './CalendarToolbar';
 import DateDisplay from './DateDisplay';
 import SlideInTransitionGroup from '../internal/SlideIn';
 import ClearFix from '../internal/ClearFix';
-import getMuiTheme from '../styles/getMuiTheme';
 
 const daysArray = [...Array(7)];
 
@@ -33,10 +32,6 @@ const Calendar = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       disableYearSelection: false,
@@ -48,7 +43,6 @@ const Calendar = React.createClass({
 
   getInitialState() {
     return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
       displayDate: DateTime.getFirstDayOfMonth(this.props.initialDate),
       displayMonthDay: true,
       selectedDate: this.props.initialDate,
@@ -57,15 +51,7 @@ const Calendar = React.createClass({
     };
   },
 
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    const muiTheme = nextContext.muiTheme || this.state.muiTheme;
-
+  componentWillReceiveProps(nextProps) {
     if (nextProps.initialDate !== this.props.initialDate) {
       const d = nextProps.initialDate || new Date();
       this.setState({
@@ -73,8 +59,6 @@ const Calendar = React.createClass({
         selectedDate: d,
       });
     }
-
-    this.setState({muiTheme});
   },
 
   _yearSelector() {
@@ -231,10 +215,7 @@ const Calendar = React.createClass({
   },
 
   render() {
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
+    const {prepareStyles} = this.context.muiTheme;
     const yearCount = DateTime.yearDiff(this.props.maxDate, this.props.minDate) + 1;
     const weekCount = DateTime.getWeekArray(this.state.displayDate, this.props.firstDayOfWeek).length;
     const toolbarInteractions = this._getToolbarInteractions();
@@ -307,7 +288,6 @@ const Calendar = React.createClass({
           onTouchTapYear={this.handleTouchTapClick}
           monthDaySelected={this.state.displayMonthDay}
           mode={this.props.mode}
-          muiTheme={this.state.muiTheme}
           weekCount={weekCount}
         />
         {this.state.displayMonthDay &&

--- a/src/DatePicker/Calendar.js
+++ b/src/DatePicker/Calendar.js
@@ -29,7 +29,7 @@ const Calendar = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/DatePicker/CalendarToolbar.js
+++ b/src/DatePicker/CalendarToolbar.js
@@ -36,7 +36,7 @@ const CalendarToolbar = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/DatePicker/CalendarToolbar.js
+++ b/src/DatePicker/CalendarToolbar.js
@@ -5,7 +5,6 @@ import ToolbarGroup from '../Toolbar/ToolbarGroup';
 import NavigationChevronLeft from '../svg-icons/navigation/chevron-left';
 import NavigationChevronRight from '../svg-icons/navigation/chevron-right';
 import SlideInTransitionGroup from '../internal/SlideIn';
-import getMuiTheme from '../styles/getMuiTheme';
 
 const styles = {
   root: {
@@ -40,11 +39,6 @@ const CalendarToolbar = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  //for passing default theme context to children
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       nextMonth: true,
@@ -54,23 +48,11 @@ const CalendarToolbar = React.createClass({
 
   getInitialState() {
     return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
       transitionDirection: 'up',
     };
   },
 
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  //to update theme inside state whenever a new theme is passed down
-  //from the parent / owner using context
-  componentWillReceiveProps(nextProps, nextContext) {
-    const newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
-
+  componentWillReceiveProps(nextProps) {
     if (nextProps.displayDate !== this.props.displayDate) {
       const direction = nextProps.displayDate > this.props.displayDate ? 'up' : 'down';
       this.setState({
@@ -99,8 +81,8 @@ const CalendarToolbar = React.createClass({
       year: 'numeric',
     }).format(displayDate);
 
-    const nextButtonIcon = this.state.muiTheme.isRtl ? <NavigationChevronRight /> : <NavigationChevronLeft />;
-    const prevButtonIcon = this.state.muiTheme.isRtl ? <NavigationChevronLeft /> : <NavigationChevronRight />;
+    const nextButtonIcon = this.context.muiTheme.isRtl ? <NavigationChevronRight /> : <NavigationChevronLeft />;
+    const prevButtonIcon = this.context.muiTheme.isRtl ? <NavigationChevronLeft /> : <NavigationChevronRight />;
 
     return (
       <Toolbar style={styles.root} noGutter={true}>

--- a/src/DatePicker/CalendarYear.js
+++ b/src/DatePicker/CalendarYear.js
@@ -14,7 +14,7 @@ const CalendarYear = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   componentDidMount() {

--- a/src/DatePicker/CalendarYear.js
+++ b/src/DatePicker/CalendarYear.js
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import DateTime from '../utils/dateTime';
 import YearButton from './YearButton';
-import getMuiTheme from '../styles/getMuiTheme';
 
 const CalendarYear = React.createClass({
 
@@ -16,22 +15,6 @@ const CalendarYear = React.createClass({
 
   contextTypes: {
     muiTheme: React.PropTypes.object,
-  },
-
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
   },
 
   componentDidMount() {
@@ -91,7 +74,7 @@ const CalendarYear = React.createClass({
 
   render() {
     const years = this._getYears();
-    const backgroundColor = this.state.muiTheme.datePicker.calendarYearBackgroundColor;
+    const backgroundColor = this.context.muiTheme.datePicker.calendarYearBackgroundColor;
     const styles = {
       position: 'relative',
       height: 'inherit',

--- a/src/DatePicker/Date-PickerInline.js
+++ b/src/DatePicker/Date-PickerInline.js
@@ -49,9 +49,7 @@ class DatePickerInline extends React.Component {
       ...other,
     } = this.props;
 
-    const {
-      anchorEl,
-    } = this.state;
+    const {anchorEl} = this.state;
 
     return (
       <div {...other} ref="root" style={style}>

--- a/src/DatePicker/DateDisplay.js
+++ b/src/DatePicker/DateDisplay.js
@@ -62,7 +62,7 @@ const DateDisplay = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/DatePicker/DateDisplay.js
+++ b/src/DatePicker/DateDisplay.js
@@ -2,14 +2,9 @@ import React from 'react';
 import transitions from '../styles/transitions';
 import SlideInTransitionGroup from '../internal/SlideIn';
 
-function getStyles(props, state) {
-  const {
-    datePicker,
-  } = props.muiTheme;
-
-  const {
-    selectedYear,
-  } = state;
+function getStyles(props, context, state) {
+  const {datePicker} = context.muiTheme;
+  const {selectedYear} = state;
 
   const styles = {
     root: {
@@ -57,26 +52,17 @@ const DateDisplay = React.createClass({
     DateTimeFormat: React.PropTypes.func.isRequired,
     disableYearSelection: React.PropTypes.bool,
     locale: React.PropTypes.string.isRequired,
-    mode: React.PropTypes.oneOf([
-      'portrait',
-      'landscape',
-    ]),
+    mode: React.PropTypes.oneOf(['portrait', 'landscape']),
     monthDaySelected: React.PropTypes.bool,
-
-    /**
-     * @ignore
-     * The material-ui theme applied to this component.
-     */
-    muiTheme: React.PropTypes.object.isRequired,
     onTouchTapMonthDay: React.PropTypes.func,
     onTouchTapYear: React.PropTypes.func,
     selectedDate: React.PropTypes.object.isRequired,
-
-    /**
-     * Override the inline-styles of the root element.
-     */
     style: React.PropTypes.object,
     weekCount: React.PropTypes.number,
+  },
+
+  contextTypes: {
+    muiTheme: React.PropTypes.object,
   },
 
   getDefaultProps() {
@@ -133,14 +119,12 @@ const DateDisplay = React.createClass({
       locale,
       selectedDate,
       style,
-      muiTheme: {
-        prepareStyles,
-      },
       ...other,
     } = this.props;
 
+    const {prepareStyles} = this.context.muiTheme;
     const year = selectedDate.getFullYear();
-    const styles = getStyles(this.props, this.state);
+    const styles = getStyles(this.props, this.context, this.state);
 
     const dateTimeFormatted = new DateTimeFormat(locale, {
       month: 'short',

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -162,7 +162,7 @@ const DatePicker = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -2,7 +2,6 @@ import React from 'react';
 import DateTime from '../utils/dateTime';
 import DatePickerDialog from './DatePickerDialog';
 import TextField from '../TextField';
-import getMuiTheme from '../styles/getMuiTheme';
 import deprecated from '../utils/deprecatedPropType';
 
 const DatePicker = React.createClass({
@@ -20,7 +19,6 @@ const DatePicker = React.createClass({
      * If true, automatically accept and close the picker on select a date.
      */
     autoOk: React.PropTypes.bool,
-
 
     /**
      * Override the default text of the 'Cancel' button.
@@ -167,10 +165,6 @@ const DatePicker = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       autoOk: false,
@@ -187,21 +181,10 @@ const DatePicker = React.createClass({
   getInitialState() {
     return {
       date: this._isControlled() ? this._getControlledDate() : this.props.defaultDate,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
     };
   },
 
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-
+  componentWillReceiveProps(nextProps) {
     if (this._isControlled()) {
       const newDate = this._getControlledDate(nextProps);
       if (!DateTime.isEqualDate(this.state.date, newDate)) {
@@ -318,8 +301,8 @@ const DatePicker = React.createClass({
       ...other,
     } = this.props;
 
+    const {prepareStyles} = this.context.muiTheme;
     const formatDate = this.props.formatDate || this._formatDate;
-    const {prepareStyles} = this.state.muiTheme;
 
     return (
       <div style={prepareStyles(Object.assign({}, style))}>

--- a/src/DatePicker/DatePickerDialog.js
+++ b/src/DatePicker/DatePickerDialog.js
@@ -5,7 +5,6 @@ import Calendar from './Calendar';
 import Dialog from '../Dialog';
 import DatePickerInline from './Date-PickerInline';
 import FlatButton from '../FlatButton';
-import getMuiTheme from '../styles/getMuiTheme';
 import DateTime from '../utils/dateTime';
 
 const DatePickerDialog = React.createClass({
@@ -27,19 +26,11 @@ const DatePickerDialog = React.createClass({
     onDismiss: React.PropTypes.func,
     onShow: React.PropTypes.func,
     shouldDisableDate: React.PropTypes.func,
-
-    /**
-     * Override the inline-styles of the root element.
-     */
     style: React.PropTypes.object,
     wordings: React.PropTypes.object,
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  childContextTypes: {
     muiTheme: React.PropTypes.object,
   },
 
@@ -56,20 +47,7 @@ const DatePickerDialog = React.createClass({
   getInitialState() {
     return {
       open: false,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
     };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   show() {
@@ -136,14 +114,13 @@ const DatePickerDialog = React.createClass({
       ...other,
     } = this.props;
 
+    const {open} = this.state;
+
     const {
-      open,
-      muiTheme: {
-        datePicker: {
-          calendarTextColor,
-        },
+      datePicker: {
+        calendarTextColor,
       },
-    } = this.state;
+    } = this.context.muiTheme;
 
     const styles = {
       root: {

--- a/src/DatePicker/DatePickerDialog.js
+++ b/src/DatePicker/DatePickerDialog.js
@@ -31,7 +31,7 @@ const DatePickerDialog = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps: function() {

--- a/src/DatePicker/DayButton.js
+++ b/src/DatePicker/DayButton.js
@@ -10,9 +10,7 @@ function getStyles(props, context) {
     selected,
   } = props;
 
-  const {
-    hover,
-  } = context;
+  const {hover} = context;
 
   const {
     baseTheme,

--- a/src/DatePicker/DayButton.js
+++ b/src/DatePicker/DayButton.js
@@ -70,7 +70,7 @@ const DayButton = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/DatePicker/DayButton.js
+++ b/src/DatePicker/DayButton.js
@@ -2,9 +2,8 @@ import React from 'react';
 import Transition from '../styles/transitions';
 import DateTime from '../utils/dateTime';
 import EnhancedButton from '../internal/EnhancedButton';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     date,
     disabled,
@@ -13,12 +12,12 @@ function getStyles(props, state) {
 
   const {
     hover,
-  } = state;
+  } = context;
 
   const {
     baseTheme,
     datePicker,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   let labelColor = baseTheme.palette.textColor;
   let buttonStateOpacity = 0;
@@ -74,10 +73,6 @@ const DayButton = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       selected: false,
@@ -88,20 +83,7 @@ const DayButton = React.createClass({
   getInitialState() {
     return {
       hover: false,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
     };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   handleMouseEnter() {
@@ -130,11 +112,8 @@ const DayButton = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     return this.props.date ? (
       <EnhancedButton

--- a/src/DatePicker/YearButton.js
+++ b/src/DatePicker/YearButton.js
@@ -58,7 +58,7 @@ const YearButton = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/DatePicker/YearButton.js
+++ b/src/DatePicker/YearButton.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import EnhancedButton from '../internal/EnhancedButton';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     selected,
     year,
@@ -10,12 +9,12 @@ function getStyles(props, state) {
 
   const {
     hover,
-  } = state;
+  } = context;
 
   const {
     baseTheme,
     datePicker,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   return {
     root: {
@@ -62,10 +61,6 @@ const YearButton = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       selected: false,
@@ -75,20 +70,7 @@ const YearButton = React.createClass({
   getInitialState() {
     return {
       hover: false,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
     };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   handleMouseEnter() {
@@ -112,11 +94,8 @@ const YearButton = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     return (
       <EnhancedButton

--- a/src/DatePicker/YearButton.js
+++ b/src/DatePicker/YearButton.js
@@ -7,9 +7,7 @@ function getStyles(props, context) {
     year,
   } = props;
 
-  const {
-    hover,
-  } = context;
+  const {hover} = context;
 
   const {
     baseTheme,

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -17,7 +17,7 @@ const TransitionItem = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getInitialState() {
@@ -166,7 +166,7 @@ const DialogInline = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   componentDidMount() {

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -6,7 +6,6 @@ import transitions from '../styles/transitions';
 import Overlay from '../internal/Overlay';
 import RenderToLayer from '../internal/RenderToLayer';
 import Paper from '../Paper';
-import getMuiTheme from '../styles/getMuiTheme';
 
 import ReactTransitionGroup from 'react-addons-transition-group';
 
@@ -21,27 +20,10 @@ const TransitionItem = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getInitialState() {
     return {
       style: {},
-      muiTheme: this.context.muiTheme || getMuiTheme(),
     };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   componentWillUnmount() {
@@ -54,7 +36,7 @@ const TransitionItem = React.createClass({
   },
 
   componentWillAppear(callback) {
-    const spacing = this.state.muiTheme.baseTheme.spacing;
+    const spacing = this.context.muiTheme.baseTheme.spacing;
 
     this.setState({
       style: {
@@ -84,9 +66,7 @@ const TransitionItem = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
+    const {prepareStyles} = this.context.muiTheme;
 
     return (
       <div {...other} style={prepareStyles(Object.assign({}, this.state.style, style))}>
@@ -96,7 +76,7 @@ const TransitionItem = React.createClass({
   },
 });
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     autoScrollBodyContent,
     open,
@@ -105,7 +85,7 @@ function getStyles(props, state) {
   const {
     baseTheme,
     zIndex,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   const gutter = baseTheme.spacing.desktopGutter;
 
@@ -189,30 +169,8 @@ const DialogInline = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
   componentDidMount() {
     this._positionDialog();
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   componentDidUpdate() {
@@ -256,7 +214,7 @@ const DialogInline = React.createClass({
 
     // Force a height if the dialog is taller than clientHeight
     if (autoDetectWindowHeight || autoScrollBodyContent) {
-      const styles = getStyles(this.props, this.state);
+      const styles = getStyles(this.props, this.context);
       styles.body = Object.assign(styles.body, bodyStyle);
       let maxDialogContentHeight = clientHeight - 2 * (styles.body.padding + 64);
 
@@ -314,11 +272,8 @@ const DialogInline = React.createClass({
       style,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     styles.root = Object.assign(styles.root, style);
     styles.content = Object.assign(styles.content, contentStyle);

--- a/src/Divider/Divider.js
+++ b/src/Divider/Divider.js
@@ -22,7 +22,7 @@ const defaultProps = {
 };
 
 const contextTypes = {
-  muiTheme: React.PropTypes.object,
+  muiTheme: React.PropTypes.object.isRequired,
 };
 
 const Divider = (props, context) => {

--- a/src/Divider/Divider.js
+++ b/src/Divider/Divider.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import muiThemeable from '../styles/muiThemeable';
 
 const propTypes = {
   /**
@@ -13,12 +12,6 @@ const propTypes = {
   inset: React.PropTypes.bool,
 
   /**
-   * @ignore
-   * The material-ui theme applied to this component.
-   */
-  muiTheme: React.PropTypes.object.isRequired,
-
-  /**
    * Override the inline-styles of the root element.
    */
   style: React.PropTypes.object,
@@ -28,17 +21,19 @@ const defaultProps = {
   inset: false,
 };
 
-let Divider = (props) => {
+const contextTypes = {
+  muiTheme: React.PropTypes.object,
+};
+
+const Divider = (props, context) => {
   const {
     inset,
-    muiTheme,
     style,
     ...other,
   } = props;
 
-  const {
-    prepareStyles,
-  } = muiTheme;
+  const {muiTheme} = context;
+  const {prepareStyles} = muiTheme;
 
   const styles = {
     root: {
@@ -58,8 +53,6 @@ let Divider = (props) => {
 
 Divider.propTypes = propTypes;
 Divider.defaultProps = defaultProps;
-
-Divider = muiThemeable()(Divider);
-Divider.displayName = 'Divider';
+Divider.contextTypes = contextTypes;
 
 export default Divider;

--- a/src/Divider/Divider.js
+++ b/src/Divider/Divider.js
@@ -42,7 +42,7 @@ const Divider = (props, context) => {
       marginLeft: inset ? 72 : 0,
       height: 1,
       border: 'none',
-      backgroundColor: muiTheme.rawTheme.palette.borderColor,
+      backgroundColor: muiTheme.baseTheme.palette.borderColor,
     },
   };
 

--- a/src/Divider/Divider.spec.js
+++ b/src/Divider/Divider.spec.js
@@ -3,10 +3,14 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import {assert} from 'chai';
 import Divider from './Divider';
+import getMuiTheme from '../styles/getMuiTheme';
 
 describe('<Divider />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
   it('renders className', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Divider
         className="test-class-name"
       />
@@ -16,7 +20,7 @@ describe('<Divider />', () => {
   });
 
   it('renders inset', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Divider
         inset={true}
       />
@@ -30,7 +34,7 @@ describe('<Divider />', () => {
     const style = {
       backgroundColor: 'red',
     };
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Divider
         style={style}
       />

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -133,15 +133,17 @@ const Drawer = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    const newState = {};
-
-    // If docked is changed, change the open state for when uncontrolled.
-    if (this.props.docked !== nextProps.docked) newState.open = nextProps.docked;
-
     // If controlled then the open prop takes precedence.
-    if (nextProps.open !== null) newState.open = nextProps.open;
-
-    this.setState(newState);
+    if (nextProps.open !== null) {
+      this.setState({
+        open: nextProps.open,
+      });
+      // Otherwise, if docked is changed, change the open state for when uncontrolled.
+    } else if (this.props.docked !== nextProps.docked) {
+      this.setState({
+        open: nextProps.docked,
+      });
+    }
   },
 
   componentDidUpdate() {

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -101,7 +101,7 @@ const Drawer = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -6,7 +6,6 @@ import autoPrefix from '../utils/autoPrefix';
 import transitions from '../styles/transitions';
 import Overlay from '../internal/Overlay';
 import Paper from '../Paper';
-import getMuiTheme from '../styles/getMuiTheme';
 import propTypes from '../utils/propTypes';
 
 let openNavEventHandler = null;
@@ -105,10 +104,6 @@ const Drawer = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       disableSwipeToOpen: false,
@@ -130,13 +125,6 @@ const Drawer = React.createClass({
     return {
       open: (this.props.open !== null ) ? this.props.open : this.props.docked,
       swiping: null,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
     };
   },
 
@@ -144,8 +132,8 @@ const Drawer = React.createClass({
     this._enableSwipeHandling();
   },
 
-  componentWillReceiveProps(nextProps, nextContext) {
-    const newState = {muiTheme: nextContext.muiTheme || this.state.muiTheme};
+  componentWillReceiveProps(nextProps) {
+    const newState = {};
 
     // If docked is changed, change the open state for when uncontrolled.
     if (this.props.docked !== nextProps.docked) newState.open = nextProps.docked;
@@ -165,7 +153,7 @@ const Drawer = React.createClass({
   },
 
   getStyles() {
-    const muiTheme = this.state.muiTheme;
+    const muiTheme = this.context.muiTheme;
     const theme = muiTheme.navDrawer;
 
     const x = this._getTranslateMultiplier() * (this.state.open ? 0 : this._getMaxTranslateX());
@@ -225,7 +213,7 @@ const Drawer = React.createClass({
   },
 
   _getMaxTranslateX() {
-    const width = this.props.width || this.state.muiTheme.navDrawer.width;
+    const width = this.props.width || this.context.muiTheme.navDrawer.width;
     return width + 10;
   },
 
@@ -288,7 +276,7 @@ const Drawer = React.createClass({
     const drawer = ReactDOM.findDOMNode(this.refs.clickAwayableElement);
     const transformCSS = `translate3d(${(this._getTranslateMultiplier() * translateX)}px, 0, 0)`;
     this.refs.overlay.setOpacity(1 - translateX / this._getMaxTranslateX());
-    autoPrefix.set(drawer.style, 'transform', transformCSS, this.state.muiTheme);
+    autoPrefix.set(drawer.style, 'transform', transformCSS);
   },
 
   _getTranslateX(currentX) {

--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -3,7 +3,6 @@ import transitions from '../styles/transitions';
 import DropDownArrow from '../svg-icons/navigation/arrow-drop-down';
 import Menu from '../Menu/Menu';
 import ClearFix from '../internal/ClearFix';
-import getMuiTheme from '../styles/getMuiTheme';
 import Popover from '../Popover/Popover';
 import PopoverAnimationFromTop from '../Popover/PopoverAnimationVertical';
 
@@ -11,6 +10,62 @@ const anchorOrigin = {
   vertical: 'top',
   horizontal: 'left',
 };
+
+function getStyles(props, context) {
+  const {disabled} = props;
+  const spacing = context.muiTheme.baseTheme.spacing;
+  const palette = context.muiTheme.baseTheme.palette;
+  const accentColor = context.muiTheme.dropDownMenu.accentColor;
+  return {
+    control: {
+      cursor: disabled ? 'not-allowed' : 'pointer',
+      height: '100%',
+      position: 'relative',
+      width: '100%',
+    },
+    icon: {
+      fill: accentColor,
+      position: 'absolute',
+      right: spacing.desktopGutterLess,
+      top: ((spacing.desktopToolbarHeight - 24) / 2),
+    },
+    label: {
+      color: disabled ? palette.disabledColor : palette.textColor,
+      lineHeight: `${spacing.desktopToolbarHeight}px`,
+      opacity: 1,
+      position: 'relative',
+      paddingLeft: spacing.desktopGutter,
+      paddingRight: spacing.iconSize +
+      spacing.desktopGutterLess +
+      spacing.desktopGutterMini,
+      top: 0,
+    },
+    labelWhenOpen: {
+      opacity: 0,
+      top: (spacing.desktopToolbarHeight / 8),
+    },
+    root: {
+      display: 'inline-block',
+      fontSize: spacing.desktopDropDownMenuFontSize,
+      height: spacing.desktopSubheaderHeight,
+      fontFamily: context.muiTheme.baseTheme.fontFamily,
+      outline: 'none',
+      position: 'relative',
+      transition: transitions.easeOut(),
+    },
+    rootWhenOpen: {
+      opacity: 1,
+    },
+    underline: {
+      borderTop: `solid 1px ${accentColor}`,
+      bottom: 1,
+      left: 0,
+      margin: `-1px ${spacing.desktopGutter}px`,
+      right: 0,
+      position: 'absolute',
+    },
+  };
+}
 
 const DropDownMenu = React.createClass({
 
@@ -100,11 +155,6 @@ const DropDownMenu = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  //for passing default theme context to children
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       autoWidth: true,
@@ -117,13 +167,6 @@ const DropDownMenu = React.createClass({
   getInitialState() {
     return {
       open: false,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
     };
   },
 
@@ -132,8 +175,9 @@ const DropDownMenu = React.createClass({
       this.setWidth();
     }
     if (this.props.openImmediately) {
-      // Temorary fix to make openImmediately work with popover.
+      // TODO: Temporary fix to make openImmediately work with popover.
       /*eslint-disable react/no-did-mount-set-state */
+      setTimeout(() => this.setState({open: true, anchorEl: this.refs.root}));
       setTimeout(() => this.setState({
         open: true,
         anchorEl: this.refs.root,
@@ -142,74 +186,14 @@ const DropDownMenu = React.createClass({
     }
   },
 
-  componentWillReceiveProps(nextProps, nextContext) {
-    const newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
-
+  componentWillReceiveProps() {
     if (this.props.autoWidth) {
       this.setWidth();
     }
   },
-
-  getStyles() {
-    const {disabled} = this.props;
-    const spacing = this.state.muiTheme.rawTheme.spacing;
-    const palette = this.state.muiTheme.rawTheme.palette;
-    const accentColor = this.state.muiTheme.dropDownMenu.accentColor;
-    return {
-      root: {
-        display: 'inline-block',
-        fontSize: spacing.desktopDropDownMenuFontSize,
-        height: spacing.desktopSubheaderHeight,
-        fontFamily: this.state.muiTheme.rawTheme.fontFamily,
-        outline: 'none',
-        position: 'relative',
-        transition: transitions.easeOut(),
-      },
-      rootWhenOpen: {
-        opacity: 1,
-      },
-      control: {
-        cursor: disabled ? 'not-allowed' : 'pointer',
-        height: '100%',
-        position: 'relative',
-        width: '100%',
-      },
-      icon: {
-        fill: accentColor,
-        position: 'absolute',
-        right: spacing.desktopGutterLess,
-        top: (spacing.desktopToolbarHeight - 24) / 2,
-      },
-      label: {
-        color: disabled ? palette.disabledColor : palette.textColor,
-        lineHeight: `${spacing.desktopToolbarHeight}px`,
-        opacity: 1,
-        position: 'relative',
-        paddingLeft: spacing.desktopGutter,
-        paddingRight: spacing.iconSize +
-                      spacing.desktopGutterLess +
-                      spacing.desktopGutterMini,
-        top: 0,
-      },
-      labelWhenOpen: {
-        opacity: 0,
-        top: spacing.desktopToolbarHeight / 8,
-      },
-      underline: {
-        borderTop: `solid 1px ${accentColor}`,
-        bottom: 1,
-        left: 0,
-        margin: `-1px ${spacing.desktopGutter}px`,
-        right: 0,
-        position: 'absolute',
-      },
-    };
-  },
-
   /**
    * This method is deprecated but still here because the TextField
-   * need it in order to work. That will be addressed later.
+   * need it in order to work. TODO: That will be addressed later.
    */
   getInputNode() {
     const root = this.refs.root;
@@ -277,14 +261,10 @@ const DropDownMenu = React.createClass({
     const {
       anchorEl,
       open,
-      muiTheme,
     } = this.state;
 
-    const {
-      prepareStyles,
-    } = muiTheme;
-
-    const styles = this.getStyles();
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     let displayValue = '';
     React.Children.forEach(children, (child) => {

--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -152,7 +152,7 @@ const DropDownMenu = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -126,7 +126,7 @@ const FlatButton = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -4,7 +4,6 @@ import {createChildFragment} from '../utils/childUtils';
 import ColorManipulator from '../utils/colorManipulator';
 import EnhancedButton from '../internal/EnhancedButton';
 import FlatButtonLabel from './FlatButtonLabel';
-import getMuiTheme from '../styles/getMuiTheme';
 
 function validateLabel(props, propName, componentName) {
   if (!props.children && !props.label && !props.icon) {
@@ -130,10 +129,6 @@ const FlatButton = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       disabled: false,
@@ -153,20 +148,7 @@ const FlatButton = React.createClass({
       hovered: false,
       isKeyboardFocused: false,
       touch: false,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
     };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   handleKeyboardFocus(event, isKeyboardFocused) {
@@ -225,7 +207,7 @@ const FlatButton = React.createClass({
         textColor,
         textTransform = buttonTextTransform || 'uppercase',
       },
-    } = this.state.muiTheme;
+    } = this.context.muiTheme;
     const defaultTextColor = disabled ? disabledTextColor :
       primary ? primaryTextColor :
       secondary ? secondaryTextColor :
@@ -295,6 +277,7 @@ const FlatButton = React.createClass({
       iconCloned,
       labelElement,
     };
+
     const enhancedButtonChildren = createChildFragment(childrenFragment);
 
     return (

--- a/src/FlatButton/FlatButton.spec.js
+++ b/src/FlatButton/FlatButton.spec.js
@@ -2,22 +2,24 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import {assert} from 'chai';
-import getMuiTheme from '../styles/getMuiTheme';
 import FlatButton from './FlatButton';
+import getMuiTheme from '../styles/getMuiTheme';
 
 describe('<FlatButton />', () => {
-  const flatButtonTheme = getMuiTheme().flatButton;
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+  const flatButtonTheme = muiTheme.flatButton;
   const testChildren = <div className="unique">Hello World</div>;
 
   it('renders an enhanced button', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <FlatButton>Button</FlatButton>
     );
     assert.ok(wrapper.is('EnhancedButton'));
   });
 
   it('renders children', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <FlatButton>{testChildren}</FlatButton>
     );
     assert.ok(wrapper.contains(testChildren), 'should contain the children');
@@ -32,7 +34,7 @@ describe('<FlatButton />', () => {
       name: 'Hello World',
     };
 
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <FlatButton {...props}>Button</FlatButton>
     );
 
@@ -41,7 +43,7 @@ describe('<FlatButton />', () => {
   });
 
   it('renders a label with an icon before', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <FlatButton
         icon={<span className="test-icon" />}
         label="Hello"
@@ -56,7 +58,7 @@ describe('<FlatButton />', () => {
   });
 
   it('renders a label with an icon after', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <FlatButton
         icon={<span className="test-icon" />}
         label="Hello"
@@ -72,7 +74,7 @@ describe('<FlatButton />', () => {
   });
 
   it('colors the button the primary theme color', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <FlatButton
         label="Button"
         icon={<span className="test-icon" />}
@@ -91,7 +93,7 @@ describe('<FlatButton />', () => {
   });
 
   it('colors the button the secondary theme color', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <FlatButton secondary={true} icon={<span className="test-icon" />}>Button</FlatButton>
     );
     assert.ok(wrapper.is('EnhancedButton'));
@@ -103,7 +105,7 @@ describe('<FlatButton />', () => {
   });
 
   it('overrides hover and background color styles via props', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <FlatButton
         backgroundColor="rgba(159,159,159)"
         hoverColor="yellow"
@@ -127,7 +129,7 @@ describe('<FlatButton />', () => {
   });
 
   it('overrides the ripple color via props', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <FlatButton rippleColor="yellow" label="Button" />
     );
     assert.strictEqual(wrapper.node.props.focusRippleColor, 'yellow', 'should be yellow');

--- a/src/FlatButton/FlatButtonLabel.js
+++ b/src/FlatButton/FlatButtonLabel.js
@@ -27,7 +27,7 @@ const FlatButtonLabel = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   render: function() {

--- a/src/FlatButton/FlatButtonLabel.js
+++ b/src/FlatButton/FlatButtonLabel.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     baseTheme,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   return {
     root: {
@@ -31,39 +30,14 @@ const FlatButtonLabel = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-  },
-
   render: function() {
     const {
       label,
       style,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     return (
       <span style={prepareStyles(Object.assign(styles.root, style))}>{label}</span>

--- a/src/FlatButton/FlatButtonLabel.js
+++ b/src/FlatButton/FlatButtonLabel.js
@@ -1,9 +1,7 @@
 import React from 'react';
 
 function getStyles(props, context) {
-  const {
-    baseTheme,
-  } = context.muiTheme;
+  const {baseTheme} = context.muiTheme;
 
   return {
     root: {

--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -5,14 +5,13 @@ import EnhancedButton from '../internal/EnhancedButton';
 import FontIcon from '../FontIcon';
 import Paper from '../Paper';
 import {extendChildren} from '../utils/childUtils';
-import getMuiTheme from '../styles/getMuiTheme';
 import warning from 'warning';
 import propTypes from '../utils/propTypes';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     floatingActionButton,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   let backgroundColor = props.backgroundColor || floatingActionButton.color;
   let iconColor = floatingActionButton.iconColor;
@@ -187,10 +186,6 @@ const FloatingActionButton = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       disabled: false,
@@ -205,13 +200,6 @@ const FloatingActionButton = React.createClass({
       hovered: false,
       touch: false,
       zDepth: this.props.disabled ? 0 : this.props.zDepth,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
     };
   },
 
@@ -222,10 +210,8 @@ const FloatingActionButton = React.createClass({
       'icons to FloatingActionButtons.');
   },
 
-  componentWillReceiveProps(nextProps, nextContext) {
-    const newState = {
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    };
+  componentWillReceiveProps(nextProps) {
+    const newState = {};
 
     if (nextProps.disabled !== this.props.disabled) {
       const zDepth = nextProps.disabled ? 0 : this.props.zDepth;
@@ -294,11 +280,8 @@ const FloatingActionButton = React.createClass({
       iconClassName,
       ...other} = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     let iconElement;
     if (iconClassName) {

--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -183,7 +183,7 @@ const FloatingActionButton = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -9,9 +9,7 @@ import warning from 'warning';
 import propTypes from '../utils/propTypes';
 
 function getStyles(props, context) {
-  const {
-    floatingActionButton,
-  } = context.muiTheme;
+  const {floatingActionButton} = context.muiTheme;
 
   let backgroundColor = props.backgroundColor || floatingActionButton.color;
   let iconColor = floatingActionButton.iconColor;

--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -211,14 +211,11 @@ const FloatingActionButton = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    const newState = {};
-
     if (nextProps.disabled !== this.props.disabled) {
-      const zDepth = nextProps.disabled ? 0 : this.props.zDepth;
-      newState.zDepth = zDepth;
+      this.setState({
+        zDepth: nextProps.disabled ? 0 : this.props.zDepth,
+      });
     }
-
-    this.setState(newState);
   },
 
   _handleMouseDown(event) {

--- a/src/FontIcon/FontIcon.js
+++ b/src/FontIcon/FontIcon.js
@@ -1,17 +1,13 @@
 import React from 'react';
 import transitions from '../styles/transitions';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context, state) {
   const {
     color,
     hoverColor,
   } = props;
 
-  const {
-    baseTheme,
-  } = state.muiTheme;
-
+  const {baseTheme} = context.muiTheme;
   const offColor = color || baseTheme.palette.textColor;
   const onColor = hoverColor || offColor;
 
@@ -26,7 +22,6 @@ function getStyles(props, state) {
     },
   };
 }
-
 
 const FontIcon = React.createClass({
 
@@ -66,10 +61,6 @@ const FontIcon = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       onMouseEnter: () => {},
@@ -80,20 +71,7 @@ const FontIcon = React.createClass({
   getInitialState() {
     return {
       hovered: false,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
     };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   handleMouseLeave(event) {
@@ -122,11 +100,8 @@ const FontIcon = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context, this.state);
 
     return (
       <span

--- a/src/FontIcon/FontIcon.js
+++ b/src/FontIcon/FontIcon.js
@@ -58,7 +58,7 @@ const FontIcon = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/FontIcon/FontIcon.spec.js
+++ b/src/FontIcon/FontIcon.spec.js
@@ -4,10 +4,14 @@ import sinon from 'sinon';
 import {shallow} from 'enzyme';
 import {assert} from 'chai';
 import FontIcon from './FontIcon';
+import getMuiTheme from '../styles/getMuiTheme';
 
 describe('<FontIcon />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
   it('renders className', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <FontIcon
         className="muidocs-icon-action-home"
       />
@@ -17,7 +21,7 @@ describe('<FontIcon />', () => {
   });
 
   it('renders children by default', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <FontIcon className="material-icons">home</FontIcon>
     );
 
@@ -25,7 +29,7 @@ describe('<FontIcon />', () => {
   });
 
   it('renders children and color', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <FontIcon className="material-icons" color="red">home</FontIcon>
     );
 
@@ -35,7 +39,7 @@ describe('<FontIcon />', () => {
 
   it('renders children and hoverColor when mouseEnter', () => {
     const onMouseEnter = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <FontIcon
         className="material-icons"
         color="red"
@@ -56,7 +60,7 @@ describe('<FontIcon />', () => {
 
   it('renders children and call onMouseEnter callback', () => {
     const onMouseEnter = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <FontIcon className="material-icons" onMouseEnter={onMouseEnter}>home</FontIcon>
     );
 
@@ -68,7 +72,7 @@ describe('<FontIcon />', () => {
 
   it('renders children and call onMouseLeave callback', () => {
     const onMouseLeave = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <FontIcon className="material-icons" onMouseLeave={onMouseLeave}>home</FontIcon>
     );
 
@@ -82,7 +86,7 @@ describe('<FontIcon />', () => {
     const style = {
       backgroundColor: 'red',
     };
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <FontIcon className="material-icons" style={style}>home</FontIcon>
     );
 

--- a/src/GridList/GridList.js
+++ b/src/GridList/GridList.js
@@ -44,7 +44,7 @@ const GridList = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/GridList/GridList.js
+++ b/src/GridList/GridList.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
 function getStyles(props) {
   return {
@@ -48,34 +47,12 @@ const GridList = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       cols: 2,
       padding: 4,
       cellHeight: 180,
     };
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   render() {
@@ -88,12 +65,8 @@ const GridList = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
-
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
     const mergedRootStyles = Object.assign(styles.root, style);
 
     const wrappedChildren = React.Children.map(children, (currentChild) => {

--- a/src/GridList/GridList.spec.js
+++ b/src/GridList/GridList.spec.js
@@ -3,8 +3,12 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import {assert} from 'chai';
 import GridList from './GridList';
+import getMuiTheme from '../styles/getMuiTheme';
 
 describe('<GridList />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
   const tilesData = [
     {
       img: 'images/grid-list/00-52-29-429_640.jpg',
@@ -20,7 +24,7 @@ describe('<GridList />', () => {
 
   it('renders children and change cellHeight', () => {
     const cellHeight = 250;
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <GridList cellHeight={cellHeight}>
         {tilesData.map((tile) => (
           <span
@@ -40,7 +44,7 @@ describe('<GridList />', () => {
   });
 
   it('renders children by default', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <GridList>
         {tilesData.map((tile) => (
           <span
@@ -59,7 +63,7 @@ describe('<GridList />', () => {
   });
 
   it('renders children and change cols', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <GridList cols={4}>
         {tilesData.map((tile) => (
           <span
@@ -80,7 +84,7 @@ describe('<GridList />', () => {
 
   it('renders children and change padding', () => {
     const padding = 10;
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <GridList padding={padding}>
         {tilesData.map((tile) => (
           <span
@@ -103,7 +107,7 @@ describe('<GridList />', () => {
     const style = {
       backgroundColor: 'red',
     };
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <GridList style={style}>
         {tilesData.map((tile) => (
           <span

--- a/src/GridList/GridTile.js
+++ b/src/GridList/GridTile.js
@@ -128,7 +128,7 @@ const GridTile = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/GridList/GridTile.js
+++ b/src/GridList/GridTile.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     baseTheme,
     gridTile,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   const actionPos = props.actionIcon && props.actionPosition;
 
@@ -132,10 +131,6 @@ const GridTile = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       titlePosition: 'bottom',
@@ -147,26 +142,8 @@ const GridTile = React.createClass({
     };
   },
 
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
   componentDidMount() {
     this._ensureImageCover();
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   componentDidUpdate() {
@@ -196,7 +173,6 @@ const GridTile = React.createClass({
     }
   },
 
-
   render() {
     const {
       title,
@@ -211,12 +187,8 @@ const GridTile = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
-
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
     const mergedRootStyles = Object.assign(styles.root, style);
 
     let titleBar = null;

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -5,12 +5,11 @@ import EnhancedButton from '../internal/EnhancedButton';
 import FontIcon from '../FontIcon';
 import Tooltip from '../internal/Tooltip';
 import {extendChildren} from '../utils/childUtils';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     baseTheme,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   return {
     root: {
@@ -152,10 +151,6 @@ const IconButton = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       disabled: false,
@@ -169,20 +164,7 @@ const IconButton = React.createClass({
   getInitialState() {
     return {
       tooltipShown: false,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
     };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   setKeyboardFocus() {
@@ -248,7 +230,7 @@ const IconButton = React.createClass({
     } = this.props;
     let fonticon;
 
-    const styles = getStyles(this.props, this.state);
+    const styles = getStyles(this.props, this.context);
     const tooltipPosition = this.props.tooltipPosition.split('-');
 
     const tooltipElement = tooltip ? (

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -148,7 +148,7 @@ const IconButton = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -7,9 +7,7 @@ import Tooltip from '../internal/Tooltip';
 import {extendChildren} from '../utils/childUtils';
 
 function getStyles(props, context) {
-  const {
-    baseTheme,
-  } = context.muiTheme;
+  const {baseTheme} = context.muiTheme;
 
   return {
     root: {

--- a/src/IconMenu/IconMenu.js
+++ b/src/IconMenu/IconMenu.js
@@ -143,7 +143,7 @@ const IconMenu = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/IconMenu/IconMenu.js
+++ b/src/IconMenu/IconMenu.js
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom';
 import Events from '../utils/events';
 import propTypes from '../utils/propTypes';
 import Menu from '../Menu/Menu';
-import getMuiTheme from '../styles/getMuiTheme';
 import Popover from '../Popover/Popover';
 
 const IconMenu = React.createClass({
@@ -147,10 +146,6 @@ const IconMenu = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       anchorOrigin: {
@@ -178,23 +173,12 @@ const IconMenu = React.createClass({
 
   getInitialState() {
     return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
       iconButtonRef: this.props.iconButtonElement.props.ref || 'iconButton',
       menuInitiallyKeyboardFocused: false,
       open: false,
     };
   },
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-
+  componentWillReceiveProps(nextProps) {
     if (nextProps.open != null) {
       this.setState({
         open: nextProps.open,
@@ -288,10 +272,7 @@ const IconMenu = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
+    const {prepareStyles} = this.context.muiTheme;
     const {open, anchorEl} = this.state;
 
     const styles = {
@@ -299,7 +280,6 @@ const IconMenu = React.createClass({
         display: 'inline-block',
         position: 'relative',
       },
-
       menu: {
         position: 'relative',
       },

--- a/src/LinearProgress/LinearProgress.js
+++ b/src/LinearProgress/LinearProgress.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import transitions from '../styles/transitions';
-import getMuiTheme from '../styles/getMuiTheme';
 
 function getRelativeValue(value, min, max) {
   const clampedValue = Math.min(Math.max(min, value), max);
@@ -9,18 +8,14 @@ function getRelativeValue(value, min, max) {
   return relValue * 100;
 }
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     max,
     min,
     value,
   } = props;
 
-  const {
-    baseTheme: {
-      palette,
-    },
-  } = state.muiTheme;
+  const {baseTheme: {palette}} = context.muiTheme;
 
   const styles = {
     root: {
@@ -106,28 +101,12 @@ const LinearProgress = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       mode: 'indeterminate',
       value: 0,
       min: 0,
       max: 100,
-    };
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
     };
   },
 
@@ -147,12 +126,6 @@ const LinearProgress = React.createClass({
     }, 850);
   },
 
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-  },
-
   componentWillUnmount() {
     clearTimeout(this.timers.bar1);
     clearTimeout(this.timers.bar2);
@@ -164,8 +137,8 @@ const LinearProgress = React.createClass({
     step = step || 0;
     step %= 4;
 
-    const right = this.state.muiTheme.isRtl ? 'left' : 'right';
-    const left = this.state.muiTheme.isRtl ? 'right' : 'left';
+    const right = this.context.muiTheme.isRtl ? 'left' : 'right';
+    const left = this.context.muiTheme.isRtl ? 'right' : 'left';
 
     if (step === 0) {
       barElement.style[left] = `${stepValues[0][0]}%`;
@@ -187,11 +160,8 @@ const LinearProgress = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     return (
       <div {...other} style={prepareStyles(Object.assign(styles.root, style))}>

--- a/src/LinearProgress/LinearProgress.js
+++ b/src/LinearProgress/LinearProgress.js
@@ -98,7 +98,7 @@ const LinearProgress = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/List/List.js
+++ b/src/List/List.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import propTypes from '../utils/propTypes';
-import getMuiTheme from '../styles/getMuiTheme';
 import Subheader from '../Subheader';
 import deprecated from '../utils/deprecatedPropType';
 import warning from 'warning';
@@ -47,28 +46,6 @@ const List = React.createClass({
 
   contextTypes: {
     muiTheme: React.PropTypes.object,
-  },
-
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   render() {

--- a/src/List/List.js
+++ b/src/List/List.js
@@ -45,7 +45,7 @@ const List = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   render() {

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -328,12 +328,15 @@ const ListItem = React.createClass({
   },
 
   handleRightIconButtonKeyboardFocus(event, isKeyboardFocused) {
-    const iconButton = this.props.rightIconButton;
-    const newState = {};
 
-    newState.rightIconButtonKeyboardFocused = isKeyboardFocused;
-    if (isKeyboardFocused) newState.isKeyboardFocused = false;
-    this.setState(newState);
+    if (isKeyboardFocused) {
+      this.setState({
+        isKeyboardFocused: false,
+        rightIconButtonKeyboardFocused: isKeyboardFocused,
+      });
+    }
+
+    const iconButton = this.props.rightIconButton;
 
     if (iconButton && iconButton.props.onKeyboardFocus) iconButton.props.onKeyboardFocus(event, isKeyboardFocused);
   },

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -419,7 +419,7 @@ const ListItem = React.createClass({
       listItem,
     } = this.context.muiTheme;
 
-    const textColor = this.context.muiTheme.rawTheme.palette.textColor;
+    const textColor = this.context.muiTheme.baseTheme.palette.textColor;
     const hoverColor = ColorManipulator.fade(textColor, 0.1);
     const singleAvatar = !secondaryText && (leftAvatar || rightAvatar);
     const singleNoAvatar = !secondaryText && !(leftAvatar || rightAvatar);

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -9,6 +9,139 @@ import OpenIcon from '../svg-icons/navigation/arrow-drop-up';
 import CloseIcon from '../svg-icons/navigation/arrow-drop-down';
 import NestedList from './NestedIist';
 
+function getStyles(props, context, state) {
+  const {
+    insetChildren,
+    leftAvatar,
+    leftCheckbox,
+    leftIcon,
+    nestedLevel,
+    rightAvatar,
+    rightIcon,
+    rightIconButton,
+    rightToggle,
+    secondaryText,
+    secondaryTextLines,
+  } = props;
+
+  const {muiTheme} = context;
+  const {listItem} = muiTheme;
+
+  const textColor = muiTheme.baseTheme.palette.textColor;
+  const hoverColor = ColorManipulator.fade(textColor, 0.1);
+  const singleAvatar = !secondaryText && (leftAvatar || rightAvatar);
+  const singleNoAvatar = !secondaryText && !(leftAvatar || rightAvatar);
+  const twoLine = secondaryText && secondaryTextLines === 1;
+  const threeLine = secondaryText && secondaryTextLines > 1;
+
+  const styles = {
+    root: {
+      backgroundColor: (state.isKeyboardFocused || state.hovered) &&
+      !state.rightIconButtonHovered &&
+      !state.rightIconButtonKeyboardFocused ? hoverColor : null,
+      color: textColor,
+      display: 'block',
+      fontSize: 16,
+      lineHeight: '16px',
+      position: 'relative',
+      transition: transitions.easeOut(),
+    },
+
+    //This inner div is needed so that ripples will span the entire container
+    innerDiv: {
+      marginLeft: nestedLevel * muiTheme.listItem.nestedLevelDepth,
+      paddingLeft: leftIcon || leftAvatar || leftCheckbox || insetChildren ? 72 : 16,
+      paddingRight: rightIcon || rightAvatar || rightIconButton ? 56 : rightToggle ? 72 : 16,
+      paddingBottom: singleAvatar ? 20 : 16,
+      paddingTop: singleNoAvatar || threeLine ? 16 : 20,
+      position: 'relative',
+    },
+
+    icons: {
+      height: 24,
+      width: 24,
+      display: 'block',
+      position: 'absolute',
+      top: twoLine ? 12 : singleAvatar ? 4 : 0,
+      margin: 12,
+    },
+
+    leftIcon: {
+      color: listItem.leftIconColor,
+      fill: listItem.leftIconColor,
+      left: 4,
+    },
+
+    rightIcon: {
+      color: listItem.rightIconColor,
+      fill: listItem.rightIconColor,
+      right: 4,
+    },
+
+    avatars: {
+      position: 'absolute',
+      top: singleAvatar ? 8 : 16,
+    },
+
+    label: {
+      cursor: 'pointer',
+    },
+
+    leftAvatar: {
+      left: 16,
+    },
+
+    rightAvatar: {
+      right: 16,
+    },
+
+    leftCheckbox: {
+      position: 'absolute',
+      display: 'block',
+      width: 24,
+      top: twoLine ? 24 : singleAvatar ? 16 : 12,
+      left: 16,
+    },
+
+    primaryText: {
+    },
+
+    rightIconButton: {
+      position: 'absolute',
+      display: 'block',
+      top: twoLine ? 12 : singleAvatar ? 4 : 0,
+      right: 4,
+    },
+
+    rightToggle: {
+      position: 'absolute',
+      display: 'block',
+      width: 54,
+      top: twoLine ? 25 : singleAvatar ? 17 : 13,
+      right: 8,
+    },
+
+    secondaryText: {
+      fontSize: 14,
+      lineHeight: threeLine ? '18px' : '16px',
+      height: threeLine ? 36 : 16,
+      margin: 0,
+      marginTop: 4,
+      color: listItem.secondaryTextColor,
+
+      //needed for 2 and 3 line ellipsis
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: threeLine ? null : 'nowrap',
+      display: threeLine ? '-webkit-box' : null,
+      WebkitLineClamp: threeLine ? 2 : null,
+      WebkitBoxOrient: threeLine ? 'vertical' : null,
+    },
+  };
+
+  return styles;
+}
+
 const ListItem = React.createClass({
 
   propTypes: {
@@ -415,123 +548,8 @@ const ListItem = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      listItem,
-    } = this.context.muiTheme;
-
-    const textColor = this.context.muiTheme.baseTheme.palette.textColor;
-    const hoverColor = ColorManipulator.fade(textColor, 0.1);
-    const singleAvatar = !secondaryText && (leftAvatar || rightAvatar);
-    const singleNoAvatar = !secondaryText && !(leftAvatar || rightAvatar);
-    const twoLine = secondaryText && secondaryTextLines === 1;
-    const threeLine = secondaryText && secondaryTextLines > 1;
-    const hasCheckbox = leftCheckbox || rightToggle;
-
-    const styles = {
-      root: {
-        backgroundColor: (this.state.isKeyboardFocused || this.state.hovered) &&
-          !this.state.rightIconButtonHovered &&
-          !this.state.rightIconButtonKeyboardFocused ? hoverColor : null,
-        color: textColor,
-        display: 'block',
-        fontSize: 16,
-        lineHeight: '16px',
-        position: 'relative',
-        transition: transitions.easeOut(),
-      },
-
-      //This inner div is needed so that ripples will span the entire container
-      innerDiv: {
-        marginLeft: nestedLevel * this.context.muiTheme.listItem.nestedLevelDepth,
-        paddingLeft: leftIcon || leftAvatar || leftCheckbox || insetChildren ? 72 : 16,
-        paddingRight: rightIcon || rightAvatar || rightIconButton ? 56 : rightToggle ? 72 : 16,
-        paddingBottom: singleAvatar ? 20 : 16,
-        paddingTop: singleNoAvatar || threeLine ? 16 : 20,
-        position: 'relative',
-      },
-
-      icons: {
-        height: 24,
-        width: 24,
-        display: 'block',
-        position: 'absolute',
-        top: twoLine ? 12 : singleAvatar ? 4 : 0,
-        margin: 12,
-      },
-
-      leftIcon: {
-        color: listItem.leftIconColor,
-        fill: listItem.leftIconColor,
-        left: 4,
-      },
-
-      rightIcon: {
-        color: listItem.rightIconColor,
-        fill: listItem.rightIconColor,
-        right: 4,
-      },
-
-      avatars: {
-        position: 'absolute',
-        top: singleAvatar ? 8 : 16,
-      },
-
-      label: {
-        cursor: 'pointer',
-      },
-
-      leftAvatar: {
-        left: 16,
-      },
-
-      rightAvatar: {
-        right: 16,
-      },
-
-      leftCheckbox: {
-        position: 'absolute',
-        display: 'block',
-        width: 24,
-        top: twoLine ? 24 : singleAvatar ? 16 : 12,
-        left: 16,
-      },
-
-      primaryText: {
-      },
-
-      rightIconButton: {
-        position: 'absolute',
-        display: 'block',
-        top: twoLine ? 12 : singleAvatar ? 4 : 0,
-        right: 4,
-      },
-
-      rightToggle: {
-        position: 'absolute',
-        display: 'block',
-        width: 54,
-        top: twoLine ? 25 : singleAvatar ? 17 : 13,
-        right: 8,
-      },
-
-      secondaryText: {
-        fontSize: 14,
-        lineHeight: threeLine ? '18px' : '16px',
-        height: threeLine ? 36 : 16,
-        margin: 0,
-        marginTop: 4,
-        color: listItem.secondaryTextColor,
-
-        //needed for 2 and 3 line ellipsis
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        whiteSpace: threeLine ? null : 'nowrap',
-        display: threeLine ? '-webkit-box' : null,
-        WebkitLineClamp: threeLine ? 2 : null,
-        WebkitBoxOrient: threeLine ? 'vertical' : null,
-      },
-    };
-
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context, this.state);
     const contentChildren = [children];
 
     if (leftIcon) {
@@ -638,6 +656,8 @@ const ListItem = React.createClass({
       </NestedList>
     ) : undefined;
 
+    const hasCheckbox = leftCheckbox || rightToggle;
+
     return (
       <div>
         {
@@ -656,7 +676,7 @@ const ListItem = React.createClass({
               ref="enhancedButton"
               style={Object.assign({}, styles.root, style)}
             >
-              <div style={this.context.muiTheme.prepareStyles(Object.assign(styles.innerDiv, innerDivStyle))}>
+              <div style={prepareStyles(Object.assign(styles.innerDiv, innerDivStyle))}>
                 {contentChildren}
               </div>
             </EnhancedButton>

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -8,7 +8,6 @@ import IconButton from '../IconButton';
 import OpenIcon from '../svg-icons/navigation/arrow-drop-up';
 import CloseIcon from '../svg-icons/navigation/arrow-drop-down';
 import NestedList from './NestedIist';
-import getMuiTheme from '../styles/getMuiTheme';
 
 const ListItem = React.createClass({
 
@@ -187,10 +186,6 @@ const ListItem = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   mixins: [
     PureRenderMixin,
   ],
@@ -222,20 +217,7 @@ const ListItem = React.createClass({
       rightIconButtonHovered: false,
       rightIconButtonKeyboardFocused: false,
       touch: false,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
     };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   // This method is needed by the `MenuItem` component.
@@ -276,7 +258,7 @@ const ListItem = React.createClass({
     return (
       <div
         {...additionalProps}
-        style={this.state.muiTheme.prepareStyles(mergedDivStyles)}
+        style={this.context.muiTheme.prepareStyles(mergedDivStyles)}
       >
         {contentChildren}
       </div>
@@ -300,7 +282,7 @@ const ListItem = React.createClass({
     return (
       <label
         {...additionalProps}
-        style={this.state.muiTheme.prepareStyles(mergedLabelStyles)}
+        style={this.context.muiTheme.prepareStyles(mergedLabelStyles)}
       >
         {contentChildren}
       </label>
@@ -315,10 +297,10 @@ const ListItem = React.createClass({
     return isAnElement ? (
       React.cloneElement(data, {
         key: key,
-        style: this.state.muiTheme.prepareStyles(mergedStyles),
+        style: this.context.muiTheme.prepareStyles(mergedStyles),
       })
     ) : (
-      <div key={key} style={this.state.muiTheme.prepareStyles(styles)}>
+      <div key={key} style={this.context.muiTheme.prepareStyles(styles)}>
         {data}
       </div>
     );
@@ -407,7 +389,7 @@ const ListItem = React.createClass({
       disabled,
       disableKeyboardFocus,
       innerDivStyle,
-      insetChildren,
+      insetChildren, // eslint-disable-line no-unused-vars
       leftAvatar,
       leftCheckbox,
       leftIcon,
@@ -426,16 +408,16 @@ const ListItem = React.createClass({
       primaryText,
       primaryTogglesNestedList,
       secondaryText,
-      secondaryTextLines,
+      secondaryTextLines, // eslint-disable-line no-unused-vars
       style,
       ...other,
     } = this.props;
 
     const {
       listItem,
-    } = this.state.muiTheme;
+    } = this.context.muiTheme;
 
-    const textColor = this.state.muiTheme.rawTheme.palette.textColor;
+    const textColor = this.context.muiTheme.rawTheme.palette.textColor;
     const hoverColor = ColorManipulator.fade(textColor, 0.1);
     const singleAvatar = !secondaryText && (leftAvatar || rightAvatar);
     const singleNoAvatar = !secondaryText && !(leftAvatar || rightAvatar);
@@ -458,7 +440,7 @@ const ListItem = React.createClass({
 
       //This inner div is needed so that ripples will span the entire container
       innerDiv: {
-        marginLeft: nestedLevel * this.state.muiTheme.listItem.nestedLevelDepth,
+        marginLeft: nestedLevel * this.context.muiTheme.listItem.nestedLevelDepth,
         paddingLeft: leftIcon || leftAvatar || leftCheckbox || insetChildren ? 72 : 16,
         paddingRight: rightIcon || rightAvatar || rightIconButton ? 56 : rightToggle ? 72 : 16,
         paddingBottom: singleAvatar ? 20 : 16,
@@ -672,7 +654,7 @@ const ListItem = React.createClass({
               ref="enhancedButton"
               style={Object.assign({}, styles.root, style)}
             >
-              <div style={this.state.muiTheme.prepareStyles(Object.assign(styles.innerDiv, innerDivStyle))}>
+              <div style={this.context.muiTheme.prepareStyles(Object.assign(styles.innerDiv, innerDivStyle))}>
                 {contentChildren}
               </div>
             </EnhancedButton>

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -183,7 +183,7 @@ const ListItem = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   mixins: [
@@ -328,7 +328,6 @@ const ListItem = React.createClass({
   },
 
   handleRightIconButtonKeyboardFocus(event, isKeyboardFocused) {
-
     if (isKeyboardFocused) {
       this.setState({
         isKeyboardFocused: false,

--- a/src/List/MakeSelectable.js
+++ b/src/List/MakeSelectable.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 import ColorManipulator from '../utils/colorManipulator';
 
 export const MakeSelectable = (Component) => {
@@ -18,28 +17,6 @@ export const MakeSelectable = (Component) => {
 
     contextTypes: {
       muiTheme: React.PropTypes.object,
-    },
-
-    childContextTypes: {
-      muiTheme: React.PropTypes.object,
-    },
-
-    getInitialState() {
-      return {
-        muiTheme: this.context.muiTheme || getMuiTheme(),
-      };
-    },
-
-    getChildContext() {
-      return {
-        muiTheme: this.state.muiTheme,
-      };
-    },
-
-    componentWillReceiveProps(nextProps, nextContext) {
-      this.setState({
-        muiTheme: nextContext.muiTheme || this.state.muiTheme,
-      });
     },
 
     getValueLink: function(props) {
@@ -114,7 +91,7 @@ export const MakeSelectable = (Component) => {
       let styles = {};
 
       if (!selectedItemStyle) {
-        const textColor = this.state.muiTheme.rawTheme.palette.textColor;
+        const textColor = this.context.muiTheme.rawTheme.palette.textColor;
         const selectedColor = ColorManipulator.fade(textColor, 0.2);
         styles = {
           backgroundColor: selectedColor,

--- a/src/List/MakeSelectable.js
+++ b/src/List/MakeSelectable.js
@@ -16,7 +16,7 @@ export const MakeSelectable = (Component) => {
     },
 
     contextTypes: {
-      muiTheme: React.PropTypes.object,
+      muiTheme: React.PropTypes.object.isRequired,
     },
 
     getValueLink: function(props) {

--- a/src/List/MakeSelectable.js
+++ b/src/List/MakeSelectable.js
@@ -91,7 +91,7 @@ export const MakeSelectable = (Component) => {
       let styles = {};
 
       if (!selectedItemStyle) {
-        const textColor = this.context.muiTheme.rawTheme.palette.textColor;
+        const textColor = this.context.muiTheme.baseTheme.palette.textColor;
         const selectedColor = ColorManipulator.fade(textColor, 0.2);
         styles = {
           backgroundColor: selectedColor,

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -525,9 +525,7 @@ const Menu = React.createClass({
     warning((typeof zDepth === 'undefined'), 'Menu no longer supports `zDepth`. Instead, wrap it in `Paper` ' +
       'or another component that provides `zDepth`.');
 
-    const {
-      focusIndex,
-    } = this.state;
+    const {focusIndex} = this.state;
 
     const {prepareStyles} = this.context.muiTheme;
     const styles = getStyles(this.props, this.context);

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -10,6 +10,59 @@ import List from '../List/List';
 import deprecated from '../utils/deprecatedPropType';
 import warning from 'warning';
 
+function getStyles(props, context) {
+  const {
+    animated,
+    desktop,
+    maxHeight,
+    openDirection = 'bottom-left',
+    width,
+  } = props;
+
+  const openDown = openDirection.split('-')[0] === 'bottom';
+  const openLeft = openDirection.split('-')[1] === 'left';
+
+  const {muiTheme} = context;
+
+  const styles = {
+    root: {
+      //Nested div bacause the List scales x faster than
+      //it scales y
+      transition: animated ? transitions.easeOut('250ms', 'transform') : null,
+      zIndex: muiTheme.zIndex.menu,
+      top: openDown ? 0 : null,
+      bottom: !openDown ? 0 : null,
+      left: !openLeft ? 0 : null,
+      right: openLeft ? 0 : null,
+      transform: animated ? 'scaleX(0)' : null,
+      transformOrigin: openLeft ? 'right' : 'left',
+      opacity: 0,
+      maxHeight: maxHeight,
+      overflowY: maxHeight ? 'auto' : null,
+    },
+    divider: {
+      marginTop: 7,
+      marginBottom: 8,
+    },
+    list: {
+      display: 'table-cell',
+      paddingBottom: desktop ? 16 : 8,
+      paddingTop: desktop ? 16 : 8,
+      userSelect: 'none',
+      width: width,
+    },
+    menuItemContainer: {
+      transition: animated ? transitions.easeOut(null, 'opacity') : null,
+      opacity: 0,
+    },
+    selectedMenuItem: {
+      color: muiTheme.baseTheme.palette.accent1Color,
+    },
+  };
+
+  return styles;
+}
+
 const Menu = React.createClass({
 
   propTypes: {
@@ -476,53 +529,13 @@ const Menu = React.createClass({
       focusIndex,
     } = this.state;
 
-    const {muiTheme} = this.context;
-    const {prepareStyles} = muiTheme;
-
-    const openDown = openDirection.split('-')[0] === 'bottom';
-    const openLeft = openDirection.split('-')[1] === 'left';
-
-    const baseTheme = muiTheme.baseTheme;
-
-    const styles = {
-      root: {
-        //Nested div bacause the List scales x faster than
-        //it scales y
-        transition: animated ? transitions.easeOut('250ms', 'transform') : null,
-        zIndex: muiTheme.zIndex.menu,
-        top: openDown ? 0 : null,
-        bottom: !openDown ? 0 : null,
-        left: !openLeft ? 0 : null,
-        right: openLeft ? 0 : null,
-        transform: animated ? 'scaleX(0)' : null,
-        transformOrigin: openLeft ? 'right' : 'left',
-        opacity: 0,
-        maxHeight: maxHeight,
-        overflowY: maxHeight ? 'auto' : null,
-      },
-      divider: {
-        marginTop: 7,
-        marginBottom: 8,
-      },
-      list: {
-        display: 'table-cell',
-        paddingBottom: desktop ? 16 : 8,
-        paddingTop: desktop ? 16 : 8,
-        userSelect: 'none',
-        width: width,
-      },
-      menuItemContainer: {
-        transition: animated ? transitions.easeOut(null, 'opacity') : null,
-        opacity: 0,
-      },
-      selectedMenuItem: {
-        color: baseTheme.palette.accent1Color,
-      },
-    };
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     const mergedRootStyles = Object.assign(styles.root, style);
     const mergedListStyles = Object.assign(styles.list, listStyle);
 
+    const openDown = openDirection.split('-')[0] === 'bottom';
     const filteredChildren = this.getFilteredChildren(children);
 
     //Cascade children opacity

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -148,7 +148,7 @@ const Menu = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -7,7 +7,6 @@ import transitions from '../styles/transitions';
 import keycode from 'keycode';
 import propTypes from '../utils/propTypes';
 import List from '../List/List';
-import getMuiTheme from '../styles/getMuiTheme';
 import deprecated from '../utils/deprecatedPropType';
 import warning from 'warning';
 
@@ -152,10 +151,6 @@ const Menu = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       autoWidth: true,
@@ -179,13 +174,6 @@ const Menu = React.createClass({
       focusIndex: this.props.disableAutoFocus ? -1 : selectedIndex >= 0 ? selectedIndex : 0,
       isKeyboardFocused: this.props.initiallyKeyboardFocused,
       keyWidth: this.props.desktop ? 64 : 56,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
     };
   },
 
@@ -195,14 +183,13 @@ const Menu = React.createClass({
     this.setScollPosition();
   },
 
-  componentWillReceiveProps(nextProps, nextContext) {
+  componentWillReceiveProps(nextProps) {
     const filteredChildren = this.getFilteredChildren(nextProps.children);
     const selectedIndex = this.getSelectedIndex(nextProps, filteredChildren);
 
     this.setState({
       focusIndex: nextProps.disableAutoFocus ? -1 : selectedIndex >= 0 ? selectedIndex : 0,
       keyWidth: nextProps.desktop ? 64 : 56,
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
     });
   },
 
@@ -247,8 +234,8 @@ const Menu = React.createClass({
     const scrollContainerStyle = ReactDOM.findDOMNode(this.refs.scrollContainer).style;
     const menuContainers = ReactDOM.findDOMNode(this.refs.list).childNodes;
 
-    autoPrefix.set(rootStyle, 'transform', 'scaleX(1)', this.state.muiTheme);
-    autoPrefix.set(scrollContainerStyle, 'transform', 'scaleY(1)', this.state.muiTheme);
+    autoPrefix.set(rootStyle, 'transform', 'scaleX(1)');
+    autoPrefix.set(scrollContainerStyle, 'transform', 'scaleY(1)');
     scrollContainerStyle.opacity = 1;
 
     for (let i = 0; i < menuContainers.length; ++i) {
@@ -470,14 +457,14 @@ const Menu = React.createClass({
       desktop,
       initiallyKeyboardFocused, // eslint-disable-line no-unused-vars
       listStyle,
-      maxHeight,
+      maxHeight, // eslint-disable-line no-unused-vars
       multiple, // eslint-disable-line no-unused-vars
       openDirection = 'bottom-left',
       selectedMenuItemStyle, // eslint-disable-line no-unused-vars
       style,
       value, // eslint-disable-line no-unused-vars
       valueLink, // eslint-disable-line no-unused-vars
-      width,
+      width, // eslint-disable-line no-unused-vars
       zDepth,
       ...other,
     } = this.props;
@@ -487,12 +474,10 @@ const Menu = React.createClass({
 
     const {
       focusIndex,
-      muiTheme,
     } = this.state;
 
-    const {
-      prepareStyles,
-    } = muiTheme;
+    const {muiTheme} = this.context;
+    const {prepareStyles} = muiTheme;
 
     const openDown = openDirection.split('-')[0] === 'bottom';
     const openLeft = openDirection.split('-')[1] === 'left';

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -482,7 +482,7 @@ const Menu = React.createClass({
     const openDown = openDirection.split('-')[0] === 'bottom';
     const openLeft = openDirection.split('-')[1] === 'left';
 
-    const rawTheme = muiTheme.rawTheme;
+    const baseTheme = muiTheme.baseTheme;
 
     const styles = {
       root: {
@@ -516,7 +516,7 @@ const Menu = React.createClass({
         opacity: 0,
       },
       selectedMenuItem: {
-        color: rawTheme.palette.accent1Color,
+        color: baseTheme.palette.accent1Color,
       },
     };
 

--- a/src/MenuItem/MenuItem.js
+++ b/src/MenuItem/MenuItem.js
@@ -4,7 +4,6 @@ import PureRenderMixin from 'react-addons-pure-render-mixin';
 import Popover from '../Popover/Popover';
 import CheckIcon from '../svg-icons/navigation/check';
 import ListItem from '../List/ListItem';
-import getMuiTheme from '../styles/getMuiTheme';
 import Menu from '../Menu/Menu';
 
 const nestedMenuStyle = {
@@ -104,10 +103,6 @@ const MenuItem = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   mixins: [
     PureRenderMixin,
   ],
@@ -124,14 +119,7 @@ const MenuItem = React.createClass({
 
   getInitialState() {
     return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
       open: false,
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
     };
   },
 
@@ -139,11 +127,7 @@ const MenuItem = React.createClass({
     this._applyFocusState();
   },
 
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-
+  componentWillReceiveProps(nextProps) {
     if (this.state.open && nextProps.focusState === 'none') {
       this.handleRequestClose();
     }
@@ -221,10 +205,10 @@ const MenuItem = React.createClass({
     const {
       prepareStyles,
       menuItem,
-    } = this.state.muiTheme;
+    } = this.context.muiTheme;
 
-    const disabledColor = this.state.muiTheme.rawTheme.palette.disabledColor;
-    const textColor = this.state.muiTheme.rawTheme.palette.textColor;
+    const disabledColor = this.context.muiTheme.rawTheme.palette.disabledColor;
+    const textColor = this.context.muiTheme.rawTheme.palette.textColor;
     const leftIndent = desktop ? 64 : 72;
     const sidePadding = desktop ? 24 : 16;
 

--- a/src/MenuItem/MenuItem.js
+++ b/src/MenuItem/MenuItem.js
@@ -10,6 +10,54 @@ const nestedMenuStyle = {
   position: 'relative',
 };
 
+function getStyles(props, context) {
+  const disabledColor = context.muiTheme.baseTheme.palette.disabledColor;
+  const textColor = context.muiTheme.baseTheme.palette.textColor;
+  const leftIndent = props.desktop ? 64 : 72;
+  const sidePadding = props.desktop ? 24 : 16;
+
+  const styles = {
+    root: {
+      color: props.disabled ? disabledColor : textColor,
+      lineHeight: props.desktop ? '32px' : '48px',
+      fontSize: props.desktop ? 15 : 16,
+      whiteSpace: 'nowrap',
+    },
+
+    innerDivStyle: {
+      paddingLeft: props.leftIcon || props.insetChildren || props.checked ? leftIndent : sidePadding,
+      paddingRight: sidePadding,
+      paddingBottom: 0,
+      paddingTop: 0,
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignContent: 'space-between',
+    },
+
+    secondaryText: {
+      order: 2,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    },
+
+    leftIconDesktop: {
+      margin: 0,
+      left: 24,
+      top: 4,
+    },
+
+    rightIconDesktop: {
+      margin: 0,
+      right: 24,
+      top: 4,
+      fill: context.muiTheme.menuItem.rightIconDesktopFill,
+    },
+  };
+
+  return styles;
+}
+
 const MenuItem = React.createClass({
 
   propTypes: {
@@ -202,55 +250,8 @@ const MenuItem = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-      menuItem,
-    } = this.context.muiTheme;
-
-    const disabledColor = this.context.muiTheme.rawTheme.palette.disabledColor;
-    const textColor = this.context.muiTheme.rawTheme.palette.textColor;
-    const leftIndent = desktop ? 64 : 72;
-    const sidePadding = desktop ? 24 : 16;
-
-    const styles = {
-      root: {
-        color: disabled ? disabledColor : textColor,
-        lineHeight: desktop ? '32px' : '48px',
-        fontSize: desktop ? 15 : 16,
-        whiteSpace: 'nowrap',
-      },
-
-      innerDivStyle: {
-        paddingLeft: leftIcon || insetChildren || checked ? leftIndent : sidePadding,
-        paddingRight: sidePadding,
-        paddingBottom: 0,
-        paddingTop: 0,
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignContent: 'space-between',
-      },
-
-      secondaryText: {
-        order: 2,
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
-      },
-
-      leftIconDesktop: {
-        margin: 0,
-        left: 24,
-        top: 4,
-      },
-
-      rightIconDesktop: {
-        margin: 0,
-        right: 24,
-        top: 4,
-        fill: menuItem.rightIconDesktopFill,
-      },
-    };
-
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
     const mergedRootStyles = Object.assign(styles.root, style);
     const mergedInnerDivStyles = Object.assign(styles.innerDivStyle, innerDivStyle);
 

--- a/src/MenuItem/MenuItem.js
+++ b/src/MenuItem/MenuItem.js
@@ -100,7 +100,7 @@ const MenuItem = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   mixins: [

--- a/src/Paper/Paper.js
+++ b/src/Paper/Paper.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import propTypes from '../utils/propTypes';
 import transitions from '../styles/transitions';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     circle,
     rounded,
@@ -14,7 +13,7 @@ function getStyles(props, state) {
   const {
     baseTheme,
     paper,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   return {
     root: {
@@ -69,10 +68,6 @@ const Paper = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       circle: false,
@@ -82,24 +77,6 @@ const Paper = React.createClass({
     };
   },
 
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-  },
-
   render() {
     const {
       children,
@@ -107,11 +84,8 @@ const Paper = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     return (
       <div {...other} style={prepareStyles(Object.assign(styles.root, style))}>

--- a/src/Paper/Paper.js
+++ b/src/Paper/Paper.js
@@ -65,7 +65,7 @@ const Paper = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/Paper/Paper.spec.js
+++ b/src/Paper/Paper.spec.js
@@ -6,11 +6,12 @@ import Paper from './Paper';
 import getMuiTheme from '../styles/getMuiTheme';
 
 describe('<Paper />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
   const testChildren = <div className="unique">Hello World</div>;
-  const theme = getMuiTheme();
 
   it('renders children by default', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Paper>{testChildren}</Paper>
     );
 
@@ -18,7 +19,7 @@ describe('<Paper />', () => {
   });
 
   it('renders children and have borderRadius by default', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Paper>{testChildren}</Paper>
     );
 
@@ -27,7 +28,7 @@ describe('<Paper />', () => {
   });
 
   it('renders children and should be a circle', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Paper circle={true}>{testChildren}</Paper>
     );
 
@@ -36,7 +37,7 @@ describe('<Paper />', () => {
   });
 
   it('renders children and does not have rounded corners', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Paper rounded={false}>{testChildren}</Paper>
     );
 
@@ -49,7 +50,7 @@ describe('<Paper />', () => {
       backgroundColor: 'red',
       borderRadius: '70px',
     };
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Paper style={style}>{testChildren}</Paper>
     );
 
@@ -59,7 +60,7 @@ describe('<Paper />', () => {
   });
 
   it('renders children and has css transitions by default', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Paper>{testChildren}</Paper>
     );
 
@@ -68,7 +69,7 @@ describe('<Paper />', () => {
   });
 
   it('renders children and disable css transitions', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Paper transitionEnabled={false}>{testChildren}</Paper>
     );
 
@@ -78,12 +79,12 @@ describe('<Paper />', () => {
 
   it('renders children and change zDepth', () => {
     const zDepth = 3;
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Paper zDepth={zDepth}>{testChildren}</Paper>
     );
 
     assert.ok(wrapper.contains(testChildren), 'should contain the children');
-    assert.strictEqual(wrapper.prop('style').boxShadow, theme.paper.zDepthShadows[zDepth - 1],
+    assert.strictEqual(wrapper.prop('style').boxShadow, muiTheme.paper.zDepthShadows[zDepth - 1],
       'should have good zDepthShadows');
   });
 });

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -5,7 +5,6 @@ import RenderToLayer from '../internal/RenderToLayer';
 import propTypes from '../utils/propTypes';
 import Paper from '../Paper';
 import throttle from 'lodash.throttle';
-import getMuiTheme from '../styles/getMuiTheme';
 import PopoverAnimationDefault from './PopoverAnimationDefault';
 
 const Popover = React.createClass({
@@ -103,10 +102,6 @@ const Popover = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       anchorOrigin: {
@@ -137,26 +132,16 @@ const Popover = React.createClass({
     return {
       open: this.props.open,
       closing: false,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
     };
   },
 
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    const newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-
+  componentWillReceiveProps(nextProps) {
     if (nextProps.open !== this.state.open) {
       if (nextProps.open) {
         this.anchorEl = nextProps.anchorEl || this.props.anchorEl;
         this.setState({
           open: true,
           closing: false,
-          muiTheme: newMuiTheme,
         });
       } else {
         if (nextProps.animated) {
@@ -164,13 +149,11 @@ const Popover = React.createClass({
           this.timeout = setTimeout(() => {
             this.setState({
               open: false,
-              muiTheme: newMuiTheme,
             });
           }, 500);
         } else {
           this.setState({
             open: false,
-            muiTheme: newMuiTheme,
           });
         }
       }

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -99,7 +99,7 @@ const Popover = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/Popover/PopoverAnimationDefault.js
+++ b/src/Popover/PopoverAnimationDefault.js
@@ -56,7 +56,7 @@ const PopoverDefaultAnimation = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/Popover/PopoverAnimationDefault.js
+++ b/src/Popover/PopoverAnimationDefault.js
@@ -1,21 +1,12 @@
 import transitions from '../styles/transitions';
 import React from 'react';
 import propTypes from '../utils/propTypes';
-import getMuiTheme from '../styles/getMuiTheme';
 import Paper from '../Paper';
 
-function getStyles(props, state) {
-  const {
-    targetOrigin,
-  } = props;
-
-  const {
-    open,
-    muiTheme: {
-      zIndex,
-    },
-  } = state;
-
+function getStyles(props, context, state) {
+  const {targetOrigin} = props;
+  const {open} = state;
+  const {muiTheme} = context;
   const horizontal = targetOrigin.horizontal.replace('middle', 'vertical');
 
   return {
@@ -24,7 +15,7 @@ function getStyles(props, state) {
       transform: open ? 'scale(1, 1)' : 'scale(0, 0)',
       transformOrigin: `${horizontal} ${targetOrigin.vertical}`,
       position: 'fixed',
-      zIndex: zIndex.popover,
+      zIndex: muiTheme.zIndex.popover,
       transition: transitions.easeOut('250ms', ['transform', 'opacity']),
       maxHeight: '100%',
     },
@@ -68,10 +59,6 @@ const PopoverDefaultAnimation = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       style: {},
@@ -81,14 +68,7 @@ const PopoverDefaultAnimation = React.createClass({
 
   getInitialState() {
     return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
       open: false,
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
     };
   },
 
@@ -96,10 +76,9 @@ const PopoverDefaultAnimation = React.createClass({
     this.setState({open: true}); //eslint-disable-line react/no-did-mount-set-state
   },
 
-  componentWillReceiveProps(nextProps, nextContext) {
+  componentWillReceiveProps(nextProps) {
     this.setState({
       open: nextProps.open,
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
     });
   },
 
@@ -110,11 +89,8 @@ const PopoverDefaultAnimation = React.createClass({
       zDepth,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context, this.state);
 
     return (
       <Paper

--- a/src/Popover/PopoverAnimationVertical.js
+++ b/src/Popover/PopoverAnimationVertical.js
@@ -38,7 +38,7 @@ const PopoverAnimationVertical = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/Popover/PopoverAnimationVertical.js
+++ b/src/Popover/PopoverAnimationVertical.js
@@ -1,21 +1,12 @@
 import React from 'react';
 import Paper from '../Paper';
 import transitions from '../styles/transitions';
-import getMuiTheme from '../styles/getMuiTheme';
 import propTypes from '../utils/propTypes';
 
-function getStyles(props, state) {
-  const {
-    targetOrigin,
-  } = props;
-
-  const {
-    open,
-    muiTheme: {
-      zIndex,
-    },
-  } = state;
-
+function getStyles(props, context, state) {
+  const {targetOrigin} = props;
+  const {open} = state;
+  const {muiTheme} = context;
   const horizontal = targetOrigin.horizontal.replace('middle', 'vertical');
 
   return {
@@ -24,7 +15,7 @@ function getStyles(props, state) {
       transform: open ? 'scaleY(1)' : 'scaleY(0)',
       transformOrigin: `${horizontal} ${targetOrigin.vertical}`,
       position: 'fixed',
-      zIndex: zIndex.popover,
+      zIndex: muiTheme.zIndex.popover,
       transition: transitions.easeOut('450ms', ['transform', 'opacity']),
       maxHeight: '100%',
     },
@@ -50,10 +41,6 @@ const PopoverAnimationVertical = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       style: {},
@@ -63,14 +50,7 @@ const PopoverAnimationVertical = React.createClass({
 
   getInitialState() {
     return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
       open: false,
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
     };
   },
 
@@ -78,10 +58,9 @@ const PopoverAnimationVertical = React.createClass({
     this.setState({open: true}); //eslint-disable-line react/no-did-mount-set-state
   },
 
-  componentWillReceiveProps(nextProps, nextContext) {
+  componentWillReceiveProps(nextProps) {
     this.setState({
       open: nextProps.open,
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
     });
   },
 
@@ -92,7 +71,7 @@ const PopoverAnimationVertical = React.createClass({
       zDepth,
     } = this.props;
 
-    const styles = getStyles(this.props, this.state);
+    const styles = getStyles(this.props, this.context, this.state);
 
     return (
       <Paper

--- a/src/RadioButton/RadioButton.js
+++ b/src/RadioButton/RadioButton.js
@@ -121,7 +121,7 @@ const RadioButton = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/RadioButton/RadioButton.js
+++ b/src/RadioButton/RadioButton.js
@@ -3,12 +3,9 @@ import transitions from '../styles/transitions';
 import EnhancedSwitch from '../internal/EnhancedSwitch';
 import RadioButtonOff from '../svg-icons/toggle/radio-button-unchecked';
 import RadioButtonOn from '../svg-icons/toggle/radio-button-checked';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
-  const {
-    radioButton,
-  } = state.muiTheme;
+function getStyles(props, context) {
+  const {radioButton} = context.muiTheme;
 
   return {
     icon: {
@@ -127,10 +124,6 @@ const RadioButton = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       checked: false,
@@ -139,26 +132,7 @@ const RadioButton = React.createClass({
     };
   },
 
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-  },
-
-  getTheme() {
-    return this.state.muiTheme.radioButton;
+  handleStateChange() {
   },
 
   // Only called when selected, not when unselected.
@@ -193,7 +167,7 @@ const RadioButton = React.createClass({
       ...other,
     } = this.props;
 
-    const styles = getStyles(this.props, this.state);
+    const styles = getStyles(this.props, this.context);
 
     const uncheckedStyles = Object.assign(
       styles.target,
@@ -236,6 +210,7 @@ const RadioButton = React.createClass({
         iconStyle={mergedIconStyle}
         labelStyle={mergedLabelStyle}
         labelPosition={labelPosition}
+        onParentShouldUpdate={this.handleStateChange}
         onSwitch={this.handleSwitch}
         switchElement={<div>{uncheckedElement}{checkedElement}</div>}
       />

--- a/src/RadioButton/RadioButtonGroup.js
+++ b/src/RadioButton/RadioButtonGroup.js
@@ -56,7 +56,7 @@ const RadioButtonGroup = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {
@@ -85,7 +85,7 @@ const RadioButtonGroup = React.createClass({
   componentWillReceiveProps(nextProps) {
     if (nextProps.hasOwnProperty('valueSelected')) {
       this.setState({
-        selected: nextProps.valueSelected
+        selected: nextProps.valueSelected,
       });
     }
   },

--- a/src/RadioButton/RadioButtonGroup.js
+++ b/src/RadioButton/RadioButtonGroup.js
@@ -83,13 +83,11 @@ const RadioButtonGroup = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    const newState = {};
-
     if (nextProps.hasOwnProperty('valueSelected')) {
-      newState.selected = nextProps.valueSelected;
+      this.setState({
+        selected: nextProps.valueSelected
+      });
     }
-
-    this.setState(newState);
   },
 
   _hasCheckAttribute(radioButton) {

--- a/src/RadioButton/RadioButtonGroup.js
+++ b/src/RadioButton/RadioButtonGroup.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import RadioButton from '../RadioButton';
-import getMuiTheme from '../styles/getMuiTheme';
 import warning from 'warning';
 
 const RadioButtonGroup = React.createClass({
@@ -60,10 +59,6 @@ const RadioButtonGroup = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       style: {},
@@ -74,13 +69,6 @@ const RadioButtonGroup = React.createClass({
     return {
       numberCheckedRadioButtons: 0,
       selected: this.props.valueSelected || this.props.defaultSelected || '',
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
     };
   },
 
@@ -94,8 +82,8 @@ const RadioButtonGroup = React.createClass({
     this.setState({numberCheckedRadioButtons: cnt});
   },
 
-  componentWillReceiveProps(nextProps, nextContext) {
-    const newState = {muiTheme: nextContext.muiTheme || this.state.muiTheme};
+  componentWillReceiveProps(nextProps) {
+    const newState = {};
 
     if (nextProps.hasOwnProperty('valueSelected')) {
       newState.selected = nextProps.valueSelected;
@@ -140,9 +128,7 @@ const RadioButtonGroup = React.createClass({
   },
 
   render() {
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
+    const {prepareStyles} = this.context.muiTheme;
 
     const options = React.Children.map(this.props.children, (option) => {
       const {

--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -244,7 +244,7 @@ const RaisedButton = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps: function() {

--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -4,7 +4,6 @@ import ColorManipulator from '../utils/colorManipulator';
 import {createChildFragment} from '../utils/childUtils';
 import EnhancedButton from '../internal/EnhancedButton';
 import Paper from '../Paper';
-import getMuiTheme from '../styles/getMuiTheme';
 
 function validateLabel(props, propName, componentName) {
   if (!props.children && !props.label && !props.icon) {
@@ -12,12 +11,12 @@ function validateLabel(props, propName, componentName) {
   }
 }
 
-function getStyles(props, state) {
+function getStyles(props, context, state) {
   const {
     baseTheme,
     button,
     raisedButton,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   const {
     disabled,
@@ -248,10 +247,6 @@ const RaisedButton = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps: function() {
     return {
       disabled: false,
@@ -269,22 +264,14 @@ const RaisedButton = React.createClass({
       touched: false,
       initialZDepth: zDepth,
       zDepth: zDepth,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
     };
   },
 
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
+  componentWillReceiveProps(nextProps) {
     const zDepth = nextProps.disabled ? 0 : 1;
     this.setState({
       zDepth: zDepth,
       initialZDepth: zDepth,
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
     });
   },
 
@@ -327,7 +314,7 @@ const RaisedButton = React.createClass({
   },
 
   handleKeyboardFocus(event, keyboardFocused) {
-    const styles = getStyles(this.props, this.state);
+    const styles = getStyles(this.props, this.context);
 
     if (keyboardFocused && !this.props.disabled) {
       this.setState({
@@ -359,11 +346,8 @@ const RaisedButton = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context, this.state);
     const mergedRippleStyles = Object.assign({}, styles.ripple, rippleStyle);
 
     const buttonEventHandlers = disabled ? {} : {
@@ -398,6 +382,7 @@ const RaisedButton = React.createClass({
       iconCloned,
       labelElement,
     };
+
     const enhancedButtonChildren = createChildFragment(childrenFragment);
 
     return (

--- a/src/RefreshIndicator/RefreshIndicator.js
+++ b/src/RefreshIndicator/RefreshIndicator.js
@@ -302,10 +302,7 @@ const RefreshIndicator = React.createClass({
   },
 
   render() {
-    const {
-      style,
-    } = this.props;
-
+    const {style} = this.props;
     const styles = getStyles(this.props, this.context);
 
     return (

--- a/src/RefreshIndicator/RefreshIndicator.js
+++ b/src/RefreshIndicator/RefreshIndicator.js
@@ -74,7 +74,7 @@ const RefreshIndicator = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/RefreshIndicator/RefreshIndicator.js
+++ b/src/RefreshIndicator/RefreshIndicator.js
@@ -2,7 +2,6 @@ import React from 'react';
 import autoPrefix from '../utils/autoPrefix';
 import transitions from '../styles/transitions';
 import Paper from '../Paper';
-import getMuiTheme from '../styles/getMuiTheme';
 
 const VIEWBOX_SIZE = 32;
 
@@ -78,10 +77,6 @@ const RefreshIndicator = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       percentage: 0,
@@ -90,26 +85,8 @@ const RefreshIndicator = React.createClass({
     };
   },
 
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
   componentDidMount() {
     this.componentDidUpdate();
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   componentDidUpdate() {
@@ -124,11 +101,9 @@ const RefreshIndicator = React.createClass({
   },
 
   _renderChildren() {
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
+    const {prepareStyles} = this.context.muiTheme;
     const paperSize = this._getPaperSize();
+
     let childrenCmp = null;
     if (this.props.status !== 'ready') {
       const circleStyle = this._getCircleStyle(paperSize);
@@ -181,7 +156,7 @@ const RefreshIndicator = React.createClass({
   },
 
   _getTheme() {
-    return this.state.muiTheme.refreshIndicator;
+    return this.context.muiTheme.refreshIndicator;
   },
 
   _getPaddingSize() {
@@ -303,9 +278,9 @@ const RefreshIndicator = React.createClass({
       transitionDuration = '850ms';
     }
 
-    autoPrefix.set(path.style, 'strokeDasharray', strokeDasharray, this.state.muiTheme);
-    autoPrefix.set(path.style, 'strokeDashoffset', strokeDashoffset, this.state.muiTheme);
-    autoPrefix.set(path.style, 'transitionDuration', transitionDuration, this.state.muiTheme);
+    autoPrefix.set(path.style, 'strokeDasharray', strokeDasharray);
+    autoPrefix.set(path.style, 'strokeDashoffset', strokeDashoffset);
+    autoPrefix.set(path.style, 'transitionDuration', transitionDuration);
 
     this.scalePathTimer = setTimeout(() => this._scalePath(path, currStep + 1), currStep ? 750 : 250);
   },
@@ -313,14 +288,14 @@ const RefreshIndicator = React.createClass({
   _rotateWrapper(wrapper) {
     if (this.props.status !== 'loading') return;
 
-    autoPrefix.set(wrapper.style, 'transform', null, this.state.muiTheme);
-    autoPrefix.set(wrapper.style, 'transform', 'rotate(0deg)', this.state.muiTheme);
-    autoPrefix.set(wrapper.style, 'transitionDuration', '0ms', this.state.muiTheme);
+    autoPrefix.set(wrapper.style, 'transform', null);
+    autoPrefix.set(wrapper.style, 'transform', 'rotate(0deg)');
+    autoPrefix.set(wrapper.style, 'transitionDuration', '0ms');
 
     this.rotateWrapperSecondTimer = setTimeout(() => {
-      autoPrefix.set(wrapper.style, 'transform', 'rotate(1800deg)', this.state.muiTheme);
-      autoPrefix.set(wrapper.style, 'transitionDuration', '10s', this.state.muiTheme);
-      autoPrefix.set(wrapper.style, 'transitionTimingFunction', 'linear', this.state.muiTheme);
+      autoPrefix.set(wrapper.style, 'transform', 'rotate(1800deg)');
+      autoPrefix.set(wrapper.style, 'transitionDuration', '10s');
+      autoPrefix.set(wrapper.style, 'transitionTimingFunction', 'linear');
     }, 50);
 
     this.rotateWrapperTimer = setTimeout(() => this._rotateWrapper(wrapper), 10050);
@@ -331,7 +306,7 @@ const RefreshIndicator = React.createClass({
       style,
     } = this.props;
 
-    const styles = getStyles(this.props, this.state);
+    const styles = getStyles(this.props, this.context);
 
     return (
       <Paper

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -133,7 +133,7 @@ const SelectField = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import TextField from '../TextField';
 import DropDownMenu from '../DropDownMenu';
-import getMuiTheme from '../styles/getMuiTheme';
 
 function getStyles(props) {
   return {
@@ -137,34 +136,12 @@ const SelectField = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       autoWidth: false,
       disabled: false,
       fullWidth: false,
     };
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   render() {
@@ -193,7 +170,7 @@ const SelectField = React.createClass({
       ...other,
     } = this.props;
 
-    const styles = getStyles(this.props, this.state);
+    const styles = getStyles(this.props, this.context);
 
     return (
       <TextField

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -244,7 +244,7 @@ const Slider = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/Slider/Slider.spec.js
+++ b/src/Slider/Slider.spec.js
@@ -5,8 +5,12 @@ import {assert} from 'chai';
 import sinon from 'sinon';
 import keycode from 'keycode';
 import Slider from './Slider';
+import getMuiTheme from '../styles/getMuiTheme';
 
 describe('<Slider />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
   sinon.assert.expose(assert, {prefix: ''});
 
   const getThumbElement = function(shallowWrapper) {
@@ -18,7 +22,7 @@ describe('<Slider />', () => {
   };
 
   it('renders slider and the hidden input', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Slider name="slider" />
     );
 
@@ -26,7 +30,7 @@ describe('<Slider />', () => {
   });
 
   it('renders slider with an initial value', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Slider name="slider" value={0.5} />
     );
 
@@ -40,7 +44,7 @@ describe('<Slider />', () => {
   });
 
   it('renders slider as a required element in a form', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Slider name="slider" required={true} />
     );
 
@@ -51,7 +55,7 @@ describe('<Slider />', () => {
     const rootStyle = {
       backgroundColor: 'red',
     };
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Slider name="slider" style={rootStyle} />
     );
 
@@ -59,7 +63,7 @@ describe('<Slider />', () => {
   });
 
   it('checks slider initial state', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Slider name="slider" />
     );
 
@@ -71,7 +75,7 @@ describe('<Slider />', () => {
 
   it('checks drag start state', () => {
     const handleDragStart = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Slider name="slider" onDragStart={handleDragStart} />
     );
 
@@ -83,7 +87,7 @@ describe('<Slider />', () => {
 
   it('checks drag stop state', () => {
     const handleDragStop = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Slider name="slider" onDragStop={handleDragStop} />
     );
 
@@ -94,7 +98,7 @@ describe('<Slider />', () => {
   });
 
   it('checks that percent and value are being updated correctly', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Slider
         name="slider"
         step={0.5}
@@ -111,7 +115,7 @@ describe('<Slider />', () => {
   it('checks events do not fire on the handle when the slider is disabled', () => {
     const handleDragStart = sinon.spy();
     const handleChange = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Slider
         name="slider"
         disabled={true}
@@ -134,7 +138,7 @@ describe('<Slider />', () => {
 
   it('simulates focus event', () => {
     const handleFocus = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Slider name="slider" onFocus={handleFocus} />
     );
 
@@ -144,7 +148,7 @@ describe('<Slider />', () => {
 
   it('simulates blur event', () => {
     const handleBlur = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Slider name="slider" onBlur={handleBlur} />
     );
 
@@ -153,7 +157,7 @@ describe('<Slider />', () => {
   });
 
   it('simulates onmouseenter event', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Slider name="slider" />
     );
 
@@ -162,7 +166,7 @@ describe('<Slider />', () => {
   });
 
   it('simulates onmouseleave event', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Slider name="slider" />
     );
 
@@ -172,7 +176,7 @@ describe('<Slider />', () => {
 
   it('simulates keydown event with a non tracked key', () => {
     const handleChange = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Slider name="slider" onChange={handleChange} />
     );
     const event = {
@@ -186,7 +190,7 @@ describe('<Slider />', () => {
 
   it('simulates keydown event for the end key', () => {
     const handleChange = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Slider name="slider" onChange={handleChange} />
     );
     const event = {
@@ -201,7 +205,7 @@ describe('<Slider />', () => {
 
   it('simulates keydown event for the up arrow key', () => {
     const handleChange = sinon.spy();
-    const wrapper = shallow(<Slider name="slider" onChange={handleChange} />);
+    const wrapper = shallowWithContext(<Slider name="slider" onChange={handleChange} />);
     const previousPercent = wrapper.state().percent;
     const event = {
       keyCode: keycode('up'),
@@ -215,7 +219,7 @@ describe('<Slider />', () => {
 
   it('simulates keydown event for the right arrow key', () => {
     const handleChange = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Slider name="slider" onChange={handleChange} />
     );
     const previousPercent = wrapper.state().percent;
@@ -231,7 +235,7 @@ describe('<Slider />', () => {
 
   it('simulates keydown event for the home key', () => {
     const handleChange = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Slider name="slider" onChange={handleChange} />
     );
     const event = {
@@ -246,7 +250,7 @@ describe('<Slider />', () => {
 
   it('simulates keydown event for the down arrow key', () => {
     const handleChange = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Slider name="slider" onChange={handleChange} />
     );
     const event = {
@@ -261,7 +265,7 @@ describe('<Slider />', () => {
 
   it('simulates keydown event for the left arrow key', () => {
     const handleChange = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Slider name="slider" onChange={handleChange} />
     );
     const event = {

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -133,7 +133,7 @@ const Snackbar = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   mixins: [

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -2,18 +2,18 @@ import React from 'react';
 import transitions from '../styles/transitions';
 import ClickAwayListener from '../internal/ClickAwayListener';
 import FlatButton from '../FlatButton';
-import getMuiTheme from '../styles/getMuiTheme';
 import StyleResizable from '../utils/styleResizable';
 
-function getStyles(props, state) {
+function getStyles(props, context, state) {
   const {
     muiTheme: {
       baseTheme,
       snackbar,
       zIndex,
     },
-    open,
-  } = state;
+  } = context;
+
+  const {open} = state;
 
   const {
     desktopGutter,
@@ -136,10 +136,6 @@ const Snackbar = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   mixins: [
     StyleResizable,
   ],
@@ -149,13 +145,6 @@ const Snackbar = React.createClass({
       open: this.props.open,
       message: this.props.message,
       action: this.props.action,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
     };
   },
 
@@ -166,11 +155,7 @@ const Snackbar = React.createClass({
     }
   },
 
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-
+  componentWillReceiveProps(nextProps) {
     if (this.state.open && nextProps.open === this.props.open &&
         (nextProps.message !== this.props.message || nextProps.action !== this.props.action)) {
       this.setState({
@@ -257,13 +242,11 @@ const Snackbar = React.createClass({
     const {
       action,
       message,
-      muiTheme: {
-        prepareStyles,
-      },
       open,
     } = this.state;
 
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context, this.state);
 
     const actionButton = action && (
       <FlatButton

--- a/src/Snackbar/Snackbar.spec.js
+++ b/src/Snackbar/Snackbar.spec.js
@@ -3,10 +3,14 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import {assert} from 'chai';
 import Snackbar from './Snackbar';
+import getMuiTheme from '../styles/getMuiTheme';
 
 describe('<Snackbar />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
   it('renders hidden by default', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <Snackbar open={false} message="Message" autoHideDuration={4000} />
     );
 

--- a/src/Stepper/HorizontalStep.js
+++ b/src/Stepper/HorizontalStep.js
@@ -71,7 +71,7 @@ const HorizontalStep = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
     createIcon: React.PropTypes.func,
     updateAvatarBackgroundColor: React.PropTypes.func,
   },

--- a/src/Stepper/HorizontalStep.js
+++ b/src/Stepper/HorizontalStep.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import TouchRipple from '../internal/TouchRipple';
 import Avatar from '../Avatar';
-import getMuiTheme from '../styles/getMuiTheme';
 
 const HorizontalStep = React.createClass({
   propTypes: {
@@ -77,23 +76,6 @@ const HorizontalStep = React.createClass({
     updateAvatarBackgroundColor: React.PropTypes.func,
   },
 
-  //for passing default theme context to children
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
 
   getStyles() {
     const {
@@ -104,7 +86,7 @@ const HorizontalStep = React.createClass({
       stepHeaderWrapperStyle,
     } = this.props;
 
-    const theme = this.state.muiTheme.stepper;
+    const theme = this.context.muiTheme.stepper;
 
     const customAvatarBackgroundColor = this.context.updateAvatarBackgroundColor(this);
     const avatarBackgroundColor = customAvatarBackgroundColor ||
@@ -190,7 +172,6 @@ const HorizontalStep = React.createClass({
     this.props.onStepHeaderTouch(this.props.stepIndex, this);
   },
 
-
   handleStepHeaderMouseHover() {
     this.props.onStepHeaderHover(this.props.stepIndex);
   },
@@ -217,7 +198,7 @@ const HorizontalStep = React.createClass({
         onMouseOver={this.handleStepHeaderMouseHover}
         onMouseLeave={this.handleStepHeaderMouseLeave}
       >
-        <TouchRipple muiTheme={this.state.muiTheme}>
+        <TouchRipple muiTheme={this.context.muiTheme}>
           {avatarView}
           <div style={styles.stepLabel}>{stepLabel}</div>
           {!isFirstStep && <div style={styles.connectorLineLeft}></div>}

--- a/src/Stepper/Stepper.js
+++ b/src/Stepper/Stepper.js
@@ -69,11 +69,10 @@ const Stepper = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: PropTypes.object,
+    muiTheme: PropTypes.object.isRequired,
   },
 
   childContextTypes: {
-    muiTheme: PropTypes.object,
     createIcon: PropTypes.func,
     updateAvatarBackgroundColor: PropTypes.func,
   },

--- a/src/Stepper/Stepper.js
+++ b/src/Stepper/Stepper.js
@@ -1,5 +1,4 @@
 import React, {PropTypes} from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 import Paper from '../Paper';
 
 const Stepper = React.createClass({
@@ -92,15 +91,12 @@ const Stepper = React.createClass({
   getInitialState() {
     return {
       hoveredHeaderStepIndex: -1,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
       itemWidth: 0,
     };
   },
 
-
   getChildContext() {
     return {
-      muiTheme: this.state.muiTheme,
       createIcon: this.props.createIcon,
       updateAvatarBackgroundColor: this.props.updateAvatarBackgroundColor,
     };
@@ -162,7 +158,6 @@ const Stepper = React.createClass({
       style
     );
 
-
     const container = Object.assign({
       transition: 'all 0.5s',
       height: 0,
@@ -201,9 +196,7 @@ const Stepper = React.createClass({
        updateCompletedStatus,
     } = this.props;
 
-    const {
-      hoveredHeaderStepIndex,
-    } = this.state;
+    const {hoveredHeaderStepIndex} = this.state;
 
     const setOfChildren = [];
     const setOfActions = [];
@@ -245,7 +238,6 @@ const Stepper = React.createClass({
           {steps}
         </Paper>
 
-
         <div style={styles.container} ref="containerWrapper">
           <div style={styles.childrenWrapper} ref="childrenWrapper">
             <div style={{display: 'inline-flex'}}>
@@ -272,9 +264,7 @@ const Stepper = React.createClass({
      updateCompletedStatus,
    } = this.props;
 
-    const {
-      hoveredHeaderStepIndex,
-    } = this.state;
+    const {hoveredHeaderStepIndex} = this.state;
 
     const steps = React.Children.map(children, (step, index) => {
       return React.cloneElement(step, {
@@ -298,9 +288,7 @@ const Stepper = React.createClass({
   },
 
   render() {
-    const {
-      horizontal,
-    } = this.props;
+    const {horizontal} = this.props;
 
     if (horizontal) {
       return this.renderHorizontalStepper();
@@ -308,7 +296,6 @@ const Stepper = React.createClass({
 
     return this.renderVerticalStepper();
   },
-
 
 });
 

--- a/src/Stepper/Stepper.js
+++ b/src/Stepper/Stepper.js
@@ -177,9 +177,7 @@ const Stepper = React.createClass({
   },
 
   findFurthestOptionalStep(index) {
-    const {
-      children,
-    } = this.props;
+    const {children} = this.props;
 
     while (index > 0 && children[index - 1].props.optional) {
       index--;

--- a/src/Stepper/VerticalStep.js
+++ b/src/Stepper/VerticalStep.js
@@ -103,9 +103,7 @@ const Step = React.createClass({
 
 
   componentDidMount() {
-    const {
-      isActive,
-    } = this.props;
+    const {isActive} = this.props;
 
     if (isActive) {
       const childrenWrapperNode = this.refs.childrenWrapper;
@@ -122,9 +120,7 @@ const Step = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    const {
-      isActive,
-    } = this.props;
+    const {isActive} = this.props;
 
     if (!isActive && nextProps.isActive) {
       const childrenWrapperNode = this.refs.childrenWrapper;

--- a/src/Stepper/VerticalStep.js
+++ b/src/Stepper/VerticalStep.js
@@ -96,7 +96,7 @@ const Step = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: PropTypes.object,
+    muiTheme: PropTypes.object.isRequired,
     createIcon: PropTypes.func,
     updateAvatarBackgroundColor: PropTypes.func,
   },

--- a/src/Stepper/VerticalStep.js
+++ b/src/Stepper/VerticalStep.js
@@ -1,7 +1,6 @@
 import React, {PropTypes} from 'react';
 import TouchRipple from '../internal/TouchRipple';
 import Avatar from '../Avatar';
-import getMuiTheme from '../styles/getMuiTheme';
 
 const Step = React.createClass({
   propTypes: {
@@ -102,22 +101,6 @@ const Step = React.createClass({
     updateAvatarBackgroundColor: PropTypes.func,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
 
   componentDidMount() {
     const {
@@ -166,7 +149,6 @@ const Step = React.createClass({
     }
   },
 
-
   handleStepHeaderTouch() {
     this.props.onStepHeaderTouch(this.props.stepIndex, this);
   },
@@ -178,7 +160,6 @@ const Step = React.createClass({
   handleStepHeaderMouseLeave() {
     this.props.onStepHeaderHover(-1);
   },
-
 
   getStyles() {
     const {
@@ -194,7 +175,7 @@ const Step = React.createClass({
       childrenWrapperStyle,
     } = this.props;
 
-    const theme = this.state.muiTheme.stepper;
+    const theme = this.context.muiTheme.stepper;
 
     const customAvatarBackgroundColor = this.context.updateAvatarBackgroundColor(this);
 
@@ -304,7 +285,6 @@ const Step = React.createClass({
       isLastStep,
     } = this.props;
 
-
     const styles = this.getStyles();
 
     const icon = this.context.createIcon(this);
@@ -319,7 +299,7 @@ const Step = React.createClass({
           onMouseOver={this.handleStepHeaderMouseHover}
           onMouseLeave={this.handleStepHeaderMouseLeave}
         >
-          <TouchRipple muiTheme={this.state.muiTheme}>
+          <TouchRipple muiTheme={this.context.muiTheme}>
             <div style={styles.stepHeader}>
               {avatarView}
               {stepLabel}
@@ -343,7 +323,6 @@ const Step = React.createClass({
       </div>
     );
   },
-
 
 });
 

--- a/src/Subheader/Subheader.js
+++ b/src/Subheader/Subheader.js
@@ -22,7 +22,7 @@ const defaultProps = {
 };
 
 const contextTypes = {
-  muiTheme: React.PropTypes.object,
+  muiTheme: React.PropTypes.object.isRequired,
 };
 
 const Subheader = (props, context) => {

--- a/src/Subheader/Subheader.js
+++ b/src/Subheader/Subheader.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import muiThemeable from '../styles/muiThemeable';
 
 const propTypes = {
   /**
@@ -13,12 +12,6 @@ const propTypes = {
   inset: React.PropTypes.bool,
 
   /**
-   * @ignore
-   * The material-ui theme applied to this component.
-   */
-  muiTheme: React.PropTypes.object.isRequired,
-
-  /**
    * Override the inline-styles of the root element.
    */
   style: React.PropTypes.object,
@@ -28,19 +21,19 @@ const defaultProps = {
   inset: false,
 };
 
-let Subheader = (props) => {
+const contextTypes = {
+  muiTheme: React.PropTypes.object,
+};
+
+const Subheader = (props, context) => {
   const {
-    muiTheme,
     children,
     inset,
     style,
     ...other,
   } = props;
 
-  const {
-    prepareStyles,
-    subheader,
-  } = muiTheme;
+  const {prepareStyles, subheader} = context.muiTheme;
 
   const styles = {
     root: {
@@ -63,8 +56,6 @@ let Subheader = (props) => {
 
 Subheader.propTypes = propTypes;
 Subheader.defaultProps = defaultProps;
-
-Subheader = muiThemeable()(Subheader);
-Subheader.displayName = 'Subheader';
+Subheader.contextTypes = contextTypes;
 
 export default Subheader;

--- a/src/SvgIcon/SvgIcon.js
+++ b/src/SvgIcon/SvgIcon.js
@@ -48,7 +48,7 @@ const SvgIcon = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/SvgIcon/SvgIcon.js
+++ b/src/SvgIcon/SvgIcon.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import transitions from '../styles/transitions';
-import getMuiTheme from '../styles/getMuiTheme';
 
 const SvgIcon = React.createClass({
 
@@ -52,10 +51,6 @@ const SvgIcon = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       onMouseEnter: () => {},
@@ -67,20 +62,7 @@ const SvgIcon = React.createClass({
   getInitialState() {
     return {
       hovered: false,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
     };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   handleMouseLeave(event) {
@@ -108,7 +90,7 @@ const SvgIcon = React.createClass({
     const {
       baseTheme,
       prepareStyles,
-    } = this.state.muiTheme;
+    } = this.context.muiTheme;
 
     const offColor = color ? color :
       style && style.fill ? style.fill :

--- a/src/SvgIcon/SvgIcon.spec.js
+++ b/src/SvgIcon/SvgIcon.spec.js
@@ -4,12 +4,15 @@ import sinon from 'sinon';
 import {shallow} from 'enzyme';
 import {assert} from 'chai';
 import SvgIcon from './SvgIcon';
+import getMuiTheme from '../styles/getMuiTheme';
 
 describe('<SvgIcon />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
   const path = <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />;
 
   it('renders children by default', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <SvgIcon>{path}</SvgIcon>
     );
 
@@ -17,7 +20,7 @@ describe('<SvgIcon />', () => {
   });
 
   it('renders children and color', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <SvgIcon color="red">{path}</SvgIcon>
     );
 
@@ -27,7 +30,7 @@ describe('<SvgIcon />', () => {
 
   it('renders children and hoverColor when mouseEnter', () => {
     const onMouseEnter = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <SvgIcon
         className="material-icons"
         color="red"
@@ -48,7 +51,7 @@ describe('<SvgIcon />', () => {
 
   it('renders children and call onMouseEnter callback', () => {
     const onMouseEnter = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <SvgIcon onMouseEnter={onMouseEnter} hoverColor="green">{path}</SvgIcon>
     );
 
@@ -60,7 +63,7 @@ describe('<SvgIcon />', () => {
 
   it('renders children and call onMouseEnter callback even when hoverColor is not set', () => {
     const onMouseEnter = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <SvgIcon onMouseEnter={onMouseEnter}>{path}</SvgIcon>
     );
 
@@ -72,7 +75,7 @@ describe('<SvgIcon />', () => {
 
   it('renders children and call onMouseLeave callback', () => {
     const onMouseLeave = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <SvgIcon onMouseLeave={onMouseLeave} hoverColor="green">{path}</SvgIcon>
     );
 
@@ -84,7 +87,7 @@ describe('<SvgIcon />', () => {
 
   it('renders children and call onMouseLeave callback even when hoverColor is not set', () => {
     const onMouseLeave = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <SvgIcon onMouseLeave={onMouseLeave}>{path}</SvgIcon>
     );
 
@@ -98,7 +101,7 @@ describe('<SvgIcon />', () => {
     const style = {
       backgroundColor: 'red',
     };
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <SvgIcon style={style}>{path}</SvgIcon>
     );
 

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -145,7 +145,7 @@ const Table = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     baseTheme,
     table,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   return {
     root: {
@@ -149,10 +148,6 @@ const Table = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       allRowsSelected: false,
@@ -166,21 +161,8 @@ const Table = React.createClass({
 
   getInitialState() {
     return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
       allRowsSelected: this.props.allRowsSelected,
     };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   isScrollbarVisible() {
@@ -273,11 +255,8 @@ const Table = React.createClass({
       footerStyle,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     let tHead;
     let tFoot;

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -144,15 +144,17 @@ const TableBody = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    const newState = {};
     if (this.props.allRowsSelected && !nextProps.allRowsSelected) {
-      newState.selectedRows = this.state.selectedRows.length > 0 ?
-        [this.state.selectedRows[this.state.selectedRows.length - 1]] : [];
+      this.setState({
+        selectedRows: this.state.selectedRows.length > 0 ?
+          [this.state.selectedRows[this.state.selectedRows.length - 1]] : [],
+      });
+      // TODO: should else be conditional, not run any time props other than allRowsSelected change?
     } else {
-      newState.selectedRows = this._calculatePreselectedRows(nextProps);
+      this.setState({
+        selectedRows: this._calculatePreselectedRows(nextProps),
+      });
     }
-
-    this.setState(newState);
   },
 
   handleClickAway() {

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -122,7 +122,7 @@ const TableBody = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -2,7 +2,6 @@ import React from 'react';
 import Checkbox from '../Checkbox';
 import TableRowColumn from './TableRowColumn';
 import ClickAwayListener from '../internal/ClickAwayListener';
-import getMuiTheme from '../styles/getMuiTheme';
 
 const TableBody = React.createClass({
 
@@ -126,10 +125,6 @@ const TableBody = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       allRowsSelected: false,
@@ -144,22 +139,12 @@ const TableBody = React.createClass({
 
   getInitialState() {
     return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
       selectedRows: this._calculatePreselectedRows(this.props),
     };
   },
 
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    const newState = {
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    };
-
+  componentWillReceiveProps(nextProps) {
+    const newState = {};
     if (this.props.allRowsSelected && !nextProps.allRowsSelected) {
       newState.selectedRows = this.state.selectedRows.length > 0 ?
         [this.state.selectedRows[this.state.selectedRows.length - 1]] : [];
@@ -419,10 +404,7 @@ const TableBody = React.createClass({
       style,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
+    const {prepareStyles} = this.context.muiTheme;
     const rows = this._createRows();
 
     return (

--- a/src/Table/TableFooter.js
+++ b/src/Table/TableFooter.js
@@ -47,7 +47,7 @@ const TableFooter = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/Table/TableFooter.js
+++ b/src/Table/TableFooter.js
@@ -2,9 +2,7 @@ import React from 'react';
 import TableRowColumn from './TableRowColumn';
 
 function getStyles(props, context) {
-  const {
-    tableFooter,
-  } = context.muiTheme;
+  const {tableFooter} = context.muiTheme;
 
   return {
     cell: {

--- a/src/Table/TableFooter.js
+++ b/src/Table/TableFooter.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import TableRowColumn from './TableRowColumn';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     tableFooter,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   return {
     cell: {
@@ -51,33 +50,11 @@ const TableFooter = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       adjustForCheckbox: true,
       style: {},
     };
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   render() {
@@ -89,11 +66,8 @@ const TableFooter = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     const footerRows = React.Children.map(children, (child, rowNumber) => {
       const newChildProps = {

--- a/src/Table/TableHeader.js
+++ b/src/Table/TableHeader.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import Checkbox from '../Checkbox';
 import TableHeaderColumn from './TableHeaderColumn';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     tableHeader,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   return {
     root: {
@@ -73,10 +72,6 @@ const TableHeader = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       adjustForCheckbox: true,
@@ -84,24 +79,6 @@ const TableHeader = React.createClass({
       enableSelectAll: true,
       selectAllSelected: false,
     };
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   _createSuperHeaderRows() {
@@ -195,12 +172,8 @@ const TableHeader = React.createClass({
       style,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
-
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
     const superHeaderRows = this._createSuperHeaderRows();
     const baseHeaderRow = this._createBaseHeaderRow();
 

--- a/src/Table/TableHeader.js
+++ b/src/Table/TableHeader.js
@@ -3,9 +3,7 @@ import Checkbox from '../Checkbox';
 import TableHeaderColumn from './TableHeaderColumn';
 
 function getStyles(props, context) {
-  const {
-    tableHeader,
-  } = context.muiTheme;
+  const {tableHeader} = context.muiTheme;
 
   return {
     root: {

--- a/src/Table/TableHeader.js
+++ b/src/Table/TableHeader.js
@@ -69,7 +69,7 @@ const TableHeader = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/Table/TableHeaderColumn.js
+++ b/src/Table/TableHeaderColumn.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import Tooltip from '../internal/Tooltip';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     tableHeaderColumn,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   return {
     root: {
@@ -75,27 +74,10 @@ const TableHeaderColumn = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getInitialState() {
     return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
       hovered: false,
     };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   _onMouseEnter() {
@@ -122,11 +104,9 @@ const TableHeaderColumn = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
-    const styles = getStyles(this.props, this.state);
     const handlers = {
       onMouseEnter: this._onMouseEnter,
       onMouseLeave: this._onMouseLeave,

--- a/src/Table/TableHeaderColumn.js
+++ b/src/Table/TableHeaderColumn.js
@@ -2,9 +2,7 @@ import React from 'react';
 import Tooltip from '../internal/Tooltip';
 
 function getStyles(props, context) {
-  const {
-    tableHeaderColumn,
-  } = context.muiTheme;
+  const {tableHeaderColumn} = context.muiTheme;
 
   return {
     root: {

--- a/src/Table/TableHeaderColumn.js
+++ b/src/Table/TableHeaderColumn.js
@@ -71,7 +71,7 @@ const TableHeaderColumn = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getInitialState() {

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -1,10 +1,7 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
-  const {
-    tableRow,
-  } = state.muiTheme;
+function getStyles(props, context, state) {
+  const {tableRow} = context.muiTheme;
 
   let cellBgColor = 'inherit';
   if (props.hovered || state.hovered) {
@@ -137,10 +134,6 @@ const TableRow = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       displayBorder: true,
@@ -154,21 +147,8 @@ const TableRow = React.createClass({
 
   getInitialState() {
     return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
       hovered: false,
     };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   _onRowClick(event) {
@@ -226,11 +206,8 @@ const TableRow = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context, this.state);
 
     const rowColumns = React.Children.map(this.props.children, (child, columnNumber) => {
       if (React.isValidElement(child)) {

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -131,7 +131,7 @@ const TableRow = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/Table/TableRowColumn.js
+++ b/src/Table/TableRowColumn.js
@@ -1,9 +1,7 @@
 import React from 'react';
 
 function getStyles(props, context) {
-  const {
-    tableRowColumn,
-  } = context.muiTheme;
+  const {tableRowColumn} = context.muiTheme;
 
   const styles = {
     root: {

--- a/src/Table/TableRowColumn.js
+++ b/src/Table/TableRowColumn.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     tableRowColumn,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   const styles = {
     root: {
@@ -82,10 +81,6 @@ const TableRowColumn = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       hoverable: false,
@@ -94,21 +89,8 @@ const TableRowColumn = React.createClass({
 
   getInitialState() {
     return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
       hovered: false,
     };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   _onClick(event) {
@@ -142,11 +124,8 @@ const TableRowColumn = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     const handlers = {
       onClick: this._onClick,

--- a/src/Table/TableRowColumn.js
+++ b/src/Table/TableRowColumn.js
@@ -78,7 +78,7 @@ const TableRowColumn = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/Tabs/InkBar.js
+++ b/src/Tabs/InkBar.js
@@ -35,7 +35,7 @@ const InkBar = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   render() {

--- a/src/Tabs/InkBar.js
+++ b/src/Tabs/InkBar.js
@@ -2,9 +2,7 @@ import React from 'react';
 import transitions from '../styles/transitions';
 
 function getStyles(props, context) {
-  const {
-    inkBar,
-  } = context.muiTheme;
+  const {inkBar} = context.muiTheme;
 
   return {
     root: {
@@ -39,10 +37,7 @@ const InkBar = React.createClass({
   },
 
   render() {
-    const {
-      style,
-    } = this.props;
-
+    const {style} = this.props;
     const {prepareStyles} = this.context.muiTheme;
     const styles = getStyles(this.props, this.context);
 

--- a/src/Tabs/InkBar.js
+++ b/src/Tabs/InkBar.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import transitions from '../styles/transitions';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     inkBar,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   return {
     root: {
@@ -39,38 +38,13 @@ const InkBar = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-  },
-
   render() {
     const {
       style,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     return (
       <div style={prepareStyles(Object.assign(styles.root, style))} />

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 import EnhancedButton from '../internal/EnhancedButton';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     tabs,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   return {
     root: {
@@ -81,28 +80,6 @@ const Tab = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-  },
-
   handleTouchTap(event) {
     if (this.props.onTouchTap) {
       this.props.onTouchTap(this.props.value, event, this);
@@ -122,7 +99,7 @@ const Tab = React.createClass({
       ...other,
     } = this.props;
 
-    const styles = getStyles(this.props, this.state);
+    const styles = getStyles(this.props, this.context);
 
     let iconElement;
     if (icon && React.isValidElement(icon)) {

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -77,7 +77,7 @@ const Tab = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   handleTouchTap(event) {

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -2,9 +2,7 @@ import React from 'react';
 import EnhancedButton from '../internal/EnhancedButton';
 
 function getStyles(props, context) {
-  const {
-    tabs,
-  } = context.muiTheme;
+  const {tabs} = context.muiTheme;
 
   return {
     root: {

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -2,13 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import TabTemplate from './TabTemplate';
 import InkBar from './InkBar';
-import getMuiTheme from '../styles/getMuiTheme';
 import warning from 'warning';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     tabs,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   return {
     tabItemContainer: {
@@ -20,7 +19,6 @@ function getStyles(props, state) {
     },
   };
 }
-
 
 const Tabs = React.createClass({
 
@@ -88,10 +86,6 @@ const Tabs = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       initialSelectedIndex: 0,
@@ -109,20 +103,13 @@ const Tabs = React.createClass({
         initialIndex < this.getTabCount() ?
         initialIndex :
         0,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
     };
   },
 
   componentWillReceiveProps(newProps, nextContext) {
     const valueLink = this.getValueLink(newProps);
     const newState = {
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
+      muiTheme: nextContext.muiTheme || this.context.muiTheme,
     };
 
     if (valueLink.value !== undefined) {
@@ -200,16 +187,11 @@ const Tabs = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
-
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
     const valueLink = this.getValueLink(this.props);
     const tabValue = valueLink.value;
     const tabContent = [];
-
     const width = 100 / this.getTabCount();
 
     const tabs = React.Children.map(children, (tab, index) => {

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -5,9 +5,7 @@ import InkBar from './InkBar';
 import warning from 'warning';
 
 function getStyles(props, context) {
-  const {
-    tabs,
-  } = context.muiTheme;
+  const {tabs} = context.muiTheme;
 
   return {
     tabItemContainer: {

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -83,7 +83,7 @@ const Tabs = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/TextField/EnhancedTextarea.js
+++ b/src/TextField/EnhancedTextarea.js
@@ -49,7 +49,7 @@ const EnhancedTextarea = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/TextField/EnhancedTextarea.js
+++ b/src/TextField/EnhancedTextarea.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 import EventListener from 'react-event-listener';
 
 const rowsHeight = 24;
 
-function getStyles(props, state) {
+function getStyles(props, context, state) {
   return {
     root: {
       position: 'relative', //because the shadow has position: 'absolute'
@@ -53,10 +52,6 @@ const EnhancedTextarea = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       rows: 1,
@@ -66,13 +61,6 @@ const EnhancedTextarea = React.createClass({
   getInitialState() {
     return {
       height: this.props.rows * rowsHeight,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
     };
   },
 
@@ -80,14 +68,10 @@ const EnhancedTextarea = React.createClass({
     this._syncHeightWithShadow();
   },
 
-  componentWillReceiveProps(nextProps, nextContext) {
+  componentWillReceiveProps(nextProps) {
     if (nextProps.value !== this.props.value) {
       this._syncHeightWithShadow(nextProps.value);
     }
-
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   handleResize(event) {
@@ -153,11 +137,8 @@ const EnhancedTextarea = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context, this.state);
     const rootStyles = Object.assign({}, styles.root, style);
     const textareaStyles = Object.assign({}, styles.textarea, textareaStyle);
     const shadowStyles = Object.assign({}, textareaStyles, styles.shadow, shadowStyle);

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -6,7 +6,6 @@ import ColorManipulator from '../utils/colorManipulator';
 import transitions from '../styles/transitions';
 import deprecated from '../utils/deprecatedPropType';
 import EnhancedTextarea from './EnhancedTextarea';
-import getMuiTheme from '../styles/getMuiTheme';
 import TextFieldHint from './TextFieldHint';
 import TextFieldLabel from './TextFieldLabel';
 import TextFieldUnderline from './TextFieldUnderline';
@@ -283,10 +282,6 @@ const TextField = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       disabled: false,
@@ -307,13 +302,6 @@ const TextField = React.createClass({
       errorText: this.props.errorText,
       hasValue: isValid(propsLeaf.value) || isValid(propsLeaf.defaultValue),
       isClean: true,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
     };
   },
 
@@ -333,10 +321,9 @@ const TextField = React.createClass({
     this.uniqueId = uniqueId.replace(/[^A-Za-z0-9-]/gi, '');
   },
 
-  componentWillReceiveProps(nextProps, nextContext) {
+  componentWillReceiveProps(nextProps) {
     const newState = {
       errorText: nextProps.errorText,
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
     };
 
     if (nextProps.children && nextProps.children.props) {
@@ -443,12 +430,8 @@ const TextField = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
-
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
     const inputId = id || this.uniqueId;
 
     const errorTextElement = this.state.errorText && (
@@ -457,7 +440,7 @@ const TextField = React.createClass({
 
     const floatingLabelTextElement = floatingLabelText && (
       <TextFieldLabel
-        muiTheme={this.state.muiTheme}
+        muiTheme={this.context.muiTheme}
         style={Object.assign(styles.floatingLabel, this.props.floatingLabelStyle)}
         htmlFor={inputId}
         shrink={this.state.hasValue || this.state.isFocused || floatingLabelFixed}
@@ -513,7 +496,7 @@ const TextField = React.createClass({
         {floatingLabelTextElement}
         {hintText ?
           <TextFieldHint
-            muiTheme={this.state.muiTheme}
+            muiTheme={this.context.muiTheme}
             show={!(this.state.hasValue || (floatingLabelText && !this.state.isFocused)) ||
                   (!this.state.hasValue && floatingLabelText && floatingLabelFixed && !this.state.isFocused)}
             style={hintStyle}
@@ -530,7 +513,7 @@ const TextField = React.createClass({
             errorStyle={errorStyle}
             focus={this.state.isFocused}
             focusStyle={underlineFocusStyle}
-            muiTheme={this.state.muiTheme}
+            muiTheme={this.context.muiTheme}
             style={underlineStyle}
           /> :
           null

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -279,7 +279,7 @@ const TextField = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -322,20 +322,26 @@ const TextField = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    const newState = {
-      errorText: nextProps.errorText,
-    };
+    if (nextProps.errorText !== this.props.errorText) {
+      this.setState({
+        errorText: nextProps.errorText,
+      });
+    }
 
     if (nextProps.children && nextProps.children.props) {
       nextProps = nextProps.children.props;
     }
 
     if (nextProps.hasOwnProperty('value')) {
-      newState.hasValue = isValid(nextProps.value) ||
+      const hasValue = isValid(nextProps.value) ||
         (this.state.isClean && isValid(nextProps.defaultValue));
-    }
 
-    if (newState) this.setState(newState);
+      if (hasValue !== this.state.hasValue) {
+        this.setState({
+          hasValue: hasValue,
+        });
+      }
+    }
   },
 
   shouldComponentUpdate(nextProps, nextState, nextContext) {

--- a/src/TextField/TextField.spec.js
+++ b/src/TextField/TextField.spec.js
@@ -33,11 +33,11 @@ describe('<TextField />', () => {
       />
     );
 
-    assert.equal(wrapper.find(TextFieldLabel).props().shrink, true, 'should shrink TextFieldLabel');
+    assert.strictEqual(wrapper.find(TextFieldLabel).props().shrink, true, 'should shrink TextFieldLabel');
 
     // set a new prop to trigger componentWillReceiveProps
     wrapper.setProps({id: '1'});
-    assert.equal(wrapper.find(TextFieldLabel).props().shrink, true, 'should shrink TextFieldLabel');
+    assert.strictEqual(wrapper.find(TextFieldLabel).props().shrink, true, 'should shrink TextFieldLabel');
   });
 
   it(`unshrinks TextFieldLabel when defaultValue is set, the component has had input change,
@@ -49,17 +49,17 @@ describe('<TextField />', () => {
         value={null}
       />
       );
-    assert.equal(wrapper.find(TextFieldLabel).props().shrink, true, 'should shrink TextFieldLabel');
+    assert.strictEqual(wrapper.find(TextFieldLabel).props().shrink, true, 'should shrink TextFieldLabel');
 
     // make input change
     const input = wrapper.find('input');
     input.simulate('change', {target: {value: 'foo'}});
-    assert.equal(wrapper.find(TextFieldLabel).props().shrink, true, 'should shrink TextFieldLabel');
+    assert.strictEqual(wrapper.find(TextFieldLabel).props().shrink, true, 'should shrink TextFieldLabel');
 
     // set value to null again, which should unshrink the TextFieldLabel, even though TextField's isClean
-    // state propety is false.
+    // state property is false.
     wrapper.setProps({value: null});
-    assert.equal(wrapper.state().isClean, false);
-    assert.equal(wrapper.find(TextFieldLabel).props().shrink, false, 'should shrink TextFieldLabel');
+    assert.strictEqual(wrapper.state().isClean, false);
+    assert.strictEqual(wrapper.find(TextFieldLabel).props().shrink, false, 'should not shrink TextFieldLabel');
   });
 });

--- a/src/TextField/TextField.spec.js
+++ b/src/TextField/TextField.spec.js
@@ -4,10 +4,14 @@ import {shallow} from 'enzyme';
 import {assert} from 'chai';
 import TextField from './TextField';
 import TextFieldLabel from './TextFieldLabel';
+import getMuiTheme from '../styles/getMuiTheme';
 
 describe('<TextField />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
   it('passes event and value to the onChange callback', (done) => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <TextField
         onChange={(event, value) => {
           assert.strictEqual(event.target.value, 'woof');
@@ -21,7 +25,7 @@ describe('<TextField />', () => {
   });
 
   it('shrinks TextFieldLabel when defaultValue is set and value is null', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <TextField
         floatingLabelText="floating label text"
         defaultValue="default value"
@@ -38,7 +42,7 @@ describe('<TextField />', () => {
 
   it(`unshrinks TextFieldLabel when defaultValue is set, the component has had input change,
         and value is re-set to null`, () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <TextField
         floatingLabelText="floating label text"
         defaultValue="default value"

--- a/src/TextField/TextFieldLabel.js
+++ b/src/TextField/TextFieldLabel.js
@@ -78,9 +78,7 @@ const TextFieldLabel = (props) => {
     },
   };
 
-  const {
-    prepareStyles,
-  } = muiTheme;
+  const {prepareStyles} = muiTheme;
 
   return (
     <label

--- a/src/TextField/TextFieldUnderline.js
+++ b/src/TextField/TextFieldUnderline.js
@@ -80,7 +80,6 @@ const TextFieldUnderline = (props) => {
     },
   } = muiTheme;
 
-
   const styles = {
     root: {
       border: 'none',

--- a/src/TextField/TextFieldUnderline.js
+++ b/src/TextField/TextFieldUnderline.js
@@ -66,9 +66,7 @@ const TextFieldUnderline = (props) => {
     style,
   } = props;
 
-  const {
-    color: errorStyleColor,
-  } = errorStyle;
+  const {color: errorStyleColor} = errorStyle;
 
   const {
     prepareStyles,

--- a/src/TimePicker/Clock.js
+++ b/src/TimePicker/Clock.js
@@ -2,7 +2,6 @@ import React from 'react';
 import TimeDisplay from './TimeDisplay';
 import ClockHours from './ClockHours';
 import ClockMinutes from './ClockMinutes';
-import getMuiTheme from '../styles/getMuiTheme';
 
 const Clock = React.createClass({
 
@@ -27,15 +26,13 @@ const Clock = React.createClass({
 
   getInitialState() {
     return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
       selectedTime: this.props.initialTime || new Date(),
       mode: 'hour',
     };
   },
 
-  componentWillReceiveProps(nextProps, nextContext) {
+  componentWillReceiveProps(nextProps) {
     this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
       selectedTime: nextProps.initialTime || new Date(),
     });
   },
@@ -128,26 +125,22 @@ const Clock = React.createClass({
   render() {
     let clock = null;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
+    const {prepareStyles} = this.context.muiTheme;
 
     const styles = {
       root: {},
-
       container: {
         height: 280,
         padding: 10,
         position: 'relative',
       },
-
       circle: {
         position: 'absolute',
         top: 20,
         width: 260,
         height: 260,
         borderRadius: '100%',
-        backgroundColor: this.state.muiTheme.timePicker.clockCircleColor,
+        backgroundColor: this.context.muiTheme.timePicker.clockCircleColor,
       },
     };
 

--- a/src/TimePicker/Clock.js
+++ b/src/TimePicker/Clock.js
@@ -15,7 +15,7 @@ const Clock = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/TimePicker/ClockHours.js
+++ b/src/TimePicker/ClockHours.js
@@ -28,7 +28,7 @@ const ClockHours = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/TimePicker/ClockHours.js
+++ b/src/TimePicker/ClockHours.js
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ClockNumber from './ClockNumber';
 import ClockPointer from './ClockPointer';
-import getMuiTheme from '../styles/getMuiTheme';
 
 function rad2deg(rad) {
   return rad * 57.29577951308232;
@@ -32,27 +31,11 @@ const ClockHours = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       initialHours: new Date().getHours(),
       onChange: () => {},
       format: 'ampm',
-    };
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
     };
   },
 
@@ -68,12 +51,6 @@ const ClockHours = React.createClass({
       x: this.center.x,
       y: 0,
     };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   isMousePressed(event) {
@@ -203,10 +180,7 @@ const ClockHours = React.createClass({
       },
     };
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
+    const {prepareStyles} = this.context.muiTheme;
     const hours = this._getSelected();
     const numbers = this._getHourNumbers();
 

--- a/src/TimePicker/ClockMinutes.js
+++ b/src/TimePicker/ClockMinutes.js
@@ -25,7 +25,7 @@ const ClockMinutes = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/TimePicker/ClockMinutes.js
+++ b/src/TimePicker/ClockMinutes.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ClockNumber from './ClockNumber';
 import ClockPointer from './ClockPointer';
-import getMuiTheme from '../styles/getMuiTheme';
 
 function rad2deg(rad) {
   return rad * 57.29577951308232;
@@ -29,26 +28,10 @@ const ClockMinutes = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       initialMinutes: new Date().getMinutes(),
       onChange: () => {},
-    };
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
     };
   },
 
@@ -64,12 +47,6 @@ const ClockMinutes = React.createClass({
       x: this.center.x,
       y: 0,
     };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   isMousePressed(event) {
@@ -170,10 +147,7 @@ const ClockMinutes = React.createClass({
       },
     };
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
+    const {prepareStyles} = this.context.muiTheme;
     const minutes = this._getMinuteNumbers();
 
     return (

--- a/src/TimePicker/ClockNumber.js
+++ b/src/TimePicker/ClockNumber.js
@@ -10,7 +10,7 @@ const ClockNumber = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/TimePicker/ClockNumber.js
+++ b/src/TimePicker/ClockNumber.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
 const ClockNumber = React.createClass({
 
@@ -14,10 +13,6 @@ const ClockNumber = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       value: 0,
@@ -26,32 +21,12 @@ const ClockNumber = React.createClass({
     };
   },
 
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-  },
-
   getTheme() {
-    return this.state.muiTheme.timePicker;
+    return this.context.muiTheme.timePicker;
   },
 
   render() {
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
+    const {prepareStyles} = this.context.muiTheme;
 
     let pos = this.props.value;
     let inner = false;

--- a/src/TimePicker/ClockPointer.js
+++ b/src/TimePicker/ClockPointer.js
@@ -62,7 +62,7 @@ const ClockPointer = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/TimePicker/ClockPointer.js
+++ b/src/TimePicker/ClockPointer.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
 function calcAngle(value, base) {
   value %= base;
@@ -14,19 +13,15 @@ function isInner(props) {
   return props.value < 1 || props.value > 12 ;
 }
 
-function getStyles(props, state) {
+function getStyles(props, context, state) {
   const {
     hasSelected,
     type,
     value,
   } = props;
 
-  const {
-    inner,
-    muiTheme: {
-      timePicker,
-    },
-  } = state;
+  const {inner} = state;
+  const {timePicker} = context.muiTheme;
 
   const angle = type === 'hour' ? calcAngle(value, 12) : calcAngle(value, 60);
 
@@ -70,10 +65,6 @@ const ClockPointer = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       value: null,
@@ -85,20 +76,12 @@ const ClockPointer = React.createClass({
   getInitialState() {
     return {
       inner: isInner(this.props),
-      muiTheme: this.context.muiTheme || getMuiTheme(),
     };
   },
 
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
+  componentWillReceiveProps(nextProps) {
     this.setState({
       inner: isInner(nextProps),
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
     });
   },
 
@@ -107,11 +90,9 @@ const ClockPointer = React.createClass({
       return <span />;
     }
 
-    const styles = getStyles(this.props, this.state);
+    const styles = getStyles(this.props, this.context, this.state);
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
+    const {prepareStyles} = this.context.muiTheme;
 
     return (
       <div style={prepareStyles(styles.root)} >

--- a/src/TimePicker/TimeDisplay.js
+++ b/src/TimePicker/TimeDisplay.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
 const TimeDisplay = React.createClass({
 
@@ -17,10 +16,6 @@ const TimeDisplay = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       mode: 'hour',
@@ -31,21 +26,10 @@ const TimeDisplay = React.createClass({
   getInitialState() {
     return {
       transitionDirection: 'up',
-      muiTheme: this.context.muiTheme || getMuiTheme(),
     };
   },
 
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-
+  componentWillReceiveProps(nextProps) {
     if (nextProps.selectedTime !== this.props.selectedTime) {
       const direction = nextProps.selectedTime > this.props.selectedTime ? 'up' : 'down';
 
@@ -72,7 +56,7 @@ const TimeDisplay = React.createClass({
   },
 
   getTheme() {
-    return this.state.muiTheme.timePicker;
+    return this.context.muiTheme.timePicker;
   },
 
   render() {
@@ -86,7 +70,7 @@ const TimeDisplay = React.createClass({
     const {
       prepareStyles,
       timePicker,
-    } = this.state.muiTheme;
+    } = this.context.muiTheme;
 
     const styles = {
       root: {

--- a/src/TimePicker/TimeDisplay.js
+++ b/src/TimePicker/TimeDisplay.js
@@ -13,7 +13,7 @@ const TimeDisplay = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/TimePicker/TimePicker.js
+++ b/src/TimePicker/TimePicker.js
@@ -125,9 +125,11 @@ const TimePicker = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    const newState = this.state;
-    newState.time = this._getControlledTime(nextProps);
-    this.setState(newState);
+    if (nextProps.value !== this.props.value) {
+      this.setState({
+        time: this._getControlledTime(nextProps),
+      });
+    }
   },
 
   /**

--- a/src/TimePicker/TimePicker.js
+++ b/src/TimePicker/TimePicker.js
@@ -3,7 +3,6 @@ import warning from 'warning';
 import DateTime from '../utils/dateTime.js';
 import TimePickerDialog from './TimePickerDialog';
 import TextField from '../TextField';
-import getMuiTheme from '../styles/getMuiTheme';
 
 const emptyTime = new Date();
 emptyTime.setHours(0);
@@ -122,19 +121,14 @@ const TimePicker = React.createClass({
     return {
       time: this._isControlled() ? this._getControlledTime() : this.props.defaultTime,
       dialogTime: new Date(),
-      muiTheme: this.context.muiTheme || getMuiTheme(),
     };
   },
 
-  componentWillReceiveProps(nextProps, nextContext) {
+  componentWillReceiveProps(nextProps) {
     const newState = this.state;
-    if (nextContext.muiTheme) {
-      newState.muiTheme = nextContext.muiTheme;
-    }
     newState.time = this._getControlledTime(nextProps);
     this.setState(newState);
   },
-
 
   /**
    * Deprecated.
@@ -220,12 +214,8 @@ const TimePicker = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      muiTheme: {
-        prepareStyles,
-      },
-      time,
-    } = this.state;
+    const {prepareStyles} = this.context.muiTheme;
+    const {time} = this.state;
 
     return (
       <div style={prepareStyles(Object.assign({}, style))}>

--- a/src/TimePicker/TimePicker.js
+++ b/src/TimePicker/TimePicker.js
@@ -101,7 +101,7 @@ const TimePicker = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/TimePicker/TimePickerDialog.js
+++ b/src/TimePicker/TimePickerDialog.js
@@ -19,7 +19,7 @@ const TimePickerDialog = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/TimePicker/TimePickerDialog.js
+++ b/src/TimePicker/TimePickerDialog.js
@@ -4,7 +4,6 @@ import keycode from 'keycode';
 import Clock from './Clock';
 import Dialog from '../Dialog';
 import FlatButton from '../FlatButton';
-import getMuiTheme from '../styles/getMuiTheme';
 
 const TimePickerDialog = React.createClass({
 
@@ -23,10 +22,6 @@ const TimePickerDialog = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       okLabel: 'OK',
@@ -37,24 +32,11 @@ const TimePickerDialog = React.createClass({
   getInitialState() {
     return {
       open: false,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
     };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   getTheme() {
-    return this.state.muiTheme.timePicker;
+    return this.context.muiTheme.timePicker;
   },
 
   show() {

--- a/src/Toggle/Toggle.js
+++ b/src/Toggle/Toggle.js
@@ -2,9 +2,8 @@ import React from 'react';
 import transitions from '../styles/transitions';
 import Paper from '../Paper';
 import EnhancedSwitch from '../internal/EnhancedSwitch';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context, state) {
   const {
     disabled,
   } = props;
@@ -12,7 +11,7 @@ function getStyles(props, state) {
   const {
     baseTheme,
     toggle,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   const toggleSize = 20;
   const toggleTrackWidth = 36;
@@ -147,10 +146,6 @@ const Toggle = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       defaultToggled: false,
@@ -166,20 +161,7 @@ const Toggle = React.createClass({
         this.props.defaultToggled ||
         (this.props.valueLink && this.props.valueLink.value) ||
         false,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
     };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   isToggled() {
@@ -204,11 +186,8 @@ const Toggle = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context, this.state);
 
     const trackStyles = Object.assign({},
       styles.track,

--- a/src/Toggle/Toggle.js
+++ b/src/Toggle/Toggle.js
@@ -143,7 +143,7 @@ const Toggle = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/Toggle/Toggle.js
+++ b/src/Toggle/Toggle.js
@@ -4,9 +4,7 @@ import Paper from '../Paper';
 import EnhancedSwitch from '../internal/EnhancedSwitch';
 
 function getStyles(props, context, state) {
-  const {
-    disabled,
-  } = props;
+  const {disabled} = props;
 
   const {
     baseTheme,

--- a/src/Toolbar/Toolbar.js
+++ b/src/Toolbar/Toolbar.js
@@ -1,9 +1,7 @@
 import React from 'react';
 
 function getStyles(props, context) {
-  const {
-    noGutter,
-  } = props;
+  const {noGutter} = props;
 
   const {
     baseTheme,

--- a/src/Toolbar/Toolbar.js
+++ b/src/Toolbar/Toolbar.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     noGutter,
   } = props;
@@ -9,7 +8,7 @@ function getStyles(props, state) {
   const {
     baseTheme,
     toolbar,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   return {
     root: {
@@ -52,32 +51,10 @@ const Toolbar = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       noGutter: false,
     };
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   render() {
@@ -88,11 +65,8 @@ const Toolbar = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     return (
       <div {...other} className={className} style={prepareStyles(Object.assign({}, styles.root, style))}>

--- a/src/Toolbar/Toolbar.js
+++ b/src/Toolbar/Toolbar.js
@@ -48,7 +48,7 @@ const Toolbar = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/Toolbar/ToolbarGroup.js
+++ b/src/Toolbar/ToolbarGroup.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     firstChild,
     lastChild,
@@ -11,7 +10,7 @@ function getStyles(props, state) {
     baseTheme,
     button,
     toolbar,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   const marginHorizontal = baseTheme.spacing.desktopGutter;
   const marginVertical = (toolbar.height - button.height) / 2;
@@ -102,10 +101,6 @@ const ToolbarGroup = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       firstChild: false,
@@ -113,29 +108,9 @@ const ToolbarGroup = React.createClass({
     };
   },
 
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-  },
-
-  handleMouseEnterFontIcon(style) {
-    return (event) => {
-      event.target.style.zIndex = style.hover.zIndex;
-      event.target.style.color = style.hover.color;
-    };
+  handleMouseEnterFontIcon: (style) => (event) => {
+    event.target.style.zIndex = style.hover.zIndex;
+    event.target.style.color = style.hover.color;
   },
 
   handleMouseLeaveFontIcon(style) {
@@ -153,11 +128,8 @@ const ToolbarGroup = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     const newChildren = React.Children.map(children, (currentChild) => {
       if (!currentChild) {

--- a/src/Toolbar/ToolbarGroup.js
+++ b/src/Toolbar/ToolbarGroup.js
@@ -98,7 +98,7 @@ const ToolbarGroup = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/Toolbar/ToolbarSeparator.js
+++ b/src/Toolbar/ToolbarSeparator.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     baseTheme,
     toolbar,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   return {
     root: {
@@ -38,28 +37,6 @@ const ToolbarSeparator = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-  },
-
   render() {
     const {
       className,
@@ -67,11 +44,8 @@ const ToolbarSeparator = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     return (
       <span {...other} className={className} style={prepareStyles(Object.assign({}, styles.root, style))} />

--- a/src/Toolbar/ToolbarSeparator.js
+++ b/src/Toolbar/ToolbarSeparator.js
@@ -34,7 +34,7 @@ const ToolbarSeparator = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   render() {

--- a/src/Toolbar/ToolbarTitle.js
+++ b/src/Toolbar/ToolbarTitle.js
@@ -39,7 +39,7 @@ const ToolbarTitle = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   render() {

--- a/src/Toolbar/ToolbarTitle.js
+++ b/src/Toolbar/ToolbarTitle.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context) {
   const {
     baseTheme,
     toolbar,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   return {
     root: {
@@ -43,28 +42,6 @@ const ToolbarTitle = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-  },
-
   render() {
     const {
       className,
@@ -73,11 +50,8 @@ const ToolbarTitle = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     return (
       <span {...other} className={className} style={prepareStyles(Object.assign({}, styles.root, style))}>

--- a/src/internal/AppCanvas.js
+++ b/src/internal/AppCanvas.js
@@ -7,7 +7,7 @@ const AppCanvas = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   render() {

--- a/src/internal/AppCanvas.js
+++ b/src/internal/AppCanvas.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
 const AppCanvas = React.createClass({
 
@@ -11,33 +10,11 @@ const AppCanvas = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-  },
-
   render() {
     const {
       baseTheme,
       prepareStyles,
-    } = this.state.muiTheme;
+    } = this.context.muiTheme;
 
     const styles = {
       height: '100%',

--- a/src/internal/BeforeAfterWrapper.js
+++ b/src/internal/BeforeAfterWrapper.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 
 /**
  *  BeforeAfterWrapper
@@ -61,34 +60,12 @@ const BeforeAfterWrapper = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       beforeElementType: 'div',
       afterElementType: 'div',
       elementType: 'div',
     };
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   render() {
@@ -101,9 +78,7 @@ const BeforeAfterWrapper = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
+    const {prepareStyles} = this.context.muiTheme;
 
     let beforeElement;
     let afterElement;

--- a/src/internal/BeforeAfterWrapper.js
+++ b/src/internal/BeforeAfterWrapper.js
@@ -57,7 +57,7 @@ const BeforeAfterWrapper = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/internal/CircleRipple.js
+++ b/src/internal/CircleRipple.js
@@ -14,7 +14,7 @@ const CircleRipple = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   mixins: [

--- a/src/internal/CircleRipple.js
+++ b/src/internal/CircleRipple.js
@@ -9,19 +9,12 @@ const CircleRipple = React.createClass({
   propTypes: {
     aborted: React.PropTypes.bool,
     color: React.PropTypes.string,
-
-    /**
-     * @ignore
-     * The material-ui theme applied to this component.
-     */
-    muiTheme: React.PropTypes.object.isRequired,
-
     opacity: React.PropTypes.number,
-
-    /**
-     * Override the inline-styles of the root element.
-     */
     style: React.PropTypes.object,
+  },
+
+  contextTypes: {
+    muiTheme: React.PropTypes.object,
   },
 
   mixins: [
@@ -68,27 +61,26 @@ const CircleRipple = React.createClass({
     const style = ReactDOM.findDOMNode(this).style;
     const transitionValue = `${transitions.easeOut('2s', 'opacity')}, ${
       transitions.easeOut('1s', 'transform')}`;
-    autoPrefix.set(style, 'transition', transitionValue, this.props.muiTheme);
-    autoPrefix.set(style, 'transform', 'scale(1)', this.props.muiTheme);
+    autoPrefix.set(style, 'transition', transitionValue);
+    autoPrefix.set(style, 'transform', 'scale(1)');
   },
 
   _initializeAnimation(callback) {
     const style = ReactDOM.findDOMNode(this).style;
     style.opacity = this.props.opacity;
-    autoPrefix.set(style, 'transform', 'scale(0)', this.props.muiTheme);
+    autoPrefix.set(style, 'transform', 'scale(0)');
     this.leaveTimer = setTimeout(callback, 0);
   },
 
   render() {
     const {
       color,
-      muiTheme: {
-        prepareStyles,
-      },
       opacity, // eslint-disable-line no-unused-vars
       style,
       ...other,
     } = this.props;
+
+    const {prepareStyles} = this.context.muiTheme;
 
     const mergedStyles = Object.assign({
       position: 'absolute',

--- a/src/internal/EnhancedButton.js
+++ b/src/internal/EnhancedButton.js
@@ -67,9 +67,9 @@ const EnhancedButton = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
-  
+
   getDefaultProps() {
     return {
       containerElement: 'button',

--- a/src/internal/EnhancedButton.js
+++ b/src/internal/EnhancedButton.js
@@ -4,7 +4,6 @@ import Events from '../utils/events';
 import keycode from 'keycode';
 import FocusRipple from './FocusRipple';
 import TouchRipple from './TouchRipple';
-import getMuiTheme from '../styles/getMuiTheme';
 
 let styleInjected = false;
 let listening = false;
@@ -60,10 +59,6 @@ const EnhancedButton = React.createClass({
     onKeyUp: React.PropTypes.func,
     onKeyboardFocus: React.PropTypes.func,
     onTouchTap: React.PropTypes.func,
-
-    /**
-     * Override the inline-styles of the root element.
-     */
     style: React.PropTypes.object,
     tabIndex: React.PropTypes.number,
     touchRippleColor: React.PropTypes.string,
@@ -74,11 +69,7 @@ const EnhancedButton = React.createClass({
   contextTypes: {
     muiTheme: React.PropTypes.object,
   },
-
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
+  
   getDefaultProps() {
     return {
       containerElement: 'button',
@@ -99,13 +90,6 @@ const EnhancedButton = React.createClass({
       isKeyboardFocused: !this.props.disabled &&
         this.props.keyboardFocused &&
         !this.props.disableKeyboardFocus,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
     };
   },
 
@@ -114,11 +98,7 @@ const EnhancedButton = React.createClass({
     listenForTabPresses();
   },
 
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-
+  componentWillReceiveProps(nextProps) {
     if ((nextProps.disabled || nextProps.disableKeyboardFocus) &&
       this.state.isKeyboardFocused) {
       this.setState({isKeyboardFocused: false});
@@ -176,7 +156,6 @@ const EnhancedButton = React.createClass({
     const focusRipple = isKeyboardFocused && !disabled && !disableFocusRipple && !disableKeyboardFocus ? (
       <FocusRipple
         color={focusRippleColor}
-        muiTheme={this.state.muiTheme}
         opacity={focusRippleOpacity}
         show={isKeyboardFocused}
       />
@@ -187,7 +166,6 @@ const EnhancedButton = React.createClass({
       <TouchRipple
         centerRipple={centerRipple}
         color={touchRippleColor}
-        muiTheme={this.state.muiTheme}
         opacity={touchRippleOpacity}
       >
         {children}
@@ -286,14 +264,14 @@ const EnhancedButton = React.createClass({
     const {
       prepareStyles,
       enhancedButton,
-    } = this.state.muiTheme;
+    } = this.context.muiTheme;
 
     const mergedStyles = Object.assign({
       border: 10,
       background: 'none',
       boxSizing: 'border-box',
       display: 'inline-block',
-      fontFamily: this.state.muiTheme.rawTheme.fontFamily,
+      fontFamily: this.context.muiTheme.rawTheme.fontFamily,
       WebkitTapHighlightColor: enhancedButton.tapHighlightColor, // Remove mobile color flashing (deprecated)
       cursor: disabled ? 'default' : 'pointer',
       textDecoration: 'none',

--- a/src/internal/EnhancedButton.js
+++ b/src/internal/EnhancedButton.js
@@ -271,7 +271,7 @@ const EnhancedButton = React.createClass({
       background: 'none',
       boxSizing: 'border-box',
       display: 'inline-block',
-      fontFamily: this.context.muiTheme.rawTheme.fontFamily,
+      fontFamily: this.context.muiTheme.baseTheme.fontFamily,
       WebkitTapHighlightColor: enhancedButton.tapHighlightColor, // Remove mobile color flashing (deprecated)
       cursor: disabled ? 'default' : 'pointer',
       textDecoration: 'none',

--- a/src/internal/EnhancedButton.spec.js
+++ b/src/internal/EnhancedButton.spec.js
@@ -3,12 +3,15 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import {assert} from 'chai';
 import EnhancedButton from './EnhancedButton';
+import getMuiTheme from '../styles/getMuiTheme';
 
 describe('<EnhancedButton />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
   const testChildren = <div className="unique">Hello World</div>;
 
   it('renders a button', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <EnhancedButton>Button</EnhancedButton>
     );
     assert.ok(wrapper.text(), 'Button', 'should say Button');
@@ -16,7 +19,7 @@ describe('<EnhancedButton />', () => {
   });
 
   it('renders a link when href is provided & linkButton is true', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <EnhancedButton href="http://google.com" linkButton={true}>Button</EnhancedButton>
     );
     assert.ok(wrapper.text(), 'Button', 'should say Button');
@@ -24,7 +27,7 @@ describe('<EnhancedButton />', () => {
   });
 
   it('renders any container element', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <EnhancedButton containerElement={<div />}>Button</EnhancedButton>
     );
     assert.ok(wrapper.text(), 'Button', 'should say Button');
@@ -32,14 +35,14 @@ describe('<EnhancedButton />', () => {
   });
 
   it('renders children', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <EnhancedButton backgroundColor="red">{testChildren}</EnhancedButton>
     );
     assert.ok(wrapper.contains(testChildren), 'should contain the children');
   });
 
   it('renders a disabled button when disabled={true} which blocks onTouchTap from firing', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <EnhancedButton disabled={true}>Button</EnhancedButton>
     );
     assert.ok(wrapper.text(), 'Button', 'should say Button');
@@ -58,7 +61,7 @@ describe('<EnhancedButton />', () => {
   });
 
   it('renders a dummy link button when disabled={true} which blocks onTouchTap from firing', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <EnhancedButton
         disabled={true}
         href="http://google.com"
@@ -84,7 +87,7 @@ describe('<EnhancedButton />', () => {
   });
 
   it('can be styled', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <EnhancedButton style={{color: 'red'}}>Button</EnhancedButton>
     );
     assert.ok(wrapper.text(), 'Button', 'should say Button');
@@ -92,7 +95,7 @@ describe('<EnhancedButton />', () => {
   });
 
   it('overrides default styles', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <EnhancedButton>Button</EnhancedButton>
     );
 
@@ -106,7 +109,7 @@ describe('<EnhancedButton />', () => {
   });
 
   it('can set the button type', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <EnhancedButton type="submit">Button</EnhancedButton>
     );
     assert.ok(wrapper.text(), 'Button', 'should say Button');
@@ -116,7 +119,7 @@ describe('<EnhancedButton />', () => {
   });
 
   it('passes through other html attributes', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <EnhancedButton name="hello">Button</EnhancedButton>
     );
     assert.ok(wrapper.is('button[name="hello"]'), 'should have the name attribute');
@@ -126,7 +129,7 @@ describe('<EnhancedButton />', () => {
     const eventStack = [];
     eventStack.reset = () => eventStack.splice(0, eventStack.length);
 
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <EnhancedButton
         disableKeyboardFocus={true}
         onFocus={() => eventStack.push('focus')}
@@ -152,7 +155,7 @@ describe('<EnhancedButton />', () => {
   });
 
   it('has a TouchRipple and controls it using props', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <EnhancedButton
         centerRipple={true}
         touchRippleColor="red"
@@ -171,14 +174,14 @@ describe('<EnhancedButton />', () => {
   });
 
   it('has no TouchRipple when disableTouchRipple={true}', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <EnhancedButton disableTouchRipple={true}>Button</EnhancedButton>
     );
     assert.strictEqual(wrapper.find('TouchRipple').length, 0, 'should not have a TouchRipple');
   });
 
   it('has a FocusRipple when keyboard focused (tracked internally) and controls it using props', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <EnhancedButton
         focusRippleColor="red"
         focusRippleOpacity={0.8}
@@ -220,7 +223,7 @@ describe('<EnhancedButton />', () => {
   });
 
   it('removes a FocusRipple on blur', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <EnhancedButton>Button</EnhancedButton>
     );
     wrapper.setState({
@@ -232,7 +235,7 @@ describe('<EnhancedButton />', () => {
   });
 
   it('has no ripples when both are disabled', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <EnhancedButton
         keyboardFocused={true}
         disableFocusRipple={true}
@@ -246,7 +249,7 @@ describe('<EnhancedButton />', () => {
   });
 
   it('has no ripples when button is disabled', () => {
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <EnhancedButton keyboardFocused={true} disabled={true}>Button</EnhancedButton>
     );
     assert.strictEqual(wrapper.find('TouchRipple').length, 0, 'should not have a TouchRipple');
@@ -257,7 +260,7 @@ describe('<EnhancedButton />', () => {
     const eventStack = [];
     eventStack.reset = () => eventStack.splice(0, eventStack.length);
 
-    const wrapper = shallow(
+    const wrapper = shallowWithContext(
       <EnhancedButton
         keyboardFocused={true}
         onTouchTap={() => eventStack.push('touchTap')}

--- a/src/internal/EnhancedSwitch.js
+++ b/src/internal/EnhancedSwitch.js
@@ -127,23 +127,17 @@ const EnhancedSwitch = React.createClass({
       (nextProps.hasOwnProperty('defaultSwitched') &&
       (nextProps.defaultSwitched !== this.props.defaultSwitched));
 
-    const newState = {};
+    if (hasCheckedProp || hasToggledProp || hasNewDefaultProp) {
+      const switched = nextProps.checked || nextProps.toggled || nextProps.defaultSwitched;
 
-    if (hasCheckedProp) {
-      newState.switched = nextProps.checked;
-    } else if (hasToggledProp) {
-      newState.switched = nextProps.toggled;
-    } else if (hasNewDefaultProp) {
-      newState.switched = nextProps.defaultSwitched;
+      this.setState({
+        switched: switched,
+      });
+
+      if (this.props.onParentShouldUpdate && switched !== this.props.switched) {
+        this.props.onParentShouldUpdate(switched);
+      }
     }
-
-    if (newState.switched !== undefined &&
-      newState.switched !== this.props.switched &&
-      this.props.onParentShouldUpdate) {
-      this.props.onParentShouldUpdate(newState.switched);
-    }
-
-    this.setState(newState);
   },
 
   isSwitched() {

--- a/src/internal/EnhancedSwitch.js
+++ b/src/internal/EnhancedSwitch.js
@@ -103,7 +103,7 @@ const EnhancedSwitch = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getInitialState() {

--- a/src/internal/EnhancedSwitch.js
+++ b/src/internal/EnhancedSwitch.js
@@ -5,13 +5,10 @@ import transitions from '../styles/transitions';
 import FocusRipple from './FocusRipple';
 import TouchRipple from './TouchRipple';
 import Paper from './../Paper';
-import getMuiTheme from '../styles/getMuiTheme';
 import warning from 'warning';
 
-function getStyles(props, state) {
-  const {
-    baseTheme,
-  } = state.muiTheme;
+function getStyles(props, context) {
+  const {baseTheme} = context.muiTheme;
 
   return {
     root: {
@@ -74,10 +71,6 @@ const EnhancedSwitch = React.createClass({
 
   propTypes: {
     checked: React.PropTypes.bool,
-
-    /**
-     * The css class name of the root element.
-     */
     className: React.PropTypes.string,
     defaultSwitched: React.PropTypes.bool,
     disableFocusRipple: React.PropTypes.bool,
@@ -101,10 +94,6 @@ const EnhancedSwitch = React.createClass({
     onTouchStart: React.PropTypes.func,
     rippleColor: React.PropTypes.string,
     rippleStyle: React.PropTypes.object,
-
-    /**
-     * Override the inline-styles of the root element.
-     */
     style: React.PropTypes.object,
     switchElement: React.PropTypes.element.isRequired,
     switched: React.PropTypes.bool.isRequired,
@@ -117,20 +106,9 @@ const EnhancedSwitch = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getInitialState() {
     return {
       isKeyboardFocused: false,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
     };
   },
 
@@ -142,16 +120,14 @@ const EnhancedSwitch = React.createClass({
     }
   },
 
-  componentWillReceiveProps(nextProps, nextContext) {
+  componentWillReceiveProps(nextProps) {
     const hasCheckedProp = nextProps.hasOwnProperty('checked');
     const hasToggledProp = nextProps.hasOwnProperty('toggled');
     const hasNewDefaultProp =
       (nextProps.hasOwnProperty('defaultSwitched') &&
       (nextProps.defaultSwitched !== this.props.defaultSwitched));
 
-    const newState = {
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    };
+    const newState = {};
 
     if (hasCheckedProp) {
       newState.switched = nextProps.checked;
@@ -311,11 +287,8 @@ const EnhancedSwitch = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
     const wrapStyles = Object.assign(styles.wrap, iconStyle);
     const mergedRippleStyle = Object.assign(styles.ripple, rippleStyle);
 
@@ -339,7 +312,7 @@ const EnhancedSwitch = React.createClass({
         key="touchRipple"
         style={mergedRippleStyle}
         color={mergedRippleStyle.color}
-        muiTheme={this.state.muiTheme}
+        muiTheme={this.context.muiTheme}
         centerRipple={true}
       />
     );
@@ -349,7 +322,7 @@ const EnhancedSwitch = React.createClass({
         key="focusRipple"
         innerStyle={mergedRippleStyle}
         color={mergedRippleStyle.color}
-        muiTheme={this.state.muiTheme}
+        muiTheme={this.context.muiTheme}
         show={this.state.isKeyboardFocused}
       />
     );

--- a/src/internal/FocusRipple.js
+++ b/src/internal/FocusRipple.js
@@ -18,7 +18,7 @@ const FocusRipple = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   mixins: [

--- a/src/internal/FocusRipple.js
+++ b/src/internal/FocusRipple.js
@@ -12,20 +12,13 @@ const FocusRipple = React.createClass({
   propTypes: {
     color: React.PropTypes.string,
     innerStyle: React.PropTypes.object,
-
-    /**
-     * @ignore
-     * The material-ui theme applied to this component.
-     */
-    muiTheme: React.PropTypes.object.isRequired,
-
     opacity: React.PropTypes.number,
     show: React.PropTypes.bool,
-
-    /**
-     * Override the inline-styles of the root element.
-     */
     style: React.PropTypes.object,
+  },
+
+  contextTypes: {
+    muiTheme: React.PropTypes.object,
   },
 
   mixins: [
@@ -56,12 +49,10 @@ const FocusRipple = React.createClass({
     const {
       color,
       innerStyle,
-      muiTheme: {
-        prepareStyles,
-        ripple,
-      },
       opacity,
     } = props;
+
+    const {prepareStyles, ripple} = this.context.muiTheme;
 
     const innerStyles = Object.assign({
       position: 'absolute',
@@ -85,7 +76,7 @@ const FocusRipple = React.createClass({
     const currentScale = innerCircle.style.transform || startScale;
     const nextScale = currentScale === startScale ? endScale : startScale;
 
-    autoPrefix.set(innerCircle.style, 'transform', nextScale, this.props.muiTheme);
+    autoPrefix.set(innerCircle.style, 'transform', nextScale);
     this.timeout = setTimeout(this.pulsate, pulsateDuration);
   },
 

--- a/src/internal/Overlay.js
+++ b/src/internal/Overlay.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import getMuiTheme from '../styles/getMuiTheme';
 import transitions from '../styles/transitions';
 
-function getStyles(props, state) {
-  const {overlay} = state.muiTheme;
+function getStyles(props, context) {
+  const {overlay} = context.muiTheme;
 
   const style = {
     root: {
@@ -63,23 +62,13 @@ const Overlay = React.createClass({
     };
   },
 
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
   componentDidMount() {
     if (this.props.show) {
       this._applyAutoLockScrolling(this.props);
     }
   },
 
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
-
+  componentWillReceiveProps(nextProps) {
     if (this.props.show !== nextProps.show) {
       this._applyAutoLockScrolling(nextProps);
     }
@@ -124,11 +113,8 @@ const Overlay = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
-
-    const styles = getStyles(this.props, this.state);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
 
     return (
       <div {...other} ref="overlay" style={prepareStyles(Object.assign(styles.root, style))} />

--- a/src/internal/Overlay.js
+++ b/src/internal/Overlay.js
@@ -51,7 +51,7 @@ const Overlay = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/internal/RenderToLayer.js
+++ b/src/internal/RenderToLayer.js
@@ -13,7 +13,7 @@ const RenderToLayer = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/internal/RenderToLayer.js
+++ b/src/internal/RenderToLayer.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Dom from '../utils/dom';
-import getMuiTheme from '../styles/getMuiTheme';
 
 // heavily inspired by https://github.com/Khan/react-components/blob/master/js/layered-component-mixin.jsx
 const RenderToLayer = React.createClass({
@@ -17,40 +16,14 @@ const RenderToLayer = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  //for passing default theme context to children
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       useLayerForClickAway: true,
     };
   },
 
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
   componentDidMount() {
     this._renderLayer();
-  },
-
-  //to update theme inside state whenever a new theme is passed down
-  //from the parent / owner using context
-  componentWillReceiveProps(nextProps, nextContext) {
-    const newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({
-      muiTheme: newMuiTheme,
-    });
   },
 
   componentDidUpdate() {
@@ -123,7 +96,7 @@ const RenderToLayer = React.createClass({
           this._layer.style.bottom = 0;
           this._layer.style.left = 0;
           this._layer.style.right = 0;
-          this._layer.style.zIndex = this.state.muiTheme.zIndex.layer;
+          this._layer.style.zIndex = this.context.muiTheme.zIndex.layer;
         } else {
           setTimeout(() => {
             window.addEventListener('touchstart', this.onClickAway);

--- a/src/internal/ScaleIn.js
+++ b/src/internal/ScaleIn.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactTransitionGroup from 'react-addons-transition-group';
 import ScaleInChild from './ScaleInChild';
-import getMuiTheme from '../styles/getMuiTheme';
 
 const ScaleIn = React.createClass({
 
@@ -22,31 +21,10 @@ const ScaleIn = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps() {
     return {
       enterDelay: 0,
     };
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    const newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
   },
 
   render() {
@@ -60,9 +38,7 @@ const ScaleIn = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
+    const {prepareStyles} = this.context.muiTheme;
 
     const mergedRootStyles = Object.assign({}, {
       position: 'relative',

--- a/src/internal/ScaleIn.js
+++ b/src/internal/ScaleIn.js
@@ -18,7 +18,7 @@ const ScaleIn = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/internal/ScaleInChild.js
+++ b/src/internal/ScaleInChild.js
@@ -14,7 +14,7 @@ const ScaleInChild = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps: function() {

--- a/src/internal/ScaleInChild.js
+++ b/src/internal/ScaleInChild.js
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import autoPrefix from '../utils/autoPrefix';
 import transitions from '../styles/transitions';
-import getMuiTheme from '../styles/getMuiTheme';
 
 const ScaleInChild = React.createClass({
 
@@ -11,18 +10,10 @@ const ScaleInChild = React.createClass({
     enterDelay: React.PropTypes.number,
     maxScale: React.PropTypes.number,
     minScale: React.PropTypes.number,
-
-    /**
-     * Override the inline-styles of the root element.
-     */
     style: React.PropTypes.object,
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  childContextTypes: {
     muiTheme: React.PropTypes.object,
   },
 
@@ -32,23 +23,6 @@ const ScaleInChild = React.createClass({
       maxScale: 1,
       minScale: 0,
     };
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    const newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
   },
 
   componentWillUnmount() {
@@ -76,7 +50,7 @@ const ScaleInChild = React.createClass({
     const style = ReactDOM.findDOMNode(this).style;
 
     style.opacity = '0';
-    autoPrefix.set(style, 'transform', `scale(${this.props.minScale})`, this.state.muiTheme);
+    autoPrefix.set(style, 'transform', `scale(${this.props.minScale})`);
 
     this.leaveTimer = setTimeout(callback, 450);
   },
@@ -85,14 +59,14 @@ const ScaleInChild = React.createClass({
     const style = ReactDOM.findDOMNode(this).style;
 
     style.opacity = '1';
-    autoPrefix.set(style, 'transform', `scale(${this.props.maxScale})`, this.state.muiTheme);
+    autoPrefix.set(style, 'transform', `scale(${this.props.maxScale})`);
   },
 
   _initializeAnimation(callback) {
     const style = ReactDOM.findDOMNode(this).style;
 
     style.opacity = '0';
-    autoPrefix.set(style, 'transform', 'scale(0)', this.state.muiTheme);
+    autoPrefix.set(style, 'transform', 'scale(0)');
 
     this.enterTimer = setTimeout(callback, this.props.enterDelay);
   },
@@ -105,9 +79,7 @@ const ScaleInChild = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
+    const {prepareStyles} = this.context.muiTheme;
 
     const mergedRootStyles = Object.assign({}, {
       position: 'absolute',

--- a/src/internal/SlideIn.js
+++ b/src/internal/SlideIn.js
@@ -13,7 +13,7 @@ const SlideIn = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/internal/SlideIn.js
+++ b/src/internal/SlideIn.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactTransitionGroup from 'react-addons-transition-group';
 import SlideInChild from './SlideInChild';
-import getMuiTheme from '../styles/getMuiTheme';
 
 const SlideIn = React.createClass({
 
@@ -10,18 +9,10 @@ const SlideIn = React.createClass({
     children: React.PropTypes.node,
     direction: React.PropTypes.oneOf(['left', 'right', 'up', 'down']),
     enterDelay: React.PropTypes.number,
-
-    /**
-     * Override the inline-styles of the root element.
-     */
     style: React.PropTypes.object,
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
-  childContextTypes: {
     muiTheme: React.PropTypes.object,
   },
 
@@ -30,23 +21,6 @@ const SlideIn = React.createClass({
       enterDelay: 0,
       direction: 'left',
     };
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    const newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
   },
 
   _getLeaveDirection() {
@@ -63,9 +37,7 @@ const SlideIn = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
+    const {prepareStyles} = this.context.muiTheme;
 
     const mergedRootStyles = Object.assign({}, {
       position: 'relative',

--- a/src/internal/SlideInChild.js
+++ b/src/internal/SlideInChild.js
@@ -15,7 +15,7 @@ const SlideInChild = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps: function() {

--- a/src/internal/SlideInChild.js
+++ b/src/internal/SlideInChild.js
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import autoPrefix from '../utils/autoPrefix';
 import transitions from '../styles/transitions';
-import getMuiTheme from '../styles/getMuiTheme';
 
 const SlideInChild = React.createClass({
 
@@ -10,13 +9,8 @@ const SlideInChild = React.createClass({
     children: React.PropTypes.node,
     direction: React.PropTypes.string,
     enterDelay: React.PropTypes.number,
-    //This callback is needed bacause
-    //the direction could change when leaving the dom
+    // This callback is needed bacause the direction could change when leaving the DOM
     getLeaveDirection: React.PropTypes.func.isRequired,
-
-    /**
-     * Override the inline-styles of the root element.
-     */
     style: React.PropTypes.object,
   },
 
@@ -24,31 +18,10 @@ const SlideInChild = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getDefaultProps: function() {
     return {
       enterDelay: 0,
     };
-  },
-
-  getInitialState() {
-    return {
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
-    };
-  },
-
-  componentWillReceiveProps(nextProps, nextContext) {
-    const newMuiTheme = nextContext.muiTheme ? nextContext.muiTheme : this.state.muiTheme;
-    this.setState({muiTheme: newMuiTheme});
   },
 
   componentWillUnmount() {
@@ -64,7 +37,7 @@ const SlideInChild = React.createClass({
       this.props.direction === 'down' ? '-100%' : '0';
 
     style.opacity = '0';
-    autoPrefix.set(style, 'transform', `translate3d(${x}, ${y}, 0)`, this.state.muiTheme);
+    autoPrefix.set(style, 'transform', `translate3d(${x}, ${y}, 0)`);
 
     this.enterTimer = setTimeout(callback, this.props.enterDelay);
   },
@@ -72,7 +45,7 @@ const SlideInChild = React.createClass({
   componentDidEnter() {
     const style = ReactDOM.findDOMNode(this).style;
     style.opacity = '1';
-    autoPrefix.set(style, 'transform', 'translate3d(0,0,0)', this.state.muiTheme);
+    autoPrefix.set(style, 'transform', 'translate3d(0,0,0)');
   },
 
   componentWillLeave(callback) {
@@ -84,7 +57,7 @@ const SlideInChild = React.createClass({
       direction === 'down' ? '100%' : '0';
 
     style.opacity = '0';
-    autoPrefix.set(style, 'transform', `translate3d(${x}, ${y}, 0)`, this.state.muiTheme);
+    autoPrefix.set(style, 'transform', `translate3d(${x}, ${y}, 0)`);
 
     this.leaveTimer = setTimeout(callback, 450);
   },
@@ -98,9 +71,7 @@ const SlideInChild = React.createClass({
       ...other,
     } = this.props;
 
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
+    const {prepareStyles} = this.context.muiTheme;
 
     const mergedRootStyles = Object.assign({}, {
       position: 'absolute',

--- a/src/internal/Tooltip.js
+++ b/src/internal/Tooltip.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import transitions from '../styles/transitions';
-import getMuiTheme from '../styles/getMuiTheme';
 
-function getStyles(props, state) {
+function getStyles(props, context, state) {
   const verticalPosition = props.verticalPosition;
   const horizontalPosition = props.horizontalPosition;
   const touchMarginOffset = props.touch ? 10 : 0;
@@ -14,7 +13,7 @@ function getStyles(props, state) {
     baseTheme,
     zIndex,
     tooltip,
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   const styles = {
     root: {
@@ -101,20 +100,9 @@ const Tooltip = React.createClass({
     muiTheme: React.PropTypes.object,
   },
 
-  childContextTypes: {
-    muiTheme: React.PropTypes.object,
-  },
-
   getInitialState() {
     return {
       offsetWidth: null,
-      muiTheme: this.context.muiTheme || getMuiTheme(),
-    };
-  },
-
-  getChildContext() {
-    return {
-      muiTheme: this.state.muiTheme,
     };
   },
 
@@ -123,11 +111,8 @@ const Tooltip = React.createClass({
     this._setTooltipPosition();
   },
 
-  componentWillReceiveProps(nextProps, nextContext) {
+  componentWillReceiveProps() {
     this._setTooltipPosition();
-    this.setState({
-      muiTheme: nextContext.muiTheme || this.state.muiTheme,
-    });
   },
 
   componentDidUpdate() {
@@ -157,15 +142,13 @@ const Tooltip = React.createClass({
   },
 
   render() {
-    const {
-      prepareStyles,
-    } = this.state.muiTheme;
+    const {prepareStyles} = this.context.muiTheme;
 
     const {
       label,
       ...other,
     } = this.props;
-    const styles = getStyles(this.props, this.state);
+    const styles = getStyles(this.props, this.context, this.state);
 
     return (
       <div

--- a/src/internal/Tooltip.js
+++ b/src/internal/Tooltip.js
@@ -97,7 +97,7 @@ const Tooltip = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getInitialState() {

--- a/src/internal/TouchRipple.js
+++ b/src/internal/TouchRipple.js
@@ -22,19 +22,12 @@ const TouchRipple = React.createClass({
     centerRipple: React.PropTypes.bool,
     children: React.PropTypes.node,
     color: React.PropTypes.string,
-
-    /**
-     * @ignore
-     * The material-ui theme applied to this component.
-     */
-    muiTheme: React.PropTypes.object.isRequired,
-
     opacity: React.PropTypes.number,
-
-    /**
-     * Override the inline-styles of the root element.
-     */
     style: React.PropTypes.object,
+  },
+
+  contextTypes: {
+    muiTheme: React.PropTypes.object,
   },
 
   getDefaultProps() {
@@ -61,7 +54,7 @@ const TouchRipple = React.createClass({
   },
 
   start(event, isRippleTouchGenerated) {
-    const theme = this.props.muiTheme.ripple;
+    const theme = this.context.muiTheme.ripple;
 
     if (this._ignoreNextMouseDown && !isRippleTouchGenerated) {
       this._ignoreNextMouseDown = false;
@@ -74,7 +67,6 @@ const TouchRipple = React.createClass({
     ripples = push(ripples, (
       <CircleRipple
         key={this.state.nextKey}
-        muiTheme={this.props.muiTheme}
         style={!this.props.centerRipple ? this._getRippleStyle(event) : {}}
         color={this.props.color || theme.color}
         opacity={this.props.opacity}
@@ -207,22 +199,13 @@ const TouchRipple = React.createClass({
     return Math.sqrt((a * a) + (b * b));
   },
 
-
   render() {
-    const {
-      children,
-      muiTheme: {
-        prepareStyles,
-      },
-      style,
-    } = this.props;
-
-    const {
-      hasRipples,
-      ripples,
-    } = this.state;
+    const {children, style} = this.props;
+    const {hasRipples, ripples} = this.state;
+    const {prepareStyles} = this.context.muiTheme;
 
     let rippleGroup;
+
     if (hasRipples) {
       const mergedStyles = Object.assign({
         height: '100%',

--- a/src/internal/TouchRipple.js
+++ b/src/internal/TouchRipple.js
@@ -27,7 +27,7 @@ const TouchRipple = React.createClass({
   },
 
   contextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: React.PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/styles/MuiThemeProvider.js
+++ b/src/styles/MuiThemeProvider.js
@@ -1,4 +1,5 @@
 import {Component, PropTypes} from 'react';
+import getMuiTheme from './getMuiTheme';
 
 class MuiThemeProvider extends Component {
 
@@ -13,7 +14,7 @@ class MuiThemeProvider extends Component {
 
   getChildContext() {
     return {
-      muiTheme: this.props.muiTheme,
+      muiTheme: this.props.muiTheme || getMuiTheme(),
     };
   }
 

--- a/src/styles/MuiThemeProvider.js
+++ b/src/styles/MuiThemeProvider.js
@@ -9,7 +9,7 @@ class MuiThemeProvider extends Component {
   };
 
   static childContextTypes = {
-    muiTheme: PropTypes.object,
+    muiTheme: PropTypes.object.isRequired,
   };
 
   getChildContext() {

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -5,7 +5,6 @@ export DarkRawTheme from './baseThemes/darkBaseTheme';
 export lightBaseTheme from './baseThemes/lightBaseTheme';
 export LightRawTheme from './baseThemes/lightBaseTheme';
 export getMuiTheme from './getMuiTheme';
-export muiThemeable from './muiThemeable';
 export spacing from './spacing';
 export themeManager from './themeManager';
 export transitions from './transitions';

--- a/src/styles/muiThemeable.js
+++ b/src/styles/muiThemeable.js
@@ -13,9 +13,7 @@ function getDefaultTheme() {
 export default function muiThemeable() {
   return (Component) => {
     const MuiComponent = (props, context) => {
-      const {
-        muiTheme = getDefaultTheme(),
-      } = context;
+      const {muiTheme = getDefaultTheme()} = context;
 
       return <Component muiTheme={muiTheme} {...props} />;
     };

--- a/src/styles/muiThemeable.js
+++ b/src/styles/muiThemeable.js
@@ -21,7 +21,7 @@ export default function muiThemeable() {
     };
 
     MuiComponent.contextTypes = {
-      muiTheme: React.PropTypes.object,
+      muiTheme: React.PropTypes.object.isRequired,
     };
 
     return MuiComponent;

--- a/src/styles/themeDecorator.js
+++ b/src/styles/themeDecorator.js
@@ -7,7 +7,7 @@ export default (customTheme) => {
   return function(Component) {
     return React.createClass({
       childContextTypes: {
-        muiTheme: React.PropTypes.object,
+        muiTheme: React.PropTypes.object.isRequired,
       },
 
       getChildContext() {

--- a/src/utils/colorManipulator.js
+++ b/src/utils/colorManipulator.js
@@ -129,7 +129,6 @@ export default {
     return this._convertColorToString(color);
   },
 
-
   // Calculates the contrast ratio between two colors.
   //
   // Formula: http://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef

--- a/src/utils/rtl.js
+++ b/src/utils/rtl.js
@@ -78,4 +78,3 @@ export default function rtl(muiTheme) {
   }
 }
 
-

--- a/src/utils/stylePropable.js
+++ b/src/utils/stylePropable.js
@@ -25,7 +25,8 @@ export default {
     warn();
     const {
       prepareStyles = (style) => (style),
-    } = (this.state && this.state.muiTheme) || (this.context && this.context.muiTheme) ||
+    } = (this.state && this.state.muiTheme) ||
+        (this.context && this.context.muiTheme) ||
         (this.props && this.props.muiTheme) || {};
 
     return prepareStyles(mergeStyles(...args));

--- a/test/browser/dialog-spec.js
+++ b/test/browser/dialog-spec.js
@@ -2,12 +2,19 @@ import React from 'react';
 import Dialog from 'Dialog';
 import {spy} from 'sinon';
 import TestUtils from 'react-addons-test-utils';
+import injectTheme from './fixtures/inject-theme';
 
 describe('Dialog', () => {
+  let ThemedDialog;
+
+  beforeEach(() => {
+    ThemedDialog = injectTheme(Dialog);
+  });
+
   it('appends a dialog to the document body', () => {
     const testClass = 'test-dialog-class';
     TestUtils.renderIntoDocument(
-      <Dialog
+      <ThemedDialog
         open={true}
         contentClassName={testClass}
       />
@@ -22,7 +29,7 @@ describe('Dialog', () => {
     const testClass = 'dialog-action';
 
     TestUtils.renderIntoDocument(
-      <Dialog
+      <ThemedDialog
         open={true}
         actions={[
           <button

--- a/test/browser/es6-module-exports-spec.js
+++ b/test/browser/es6-module-exports-spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
+import injectTheme from './fixtures/inject-theme';
 
 const Divider = require('Divider').default;
 const ActionAccessibility = require('svg-icons').ActionAccessibility;
@@ -10,16 +11,20 @@ const RequireGetMuiTheme = require('styles/getMuiTheme').default;
 import ImportColorManipulator from 'utils/colorManipulator';
 const RequireColorManipulator = require('utils/colorManipulator').default;
 
-describe('require() style import of ', () => {
+describe('require() style import of ', ()
+  => {
+  const ThemedDivider = injectTheme(Divider);
+  const ThemedActionAccessibility = injectTheme(ActionAccessibility);
+
   it('Divider component should not fail when rendering', () => {
     expect(() => {
-      TestUtils.renderIntoDocument(<Divider />);
+      TestUtils.renderIntoDocument(<ThemedDivider />);
     }).to.not.throw(Error);
   });
 
   it('ActionAccessibility component should not fail when rendering', () => {
     expect(() => {
-      TestUtils.renderIntoDocument(<ActionAccessibility />);
+      TestUtils.renderIntoDocument(<ThemedActionAccessibility />);
     }).to.not.throw(Error);
   });
 

--- a/test/browser/theming-v12-spec.js
+++ b/test/browser/theming-v12-spec.js
@@ -11,16 +11,6 @@ import darkBaseTheme from 'styles/baseThemes/darkBaseTheme';
 import {deepPurpleA700} from 'styles/colors';
 
 describe('Theming', () => {
-  describe('When no theme is specified, AppBar', () => {
-    it('should display with default light theme', () => {
-      const renderedAppbar = TestUtils.renderIntoDocument(<AppBar />);
-      const appbarDivs = TestUtils.scryRenderedDOMComponentsWithTag(renderedAppbar, 'div');
-      const firstDiv = appbarDivs[0];
-
-      expect(firstDiv.style.backgroundColor).to.equal('rgb(0, 188, 212)');
-    });
-  });
-
   describe('When the dark theme is specified', () => {
     describe('using context / react lifecycle methods, AppBar', () => {
       it('should display with passed down dark theme', () => {

--- a/test/browser/time-picker/time-picker-spec.js
+++ b/test/browser/time-picker/time-picker-spec.js
@@ -3,14 +3,24 @@ import TextField from 'TextField';
 import TimePicker from 'TimePicker';
 import DateTime from 'utils/dateTime';
 import TestUtils from 'react-addons-test-utils';
+import injectTheme from '../fixtures/inject-theme';
 
 describe('TimePicker', () => {
+  let ThemedTimePicker;
+
+  beforeEach(() => {
+    ThemedTimePicker = injectTheme(TimePicker);
+  });
+
   it('has to give value prop precedence over defaultTime', () => {
     const initialTime = new Date(1448967059892); // Tue, 01 Dec 2015 10:50:59 GMT
     const valueTime = DateTime.addHours(initialTime, 2);
 
     const render = TestUtils.renderIntoDocument(
-      <TimePicker value={valueTime} format="ampm" locale="en-US"
+      <ThemedTimePicker
+        value={valueTime}
+        format="ampm"
+        locale="en-US"
         initialTime={initialTime}
       />
     );
@@ -24,9 +34,7 @@ describe('TimePicker', () => {
     const initialTime = new Date(1448967059892); // Tue, 01 Dec 2015 10:50:59 GMT
 
     const render = TestUtils.renderIntoDocument(
-      <TimePicker format="ampm" locale="en-US"
-        defaultTime={initialTime}
-      />
+      <ThemedTimePicker format="ampm" locale="en-US" defaultTime={initialTime} />
     );
 
     const timeTextField = TestUtils.findRenderedComponentWithType(render, TextField);
@@ -39,7 +47,10 @@ describe('TimePicker', () => {
     const valueTime = new Date(1448967059892); // Tue, 01 Dec 2015 10:50:59 GM
 
     const render = TestUtils.renderIntoDocument(
-      <TimePicker value={valueTime} format="ampm" locale="en-US"
+      <ThemedTimePicker
+        value={valueTime}
+        format="ampm"
+        locale="en-US"
         defaultTime={initialTime}
       />
     );


### PR DESCRIPTION
After some investigation prompted by a question from @nathanmarks about themes, it seems there is a huge amount of boilerplate associated with ensuring a theme is available when none has been defined already on context. (#1662).

Having every component check for the existence of `muiTheme` on context, and adding it if not found, results in significant added complexity to the code. This reduces code clarity and maintainability, and in some cases introduced state solely for the purpose of moving `muiTheme` through the pipeline.

By removing this code we significantly simplify the components. In addition several components are now stateless as a result.

A developer using MUI will need to pass a theme on context once in their app, (for example with `MuIThemeProvider`), so the tradeoff is 2 lines of code for the user, vs nearly 2000 in MUI.

**TL;DR**: This PR removes the code from components that adds a theme if not already on context.