### PR TITLE
[Themes] colorManipulator cleanup

### DIFF
--- a/docs/src/app/components/pages/customization/Colors.js
+++ b/docs/src/app/components/pages/customization/Colors.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Title from 'react-title-component';
 import styleResizable from 'material-ui/utils/styleResizable';
 import ClearFix from 'material-ui/internal/ClearFix';
-import colorManipulator from 'material-ui/utils/colorManipulator';
+import {getContrastRatio} from 'material-ui/utils/colorManipulator';
 import typography from 'material-ui/styles/typography';
 import * as colors from 'material-ui/styles/colors';
 
@@ -94,7 +94,7 @@ const ColorsPage = React.createClass({
     const bgColorText = colorName + colorValue;
     const bgColor = colors[bgColorText];
     let fgColor = colors.fullBlack;
-    const contrastRatio = colorManipulator.contrastRatio(bgColor, fgColor);
+    const contrastRatio = getContrastRatio(bgColor, fgColor);
     let blockTitle;
 
     if (contrastRatio < 7) fgColor = colors.fullWhite;

--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import transitions from '../styles/transitions';
 import {createChildFragment} from '../utils/childUtils';
-import ColorManipulator from '../utils/colorManipulator';
+import {fade} from '../utils/colorManipulator';
 import EnhancedButton from '../internal/EnhancedButton';
 import FlatButtonLabel from './FlatButtonLabel';
 
@@ -210,7 +210,7 @@ class FlatButton extends React.Component {
       secondary ? secondaryTextColor :
       textColor;
 
-    const defaultHoverColor = ColorManipulator.fade(buttonFilterColor, 0.2);
+    const defaultHoverColor = fade(buttonFilterColor, 0.2);
     const defaultRippleColor = buttonFilterColor;
     const buttonHoverColor = hoverColor || defaultHoverColor;
     const buttonRippleColor = rippleColor || defaultRippleColor;

--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import transitions from '../styles/transitions';
-import ColorManipulator from '../utils/colorManipulator';
+import {fade} from '../utils/colorManipulator';
 import EnhancedButton from '../internal/EnhancedButton';
 import FontIcon from '../FontIcon';
 import Paper from '../Paper';
@@ -48,7 +48,7 @@ function getStyles(props, context) {
       top: 0,
     },
     overlayWhenHovered: {
-      backgroundColor: ColorManipulator.fade(iconColor, 0.4),
+      backgroundColor: fade(iconColor, 0.4),
     },
     icon: {
       height: floatingActionButton.buttonSize,
@@ -259,7 +259,7 @@ class FloatingActionButton extends React.Component {
     if (keyboardFocused && !this.props.disabled) {
       this.setState({zDepth: this.props.zDepth + 1});
       this.refs.overlay.style.backgroundColor =
-        ColorManipulator.fade(getStyles(this.props, this.context).icon.color, 0.4);
+        fade(getStyles(this.props, this.context).icon.color, 0.4);
     } else if (!this.state.hovered) {
       this.setState({zDepth: this.props.zDepth});
       this.refs.overlay.style.backgroundColor = 'transparent';

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import shallowEqual from 'recompose/shallowEqual';
-import ColorManipulator from '../utils/colorManipulator';
+import {fade} from '../utils/colorManipulator';
 import transitions from '../styles/transitions';
 import EnhancedButton from '../internal/EnhancedButton';
 import IconButton from '../IconButton';
@@ -28,7 +28,7 @@ function getStyles(props, context, state) {
   const {listItem} = muiTheme;
 
   const textColor = muiTheme.baseTheme.palette.textColor;
-  const hoverColor = ColorManipulator.fade(textColor, 0.1);
+  const hoverColor = fade(textColor, 0.1);
   const singleAvatar = !secondaryText && (leftAvatar || rightAvatar);
   const singleNoAvatar = !secondaryText && !(leftAvatar || rightAvatar);
   const twoLine = secondaryText && secondaryTextLines === 1;

--- a/src/List/MakeSelectable.js
+++ b/src/List/MakeSelectable.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ColorManipulator from '../utils/colorManipulator';
+import {fade} from '../utils/colorManipulator';
 
 export const MakeSelectable = (Component) => {
   const composed = React.createClass({
@@ -92,7 +92,7 @@ export const MakeSelectable = (Component) => {
 
       if (!selectedItemStyle) {
         const textColor = this.context.muiTheme.baseTheme.palette.textColor;
-        const selectedColor = ColorManipulator.fade(textColor, 0.2);
+        const selectedColor = fade(textColor, 0.2);
         styles = {
           backgroundColor: selectedColor,
         };

--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import transitions from '../styles/transitions';
-import ColorManipulator from '../utils/colorManipulator';
+import {fade} from '../utils/colorManipulator';
 import {createChildFragment} from '../utils/childUtils';
 import EnhancedButton from '../internal/EnhancedButton';
 import Paper from '../Paper';
@@ -96,7 +96,7 @@ function getStyles(props, context, state) {
     },
     overlay: {
       backgroundColor: (state.keyboardFocused || state.hovered) && !disabled &&
-        ColorManipulator.fade(labelColor, amount),
+        fade(labelColor, amount),
       transition: transitions.easeOut(),
       top: 0,
     },

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import keycode from 'keycode';
 import shallowEqual from 'recompose/shallowEqual';
-import ColorManipulator from '../utils/colorManipulator';
+import {fade} from '../utils/colorManipulator';
 import transitions from '../styles/transitions';
 import deprecated from '../utils/deprecatedPropType';
 import EnhancedTextarea from './EnhancedTextarea';
@@ -78,7 +78,7 @@ const getStyles = (props, state) => {
   }
 
   if (state.hasValue) {
-    styles.floatingLabel.color = ColorManipulator.fade(props.disabled ? disabledTextColor : floatingLabelColor, 0.5);
+    styles.floatingLabel.color = fade(props.disabled ? disabledTextColor : floatingLabelColor, 0.5);
   }
 
   if (props.floatingLabelText) {

--- a/src/styles/baseThemes/darkBaseTheme.js
+++ b/src/styles/baseThemes/darkBaseTheme.js
@@ -1,10 +1,10 @@
 import {
-cyan700,
-grey600,
-pinkA100, pinkA200, pinkA400,
-fullWhite,
+  cyan700,
+  grey600,
+  pinkA100, pinkA200, pinkA400,
+  fullWhite,
 } from '../colors';
-import ColorManipulator from '../../utils/colorManipulator';
+import {fade} from '../../utils/colorManipulator';
 import spacing from '../spacing';
 
 export default {
@@ -20,9 +20,9 @@ export default {
     textColor: fullWhite,
     alternateTextColor: '#303030',
     canvasColor: '#303030',
-    borderColor: ColorManipulator.fade(fullWhite, 0.3),
-    disabledColor: ColorManipulator.fade(fullWhite, 0.3),
-    pickerHeaderColor: ColorManipulator.fade(fullWhite, 0.12),
-    clockCircleColor: ColorManipulator.fade(fullWhite, 0.12),
+    borderColor: fade(fullWhite, 0.3),
+    disabledColor: fade(fullWhite, 0.3),
+    pickerHeaderColor: fade(fullWhite, 0.12),
+    clockCircleColor: fade(fullWhite, 0.12),
   },
 };

--- a/src/styles/baseThemes/lightBaseTheme.js
+++ b/src/styles/baseThemes/lightBaseTheme.js
@@ -1,13 +1,13 @@
 import {
-cyan500, cyan700,
-pinkA200,
-grey100, grey300, grey400, grey500,
-white, darkBlack, fullBlack,
+  cyan500, cyan700,
+  pinkA200,
+  grey100, grey300, grey400, grey500,
+  white, darkBlack, fullBlack,
 } from '../colors';
-import ColorManipulator from '../../utils/colorManipulator';
+import {fade} from '../../utils/colorManipulator';
 import spacing from '../spacing';
 
-/*
+/**
  *  Light Theme is the default theme used in material-ui. It is guaranteed to
  *  have all theme variables needed for every component. Variables not defined
  *  in a custom theme will default to these values.
@@ -27,9 +27,9 @@ export default {
     alternateTextColor: white,
     canvasColor: white,
     borderColor: grey300,
-    disabledColor: ColorManipulator.fade(darkBlack, 0.3),
+    disabledColor: fade(darkBlack, 0.3),
     pickerHeaderColor: cyan500,
-    clockCircleColor: ColorManipulator.fade(darkBlack, 0.07),
+    clockCircleColor: fade(darkBlack, 0.07),
     shadowColor: fullBlack,
   },
 };

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -25,17 +25,8 @@ export default function getMuiTheme(muiTheme, ...more) {
     userAgent: undefined,
   }, lightBaseTheme, muiTheme, ...more);
 
-  const {
-    spacing,
-    fontFamily,
-    palette,
-  } = muiTheme;
-
-  const baseTheme = {
-    spacing,
-    fontFamily,
-    palette,
-  };
+  const {spacing, fontFamily, palette} = muiTheme;
+  const baseTheme = {spacing, fontFamily, palette};
 
   muiTheme = merge({
     appBar: {
@@ -49,7 +40,7 @@ export default function getMuiTheme(muiTheme, ...more) {
       color: palette.canvasColor,
       backgroundColor: getLuminance(palette.canvasColor) > 0.5 ?
         darken(palette.canvasColor, 0.26) :
-        lighten(palette.canvasColor, 1.26, 1.0),
+        lighten(palette.canvasColor, 0.26),
       borderColor: 'rgba(128, 128, 128, 0.15)',
     },
     badge: {
@@ -122,7 +113,7 @@ export default function getMuiTheme(muiTheme, ...more) {
       disabledTextColor: palette.disabledColor,
       disabledColor: getLuminance(palette.canvasColor) > 0.5 ?
         darken(palette.canvasColor, 0.12) :
-        lighten(palette.canvasColor, 1.12, 1.0),
+        lighten(palette.canvasColor, 0.12),
     },
     gridTile: {
       textColor: white,
@@ -254,7 +245,7 @@ export default function getMuiTheme(muiTheme, ...more) {
     },
     tableRow: {
       hoverColor: palette.accent2Color,
-      stripeColor: lighten(palette.primary1Color, 0.55),
+      stripeColor: fade(lighten(palette.primary1Color, 0.5), 0.4),
       selectedColor: palette.borderColor,
       textColor: palette.textColor,
       borderColor: palette.borderColor,

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -1,5 +1,5 @@
 import merge from 'lodash.merge';
-import {darken, fade, lighten, getLuminance} from '../utils/colorManipulator';
+import {darken, fade, emphasize, lighten} from '../utils/colorManipulator';
 import lightBaseTheme from './baseThemes/lightBaseTheme';
 import zIndex from './zIndex';
 import autoprefixer from '../utils/autoprefixer';
@@ -38,9 +38,7 @@ export default function getMuiTheme(muiTheme, ...more) {
     },
     avatar: {
       color: palette.canvasColor,
-      backgroundColor: getLuminance(palette.canvasColor) > 0.5 ?
-        darken(palette.canvasColor, 0.26) :
-        lighten(palette.canvasColor, 0.26),
+      backgroundColor: emphasize(palette.canvasColor, 0.26),
       borderColor: 'rgba(128, 128, 128, 0.15)',
     },
     badge: {
@@ -111,9 +109,7 @@ export default function getMuiTheme(muiTheme, ...more) {
       secondaryColor: palette.accent1Color,
       secondaryIconColor: palette.alternateTextColor,
       disabledTextColor: palette.disabledColor,
-      disabledColor: getLuminance(palette.canvasColor) > 0.5 ?
-        darken(palette.canvasColor, 0.12) :
-        lighten(palette.canvasColor, 0.12),
+      disabledColor: emphasize(palette.canvasColor, 0.12),
     },
     gridTile: {
       textColor: white,

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -1,5 +1,5 @@
 import merge from 'lodash.merge';
-import ColorManipulator from '../utils/colorManipulator';
+import {darken, fade, lighten, getLuminance} from '../utils/colorManipulator';
 import lightBaseTheme from './baseThemes/lightBaseTheme';
 import zIndex from './zIndex';
 import autoprefixer from '../utils/autoprefixer';
@@ -47,9 +47,9 @@ export default function getMuiTheme(muiTheme, ...more) {
     },
     avatar: {
       color: palette.canvasColor,
-      backgroundColor: ColorManipulator.luminance(palette.canvasColor) > 0.5 ?
-        ColorManipulator.darken(palette.canvasColor, 0.26) :
-        ColorManipulator.lighten(palette.canvasColor, 1.26, 1.0),
+      backgroundColor: getLuminance(palette.canvasColor) > 0.5 ?
+        darken(palette.canvasColor, 0.26) :
+        lighten(palette.canvasColor, 1.26, 1.0),
       borderColor: 'rgba(128, 128, 128, 0.15)',
     },
     badge: {
@@ -67,8 +67,8 @@ export default function getMuiTheme(muiTheme, ...more) {
       iconButtonSize: spacing.iconSize * 2,
     },
     card: {
-      titleColor: ColorManipulator.fade(palette.textColor, 0.87),
-      subtitleColor: ColorManipulator.fade(palette.textColor, 0.54),
+      titleColor: fade(palette.textColor, 0.87),
+      subtitleColor: fade(palette.textColor, 0.54),
       fontWeight: typography.fontWeightMedium,
     },
     cardMedia: {
@@ -105,7 +105,7 @@ export default function getMuiTheme(muiTheme, ...more) {
     flatButton: {
       color: transparent,
       buttonFilterColor: '#999999',
-      disabledTextColor: ColorManipulator.fade(palette.textColor, 0.3),
+      disabledTextColor: fade(palette.textColor, 0.3),
       textColor: palette.textColor,
       primaryTextColor: palette.primary1Color,
       secondaryTextColor: palette.accent1Color,
@@ -120,9 +120,9 @@ export default function getMuiTheme(muiTheme, ...more) {
       secondaryColor: palette.accent1Color,
       secondaryIconColor: palette.alternateTextColor,
       disabledTextColor: palette.disabledColor,
-      disabledColor: ColorManipulator.luminance(palette.canvasColor) > 0.5 ?
-        ColorManipulator.darken(palette.canvasColor, 0.12) :
-        ColorManipulator.lighten(palette.canvasColor, 1.12, 1.0),
+      disabledColor: getLuminance(palette.canvasColor) > 0.5 ?
+        darken(palette.canvasColor, 0.12) :
+        lighten(palette.canvasColor, 1.12, 1.0),
     },
     gridTile: {
       textColor: white,
@@ -151,7 +151,7 @@ export default function getMuiTheme(muiTheme, ...more) {
     menuItem: {
       dataHeight: 32,
       height: 48,
-      hoverColor: ColorManipulator.fade(palette.textColor, 0.035),
+      hoverColor: fade(palette.textColor, 0.035),
       padding: spacing.desktopGutter,
       selectedTextColor: palette.accent1Color,
       rightIconDesktopFill: grey600,
@@ -174,8 +174,8 @@ export default function getMuiTheme(muiTheme, ...more) {
         [14, 45, 0.25, 10, 18, 0.22],
         [19, 60, 0.30, 15, 20, 0.22],
       ].map((d) => (
-        `0 ${d[0]}px ${d[1]}px ${ColorManipulator.fade(palette.shadowColor, d[2])},
-         0 ${d[3]}px ${d[4]}px ${ColorManipulator.fade(palette.shadowColor, d[5])}`
+        `0 ${d[0]}px ${d[1]}px ${fade(palette.shadowColor, d[2])},
+         0 ${d[3]}px ${d[4]}px ${fade(palette.shadowColor, d[5])}`
       )),
     },
     radioButton: {
@@ -195,8 +195,8 @@ export default function getMuiTheme(muiTheme, ...more) {
       primaryTextColor: palette.alternateTextColor,
       secondaryColor: palette.accent1Color,
       secondaryTextColor: palette.alternateTextColor,
-      disabledColor: ColorManipulator.darken(palette.alternateTextColor, 0.1),
-      disabledTextColor: ColorManipulator.fade(palette.textColor, 0.3),
+      disabledColor: darken(palette.alternateTextColor, 0.1),
+      disabledTextColor: fade(palette.textColor, 0.3),
       fontWeight: typography.fontWeightMedium,
     },
     refreshIndicator: {
@@ -204,7 +204,7 @@ export default function getMuiTheme(muiTheme, ...more) {
       loadingStrokeColor: palette.primary1Color,
     },
     ripple: {
-      color: ColorManipulator.fade(palette.textColor, 0.87),
+      color: fade(palette.textColor, 0.87),
     },
     slider: {
       trackSize: 2,
@@ -224,17 +224,17 @@ export default function getMuiTheme(muiTheme, ...more) {
       actionColor: palette.accent1Color,
     },
     subheader: {
-      color: ColorManipulator.fade(palette.textColor, 0.54),
+      color: fade(palette.textColor, 0.54),
       fontWeight: typography.fontWeightMedium,
     },
     stepper: {
       backgroundColor: 'transparent',
-      hoverBackgroundColor: ColorManipulator.fade(black, 0.06),
+      hoverBackgroundColor: fade(black, 0.06),
       iconColor: palette.primary1Color,
       hoveredIconColor: grey700,
       inactiveIconColor: grey500,
-      textColor: ColorManipulator.fade(black, 0.87),
-      disabledTextColor: ColorManipulator.fade(black, 0.26),
+      textColor: fade(black, 0.87),
+      disabledTextColor: fade(black, 0.26),
       connectorLineColor: grey400,
     },
     table: {
@@ -254,7 +254,7 @@ export default function getMuiTheme(muiTheme, ...more) {
     },
     tableRow: {
       hoverColor: palette.accent2Color,
-      stripeColor: ColorManipulator.lighten(palette.primary1Color, 0.55),
+      stripeColor: lighten(palette.primary1Color, 0.55),
       selectedColor: palette.borderColor,
       textColor: palette.textColor,
       borderColor: palette.borderColor,
@@ -266,7 +266,7 @@ export default function getMuiTheme(muiTheme, ...more) {
     },
     tabs: {
       backgroundColor: palette.primary1Color,
-      textColor: ColorManipulator.fade(palette.alternateTextColor, 0.7),
+      textColor: fade(palette.alternateTextColor, 0.7),
       selectedTextColor: palette.alternateTextColor,
     },
     textField: {
@@ -294,22 +294,22 @@ export default function getMuiTheme(muiTheme, ...more) {
       thumbOffColor: palette.accent2Color,
       thumbDisabledColor: palette.borderColor,
       thumbRequiredColor: palette.primary1Color,
-      trackOnColor: ColorManipulator.fade(palette.primary1Color, 0.5),
+      trackOnColor: fade(palette.primary1Color, 0.5),
       trackOffColor: palette.primary3Color,
       trackDisabledColor: palette.primary3Color,
       labelColor: palette.textColor,
       labelDisabledColor: palette.disabledColor,
-      trackRequiredColor: ColorManipulator.fade(palette.primary1Color, 0.5),
+      trackRequiredColor: fade(palette.primary1Color, 0.5),
     },
     toolbar: {
-      color: ColorManipulator.fade(palette.textColor, 0.54),
-      hoverColor: ColorManipulator.fade(palette.textColor, 0.87),
-      backgroundColor: ColorManipulator.darken(palette.accent2Color, 0.05),
+      color: fade(palette.textColor, 0.54),
+      hoverColor: fade(palette.textColor, 0.87),
+      backgroundColor: darken(palette.accent2Color, 0.05),
       height: 56,
       titleFontSize: 20,
-      iconColor: ColorManipulator.fade(palette.textColor, 0.4),
-      separatorColor: ColorManipulator.fade(palette.textColor, 0.175),
-      menuHoverColor: ColorManipulator.fade(palette.textColor, 0.1),
+      iconColor: fade(palette.textColor, 0.4),
+      separatorColor: fade(palette.textColor, 0.175),
+      menuHoverColor: fade(palette.textColor, 0.1),
     },
     tooltip: {
       color: white,

--- a/src/utils/colorManipulator.js
+++ b/src/utils/colorManipulator.js
@@ -116,6 +116,19 @@ export function getLuminance(color) {
 }
 
 /**
+ * Darken or lighten a colour, depending on its luminance
+ * Light colors are darkened, dark colors lightened
+ *
+ * @param {string} color - CSS color, i.e. one of: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla()
+ * @param {number} coefficient=0.15 - multiplier in the range 0 - 1
+ */
+export function emphasize(color, coefficient = 0.15) {
+  return getLuminance(color) > 0.5 ?
+    darken(color, coefficient) :
+    lighten(color, coefficient);
+}
+
+/**
  * Set the absolute transparency of a color.
  * Any existing alpha values are overwritten.
  * Hex values will be converted to rgba.

--- a/src/utils/colorManipulator.js
+++ b/src/utils/colorManipulator.js
@@ -1,29 +1,43 @@
 import warning from 'warning';
 
 /**
- * @params:
- * additionalValue = An extra value that has been calculated but not included
- *                   with the original color object, such as an alpha value.
+ * Converts a color object with type and values to a string
+ *
+ * @param {object} color - Decomposed color
+ * @param {string} color.type - One of, 'rgb', 'rgba', 'hsl', 'hsla'
+ * @param {array} color.values - [n,n,n] or [n,n,n,n]
  */
-export function convertColorToString(color, additionalValue) {
-  let str = `${color.type}(${
-    parseInt(color.values[0])}, ${
-    parseInt(color.values[1])}, ${
-    parseInt(color.values[2])}`;
+export function convertColorToString(color) {
+  const {type, values} = color;
 
-  if (additionalValue !== undefined) {
-    str += `, ${additionalValue})`;
-  } else if (color.values.length === 4) {
-    str += `, ${color.values[3]})`;
-  } else {
-    str += ')';
+  if (type.indexOf('rgb') > -1) {
+    // Only convert the first 3 values to int (i.e. not alpha)
+    for (let i = 0; i < 3; i++) {
+      values[i] = parseInt(values[i]);
+    }
   }
 
-  return str;
+  let colorString;
+
+  if (type.indexOf('hsl') > -1) {
+    colorString = `${color.type}(${values[0]}, ${values[1]}%, ${values[2]}%`;
+  } else {
+    colorString = `${color.type}(${values[0]}, ${values[1]}, ${values[2]}`;
+  }
+
+  if (values.length === 4) {
+    colorString += `, ${color.values[3]})`;
+  } else {
+    colorString += ')';
+  }
+
+  return colorString;
 }
 
 /**
- * Converts a color from hex format to rgb format.
+ * Converts a color from CSS hex format to CSS rgb format.
+ *
+ *  @param {string} color - Hex color, i.e. #nnn or #nnnnnn
  */
 export function convertHexToRGB(color) {
   if (color.length === 4) {
@@ -44,7 +58,11 @@ export function convertHexToRGB(color) {
 }
 
 /**
- * Returns the type and values of a color of any given type.
+ * Returns an object with the type and values of a color.
+ *
+ * Note: Does not support rgb % values.
+ *
+ * @param {string} color - CSS color, i.e. one of: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla()
  */
 export function decomposeColor(color) {
   if (color.charAt(0) === '#') {
@@ -54,70 +72,34 @@ export function decomposeColor(color) {
   const marker = color.indexOf('(');
   const type = color.substring(0, marker);
   let values = color.substring(marker + 1, color.length - 1).split(',');
-  values = values.map((value) => parseInt(value));
+  values = values.map((value) => parseFloat(value));
 
   return {type: type, values: values};
 }
 
 /**
  * Calculates the contrast ratio between two colors.
+ *
  * Formula: http://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
+ *
+ * @param {string} foreground - CSS color, i.e. one of: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla()
+ * @param {string} background - CSS color, i.e. one of: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla()
  */
-export function getContrastRatio(background, foreground) {
-  const lumA = getLuminance(background);
-  const lumB = getLuminance(foreground);
+export function getContrastRatio(foreground, background) {
+  const lumA = getLuminance(foreground);
+  const lumB = getLuminance(background);
+  const contrastRatio = (Math.max(lumA, lumB) + 0.05) / (Math.min(lumA, lumB) + 0.05);
 
-  if (lumA >= lumB) {
-    return ((lumA + 0.05) / (lumB + 0.05)).toFixed(2);
-  } else {
-    return ((lumB + 0.05) / (lumA + 0.05)).toFixed(2);
-  }
-}
-
-/**
- * Determines how readable a color combination is based on its level.
- * Levels are defined from @LeaVerou:
- * https://github.com/LeaVerou/contrast-ratio/blob/gh-pages/contrast-ratio.js
- */
-export function getContrastRatioLevel(background, foreground) {
-  const levels = {
-    'fail': {
-      range: [0, 3],
-      color: 'hsl(0, 100%, 40%)',
-    },
-    'aa-large': {
-      range: [3, 4.5],
-      color: 'hsl(40, 100%, 45%)',
-    },
-    'aa': {
-      range: [4.5, 7],
-      color: 'hsl(80, 60%, 45%)',
-    },
-    'aaa': {
-      range: [7, 22],
-      color: 'hsl(95, 60%, 41%)',
-    },
-  };
-
-  const ratio = getContrastRatio(background, foreground);
-
-  for (const level in levels) {
-    const range = levels[level].range;
-    if (ratio >= range[0] && ratio <= range[1]) return level;
-  }
+  return Number(contrastRatio.toFixed(2)); // Truncate at two digits
 }
 
 /**
  * The relative brightness of any point in a colorspace, normalized to 0 for
- * darkest black and 1 for lightest white. RGB colors only. Does not take
- * into account alpha values.
+ * darkest black and 1 for lightest white.
  *
- * TODO:
- * - Take into account alpha values.
- * - Identify why there are minor discrepancies for some use cases
- *   (i.e. #F0F & #FFF). Note that these cases rarely occur.
+ * Formula: https://www.w3.org/WAI/GL/wiki/Relative_luminance
  *
- * Formula: http://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
+ * @param {string} color - CSS color, i.e. one of: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla()
  */
 export function getLuminance(color) {
   color = decomposeColor(color);
@@ -127,59 +109,78 @@ export function getLuminance(color) {
       val /= 255; // normalized
       return val <= 0.03928 ? val / 12.92 : Math.pow((val + 0.055) / 1.055, 2.4);
     });
-
-    return 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2];
-  } else {
-    warning(false, `Calculating the relative luminance is not available
-      for HSL and HSLA.`);
-
-    return -1;
+    return Number((0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2]).toFixed(3)); // Truncate at 3 digits
+  } else if (color.type.indexOf('hsl') > -1) {
+    return color.values[2] / 100;
   }
 }
 
 /**
  * Set the absolute transparency of a color.
  * Any existing alpha values are overwritten.
+ * Hex values will be converted to rgba.
+ *
+ * @param {string} color - CSS color, i.e. one of: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla()
+ * @param {number} value - value to set the alpha channel to in the range 0 -1
  */
-export function fade(color, amount) {
-  color = decomposeColor(color);
-  if (color.type === 'rgb' || color.type === 'hsl') color.type += 'a';
-  return convertColorToString(color, amount);
-}
-
-export function darken(color, amount) {
+export function fade(color, value) {
   color = decomposeColor(color);
 
-  if (color.type.indexOf('hsl') > -1) {
-    color.values[2] += amount;
-    return decomposeColor(convertColorToString(color));
-  } else if (color.type.indexOf('rgb') > -1) {
-    for (let i = 0; i < 3; i++) {
-      color.values[i] *= 1 - amount;
-      if (color.values[i] < 0) color.values[i] = 0;
-    }
+  if (color.type === 'rgb' || color.type === 'hsl') {
+    color.type += 'a';
   }
+  color.values[3] = value;
 
   return convertColorToString(color);
 }
 
 /**
- * Desaturates rgb and sets opacity (defaults to 0.15)
+ * Note: This naive implementation will change hue slightly,
+ * but is sufficient for our purpose.
+ * Hex values will be converted to rgb.
+ *
+ * @param {string} color - CSS color, i.e. one of: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla()
+ * @param {number} coefficient - multiplier in the range 0 - 1
  */
-export function lighten(color, amount, opacity = '0.15') {
+export function darken(color, coefficient) {
+  warning(!(coefficient < 0 || coefficient > 1),
+    'darken(color, coefficient) - coefficient must be between 0 and 1.');
+
   color = decomposeColor(color);
 
   if (color.type.indexOf('hsl') > -1) {
-    color.values[2] += amount;
-    return decomposeColor(convertColorToString(color));
+    color.values[2] *= 1 - coefficient;
   } else if (color.type.indexOf('rgb') > -1) {
     for (let i = 0; i < 3; i++) {
-      color.values[i] *= 1 + amount;
-      if (color.values[i] > 255) color.values[i] = 255;
+      color.values[i] *= 1 - coefficient;
+      if (color.values[i] < 0) {
+        color.values[i] = 0;
+      }
+    }
+  }
+  return convertColorToString(color);
+}
+
+/**
+ * Lighten color.
+ * Hex values will be converted to rgb.
+ *
+ * @param {string} color - CSS color, i.e. one of: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla()
+ * @param {number} coefficient - multiplier in the range 0 - 1
+ */
+export function lighten(color, coefficient) {
+  warning(!(coefficient < 0 || coefficient > 1),
+    'lighten(color, coefficient) - coefficient must be between 0 and 1.');
+
+  color = decomposeColor(color);
+
+  if (color.type.indexOf('hsl') > -1) {
+    color.values[2] += (100 - color.values[2]) * coefficient;
+  } else if (color.type.indexOf('rgb') > -1) {
+    for (let i = 0; i < 3; i++) {
+      color.values[i] += (255 - color.values[i]) * coefficient;
     }
   }
 
-  if (color.type.indexOf('a') <= -1) color.type += 'a';
-
-  return convertColorToString(color, opacity);
+  return convertColorToString(color);
 }

--- a/src/utils/colorManipulator.js
+++ b/src/utils/colorManipulator.js
@@ -1,178 +1,185 @@
 import warning from 'warning';
 
-export default {
+/**
+ * @params:
+ * additionalValue = An extra value that has been calculated but not included
+ *                   with the original color object, such as an alpha value.
+ */
+export function convertColorToString(color, additionalValue) {
+  let str = `${color.type}(${
+    parseInt(color.values[0])}, ${
+    parseInt(color.values[1])}, ${
+    parseInt(color.values[2])}`;
 
-  /**
-   * The relative brightness of any point in a colorspace, normalized to 0 for
-   * darkest black and 1 for lightest white. RGB colors only. Does not take
-   * into account alpha values.
-   *
-   * TODO:
-   * - Take into account alpha values.
-   * - Identify why there are minor discrepancies for some use cases
-   *   (i.e. #F0F & #FFF). Note that these cases rarely occur.
-   *
-   * Formula: http://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
-   */
-  luminance(color) {
-    color = this.decomposeColor(color);
+  if (additionalValue !== undefined) {
+    str += `, ${additionalValue})`;
+  } else if (color.values.length === 4) {
+    str += `, ${color.values[3]})`;
+  } else {
+    str += ')';
+  }
 
-    if (color.type.indexOf('rgb') > -1) {
-      const rgb = color.values.map((val) => {
-        val /= 255; // normalized
-        return val <= 0.03928 ? val / 12.92 : Math.pow((val + 0.055) / 1.055, 2.4);
-      });
+  return str;
+}
 
-      return 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2];
-    } else {
-      warning(false, `Calculating the relative luminance is not available
-        for HSL and HSLA.`);
-
-      return -1;
+/**
+ * Converts a color from hex format to rgb format.
+ */
+export function convertHexToRGB(color) {
+  if (color.length === 4) {
+    let extendedColor = '#';
+    for (let i = 1; i < color.length; i++) {
+      extendedColor += color.charAt(i) + color.charAt(i);
     }
-  },
+    color = extendedColor;
+  }
 
-  /**
-   * @params:
-   * additionalValue = An extra value that has been calculated but not included
-   *                   with the original color object, such as an alpha value.
-   */
-  convertColorToString(color, additonalValue) {
-    let str = `${color.type}(${
-      parseInt(color.values[0])}, ${
-      parseInt(color.values[1])}, ${
-      parseInt(color.values[2])}`;
+  const values = {
+    r:	parseInt(color.substr(1, 2), 16),
+    g:	parseInt(color.substr(3, 2), 16),
+    b:	parseInt(color.substr(5, 2), 16),
+  };
 
-    if (additonalValue !== undefined) {
-      str += `, ${additonalValue})`;
-    } else if (color.values.length === 4) {
-      str += `, ${color.values[3]})`;
-    } else {
-      str += ')';
+  return `rgb(${values.r}, ${values.g}, ${values.b})`;
+}
+
+/**
+ * Returns the type and values of a color of any given type.
+ */
+export function decomposeColor(color) {
+  if (color.charAt(0) === '#') {
+    return decomposeColor(convertHexToRGB(color));
+  }
+
+  const marker = color.indexOf('(');
+  const type = color.substring(0, marker);
+  let values = color.substring(marker + 1, color.length - 1).split(',');
+  values = values.map((value) => parseInt(value));
+
+  return {type: type, values: values};
+}
+
+/**
+ * Calculates the contrast ratio between two colors.
+ * Formula: http://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
+ */
+export function getContrastRatio(background, foreground) {
+  const lumA = getLuminance(background);
+  const lumB = getLuminance(foreground);
+
+  if (lumA >= lumB) {
+    return ((lumA + 0.05) / (lumB + 0.05)).toFixed(2);
+  } else {
+    return ((lumB + 0.05) / (lumA + 0.05)).toFixed(2);
+  }
+}
+
+/**
+ * Determines how readable a color combination is based on its level.
+ * Levels are defined from @LeaVerou:
+ * https://github.com/LeaVerou/contrast-ratio/blob/gh-pages/contrast-ratio.js
+ */
+export function getContrastRatioLevel(background, foreground) {
+  const levels = {
+    'fail': {
+      range: [0, 3],
+      color: 'hsl(0, 100%, 40%)',
+    },
+    'aa-large': {
+      range: [3, 4.5],
+      color: 'hsl(40, 100%, 45%)',
+    },
+    'aa': {
+      range: [4.5, 7],
+      color: 'hsl(80, 60%, 45%)',
+    },
+    'aaa': {
+      range: [7, 22],
+      color: 'hsl(95, 60%, 41%)',
+    },
+  };
+
+  const ratio = getContrastRatio(background, foreground);
+
+  for (const level in levels) {
+    const range = levels[level].range;
+    if (ratio >= range[0] && ratio <= range[1]) return level;
+  }
+}
+
+/**
+ * The relative brightness of any point in a colorspace, normalized to 0 for
+ * darkest black and 1 for lightest white. RGB colors only. Does not take
+ * into account alpha values.
+ *
+ * TODO:
+ * - Take into account alpha values.
+ * - Identify why there are minor discrepancies for some use cases
+ *   (i.e. #F0F & #FFF). Note that these cases rarely occur.
+ *
+ * Formula: http://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
+ */
+export function getLuminance(color) {
+  color = decomposeColor(color);
+
+  if (color.type.indexOf('rgb') > -1) {
+    const rgb = color.values.map((val) => {
+      val /= 255; // normalized
+      return val <= 0.03928 ? val / 12.92 : Math.pow((val + 0.055) / 1.055, 2.4);
+    });
+
+    return 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2];
+  } else {
+    warning(false, `Calculating the relative luminance is not available
+      for HSL and HSLA.`);
+
+    return -1;
+  }
+}
+
+/**
+ * Set the absolute transparency of a color.
+ * Any existing alpha values are overwritten.
+ */
+export function fade(color, amount) {
+  color = decomposeColor(color);
+  if (color.type === 'rgb' || color.type === 'hsl') color.type += 'a';
+  return convertColorToString(color, amount);
+}
+
+export function darken(color, amount) {
+  color = decomposeColor(color);
+
+  if (color.type.indexOf('hsl') > -1) {
+    color.values[2] += amount;
+    return decomposeColor(convertColorToString(color));
+  } else if (color.type.indexOf('rgb') > -1) {
+    for (let i = 0; i < 3; i++) {
+      color.values[i] *= 1 - amount;
+      if (color.values[i] < 0) color.values[i] = 0;
     }
+  }
 
-    return str;
-  },
+  return convertColorToString(color);
+}
 
-  // Converts a color from hex format to rgb format.
-  convertHexToRGB(color) {
-    if (color.length === 4) {
-      let extendedColor = '#';
-      for (let i = 1; i < color.length; i++) {
-        extendedColor += color.charAt(i) + color.charAt(i);
-      }
-      color = extendedColor;
+/**
+ * Desaturates rgb and sets opacity (defaults to 0.15)
+ */
+export function lighten(color, amount, opacity = '0.15') {
+  color = decomposeColor(color);
+
+  if (color.type.indexOf('hsl') > -1) {
+    color.values[2] += amount;
+    return decomposeColor(convertColorToString(color));
+  } else if (color.type.indexOf('rgb') > -1) {
+    for (let i = 0; i < 3; i++) {
+      color.values[i] *= 1 + amount;
+      if (color.values[i] > 255) color.values[i] = 255;
     }
+  }
 
-    const values = {
-      r:	parseInt(color.substr(1, 2), 16),
-      g:	parseInt(color.substr(3, 2), 16),
-      b:	parseInt(color.substr(5, 2), 16),
-    };
+  if (color.type.indexOf('a') <= -1) color.type += 'a';
 
-    return `rgb(${values.r}, ${values.g}, ${values.b})`;
-  },
-
-  // Returns the type and values of a color of any given type.
-  decomposeColor(color) {
-    if (color.charAt(0) === '#') {
-      return this.decomposeColor(this.convertHexToRGB(color));
-    }
-
-    const marker = color.indexOf('(');
-    const type = color.substring(0, marker);
-    const values = color.substring(marker + 1, color.length - 1).split(',');
-
-    return {type: type, values: values};
-  },
-
-  // Set the absolute transparency of a color.
-  // Any existing alpha values are overwritten.
-  fade(color, amount) {
-    color = this.decomposeColor(color);
-    if (color.type === 'rgb' || color.type === 'hsl') color.type += 'a';
-    return this.convertColorToString(color, amount);
-  },
-
-  // Desaturates rgb and sets opacity (defaults to 0.15)
-  lighten(color, amount, opacity = '0.15') {
-    color = this.decomposeColor(color);
-
-    if (color.type.indexOf('hsl') > -1) {
-      color.values[2] += amount;
-      return this.decomposeColor(this.convertColorToString(color));
-    } else if (color.type.indexOf('rgb') > -1) {
-      for (let i = 0; i < 3; i++) {
-        color.values[i] *= 1 + amount;
-        if (color.values[i] > 255) color.values[i] = 255;
-      }
-    }
-
-    if (color.type.indexOf('a') <= -1) color.type += 'a';
-
-    return this.convertColorToString(color, opacity);
-  },
-
-  darken(color, amount) {
-    color = this.decomposeColor(color);
-
-    if (color.type.indexOf('hsl') > -1) {
-      color.values[2] += amount;
-      return this.decomposeColor(this.convertColorToString(color));
-    } else if (color.type.indexOf('rgb') > -1) {
-      for (let i = 0; i < 3; i++) {
-        color.values[i] *= 1 - amount;
-        if (color.values[i] < 0) color.values[i] = 0;
-      }
-    }
-
-    return this.convertColorToString(color);
-  },
-
-  // Calculates the contrast ratio between two colors.
-  //
-  // Formula: http://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
-  contrastRatio(background, foreground) {
-    const lumA = this.luminance(background);
-    const lumB = this.luminance(foreground);
-
-    if (lumA >= lumB) {
-      return ((lumA + 0.05) / (lumB + 0.05)).toFixed(2);
-    } else {
-      return ((lumB + 0.05) / (lumA + 0.05)).toFixed(2);
-    }
-  },
-
-  /**
-   * Determines how readable a color combination is based on its level.
-   * Levels are defined from @LeaVerou:
-   * https://github.com/LeaVerou/contrast-ratio/blob/gh-pages/contrast-ratio.js
-   */
-  contrastRatioLevel(background, foreground) {
-    const levels = {
-      'fail': {
-        range: [0, 3],
-        color: 'hsl(0, 100%, 40%)',
-      },
-      'aa-large': {
-        range: [3, 4.5],
-        color: 'hsl(40, 100%, 45%)',
-      },
-      'aa': {
-        range: [4.5, 7],
-        color: 'hsl(80, 60%, 45%)',
-      },
-      'aaa': {
-        range: [7, 22],
-        color: 'hsl(95, 60%, 41%)',
-      },
-    };
-
-    const ratio = this.contrastRatio(background, foreground);
-
-    for (const level in levels) {
-      const range = levels[level].range;
-      if (ratio >= range[0] && ratio <= range[1]) return level;
-    }
-  },
-};
+  return convertColorToString(color, opacity);
+}

--- a/src/utils/colorManipulator.spec.js
+++ b/src/utils/colorManipulator.spec.js
@@ -5,6 +5,7 @@ import {
   convertHexToRGB,
   darken,
   decomposeColor,
+  emphasize,
   fade,
   getContrastRatio,
   getLuminance,
@@ -169,6 +170,39 @@ describe('utils/colorManipulator', () => {
       assert.strictEqual(
         getLuminance('hsl(100, 100%, 50%)'),
         0.5
+      );
+    });
+  });
+
+  /**
+   * emphasize()
+   */
+  describe('emphasize', () => {
+    it('lightens a dark rgb color with the coefficient provided', () => {
+      assert.strictEqual(
+        emphasize('rgb(1, 2, 3)', 0.4),
+        lighten('rgb(1, 2, 3)', 0.4)
+      );
+    });
+
+    it('darkens a light rgb color with the coefficient provided', () => {
+      assert.strictEqual(
+        emphasize('rgb(250, 240, 230)', 0.3),
+        darken('rgb(250, 240, 230)', 0.3)
+      );
+    });
+
+    it('lightens a dark rgb color with the c0efficient 0.15 by default', () => {
+      assert.strictEqual(
+        emphasize('rgb(1, 2, 3)'),
+        lighten('rgb(1, 2, 3)', 0.15)
+      );
+    });
+
+    it('darkens a light rgb color with the coefficient 0.15 by default', () => {
+      assert.strictEqual(
+        emphasize('rgb(250, 240, 230)'),
+        darken('rgb(250, 240, 230)', 0.15)
       );
     });
   });
@@ -348,7 +382,7 @@ describe('utils/colorManipulator', () => {
       );
     });
 
-    it("doesn't modify hsl colors when l is 100%", () => {
+    it("doesn't modify hsl colors when `l` is 100%", () => {
       assert.strictEqual(
         lighten('hsl(0, 50%, 100%)', 0.5),
         'hsl(0, 50%, 100%)'

--- a/src/utils/colorManipulator.spec.js
+++ b/src/utils/colorManipulator.spec.js
@@ -1,0 +1,358 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import {
+  convertColorToString,
+  convertHexToRGB,
+  darken,
+  decomposeColor,
+  fade,
+  getContrastRatio,
+  getLuminance,
+  lighten,
+} from './colorManipulator';
+
+describe('utils/colorManipulator', () => {
+  /**
+   * convertColorToString()
+   */
+  describe('convertColorToString', () => {
+    it('converts a decomposed rgb color object to a string` ', () => {
+      assert.strictEqual(
+        convertColorToString({type: 'rgb', values: [255, 255, 255]}),
+        'rgb(255, 255, 255)'
+      );
+    });
+
+    it('converts a decomposed rgba color object to a string` ', () => {
+      assert.strictEqual(
+        convertColorToString({type: 'rgba', values: [255, 255, 255, 0.5]}),
+        'rgba(255, 255, 255, 0.5)'
+      );
+    });
+
+    it('converts a decomposed hsl color object to a string` ', () => {
+      assert.strictEqual(
+        convertColorToString({type: 'hsl', values: [100, 50, 25]}),
+        'hsl(100, 50%, 25%)'
+      );
+    });
+
+    it('converts a decomposed hsla color object to a string` ', () => {
+      assert.strictEqual(
+        convertColorToString({type: 'hsla', values: [100, 50, 25, 0.5]}),
+        'hsla(100, 50%, 25%, 0.5)'
+      );
+    });
+  });
+
+  /**
+   * convertHexToRGB()
+   */
+  describe('convertHexToRGB', () => {
+    it('converts a short hex color to an rgb color` ', () => {
+      assert.strictEqual(
+        convertHexToRGB('#9f3'),
+        'rgb(153, 255, 51)'
+      );
+    });
+
+    it('converts a long hex color to an rgb color` ', () => {
+      assert.strictEqual(
+        convertHexToRGB('#A94FD3'),
+        'rgb(169, 79, 211)'
+      );
+    });
+  });
+
+  /**
+   * decomposeColor()
+   */
+  describe('decomposeColor', () => {
+    it('converts an rgb color string to an object with `type` and `value` keys', () => {
+      const {type, values} = decomposeColor('rgb(255, 255, 255)');
+      assert.strictEqual(type, 'rgb');
+      assert.deepEqual(values, [255, 255, 255]);
+    });
+
+    it('converts an rgba color string to an object with `type` and `value` keys', () => {
+      const {type, values} = decomposeColor('rgba(255, 255, 255, 0.5)');
+      assert.strictEqual(type, 'rgba');
+      assert.deepEqual(values, [255, 255, 255, 0.5]);
+    });
+
+    it('converts an hsl color string to an object with `type` and `value` keys', () => {
+      const {type, values} = decomposeColor('hsl(100, 50%, 25%)');
+      assert.strictEqual(type, 'hsl');
+      assert.deepEqual(values, [100, 50, 25]);
+    });
+
+    it('converts an hsla color string to an object with `type` and `value` keys', () => {
+      const {type, values} = decomposeColor('hsla(100, 50%, 25%, 0.5)');
+      assert.strictEqual(type, 'hsla');
+      assert.deepEqual(values, [100, 50, 25, 0.5]);
+    });
+  });
+
+  /**
+   * getContrastRatio()
+   */
+  describe('getContrastRatio', () => {
+    it('returns a ratio of 21 for black : white', () => {
+      assert.strictEqual(
+        getContrastRatio('#000', '#FFF'),
+        21
+      );
+    });
+
+    it('returns a ratio of 1 for black : black', () => {
+      assert.strictEqual(
+        getContrastRatio('#000', '#000'),
+        1
+      );
+    });
+
+    it('returns a ratio of 1 for white : white', () => {
+      assert.strictEqual(
+        getContrastRatio('#FFF', '#FFF'),
+        1
+      );
+    });
+
+    it('returns a ratio of 3.92 for dark-grey : light-grey', () => {
+      assert.strictEqual(
+        getContrastRatio('#707070', '#E5E5E5'),
+        3.93
+      );
+    });
+
+    it('returns a ratio of 3.93 for black : light-grey', () => {
+      assert.strictEqual(
+        getContrastRatio('#000', '#888'),
+        5.92
+      );
+    });
+  });
+
+  /**
+   * getLuminance()
+   */
+  describe('getLuminance', () => {
+    it('returns a luminance of 1 for rgb white', () => {
+      assert.strictEqual(
+        getLuminance('rgb(0, 0, 0)'),
+        0
+      );
+    });
+
+    it('returns a luminance of 1 for rgb white', () => {
+      assert.strictEqual(
+        getLuminance('rgb(255, 255, 255)'),
+        1
+      );
+    });
+
+    it('returns a valid luminance for rgb mid-grey', () => {
+      assert.strictEqual(
+        getLuminance('rgb(127, 127, 127)'),
+        0.212
+      );
+    });
+
+    it('returns a valid luminance for an rgb color', () => {
+      assert.strictEqual(
+        getLuminance('rgb(255, 127, 0)'),
+        0.364
+      );
+    });
+
+    it('returns a normalized luminance from an hsl color', () => {
+      assert.strictEqual(
+        getLuminance('hsl(100, 100%, 50%)'),
+        0.5
+      );
+    });
+  });
+
+  /**
+   * fade()
+   */
+  describe('fade', () => {
+    it('converts an rgb color to an rgba color with the value provided', () => {
+      assert.strictEqual(
+        fade('rgb(1, 2, 3)', 0.4),
+        'rgba(1, 2, 3, 0.4)'
+      );
+    });
+
+    it('updates an rgba color with the alpha value provided', () => {
+      assert.strictEqual(
+        fade('rgba(255, 0, 0, 0.2)', 0.5),
+        'rgba(255, 0, 0, 0.5)'
+      );
+    });
+
+    it('converts an hsl color to an hsla color with the value provided', () => {
+      assert.strictEqual(
+        fade('hsl(0, 100%, 50%)', 0.1),
+        'hsla(0, 100%, 50%, 0.1)'
+      );
+    });
+
+    it('updates an hsla color with the alpha value provided', () => {
+      assert.strictEqual(
+        fade('hsla(0, 100%, 50%, 0.2)', 0.5),
+        'hsla(0, 100%, 50%, 0.5)'
+      );
+    });
+  });
+
+  /**
+   * darken()
+   */
+  describe('darken', () => {
+    it("doesn't modify rgb black", () => {
+      assert.strictEqual(
+        darken('rgb(0, 0, 0)', 0.1),
+        'rgb(0, 0, 0)'
+      );
+    });
+
+    it('darkens rgb white to black when coefficient is 1', () => {
+      assert.strictEqual(
+        darken('rgb(255, 255, 255)', 1),
+        'rgb(0, 0, 0)'
+      );
+    });
+
+    it('retains the alpha value in an rgba color', () => {
+      assert.strictEqual(
+        darken('rgb(0, 0, 0, 0.5)', 0.1),
+        'rgb(0, 0, 0, 0.5)'
+      );
+    });
+
+    it('darkens rgb white by 10% when coefficient is 0.1', () => {
+      assert.strictEqual(
+        darken('rgb(255, 255, 255)', 0.1),
+        'rgb(229, 229, 229)'
+      );
+    });
+
+    it('darkens rgb red by 50% when coefficient is 0.5', () => {
+      assert.strictEqual(
+        darken('rgb(255, 0, 0)', 0.5),
+        'rgb(127, 0, 0)'
+      );
+    });
+
+    it('darkens rgb grey by 50% when coefficient is 0.5', () => {
+      assert.strictEqual(
+        darken('rgb(127, 127, 127)', 0.5),
+        'rgb(63, 63, 63)'
+      );
+    });
+
+    it("doesn't modify rgb colors when coefficient is 0", () => {
+      assert.strictEqual(
+        darken('rgb(255, 255, 255)', 0),
+        'rgb(255, 255, 255)'
+      );
+    });
+
+    it('darkens hsl red by 50% when coefficient is 0.5', () => {
+      assert.strictEqual(
+        darken('hsl(0, 100%, 50%)', 0.5),
+        'hsl(0, 100%, 25%)'
+      );
+    });
+
+    it("doesn't modify hsl colors when coefficient is 0", () => {
+      assert.strictEqual(
+        darken('hsl(0, 100%, 50%)', 0),
+        'hsl(0, 100%, 50%)'
+      );
+    });
+
+    it("doesn't modify hsl colors when l is 0%", () => {
+      assert.strictEqual(
+        darken('hsl(0, 50%, 0%)', 0.5),
+        'hsl(0, 50%, 0%)'
+      );
+    });
+  });
+
+  /**
+   * lighten()
+   */
+  describe('lighten', () => {
+    it("doesn't modify rgb white", () => {
+      assert.strictEqual(
+        lighten('rgb(255, 255, 255)', 0.1),
+        'rgb(255, 255, 255)'
+      );
+    });
+
+    it('lightens rgb black to white when coefficient is 1', () => {
+      assert.strictEqual(
+        lighten('rgb(0, 0, 0)', 1),
+        'rgb(255, 255, 255)'
+      );
+    });
+
+    it('retains the alpha value in an rgba color', () => {
+      assert.strictEqual(
+        lighten('rgb(255, 255, 255, 0.5)', 0.1),
+        'rgb(255, 255, 255, 0.5)'
+      );
+    });
+
+    it('lightens rgb black by 10% when coefficient is 0.1', () => {
+      assert.strictEqual(
+        lighten('rgb(0, 0, 0)', 0.1),
+        'rgb(25, 25, 25)'
+      );
+    });
+
+    it('lightens rgb red by 50% when coefficient is 0.5', () => {
+      assert.strictEqual(
+        lighten('rgb(255, 0, 0)', 0.5),
+        'rgb(255, 127, 127)'
+      );
+    });
+
+    it('lightens rgb grey by 50% when coefficient is 0.5', () => {
+      assert.strictEqual(
+        lighten('rgb(127, 127, 127)', 0.5),
+        'rgb(191, 191, 191)'
+      );
+    });
+
+    it("doesn't modify rgb colors when coefficient is 0", () => {
+      assert.strictEqual(
+        lighten('rgb(127, 127, 127)', 0),
+        'rgb(127, 127, 127)'
+      );
+    });
+
+    it('lightens hsl red by 50% when coefficient is 0.5', () => {
+      assert.strictEqual(
+        lighten('hsl(0, 100%, 50%)', 0.5),
+        'hsl(0, 100%, 75%)'
+      );
+    });
+
+    it("doesn't modify hsl colors when coefficient is 0", () => {
+      assert.strictEqual(
+        lighten('hsl(0, 100%, 50%)', 0),
+        'hsl(0, 100%, 50%)'
+      );
+    });
+
+    it("doesn't modify hsl colors when l is 100%", () => {
+      assert.strictEqual(
+        lighten('hsl(0, 50%, 100%)', 0.5),
+        'hsl(0, 50%, 100%)'
+      );
+    });
+  });
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests - **oodles** of  em! / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

This started out as work to fix a bug in `lighten()` that was affecting styling in `Chip`, but it soon became apparent that there were broader issues.

This PR has three commits:

#### [Themes] Remove default export from colorManipulator

* Self explanatory

#### [Themes] Overhaul colorManipulator

* Fix `lighten()` - it returned incorrect values
* Simplify `lighten()` - remove default alpha (use `fade()` instead)
* Fix `darken()` - it returned incorrect values, and was foobar for hsl
* Fix `converColorToString()` - Correct hsl output (adds '%' where needed)
* Fix `decomposeColor()` - return values as numbers not strings
  Previously it broke formula where addition of a number to a string resulted in a string ('2' + 2 = '22')
* Refactor `getContrastRatio()` formula - remove conditional
* Fix `getContrastRatio()` (return a number, not a string)
* Remove `getContrastRatioLevel()` (dead code)
* Update `getLuminance()` to support hsl
* Refactor and simplfy `fade()`
* Document everything, including jshint style `@param` tags
* Test all the things - **44 new unit tests!**

#### [Themes] Move some duplicate logic out of getMuiTheme.js

* Create a new function `emphasize()` which darkens a light color and lightens a dark color according to luminance. (Will be used in `Chip`)
* Update some styles in `getMuiTheme.js` to use the new function.
* _More_ tests.