### PR TITLE
[Slider] Add example showing how to access value

### DIFF
--- a/docs/src/app/components/pages/components/Slider/ExampleControlled.js
+++ b/docs/src/app/components/pages/components/Slider/ExampleControlled.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import Slider from 'material-ui/Slider';
+
+export default class SliderExampleControlled extends React.Component {
+
+  state = {
+    firstSlider: 0.5,
+    secondSlider: 50,
+  }
+
+  handleFirstSlider(event, value) {
+    this.setState({firstSlider: value});
+  }
+
+  handleSecondSlider(event, value) {
+    this.setState({secondSlider: value});
+  }
+
+  render() {
+    return (
+      <div>
+        <Slider
+          defaultValue={0.5}
+          value={this.state.firstSlider}
+          onChange={this.handleFirstSlider.bind(this)}
+        />
+        <p>
+          <span>{'The value of this slider is: '}</span>
+          <span>{this.state.firstSlider}</span>
+          <span>{' from a range of 0 to 1 inclusive'}</span>
+        </p>
+        <Slider
+          min={0}
+          max={100}
+          step={1}
+          defaultValue={50}
+          value={this.state.secondSlider}
+          onChange={this.handleSecondSlider.bind(this)}
+        />
+        <p>
+          <span>{'The value of this slider is: '}</span>
+          <span>{this.state.secondSlider}</span>
+          <span>{' from a range of 0 to 100 inclusive'}</span>
+        </p>
+      </div>
+    );
+  }
+
+}

--- a/docs/src/app/components/pages/components/Slider/Page.js
+++ b/docs/src/app/components/pages/components/Slider/Page.js
@@ -12,6 +12,8 @@ import SliderExampleDisabled from './ExampleDisabled';
 import sliderExampleDisabledCode from '!raw!./ExampleDisabled';
 import SliderExampleStep from './ExampleStep';
 import sliderExampleStepCode from '!raw!./ExampleStep';
+import SliderExampleControlled from './ExampleControlled';
+import sliderExampleControlledCode from '!raw!./ExampleControlled';
 import sliderCode from '!raw!material-ui/lib/Slider/Slider';
 
 const descriptions = {
@@ -19,6 +21,8 @@ const descriptions = {
   'not at the starting position.',
   stepped: 'By default, the slider is continuous. The `step` property causes the slider to move in discrete ' +
   'increments.',
+  value: 'The slider bar can have a set minimum and maximum, and the value can be ' +
+  'obtained through the value parameter fired on an onChange event.',
 };
 
 const SliderPage = () => (
@@ -45,6 +49,14 @@ const SliderPage = () => (
     >
       <SliderExampleStep />
     </CodeExample>
+    <CodeExample
+      title="Controlled Examples"
+      description={descriptions.value}
+      code={sliderExampleControlledCode}
+    >
+      <SliderExampleControlled />
+    </CodeExample>
+
     <PropTypeDescription code={sliderCode} />
   </div>
 );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has ~~tests~~ / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

---

Issue: It was not clear from the documentation how, exactly, to grab the value from the Slider component, as this was not mentioned on the component page.  As [Standardization of Callback Signatures #2957 states](https://github.com/callemall/material-ui/issues/2957), the way to handle this is onChange={(event, value) => /*use 'value' here*/} in most cases. I had erroneously tried (event) => event.target.value and (value) => value, and it caused me enough frustration that I felt that when I figured it out I should make a PR and add it to the docs. 

The main thing that would have helped me, I think, was to have examples which clearly show how to get the value from the slider element and use it (usually in the component state). 

I created a new file in /docs/src/app/components/pages/Slider/ExampleValue.js and amended /docs/src/app/components/pages/Slider/Page.js to include two examples, where moving the slider also alters the slider's value in the state, and re-renders it on the page.  As a bonus, I also amended Page.js to make it clear that you can assign values outside the range of 0 and 1 (such as 1-100) to "min" and "max" props. 

![slider](https://cloud.githubusercontent.com/assets/3599223/14340853/4ec0b6fa-fc51-11e5-9ec6-4a246f11217e.png)





