### PR TITLE
[MenuItem] Fix Uncaught TypeError: Cannot read property 'applyFocusState' of undefined

### DIFF
--- a/src/MenuItem/MenuItem.js
+++ b/src/MenuItem/MenuItem.js
@@ -188,7 +188,9 @@ class MenuItem extends React.Component {
   }
 
   applyFocusState() {
-    this.refs.listItem.applyFocusState(this.props.focusState);
+    if (this.refs.listItem) {
+      this.refs.listItem.applyFocusState(this.props.focusState);
+    }
   }
 
   cloneMenuItem = (item) => {


### PR DESCRIPTION
- [x] PR ~~has tests / docs demo, and~~ is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

This closes #4013 - when menu items were rendered and hidden and then rendered, the above error was occurring, the issue was that the code was not doing a null check of this.refs.listItem before trying to apply focus state.