### PR TITLE
[ListItem] Add extra width to leftCheckbox for EnhancedSwitch margin, fixes #4016

### DIFF
--- a/src/internal/EnhancedSwitch.js
+++ b/src/internal/EnhancedSwitch.js
@@ -51,6 +51,7 @@ function getStyles(props, context) {
       float: 'left',
       position: 'relative',
       display: 'block',
+      flexShrink: 0,
       width: 60 - baseTheme.spacing.desktopGutterLess,
       marginRight: (props.labelPosition === 'right') ?
         baseTheme.spacing.desktopGutterLess : 0,


### PR DESCRIPTION
Fixes #4016.

EnhancedSwitch has a built in margin and it looks like to a switch to flex internally from clearfix had a slight side effect here:

![2016-04-20 at 12 23 am](https://cloud.githubusercontent.com/assets/4420103/14663561/317d15cc-0690-11e6-89ae-50ad6f41c038.png)


- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).
