### PR TITLE
[Docs] Add react-addons-pure-render-mixin to docs devDependencies

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -39,6 +39,7 @@
     "marked": "^0.3.5",
     "raw-loader": "^0.5.1",
     "react-addons-perf": "^0.14.0",
+    "react-addons-pure-render-mixin": "^0.14.0",
     "react-docgen": "^2.4.0",
     "react-hot-loader": "^1.2.8",
     "react-motion": "^0.4.2",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted. __(N/A)__
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Several pages in the docs have `import PureRenderMixin from 'react-addons-pure-render-mixin';`, but the `react-addons-pure-render-mixin` package is not listed as a dependency in [docs/package.json](https://github.com/callemall/material-ui/blob/master/docs/package.json) (nor in the root [package.json](https://github.com/callemall/material-ui/blob/master/package.json)).  To get the docs site working locally, I had to `npm i --save-dev react-addons-pure-render-mixin`.