### PR TITLE
[MenuItem] Revert flex props from #3597, fixes #3845, reopens #3531

### DIFF
--- a/src/MenuItem/MenuItem.js
+++ b/src/MenuItem/MenuItem.js
@@ -29,16 +29,10 @@ function getStyles(props, context) {
       paddingRight: sidePadding,
       paddingBottom: 0,
       paddingTop: 0,
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignContent: 'space-between',
     },
 
     secondaryText: {
-      order: 2,
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      whiteSpace: 'nowrap',
+      float: 'right',
     },
 
     leftIconDesktop: {


### PR DESCRIPTION
Reverts changes that need a different approach, as discussed in #3845. Reverts changes from #3597 that previously had fixed #3531 

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


