### PR TITLE
[AutoComplete] Fix first item selection on keyboard focus

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -479,6 +479,7 @@ class AutoComplete extends React.Component {
         disableAutoFocus={focusTextField}
         onEscKeyDown={this.handleEscKeyDown}
         initiallyKeyboardFocused={false}
+        keyboardFocused={true}
         onItemTouchTap={this.handleItemTouchTap}
         onMouseDown={this.handleMouseDown}
         style={Object.assign(styles.menu, menuStyle)}

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -103,6 +103,11 @@ class Menu extends React.Component {
     initiallyKeyboardFocused: React.PropTypes.bool,
 
     /**
+    * If true, the menu will be focused by the keyboard.
+    */
+    keyboardFocused: React.PropTypes.bool,
+
+    /**
      * Override the inline-styles of the underlying `List` element.
      */
     listStyle: React.PropTypes.object,
@@ -205,6 +210,7 @@ class Menu extends React.Component {
     desktop: false,
     disableAutoFocus: false,
     initiallyKeyboardFocused: false,
+    isKeyboardFocused: null,
     maxHeight: null,
     multiple: false,
     onChange: () => {},
@@ -224,7 +230,7 @@ class Menu extends React.Component {
 
     this.state = {
       focusIndex: props.disableAutoFocus ? -1 : selectedIndex >= 0 ? selectedIndex : 0,
-      isKeyboardFocused: props.initiallyKeyboardFocused,
+      isKeyboardFocused: props.keyboardFocused !== null ? props.keyboardFocused : props.initiallyKeyboardFocused,
       keyWidth: props.desktop ? 64 : 56,
     };
   }
@@ -242,6 +248,7 @@ class Menu extends React.Component {
     this.setState({
       focusIndex: nextProps.disableAutoFocus ? -1 : selectedIndex >= 0 ? selectedIndex : 0,
       keyWidth: nextProps.desktop ? 64 : 56,
+      isKeyboardFocused: nextProps.keyboardFocused !== null ? nextProps.keyboardFocused : this.state.isKeyboardFocused,
     });
   }
 


### PR DESCRIPTION
This fix first item selection at autocomplete popover, described at #3629.
If you type 'a' in the input, and hit down arrow to select the first item, you don't see the selection, if you press again, the second item will be selected.
http://www.material-ui.com/#/components/auto-complete

Fixes #3629.