### PR TITLE
[EnhancedButton] Fix ripples not firing in resonse to taps

### DIFF
--- a/src/internal/CircleRipple.js
+++ b/src/internal/CircleRipple.js
@@ -4,10 +4,13 @@ import shallowEqual from 'recompose/shallowEqual';
 import autoPrefix from '../utils/autoPrefix';
 import transitions from '../styles/transitions';
 
+const animationKeyframesAlreadySetUp = {};
+
 class CircleRipple extends React.Component {
   static propTypes = {
     aborted: React.PropTypes.bool,
     color: React.PropTypes.string,
+    onRippleStart: React.PropTypes.func,
     opacity: React.PropTypes.number,
     style: React.PropTypes.object,
   };
@@ -55,18 +58,45 @@ class CircleRipple extends React.Component {
   }
 
   animate() {
-    const style = ReactDOM.findDOMNode(this).style;
-    const transitionValue = `${transitions.easeOut('2s', 'opacity')}, ${
-      transitions.easeOut('1s', 'transform')}`;
-    autoPrefix.set(style, 'transition', transitionValue);
-    autoPrefix.set(style, 'transform', 'scale(1)');
+    // These animations are driven with CSS animations because CSS transitions
+    // don't provide a start even
+    const node = ReactDOM.findDOMNode(this);
+    // TODO: Support prefixing for reals (I'll do this before landing the change)
+    node.addEventListener('webkitAnimationStart', this.props.onRippleStart);
+    // Register the animation for a ripple of this opacity in the style sheets
+    this.setUpAnimationKeyframes(this.props.opacity);
+    node.style.animation = `rippleAnimation 2s ${ transitions.easeOutFunction }`;
   }
 
   initializeAnimation(callback) {
     const style = ReactDOM.findDOMNode(this).style;
-    style.opacity = this.props.opacity;
     autoPrefix.set(style, 'transform', 'scale(0)');
     this.leaveTimer = setTimeout(callback, 0);
+  }
+
+  setUpAnimationKeyframes(opacity) {
+    // Only register keyframes for each opacity once to avoid potential memory
+    // issues
+    if (animationKeyframesAlreadySetUp[opacity]) {
+      return;
+    }
+    // Create the CSS animation
+    const animation = `@keyframes rippleAnimation {
+      0% {
+        transform: scale(0);
+        opacity: ${ opacity };
+      }
+      50% {
+        transform: scale(1);
+      }
+      100% {
+        transform: scale(1);
+        opacity: 0;
+      }
+    }`;
+    // Add it to the document stylesheet
+    document.styleSheets[0].insertRule(animation, document.styleSheets[0].rules.length);
+    animationKeyframesAlreadySetUp[opacity] = true;
   }
 
   render() {

--- a/src/internal/TouchRipple.js
+++ b/src/internal/TouchRipple.js
@@ -21,12 +21,14 @@ class TouchRipple extends React.Component {
     centerRipple: React.PropTypes.bool,
     children: React.PropTypes.node,
     color: React.PropTypes.string,
+    onRippleStart: React.PropTypes.func,
     opacity: React.PropTypes.number,
     style: React.PropTypes.object,
   };
 
   static defaultProps = {
     abortOnScroll: true,
+    onRippleStart: () => {},
   };
 
   static contextTypes = {
@@ -68,6 +70,7 @@ class TouchRipple extends React.Component {
         color={this.props.color || theme.color}
         opacity={this.props.opacity}
         touchGenerated={isRippleTouchGenerated}
+        onRippleStart={this.handleRippleStart}
       />
     ));
 
@@ -148,6 +151,8 @@ class TouchRipple extends React.Component {
       });
     }
   };
+
+  handleRippleStart = this.props.onRippleStart;
 
   startListeningForScrollAbort(event) {
     this.firstTouchY = event.touches[0].clientY;


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).
- [ ] Patch uses autoprefixing in cases of vendor prefixes. I wanted to start this review before doing a full browser compat check and fix the prefixing.

This patch fixes issue https://github.com/callemall/material-ui/issues/3484, where ripples weren't firing in response to taps because script running in `onTouchTap` blocked the main thread, preventing the animation from starting. On slow mobile devices in particular we don't ever show ripples when the user taps a button that does anything non-trivial, (see screen cap of the bug in https://github.com/callemall/material-ui/issues/3484), and this patch fixes that.

**Solution Summary:** This patch prevents the EnhancedButton's `onTouchTap` prop from being called until the ripple animation starts. To do this we need to listen for the animation starting, which isn't possible with CSS Transitions so I've moved it to using CSS Animations.

**Note:** the move to CSS Animations means we need to add the animations to the page's stylesheet dynamically instead of adding them to the element directly as was possible with Transitions. I've done this and added a caching mechanism so we never add the same animation to the page stylesheet multiple times.

**Alternative solutions considered:**

1. I attempted forcing layouts, `requestIdleCallback`, `requestAnimationFrame` and `setTimeout`
 but none of them were able to reliably defer the callback until the animation started.
2. We could instead simply delay the `onTouchTap` call for ~100ms but on fast computers that would result in not fully utilizing the CPU, while on very slow devices (emerging markets Androids) would fail to consistently fix the issue, and whether it works or not would depend on how much work the app is doing in response to the tap

Feedback greatly appreciated on code and PR style etc. I very much look forward to resolving this longstanding performance issue!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/callemall/material-ui/3958)
<!-- Reviewable:end -->
