### PR TITLE
[Core] Remove react-addons-update dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "lodash.throttle": "^4.0.1",
     "react-addons-create-fragment": "^15.0.1",
     "react-addons-transition-group": "^15.0.1",
-    "react-addons-update": "^15.0.1",
     "react-event-listener": "^0.2.1",
     "recompose": "^0.17.0",
     "simple-assign": "^0.1.0",

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -1,6 +1,5 @@
 import React, {Component, PropTypes} from 'react';
 import ReactDOM from 'react-dom';
-import update from 'react-addons-update';
 import shallowEqual from 'recompose/shallowEqual';
 import ClickAwayListener from '../internal/ClickAwayListener';
 import autoPrefix from '../utils/autoPrefix';
@@ -412,9 +411,12 @@ class Menu extends Component {
 
     if (multiple) {
       const itemIndex = menuValue.indexOf(itemValue);
-      const newMenuValue = itemIndex === -1 ?
-        update(menuValue, {$push: [itemValue]}) :
-        update(menuValue, {$splice: [[itemIndex, 1]]});
+      const [...newMenuValue] = menuValue;
+      if (itemIndex === -1) {
+        newMenuValue.push(itemValue);
+      } else {
+        newMenuValue.splice(itemIndex, 1);
+      }
 
       valueLink.requestChange(event, newMenuValue);
     } else if (!multiple && itemValue !== menuValue) {

--- a/src/internal/TouchRipple.js
+++ b/src/internal/TouchRipple.js
@@ -3,17 +3,9 @@ import ReactDOM from 'react-dom';
 import ReactTransitionGroup from 'react-addons-transition-group';
 import Dom from '../utils/dom';
 import CircleRipple from './CircleRipple';
-import update from 'react-addons-update';
 
-function push(array, obj) {
-  const newObj = Array.isArray(obj) ? obj : [obj];
-  return update(array, {$push: newObj});
-}
-
-function shift(array) {
-  // Remove the first element in the array using React immutability helpers
-  return update(array, {$splice: [[0, 1]]});
-}
+// Remove the first element of the array
+const shift = ([, ...newArray]) => newArray;
 
 class TouchRipple extends Component {
   static propTypes = {
@@ -61,7 +53,7 @@ class TouchRipple extends Component {
     let ripples = this.state.ripples;
 
     // Add a ripple to the ripples array
-    ripples = push(ripples, (
+    ripples = [...ripples, (
       <CircleRipple
         key={this.state.nextKey}
         style={!this.props.centerRipple ? this.getRippleStyle(event) : {}}
@@ -69,7 +61,7 @@ class TouchRipple extends Component {
         opacity={this.props.opacity}
         touchGenerated={isRippleTouchGenerated}
       />
-    ));
+    )];
 
     this.ignoreNextMouseDown = isRippleTouchGenerated;
     this.setState({
@@ -140,7 +132,7 @@ class TouchRipple extends Component {
       const abortedRipple = React.cloneElement(ripple, {aborted: true});
       // Remove the old ripple and replace it with the new updated one
       currentRipples = shift(currentRipples);
-      currentRipples = push(currentRipples, abortedRipple);
+      currentRipples = [...currentRipples, abortedRipple];
       this.setState({ripples: currentRipples}, () => {
         // Call end after we've set the ripple to abort otherwise the setState
         // in end() merges with this and the ripple abort fails

--- a/src/styles/themeManager.js
+++ b/src/styles/themeManager.js
@@ -1,4 +1,3 @@
-import update from 'react-addons-update';
 import merge from 'lodash.merge';
 import getMuiTheme from '../styles/getMuiTheme';
 import warning from 'warning';
@@ -7,23 +6,22 @@ export default
   {
     getMuiTheme(baseTheme, muiTheme) {
       warning(false, 'ThemeManager is deprecated. please import getMuiTheme' +
-        ' directly from "material-ui/getMuiTheme"');
+        ' directly from "material-ui/styles/getMuiTheme"');
       return getMuiTheme(baseTheme, muiTheme);
     },
     modifyRawThemeSpacing(muiTheme, spacing) {
       warning(false, 'modifyRawThemeSpacing is deprecated. please use getMuiTheme ' +
         ' to modify your theme directly. http://www.material-ui.com/#/customization/themes');
-      return getMuiTheme(update(muiTheme.baseTheme, {spacing: {$set: spacing}}));
+      return getMuiTheme(merge({}, muiTheme.baseTheme, {spacing}));
     },
     modifyRawThemePalette(muiTheme, palette) {
       warning(false, 'modifyRawThemePalette is deprecated. please use getMuiTheme ' +
         ' to modify your theme directly. http://www.material-ui.com/#/customization/themes');
-      const newPalette = merge(muiTheme.baseTheme.palette, palette);
-      return getMuiTheme(update(muiTheme.baseTheme, {palette: {$set: newPalette}}));
+      return getMuiTheme(merge({}, muiTheme.baseTheme, {baseTheme: {palette}}));
     },
     modifyRawThemeFontFamily(muiTheme, fontFamily) {
       warning(false, 'modifyRawThemeFontFamily is deprecated. please use getMuiTheme ' +
         ' to modify your theme directly. http://www.material-ui.com/#/customization/themes');
-      return getMuiTheme(update(muiTheme.baseTheme, {fontFamily: {$set: fontFamily}}));
+      return getMuiTheme(merge({}, muiTheme.baseTheme, {fontFamily}));
     },
   };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

I think the less react packages we have as a dependency, the better (and this is one less dependency 🎉). Everywhere we were using this package we could use basic ES6 destructuring syntax (or `lodash.merge`).

This is loosely related (though not a prerequisite) to us adding support for React 15. I think it's better if we don't have dependencies to react related packages and only add them as peer dependencies. That way in the future we could possibly support multiple versions of React (such as `0.14.0` and `15.0.0`).