### PR TITLE
[TextField] Fix floatingLabel color

### DIFF
--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -46,7 +46,7 @@ const getStyles = (props, context, state) => {
       transition: transitions.easeOut(),
     },
     floatingLabel: {
-      color: hintColor,
+      color: floatingLabelColor,
       pointerEvents: 'none',
     },
     input: {

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -20,7 +20,6 @@ const getStyles = (props, context, state) => {
       textColor,
       disabledTextColor,
       backgroundColor,
-      hintColor,
       errorColor,
     },
   } = context.muiTheme;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has ~~tests~~ / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

The `TextField` floatingLabel does not use the correct value from the theme.
`floatingLabel: {color:}` is set to the `hintText` but should be `floatingLabelColor`.

Fixes #3967.