### PR TITLE
[LinearProgress] determinate mode calculates wrong value if min/max is set

### DIFF
--- a/src/LinearProgress/LinearProgress.js
+++ b/src/LinearProgress/LinearProgress.js
@@ -4,7 +4,7 @@ import transitions from '../styles/transitions';
 function getRelativeValue(value, min, max) {
   const clampedValue = Math.min(Math.max(min, value), max);
   const rangeValue = max - min;
-  const relValue = Math.round(clampedValue / rangeValue * 10000) / 10000;
+  const relValue = Math.round( (clampedValue-min) / rangeValue * 10000) / 10000;
   return relValue * 100;
 }
 

--- a/src/LinearProgress/LinearProgress.js
+++ b/src/LinearProgress/LinearProgress.js
@@ -4,7 +4,7 @@ import transitions from '../styles/transitions';
 function getRelativeValue(value, min, max) {
   const clampedValue = Math.min(Math.max(min, value), max);
   const rangeValue = max - min;
-  const relValue = Math.round( (clampedValue-min) / rangeValue * 10000) / 10000;
+  const relValue = Math.round( (clampedValue - min) / rangeValue * 10000) / 10000;
   return relValue * 100;
 }
 


### PR DESCRIPTION
`<LinearProgress mode="determinate" value={50} min={50} max={100} />`
The ProgressBar is now be 0% (before fix: 100%)

`<LinearProgress mode="determinate" value={75} min={50} max={100} />`
The ProgressBar is now 50% (before fix: 150%)



fixes #4037
 
