### PR TITLE
[CircularProgress] Fix for Android

### DIFF
--- a/src/CircularProgress/CircularProgress.js
+++ b/src/CircularProgress/CircularProgress.js
@@ -46,7 +46,7 @@ function getStyles(props, context) {
       width: baseSize,
     },
     path: {
-      strokeDasharray: '89,200',
+      strokeDasharray: '89, 200',
       strokeDashoffset: 0,
       stroke: props.color || palette.primary1Color,
       strokeLinecap: 'round',
@@ -57,7 +57,7 @@ function getStyles(props, context) {
   if (props.mode === 'determinate') {
     const relVal = getRelativeValue(value, min, max);
     styles.path.transition = transitions.create('all', '0.3s', null, 'linear');
-    styles.path.strokeDasharray = `${Math.round(relVal * 1.25)},200`;
+    styles.path.strokeDasharray = `${Math.round(relVal * 1.25)}, 200`;
   }
 
   return styles;
@@ -144,7 +144,7 @@ class CircularProgress extends React.Component {
       path.style.strokeDashoffset = -35;
       path.style.transitionDuration = '750ms';
     } else {
-      path.style.strokeDasharray = '89,200';
+      path.style.strokeDasharray = '89, 200';
       path.style.strokeDashoffset = -124;
       path.style.transitionDuration = '850ms';
     }
@@ -183,9 +183,14 @@ class CircularProgress extends React.Component {
         <div ref="wrapper" style={prepareStyles(Object.assign(styles.wrapper, innerStyle))} >
           <svg style={prepareStyles(styles.svg)} >
             <circle
-              ref="path" style={prepareStyles(styles.path)} cx="25"
-              cy="25" r="20" fill="none"
-              strokeWidth="2.5" strokeMiterlimit="10"
+              ref="path"
+              style={prepareStyles(styles.path)}
+              cx="25"
+              cy="25"
+              r="20"
+              fill="none"
+              strokeWidth="2.5"
+              strokeMiterlimit="20"
             />
           </svg>
         </div>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

I have the following issue on my Android Phone.
![capture d ecran 2016-04-17 a 23 14 22](https://cloud.githubusercontent.com/assets/3165635/14590075/2a6946ce-04f2-11e6-91a0-47aa3d7e61a0.png)

Setting `strokeMiterlimit` to `20` instead of `10` fix a rendering issue.
I have no idea why and how this fix work 😁.