### PR TITLE
use 'babel-loader' as loader

### DIFF
--- a/examples/webpack-example/package.json
+++ b/examples/webpack-example/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "babel-core": "^6.3.26",
     "babel-eslint": "^6.0.0",
+    "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "eslint": "^2.5.1",

--- a/examples/webpack-example/webpack-dev-server.config.js
+++ b/examples/webpack-example/webpack-dev-server.config.js
@@ -45,7 +45,7 @@ const config = {
       {
         //React-hot loader and
         test: /\.js$/,  //All .js files
-        loaders: ['react-hot', 'babel'], //react-hot is like browser sync and babel loads jsx and es6-7
+        loaders: ['react-hot', 'babel-loader'], //react-hot is like browser sync and babel loads jsx and es6-7
         exclude: [nodeModulesPath],
       },
     ],


### PR DESCRIPTION
When cloning the repo and trying to `npm run start` the webpack-example, people will run into

```
ERROR in multi main
Module not found: Error: Cannot resolve module 'babel' in /home/user/material-ui/examples/webpack-example
 @ multi main

```

to avoid this error I added `'babel-loader'` as devDependency and changed _webpack-dev-server.config.js_ to use `'babel-loader'`. 