### PR TITLE
[Menu] Fix nested menus that can't be clicked issue

### DIFF
--- a/src/internal/ClickAwayListener.js
+++ b/src/internal/ClickAwayListener.js
@@ -9,7 +9,7 @@ const isDescendant = (el, target) => {
   return false;
 };
 
-const clickAwayEvents = ['mousedown', 'touchstart'];
+const clickAwayEvents = ['mouseup', 'touchend'];
 const bind = (callback) => clickAwayEvents.forEach((event) => events.on(document, event, callback));
 const unbind = (callback) => clickAwayEvents.forEach((event) => events.off(document, event, callback));
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


This fixes a regression that was introduced in https://github.com/callemall/material-ui/pull/3360. The previous `click-awayable` mixin listened on `mouseup` and `touchend` events and the new `ClickAwayListener` was implemented to use `mousedown` and `touchstart` events. This commit changes the events to mimick the behavior from the original mixin.

Resolves #3818