### PR TITLE
[Core] Remove dependency on lodash.flowright

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "dependencies": {
     "inline-style-prefixer": "^1.0.2",
     "keycode": "^2.1.0",
-    "lodash.flowright": "^3.2.1",
     "lodash.merge": "^4.1.0",
     "lodash.throttle": "^4.0.0",
     "react-addons-create-fragment": "^0.14.0",

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -5,7 +5,7 @@ import zIndex from './zIndex';
 import autoprefixer from '../utils/autoprefixer';
 import callOnce from '../utils/callOnce';
 import rtl from '../utils/rtl';
-import compose from 'lodash.flowright';
+import compose from 'recompose/compose';
 import typography from './typography';
 import {
   red500, grey400, grey500, grey600, grey700,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

If `recompose` is here to stay, we might as well remove `lodash.flowright` and use the compose function that `recompose` exports (which happens to be `lodash.flowright`).
