### PR TITLE
[Tests] Add process.exit() call when nodemon quits

### DIFF
--- a/test/unit.watch.js
+++ b/test/unit.watch.js
@@ -13,6 +13,7 @@ Nodemon.on('start', () => {
   console.log('Unit tests have started');
 }).on('quit', () => {
   console.log('Unit tests have quit');
+  process.exit();
 }).on('restart', (files) => {
   console.log('Unit tests restarted due to: ', files);
 });


### PR DESCRIPTION
@callemall/material-ui This is rather important, otherwise the watch command doesn't properly quit the node process and will restart the tests again before an error throws. 

