### PR TITLE
[TableHeaderColumn][TableRow][TableRowColumn] Remove props.key calls

### DIFF
--- a/src/Table/TableHeaderColumn.js
+++ b/src/Table/TableHeaderColumn.js
@@ -40,11 +40,6 @@ class TableHeaderColumn extends React.Component {
     columnNumber: React.PropTypes.number,
 
     /**
-     * Key prop for table header column.
-     */
-    key: React.PropTypes.string,
-
-    /**
      * @ignore
      * Callback function for click event.
      */
@@ -122,7 +117,6 @@ class TableHeaderColumn extends React.Component {
 
     return (
       <th
-        key={this.props.key}
         className={className}
         style={prepareStyles(Object.assign(styles.root, style))}
         {...handlers}

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -209,7 +209,7 @@ class TableRow extends React.Component {
         return React.cloneElement(child, {
           columnNumber: columnNumber,
           hoverable: this.props.hoverable,
-          key: child.props.key || `${this.props.rowNumber}-${columnNumber}`,
+          key: `${this.props.rowNumber}-${columnNumber}`,
           onClick: this.onCellClick,
           onHover: this.onCellHover,
           onHoverExit: this.onCellHoverExit,

--- a/src/Table/TableRowColumn.js
+++ b/src/Table/TableRowColumn.js
@@ -46,11 +46,6 @@ class TableRowColumn extends React.Component {
     hoverable: React.PropTypes.bool,
 
     /**
-     * Key for this element.
-     */
-    key: React.PropTypes.string,
-
-    /**
      * @ignore
      * Callback function for click event.
      */
@@ -128,7 +123,6 @@ class TableRowColumn extends React.Component {
 
     return (
       <td
-        key={this.props.key}
         className={className}
         style={prepareStyles(Object.assign(styles.root, style))}
         {...handlers}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Calls to `props.key` will throw a warning in React v15 (see [here](facebook/react#5744)).

This commit removes calls to props.key in `TableHeaderColumn`, `TableRow`, and `TableRowColumn`.  `TableRow` children are given an auto-generated `key`, and children of `TableHeaderColumn` and `TableRowColumn` can define their own `key`s as needed.  As far as I can tell, passing a component's `key` prop down to the root element of that component is unnecessary, even if a `key` is required for the component.

This PR is referenced here:  https://github.com/callemall/material-ui/pull/3913#issuecomment-207823360
