### PR TITLE
[Core] Improve import path for published lib

### DIFF
--- a/docs/src/app/components/pages/components/SvgIcon/README.md
+++ b/docs/src/app/components/pages/components/SvgIcon/README.md
@@ -14,6 +14,6 @@ directly as a React component. Any properties supplied are passed to `SvgIcon`.
 
 The import path for each _Material icons_ component includes the category and icon name, with spaces substituted with
 dashes. For example to use the [3d rotation](https://design.google.com/icons/#ic_3d_rotation) icon component, import
-`material-ui/lib/svg-icons/action/3d-rotation`.
+`material-ui/svg-icons/action/3d-rotation`.
 
 ### Examples

--- a/docs/src/app/components/pages/customization/themes.md
+++ b/docs/src/app/components/pages/customization/themes.md
@@ -24,7 +24,7 @@ Then, you can use `<MuiThemeProvider />` to provide it down the tree to componen
 ```js
 import React from 'react';
 import {cyan500} from 'material-ui/styles/colors';
-import MuiThemeProvider from 'material-ui/stylesMuiThemeProvider';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import AppBar from 'material-ui/AppBar';
 

--- a/package.json
+++ b/package.json
@@ -1,31 +1,15 @@
 {
-  "name": "material-ui",
+  "name": "material-ui-build",
+  "private": true,
   "author": "Call-em-all Engineering Team",
   "version": "0.15.0-alpha.2",
   "description": "Material Design UI components built with React",
-  "main": "./lib",
-  "scripts": {
-    "build": "babel ./src --ignore *.spec.js --out-dir ./lib",
-    "build:icon-index": "cd src/svg-icons/ && babel-node index-generator.js",
-    "coverage": "npm run test",
-    "coverage:combine": "istanbul report --dir test/coverage/combined --include test/**/*coverage.json text-summary lcovonly json",
-    "lint": "eslint src docs/src test/browser test/unit && echo \"eslint: no lint errors\"",
-    "prebuild": "rimraf lib",
-    "prepublish": "in-publish && npm run build || not-in-publish",
-    "test": "npm run test:unit && npm run test:browser && npm run test:unit:coverage && npm run coverage:combine",
-    "test:browser": "npm run test:browser:base -- --single-run",
-    "test:browser:watch": "npm run test:browser:base -- --auto-watch",
-    "test:browser:base": "karma start test/karma.conf.js",
-    "test:unit": "babel-node test/unit.js",
-    "test:unit:watch": "babel-node test/unit.watch.js",
-    "test:unit:coverage": "babel-node node_modules/.bin/isparta cover --report lcovonly --include-all-sources --dir test/coverage/unit test/unit.js"
-  },
+  "main": "./src/index.js",
   "keywords": [
     "react",
     "react-component",
     "material design",
-    "material-ui",
-    "material ui"
+    "material-ui"
   ],
   "repository": {
     "type": "git",
@@ -36,6 +20,29 @@
     "url": "https://github.com/callemall/material-ui/issues"
   },
   "homepage": "http://material-ui.com/",
+  "scripts": {
+    "build": "npm run build:icon-index && npm run build:babel && npm run build:copy-files",
+    "build:icon-index": "babel-node ./scripts/icon-index-generator.js",
+    "build:babel": "babel ./src --ignore *.spec.js --out-dir ./build",
+    "build:copy-files": "babel-node ./scripts/copy-files.js",
+    "clean:build": "rimraf build",
+    "coverage": "npm run test",
+    "coverage:combine": "istanbul report --dir test/coverage/combined --include test/**/*coverage.json text-summary lcovonly json",
+    "lint": "eslint src docs/src test/browser test/unit && echo \"eslint: no lint errors\"",
+    "prebuild": "npm run clean:build",
+    "test": "npm run test:unit && npm run test:browser && npm run test:unit:coverage && npm run coverage:combine",
+    "test:browser": "npm run test:browser:base -- --single-run",
+    "test:browser:watch": "npm run test:browser:base -- --auto-watch",
+    "test:browser:base": "karma start test/karma.conf.js",
+    "test:unit": "babel-node test/unit.js",
+    "test:unit:watch": "babel-node test/unit.watch.js",
+    "test:unit:coverage": "babel-node node_modules/.bin/isparta cover --report lcovonly --include-all-sources --dir test/coverage/unit test/unit.js"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
+    "react-tap-event-plugin": "^0.2.0"
+  },
   "dependencies": {
     "inline-style-prefixer": "^1.0.2",
     "keycode": "^2.1.0",
@@ -50,15 +57,6 @@
     "simple-assign": "^0.1.0",
     "warning": "^2.1.0"
   },
-  "peerDependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0",
-    "react-tap-event-plugin": "^0.2.0"
-  },
-  "files": [
-    "lib",
-    "src"
-  ],
   "devDependencies": {
     "app-module-path": "^1.0.5",
     "babel-cli": "^6.3.17",
@@ -82,8 +80,8 @@
     "eslint-plugin-babel": "^3.1.0",
     "eslint-plugin-material-ui": "./packages/eslint-plugin-material-ui",
     "eslint-plugin-react": "^4.0.0",
+    "fs-extra": "^0.26.7",
     "glob": "^7.0.0",
-    "in-publish": "^2.0.0",
     "isparta": "^4.0.0",
     "isparta-loader": "^2.0.0",
     "istanbul": "^0.4.2",

--- a/scripts/copy-files.js
+++ b/scripts/copy-files.js
@@ -1,0 +1,85 @@
+/* eslint-disable no-console */
+import path from 'path';
+import fse from 'fs-extra';
+
+const files = [
+  'README.md',
+  'CHANGELOG.md',
+  'LICENSE',
+];
+
+Promise.all(
+  files.map((file) => copyFile(file))
+)
+.then(() => createPackageFile());
+
+function copyFile(file) {
+  const buildPath = resolveBuildPath(file);
+  return new Promise((resolve) => {
+    fse.copy(
+      file,
+      buildPath,
+      (err) => {
+        if (err) throw err;
+        resolve();
+      }
+    );
+  })
+  .then(() => console.log(`Copied ${file} to ${buildPath}`));
+}
+
+function resolveBuildPath(file) {
+  return path.resolve(__dirname, '../build/', path.basename(file));
+}
+
+function createPackageFile() {
+  return new Promise((resolve) => {
+    fse.readFile(path.resolve(__dirname, '../package.json'), 'utf8', (err, data) => {
+      if (err) {
+        throw err;
+      }
+
+      resolve(data);
+    });
+  })
+  .then((data) => JSON.parse(data))
+  .then((packageData) => {
+    const {
+      author,
+      version,
+      description,
+      keywords,
+      repository,
+      license,
+      bugs,
+      homepage,
+      peerDependencies,
+      dependencies,
+    } = packageData;
+
+    const minimalPackage = {
+      name: 'material-ui',
+      author,
+      version,
+      description,
+      main: './index.js',
+      keywords,
+      repository,
+      license,
+      bugs,
+      homepage,
+      peerDependencies,
+      dependencies,
+    };
+
+    return new Promise((resolve) => {
+      const buildPath = path.resolve(__dirname, '../build/package.json');
+      const data = JSON.stringify(minimalPackage, null, 2);
+      fse.writeFile(buildPath, data, (err) => {
+        if (err) throw (err);
+        console.log(`Created package.json in ${buildPath}`);
+        resolve();
+      });
+    });
+  });
+}

--- a/scripts/icon-index-generator.js
+++ b/scripts/icon-index-generator.js
@@ -2,8 +2,9 @@ import fs from 'fs';
 import rrs from 'recursive-readdir-sync';
 
 const outArray = [];
+const svgIconPath = 'src/svg-icons/';
 
-rrs('./').forEach((file) => {
+rrs(svgIconPath).forEach((file) => {
   if (file !== 'index-generator.js' && file !== 'index.js') {
     const fileLines = fs.readFileSync(file, 'utf8').split('\n');
     let index = 0;
@@ -12,7 +13,7 @@ rrs('./').forEach((file) => {
     while (found === false && index < fileLines.length) {
       if (fileLines[index].indexOf('export default') > -1) {
         const moduleName = fileLines[index].split(' ')[2].replace(';', '').trim();
-        const modulePath = file.substring(0, file.length - 3);
+        const modulePath = file.substring(0, file.length - 3).replace(svgIconPath, '');
 
         outArray.push(`export ${moduleName} from './${modulePath}';\n`);
 
@@ -24,4 +25,4 @@ rrs('./').forEach((file) => {
   }
 });
 
-fs.writeFileSync('index.js', outArray.join(''));
+fs.writeFileSync(`./${svgIconPath}/index.js`, outArray.join(''));


### PR DESCRIPTION


This addresses #2679 by copying a minimal `package.json` along with the `README.md`, `CHANGELOG.md` and `LICENSE` to the build folder after the JS files have been babel'd. 

I added a script to copy the files and put it under `./scripts/`, I also moved the `svg-icon` index generator script there. 

I haven't added any tests to confirm the output from `npm run build`, but can definitely do so if this is the setup we move forward with.

Let me know if there's anything we need to move over that I forgot...!

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

