### PR TITLE
[AutoComplete] Allow devs to hook into onKeyDown

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -138,6 +138,11 @@ class AutoComplete extends React.Component {
     onFocus: React.PropTypes.func,
 
     /**
+     * Callback function that is fired when the `TextField` receives a keydown event.
+     */
+    onKeyDown: React.PropTypes.func,
+
+    /**
      * Callback function that is fired when a list item is selected, or enter is pressed in the `TextField`.
      *
      * @param {string} chosenRequest Either the `TextField` input value, if enter is pressed in the `TextField`,
@@ -296,6 +301,8 @@ class AutoComplete extends React.Component {
   };
 
   handleKeyDown = (event) => {
+    if (this.props.onKeyDown) this.props.onKeyDown(event);
+
     switch (keycode(event)) {
       case 'enter':
         this.close();


### PR DESCRIPTION
I found myself wanting to pass a `onKeyDown` prop into `AutoComplete` to check for backspace, but realized that the component totally took it over without allowing me to hook into it at all. This PR changes that.