### PR TITLE
[FontIcon] Fix for color and hoverColor being overwritten by some components

### DIFF
--- a/docs/src/app/components/pages/components/Toolbar/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/Toolbar/ExampleSimple.js
@@ -35,7 +35,7 @@ export default class ToolbarExamplesSimple extends React.Component {
         </ToolbarGroup>
         <ToolbarGroup>
           <ToolbarTitle text="Options" />
-          <FontIcon className="muidocs-icon-custom-sort" />
+          <FontIcon className="muidocs-icon-custom-sort" color="green" />
           <ToolbarSeparator />
           <RaisedButton label="Create Broadcast" primary={true} />
           <IconMenu

--- a/src/FontIcon/FontIcon.js
+++ b/src/FontIcon/FontIcon.js
@@ -13,12 +13,14 @@ function getStyles(props, context, state) {
 
   return {
     root: {
-      color: state.hovered ? onColor : offColor,
       position: 'relative',
       fontSize: baseTheme.spacing.iconSize,
       display: 'inline-block',
       userSelect: 'none',
       transition: transitions.easeOut(),
+    },
+    iconColor: {
+      color: state.hovered ? onColor : offColor,
     },
   };
 }
@@ -105,7 +107,7 @@ class FontIcon extends React.Component {
         {...other}
         onMouseLeave={this.handleMouseLeave}
         onMouseEnter={this.handleMouseEnter}
-        style={prepareStyles(Object.assign(styles.root, style))}
+        style={prepareStyles(Object.assign(styles.root, style, styles.iconColor))}
       />
     );
   }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Related to #3759 
I know it may not be the prettiest way to fix it, but I think its good enough 😄 
Any other suggestion?