### PR TITLE
[ES6] Remove any right-hand-side expressions that are not simple

### DIFF
--- a/src/List/List.js
+++ b/src/List/List.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PureRenderMixin from 'react-addons-pure-render-mixin';
 import propTypes from '../utils/propTypes';
 import getMuiTheme from '../styles/getMuiTheme';
 import Subheader from '../Subheader';
@@ -53,10 +52,6 @@ const List = React.createClass({
   childContextTypes: {
     muiTheme: React.PropTypes.object,
   },
-
-  mixins: [
-    PureRenderMixin,
-  ],
 
   getInitialState() {
     return {

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -86,7 +86,7 @@ const ListItem = React.createClass({
      */
     nestedListStyle: React.PropTypes.object,
 
-/**
+    /**
      * Callback function fired when the `ListItem` is focused or blurred by the keyboard.
      *
      * @param {object} event `focus` or `blur` event targeting the `ListItem`.

--- a/src/Paper/Paper.js
+++ b/src/Paper/Paper.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PureRenderMixin from 'react-addons-pure-render-mixin';
 import propTypes from '../utils/propTypes';
 import transitions from '../styles/transitions';
 import getMuiTheme from '../styles/getMuiTheme';
@@ -73,10 +72,6 @@ const Paper = React.createClass({
   childContextTypes: {
     muiTheme: React.PropTypes.object,
   },
-
-  mixins: [
-    PureRenderMixin,
-  ],
 
   getDefaultProps() {
     return {

--- a/src/RefreshIndicator/RefreshIndicator.js
+++ b/src/RefreshIndicator/RefreshIndicator.js
@@ -123,10 +123,6 @@ const RefreshIndicator = React.createClass({
     clearTimeout(this.rotateWrapperSecondTimer);
   },
 
-  scalePathTimer: undefined,
-  rotateWrapperTimer: undefined,
-  rotateWrapperSecondTimer: undefined,
-
   _renderChildren() {
     const {
       prepareStyles,

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -213,12 +213,6 @@ const Snackbar = React.createClass({
     clearTimeout(this.timerOneAtTheTimeId);
   },
 
-  manuallyBindClickAway: true,
-
-  timerAutoHideId: undefined,
-  timerTransitionId: undefined,
-  timerOneAtTheTimeId: undefined,
-
   componentClickAway() {
     if (this.timerTransitionId) return; // If transitioning, don't close snackbar
 

--- a/src/TimePicker/ClockHours.js
+++ b/src/TimePicker/ClockHours.js
@@ -76,9 +76,6 @@ const ClockHours = React.createClass({
     });
   },
 
-  center: {x: 0, y: 0},
-  basePoint: {x: 0, y: 0},
-
   isMousePressed(event) {
     if (typeof event.buttons === 'undefined') {
       return event.nativeEvent.which;

--- a/src/TimePicker/ClockMinutes.js
+++ b/src/TimePicker/ClockMinutes.js
@@ -72,9 +72,6 @@ const ClockMinutes = React.createClass({
     });
   },
 
-  center: {x: 0, y: 0},
-  basePoint: {x: 0, y: 0},
-
   isMousePressed(event) {
     if (typeof event.buttons === 'undefined') {
       return event.nativeEvent.which;

--- a/src/Toolbar/ToolbarGroup.js
+++ b/src/Toolbar/ToolbarGroup.js
@@ -131,14 +131,18 @@ const ToolbarGroup = React.createClass({
     });
   },
 
-  _handleMouseEnterFontIcon: (style) => (event) => {
-    event.target.style.zIndex = style.hover.zIndex;
-    event.target.style.color = style.hover.color;
+  handleMouseEnterFontIcon(style) {
+    return (event) => {
+      event.target.style.zIndex = style.hover.zIndex;
+      event.target.style.color = style.hover.color;
+    };
   },
 
-  _handleMouseLeaveFontIcon: (style) => (event) => {
-    event.target.style.zIndex = 'auto';
-    event.target.style.color = style.root.color;
+  handleMouseLeaveFontIcon(style) {
+    return (event) => {
+      event.target.style.zIndex = 'auto';
+      event.target.style.color = style.root.color;
+    };
   },
 
   render() {
@@ -177,8 +181,8 @@ const ToolbarGroup = React.createClass({
         case 'FontIcon' :
           return React.cloneElement(currentChild, {
             style: Object.assign({}, styles.icon.root, currentChild.props.style),
-            onMouseEnter: this._handleMouseEnterFontIcon(styles.icon),
-            onMouseLeave: this._handleMouseLeaveFontIcon(styles.icon),
+            onMouseEnter: this.handleMouseEnterFontIcon(styles.icon),
+            onMouseLeave: this.handleMouseLeaveFontIcon(styles.icon),
           });
         case 'ToolbarSeparator' :
         case 'ToolbarTitle' :

--- a/src/internal/EnhancedButton.js
+++ b/src/internal/EnhancedButton.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PureRenderMixin from 'react-addons-pure-render-mixin';
 import {createChildFragment} from '../utils/childUtils';
 import Events from '../utils/events';
 import keycode from 'keycode';
@@ -79,8 +78,6 @@ const EnhancedButton = React.createClass({
   childContextTypes: {
     muiTheme: React.PropTypes.object,
   },
-
-  mixins: [PureRenderMixin],
 
   getDefaultProps() {
     return {

--- a/src/internal/ScaleIn.js
+++ b/src/internal/ScaleIn.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PureRenderMixin from 'react-addons-pure-render-mixin';
 import ReactTransitionGroup from 'react-addons-transition-group';
 import ScaleInChild from './ScaleInChild';
 import getMuiTheme from '../styles/getMuiTheme';
@@ -26,10 +25,6 @@ const ScaleIn = React.createClass({
   childContextTypes: {
     muiTheme: React.PropTypes.object,
   },
-
-  mixins: [
-    PureRenderMixin,
-  ],
 
   getDefaultProps() {
     return {

--- a/src/internal/ScaleInChild.js
+++ b/src/internal/ScaleInChild.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import PureRenderMixin from 'react-addons-pure-render-mixin';
 import autoPrefix from '../utils/autoPrefix';
 import transitions from '../styles/transitions';
 import getMuiTheme from '../styles/getMuiTheme';
@@ -26,10 +25,6 @@ const ScaleInChild = React.createClass({
   childContextTypes: {
     muiTheme: React.PropTypes.object,
   },
-
-  mixins: [
-    PureRenderMixin,
-  ],
 
   getDefaultProps: function() {
     return {

--- a/src/internal/TouchRipple.js
+++ b/src/internal/TouchRipple.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import PureRenderMixin from 'react-addons-pure-render-mixin';
 import ReactTransitionGroup from 'react-addons-transition-group';
 import Dom from '../utils/dom';
 import CircleRipple from './CircleRipple';
@@ -37,10 +36,6 @@ const TouchRipple = React.createClass({
      */
     style: React.PropTypes.object,
   },
-
-  mixins: [
-    PureRenderMixin,
-  ],
 
   getDefaultProps() {
     return {


### PR DESCRIPTION
The [pure-render-mixin](https://github.com/reactjs/react-codemod#pure-render-mixin) codemod doesn't seem to work on our code base. We will probably have to do it by hand ( < 5 components).
I have removed the `PureRenderMixin` from the component that almost always take a `children` property.
That will save us some CPU cycles.