### PR TITLE
[ListItem] Use the new icons to follow the material spec

### DIFF
--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -5,8 +5,8 @@ import ColorManipulator from '../utils/colorManipulator';
 import transitions from '../styles/transitions';
 import EnhancedButton from '../internal/EnhancedButton';
 import IconButton from '../IconButton';
-import OpenIcon from '../svg-icons/navigation/arrow-drop-up';
-import CloseIcon from '../svg-icons/navigation/arrow-drop-down';
+import OpenIcon from '../svg-icons/navigation/expand-less';
+import CloseIcon from '../svg-icons/navigation/expand-more';
 import NestedList from './NestedIist';
 
 function getStyles(props, context, state) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Closes: https://github.com/callemall/material-ui/issues/3873

Added the keyboard-arrow-up and keyboard-arrow-down icons from the material-spec and replaced the existing list-item up and down arrows with them.

Before: 

![screen shot 2016-04-07 at 12 20 19 pm](https://cloud.githubusercontent.com/assets/15271922/14360257/288605ca-fcbb-11e5-91ff-73bd5d8e9ea6.png)

After:

![screen shot 2016-04-07 at 12 19 45 pm](https://cloud.githubusercontent.com/assets/15271922/14360259/2e923a88-fcbb-11e5-98cd-e476adc32ead.png)


https://www.google.com/design/spec/components/lists-controls.html#lists-controls-types-of-list-controls


