### PR TITLE
[colorManipulator] Prevent illegal color values

### DIFF
--- a/src/utils/colorManipulator.js
+++ b/src/utils/colorManipulator.js
@@ -7,7 +7,13 @@
  * @returns {number} A number in the range [min, max]
  */
 function clamp(value, min, max) {
-  return Math.min(Math.max(value, min), max);
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
 }
 
 /**

--- a/src/utils/colorManipulator.spec.js
+++ b/src/utils/colorManipulator.spec.js
@@ -251,6 +251,20 @@ describe('utils/colorManipulator', () => {
       );
     });
 
+    it("doesn't overshoot if an above-range coefficient is supplied", () => {
+      assert.strictEqual(
+        darken('rgb(0, 127, 255)', 1.5),
+        'rgb(0, 0, 0)'
+      );
+    });
+
+    it("doesn't overshoot if a below-range coefficient is supplied", () => {
+      assert.strictEqual(
+        darken('rgb(0, 127, 255)', -0.1),
+        'rgb(0, 127, 255)'
+      );
+    });
+
     it('darkens rgb white to black when coefficient is 1', () => {
       assert.strictEqual(
         darken('rgb(255, 255, 255)', 1),
@@ -323,6 +337,20 @@ describe('utils/colorManipulator', () => {
       assert.strictEqual(
         lighten('rgb(255, 255, 255)', 0.1),
         'rgb(255, 255, 255)'
+      );
+    });
+
+    it("doesn't overshoot if an above-range coefficient is supplied", () => {
+      assert.strictEqual(
+        lighten('rgb(0, 127, 255)', 1.5),
+        'rgb(255, 255, 255)'
+      );
+    });
+
+    it("doesn't overshoot if a below-range coefficient is supplied", () => {
+      assert.strictEqual(
+        lighten('rgb(0, 127, 255)', -0.1),
+        'rgb(0, 127, 255)'
       );
     });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Fixes one last niggle I had with colorManipulator:

The color can go out of range if an illegal coefficient is provided.

* Replace the warning with a `clamp()` function.
* Add jsdoc `@return` to comments.