### PR TITLE
[Tab] Fix the justify content when there is only one child

### DIFF
--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -17,10 +17,8 @@ function getStyles(props, context) {
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'center',
-      justifyContent: 'space-between',
-      height: (props.label && props.icon) ? 53 : 24,
-      padding: 12,
-      paddingBottom: (props.label && props.icon) ? 7 : 12,
+      justifyContent: 'center',
+      height: (props.label && props.icon) ? 72 : 48,
     },
   };
 }
@@ -95,13 +93,15 @@ class Tab extends React.Component {
 
   render() {
     const {
+      /* eslint-disable no-unused-vars */
+      onActive,
+      onTouchTap,
+      selected,
+      value,
+      width,
+      /* eslint-enable no-unused-vars */
       label,
-      onActive, // eslint-disable-line no-unused-vars
-      onTouchTap, // eslint-disable-line no-unused-vars
-      selected, // eslint-disable-line no-unused-vars
       style,
-      value, // eslint-disable-line no-unused-vars
-      width, // eslint-disable-line no-unused-vars
       icon,
       ...other,
     } = this.props;
@@ -110,17 +110,18 @@ class Tab extends React.Component {
 
     let iconElement;
     if (icon && React.isValidElement(icon)) {
-      const params = {
+      const iconProps = {
         style: {
           fontSize: 24,
           color: styles.root.color,
+          marginBottom: label ? 5 : 0,
         },
       };
       // If it's svg icon set color via props
       if (icon.type.muiName !== 'FontIcon') {
-        params.color = styles.root.color;
+        iconProps.color = styles.root.color;
       }
-      iconElement = React.cloneElement(icon, params);
+      iconElement = React.cloneElement(icon, iconProps);
     }
 
     const rippleOpacity = 0.3;

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -9,8 +9,6 @@ function getStyles(props, context) {
 
   return {
     tabItemContainer: {
-      margin: 0,
-      padding: 0,
       width: '100%',
       backgroundColor: tabs.backgroundColor,
       whiteSpace: 'nowrap',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

We shouldn't be using `justifyContent: 'space-between'` when there is only one child. As we can see [here](https://codepen.io/anon/pen/LNmOLX), the element is rendered at the top.
I'm using `justifyContent: 'center'` instead and I'm added a margin to have a fine control of the spacing.
![capture d ecran 2016-04-17 a 21 03 08](https://cloud.githubusercontent.com/assets/3165635/14589344/e4d15528-04df-11e6-97d1-fd98c9536733.png)

