### PR TITLE
[IconMenu] Removed props.ref call

### DIFF
--- a/src/IconMenu/IconMenu.js
+++ b/src/IconMenu/IconMenu.js
@@ -171,7 +171,6 @@ class IconMenu extends React.Component {
   };
 
   state = {
-    iconButtonRef: this.props.iconButtonElement.props.ref || 'iconButton',
     menuInitiallyKeyboardFocused: false,
     open: false,
   };
@@ -205,7 +204,7 @@ class IconMenu extends React.Component {
     this.setState({open: false}, () => {
       // Set focus on the icon button when the menu close
       if (isKeyboard) {
-        const iconButton = this.refs[this.state.iconButtonRef];
+        const iconButton = this.refs.iconButton;
         ReactDOM.findDOMNode(iconButton).focus();
         iconButton.setKeyboardFocus();
       }
@@ -293,7 +292,7 @@ class IconMenu extends React.Component {
         this.open(Events.isKeyboard(event) ? 'keyboard' : 'iconTap', event);
         if (iconButtonElement.props.onTouchTap) iconButtonElement.props.onTouchTap(event);
       },
-      ref: this.state.iconButtonRef,
+      ref: 'iconButton',
     });
 
     const menu = (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.  __(Feature had no demo before, so none was created for this PR)__
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Calls to props.ref will throw a warning in React v15.

This commit adds a prop to IconMenu called `iconButtonRef` that, if
provided, will be passed down to the child IconButton element as its ref.
The iconButtonRef element has been removed from the state object, since it
never changes after the component is initialized.

The new React warnings are discussed in this PR:
https://github.com/facebook/react/issues/5744
