### PR TITLE
[TextField] Fix incorrect state in getStyles()

### DIFF
--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -11,7 +11,7 @@ import TextFieldLabel from './TextFieldLabel';
 import TextFieldUnderline from './TextFieldUnderline';
 import warning from 'warning';
 
-const getStyles = (props, state) => {
+const getStyles = (props, context, state) => {
   const {
     baseTheme,
     textField: {
@@ -23,7 +23,7 @@ const getStyles = (props, state) => {
       hintColor,
       errorColor,
     },
-  } = state.muiTheme;
+  } = context.muiTheme;
 
   const styles = {
     root: {
@@ -438,7 +438,7 @@ class TextField extends React.Component {
     } = this.props;
 
     const {prepareStyles} = this.context.muiTheme;
-    const styles = getStyles(this.props, this.context);
+    const styles = getStyles(this.props, this.context, this.state);
     const inputId = id || this.uniqueId;
 
     const errorTextElement = this.state.errorText && (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has ~~tests~~ / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

getStyles() was reading state, from context, so dynamic styling was not being applied correctly.

Fixes #3969.