### PR TITLE
[RaisedButton] Respect theme fontSize

### DIFF
--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -78,7 +78,7 @@ function getStyles(props, context, state) {
     label: {
       position: 'relative',
       opacity: 1,
-      fontSize: '14px',
+      fontSize: raisedButton.fontSize,
       letterSpacing: 0,
       textTransform: raisedButton.textTransform || button.textTransform || 'uppercase',
       fontWeight: raisedButton.fontWeight,

--- a/src/RaisedButton/RaisedButton.spec.js
+++ b/src/RaisedButton/RaisedButton.spec.js
@@ -91,4 +91,16 @@ describe('<RaisedButton />', () => {
       );
     });
   });
+
+  it('inherits fontSize from theme', () => {
+    const wrapper = shallowWithContext(
+      <RaisedButton label="test" />
+    );
+
+    assert.strictEqual(wrapper.contains('test'), true);
+    assert.equal(
+      wrapper.find('[children="test"]').prop('style').fontSize,
+      muiTheme.raisedButton.fontSize
+    );
+  });
 });

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -189,6 +189,7 @@ export default function getMuiTheme(muiTheme, ...more) {
       secondaryTextColor: palette.alternateTextColor,
       disabledColor: darken(palette.alternateTextColor, 0.1),
       disabledTextColor: fade(palette.textColor, 0.3),
+      fontSize: typography.fontStyleButtonFontSize,
       fontWeight: typography.fontWeightMedium,
     },
     refreshIndicator: {


### PR DESCRIPTION
RaisedButton label fontSize is hard coded as 14px. This PR allows the theme to override it.

Quick question: Is this the way you guys are doing it? There are styles all over that don't inherit from the theme, and this seems like a pretty heavy-handed way of dealing with it. I do see why it's complicated with multiple nested elements inheriting from a single config object. Just wondering what the idea is for this. Thanks!