### PR TITLE
[Examples] Update import statements

### DIFF
--- a/examples/browserify-gulp-example/src/app/Main.js
+++ b/examples/browserify-gulp-example/src/app/Main.js
@@ -4,12 +4,12 @@
  */
 
 import React from 'react';
-import RaisedButton from 'material-ui/lib/raised-button';
-import Dialog from 'material-ui/lib/dialog';
-import {deepOrange500} from 'material-ui/lib/styles/colors';
-import FlatButton from 'material-ui/lib/flat-button';
-import getMuiTheme from 'material-ui/lib/styles/getMuiTheme';
-import MuiThemeProvider from 'material-ui/lib/MuiThemeProvider';
+import RaisedButton from 'material-ui/RaisedButton';
+import Dialog from 'material-ui/Dialog';
+import {deepOrange500} from 'material-ui/styles/colors';
+import FlatButton from 'material-ui/FlatButton';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 
 const styles = {
   container: {

--- a/examples/webpack-example/src/app/Main.js
+++ b/examples/webpack-example/src/app/Main.js
@@ -4,12 +4,12 @@
  */
 
 import React from 'react';
-import RaisedButton from 'material-ui/lib/raised-button';
-import Dialog from 'material-ui/lib/dialog';
-import {deepOrange500} from 'material-ui/lib/styles/colors';
-import FlatButton from 'material-ui/lib/flat-button';
-import getMuiTheme from 'material-ui/lib/styles/getMuiTheme';
-import MuiThemeProvider from 'material-ui/lib/MuiThemeProvider';
+import RaisedButton from 'material-ui/RaisedButton';
+import Dialog from 'material-ui/Dialog';
+import {deepOrange500} from 'material-ui/styles/colors';
+import FlatButton from 'material-ui/FlatButton';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 
 const styles = {
   container: {

--- a/src/styles/themeManager.js
+++ b/src/styles/themeManager.js
@@ -7,7 +7,7 @@ export default
   {
     getMuiTheme(baseTheme, muiTheme) {
       warning(false, 'ThemeManager is deprecated. please import getMuiTheme' +
-        ' directly from "material-ui/lib/getMuiTheme"');
+        ' directly from "material-ui/getMuiTheme"');
       return getMuiTheme(baseTheme, muiTheme);
     },
     modifyRawThemeSpacing(muiTheme, spacing) {


### PR DESCRIPTION
Updating import statements as reflected on the latest [CHANGELOG](https://github.com/callemall/material-ui/blob/master/CHANGELOG.md#simplify-import-statements-tada).

The PR only updates the import statements in the example apps and one occasion in the deprecation message of the source code.

The PR does not include any tests and fixes the failing example apps:
```
❯ gulp build
[03:07:01] Using gulpfile ./browserify-gulp-example/gulpfile.js
[03:07:01] Starting 'browserify'...
[03:07:01] Bundling app.js...
[03:07:01] Starting 'markup'...
[03:07:01] Finished 'markup' after 28 ms
[03:07:03] gulp-notify: [Compile Error] Cannot find module 'material-ui/lib/raised-button' from './browserify-gulp-example/src/app'
[03:07:03] Bundled app.js in 1.89 s
[03:07:03] Finished 'browserify' after 1.9 s
[03:07:03] Starting 'build'...
[03:07:03] Finished 'build' after 7.4 μs
[03:07:03] gulp-notify: [Compile Error] Cannot find module 'material-ui/lib/dialog' from './browserify-gulp-example/src/app'
[03:07:03] gulp-notify: [Compile Error] Cannot find module 'material-ui/lib/flat-button' from './browserify-gulp-example/src/app'
[03:07:03] gulp-notify: [Compile Error] Cannot find module 'material-ui/lib/MuiThemeProvider' from './browserify-gulp-example/src/app'
[03:07:03] gulp-notify: [Compile Error] Cannot find module 'material-ui/lib/styles/colors' from './browserify-gulp-example/src/app'
[03:07:03] gulp-notify: [Compile Error] Cannot find module 'material-ui/lib/styles/getMuiTheme' from './browserify-gulp-example/src/app'
```

Not sure if should the same updates be applied to the `docs/` directory.

And thanks for including 2 good example projects! They were exactly what I needed :)