### PR TITLE
[Docs] Remove localhost:3000 from link

### DIFF
--- a/docs/src/app/components/pages/components/Divider/Page.js
+++ b/docs/src/app/components/pages/components/Divider/Page.js
@@ -18,7 +18,7 @@ const descriptions = {
   simple: 'Here, `Divider` is used to separate [TextField](/#/components/text-field) components. ' +
   'It defaults to "full-bleed" (full width).',
   inset: 'The `inset` parameter allows the divider to to align with inset content, ' +
-  'such as inset [List](http://localhost:3000/#/components/list) components.',
+  'such as inset [List](/#/components/list) components.',
   menu: '`Divider` can alo be used in [Menus](/#/components/menu).',
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

In documentation for [Divider](http://www.material-ui.com/#/components/divider) component, if you click on List link it opens localhost:3000.
- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


