### PR TITLE
[Docs] Add TextField fullWidth example

### DIFF
--- a/docs/src/app/components/pages/components/TextField/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/TextField/ExampleSimple.js
@@ -39,6 +39,10 @@ const TextFieldExampleSimple = () => (
       floatingLabelText="MultiLine and FloatingLabel"
       multiLine={true}
       rows={2}
+    /><br />
+    <TextField
+      hintText="Full width"
+      fullWidth={true}
     />
   </div>
 );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted. (N/A)
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

I just felt like TextField needed a full width example.  It was probably jealous of AutoComplete.