### PR TITLE
[Tests] Remove env setting from unit test file

### DIFF
--- a/src/Slider/Slider.spec.js
+++ b/src/Slider/Slider.spec.js
@@ -55,7 +55,7 @@ describe('<Slider />', () => {
       <Slider name="slider" style={rootStyle} />
     );
 
-    assert.deepEqual(wrapper.props().style, rootStyle, 'root element should have the style object');
+    assert.strictEqual(wrapper.props().style.backgroundColor, 'red', 'root element should have the style object');
   });
 
   it('checks slider initial state', () => {

--- a/test/unit.js
+++ b/test/unit.js
@@ -2,9 +2,6 @@ import Minimist from 'minimist';
 import Mocha from 'mocha';
 import Glob from 'glob';
 
-// Stops all sorts of React warnings popping up in unit tests
-process.env.NODE_ENV = 'production';
-
 const argv = Minimist(process.argv.slice(2), {
   alias: {
     c: 'component',
@@ -16,7 +13,7 @@ const mocha = new Mocha({
   grep: argv.grep ? argv.grep : undefined,
 });
 
-Glob(`src/**/*${argv.component ? argv.component : ''}*.spec.js`, {}, (err, files) => {
+Glob(`src/**/${argv.component ? argv.component : '*'}.spec.js`, {}, (err, files) => {
   files.forEach((file) => mocha.addFile(file));
 
   mocha.run((failures) => {


### PR DESCRIPTION
I had set `NODE_ENV=production` in the unit test file entry point, which tripped up @oliviertassinari . The reasons I had it there are not necessary in our test suite at this point (not firing prop validation functions for perf testing, or other annoying warnings, but there's probably a better workaround anyways).

I also altered a unit test as it was failing since the `muiPrepared` key is in the style object now.