### PR TITLE
[SelectField] Fix server side rendering

### DIFF
--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -81,6 +81,11 @@ class SelectField extends React.Component {
     iconStyle: React.PropTypes.object,
 
     /**
+     * The id prop for the text field.
+     */
+    id: React.PropTypes.string,
+
+    /**
      * Overrides the styles of label when the `SelectField` is inactive.
      */
     labelStyle: React.PropTypes.object,
@@ -148,6 +153,7 @@ class SelectField extends React.Component {
       style,
       labelStyle,
       iconStyle,
+      id,
       underlineDisabledStyle,
       underlineFocusStyle,
       underlineStyle,
@@ -182,6 +188,7 @@ class SelectField extends React.Component {
         errorStyle={errorStyle}
         onFocus={onFocus}
         onBlur={onBlur}
+        id={id}
         underlineDisabledStyle={underlineDisabledStyle}
         underlineFocusStyle={underlineFocusStyle}
       >


### PR DESCRIPTION
We need to spread the `id` property to the `TextField` otherwise the id won't match between two renders.
Fix https://github.com/callemall/material-ui/issues/3998.