### PR TITLE
[Docs] Add beta installation details to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,20 @@ for a quick introduction before you read on.)
 ## Installation
 
 Material-UI is available as an [npm package](https://www.npmjs.org/package/material-ui).
+
+**Stable channel**
 ```sh
 npm install material-ui
 ```
-After npm install, you'll find all the .js files in the /src folder and
-their compiled versions in the /lib folder.
+
+Our next version (`0.15.0`) is coming soon! If you need React 15 support or want to preview our latest updates, you can install the current beta.
+
+**Pre-release channel (React 15 support)**
+```sh
+npm install material-ui@next
+```
+
+
 
 ### React-Tap-Event-Plugin
 

--- a/docs/src/app/components/pages/get-started/installation.md
+++ b/docs/src/app/components/pages/get-started/installation.md
@@ -1,8 +1,6 @@
 ## Installation
 
 Material-UI is available as an [npm package](https://www.npmjs.org/package/material-ui).
-After npm install, you will find all the `.jsx` files in the `/src` folder and
-their compiled versions in the pachage root.
 
 ### react-tap-event-plugin
 


### PR DESCRIPTION
Adds instructions for installing the @next npm package to the README. Also removed an incorrect line from the installation instructions.

It gives users a clear option of opting into the beta if they are starting a new project or are looking for React 15 support, or simply want to help out!

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

