### PR TITLE
[AutoComplete] error/hint/floatingLabel texts should be of PropTypes.node

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -71,7 +71,7 @@ class AutoComplete extends React.Component {
     /**
      * The error content to display.
      */
-    errorText: React.PropTypes.string,
+    errorText: React.PropTypes.node,
 
     /**
      * Callback function used to filter the auto complete.
@@ -85,7 +85,7 @@ class AutoComplete extends React.Component {
     /**
      * The content to use for adding floating label element.
      */
-    floatingLabelText: React.PropTypes.string,
+    floatingLabelText: React.PropTypes.node,
 
     /**
      * If true, the field receives the property `width: 100%`.
@@ -95,7 +95,7 @@ class AutoComplete extends React.Component {
     /**
      * The hint content to display.
      */
-    hintText: React.PropTypes.string,
+    hintText: React.PropTypes.node,
 
     /**
      * Override style for list.


### PR DESCRIPTION
Like in most of the other components, use `PropTypes.node` instead of `PropTypes.string` to accept anything that can be rendered, to allow passing a `<span>` for example for these texts (e.g. when using `react-intl` components), or even `false` (e.g. when using `redux-form`)

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).