### PR TITLE
[eslint] Pin babel-eslint temporarily to avoid peer dependency conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "app-module-path": "^1.0.5",
     "babel-cli": "^6.3.17",
     "babel-core": "^6.3.21",
-    "babel-eslint": "^5.0.0",
+    "babel-eslint": "5.0.0",
     "babel-loader": "^6.2.0",
     "babel-plugin-transform-dev-warning": "^0.1.0",
     "babel-plugin-transform-react-constant-elements": "^6.3.13",


### PR DESCRIPTION
@mbrookes This addresses the peer dependency conflict caused by this while we figure out a v6 upgrade plan: https://github.com/babel/babel-eslint/commit/e29eedb037bab1b88cf44403aff9db0a1c4e400b