### PR TITLE
[Git] Ignore jsconfig.json (VSCode config file)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ icon-builder/jsx
 .idea
 *.sublime-project
 *.sublime-workspace
+jsconfig.json
 
 # OS files
 .DS_STORE


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted. (N/A)
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

VSCode needs a `jsconfig.json` file in the root folder of a project to enable ES2015 syntax recognition.  Options are 1) to include the file in the repo, or 2) add it to `.gitignore`.  A quick [search](https://www.google.com/search?q="jsconfig.json"+gitignore) leads me to believe that option 2 is right for this project.

See [Angular](https://github.com/angular/angular-cli/blob/master/.gitignore) and [other](https://github.com/mr-doc/mr-doc/blob/master/.gitignore) [examples](https://github.com/nodegit/nodegit/blob/master/.gitignore).