### PR TITLE
 [DatePicker & TimePicker] ok/cancel labels in date/time pickers should be of PropTypes.node

### DIFF
--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -22,7 +22,7 @@ class DatePicker extends React.Component {
     /**
      * Override the default text of the 'Cancel' button.
      */
-    cancelLabel: React.PropTypes.string,
+    cancelLabel: React.PropTypes.node,
 
     /**
      * Used to control how the DatePicker will be displayed when a user tries to set a date.
@@ -91,7 +91,7 @@ class DatePicker extends React.Component {
     /**
      * Override the default text of the 'OK' button.
      */
-    okLabel: React.PropTypes.string,
+    okLabel: React.PropTypes.node,
 
     /**
      * Callback function that is fired when the date value changes.

--- a/src/DatePicker/DatePickerDialog.js
+++ b/src/DatePicker/DatePickerDialog.js
@@ -11,7 +11,7 @@ class DatePickerDialog extends React.Component {
   static propTypes = {
     DateTimeFormat: React.PropTypes.func,
     autoOk: React.PropTypes.bool,
-    cancelLabel: React.PropTypes.string,
+    cancelLabel: React.PropTypes.node,
     container: React.PropTypes.oneOf(['dialog', 'inline']),
     disableYearSelection: React.PropTypes.bool,
     firstDayOfWeek: React.PropTypes.number,
@@ -20,7 +20,7 @@ class DatePickerDialog extends React.Component {
     maxDate: React.PropTypes.object,
     minDate: React.PropTypes.object,
     mode: React.PropTypes.oneOf(['portrait', 'landscape']),
-    okLabel: React.PropTypes.string,
+    okLabel: React.PropTypes.node,
     onAccept: React.PropTypes.func,
     onDismiss: React.PropTypes.func,
     onShow: React.PropTypes.func,

--- a/src/TimePicker/TimePicker.js
+++ b/src/TimePicker/TimePicker.js
@@ -20,7 +20,7 @@ class TimePicker extends React.Component {
     /**
      * Override the label of the 'Cancel' button.
      */
-    cancelLabel: React.PropTypes.string,
+    cancelLabel: React.PropTypes.node,
 
     /**
      * The initial time value of the TimePicker.
@@ -40,7 +40,7 @@ class TimePicker extends React.Component {
     /**
      * Override the label of the 'OK' button.
      */
-    okLabel: React.PropTypes.string,
+    okLabel: React.PropTypes.node,
 
     /**
      * Callback function that is fired when the time value changes. The time value is passed in a Date Object.

--- a/src/TimePicker/TimePickerDialog.js
+++ b/src/TimePicker/TimePickerDialog.js
@@ -8,10 +8,10 @@ import FlatButton from '../FlatButton';
 class TimePickerDialog extends React.Component {
   static propTypes = {
     autoOk: React.PropTypes.bool,
-    cancelLabel: React.PropTypes.string,
+    cancelLabel: React.PropTypes.node,
     format: React.PropTypes.oneOf(['ampm', '24hr']),
     initialTime: React.PropTypes.object,
-    okLabel: React.PropTypes.string,
+    okLabel: React.PropTypes.node,
     onAccept: React.PropTypes.func,
     onDismiss: React.PropTypes.func,
     onShow: React.PropTypes.func,


### PR DESCRIPTION
fixes #3864.

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).