### PR TITLE
[Core] Remove the blank line between the propTypes definitions

### DIFF
--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -69,82 +69,68 @@ class AppBar extends Component {
      * Can be used to render a tab inside an app bar for instance.
      */
     children: PropTypes.node,
-
     /**
      * Applied to the app bar's root element.
      */
     className: PropTypes.string,
-
     /**
      * The classname of the icon on the left of the app bar.
      * If you are using a stylesheet for your icons, enter the class name for the icon to be used here.
      */
     iconClassNameLeft: PropTypes.string,
-
     /**
      * Similiar to the iconClassNameLeft prop except that
      * it applies to the icon displayed on the right of the app bar.
      */
     iconClassNameRight: PropTypes.string,
-
     /**
      * The custom element to be displayed on the left side of the
      * app bar such as an SvgIcon.
      */
     iconElementLeft: PropTypes.element,
-
     /**
      * Similiar to the iconElementLeft prop except that this element is displayed on the right of the app bar.
      */
     iconElementRight: PropTypes.element,
-
     /**
      * Override the inline-styles of the element displayed on the right side of the app bar.
      */
     iconStyleRight: PropTypes.object,
-
     /**
      * Callback function for when the left icon is selected via a touch tap.
      *
      * @param {object} event TouchTap event targeting the left `IconButton`.
      */
     onLeftIconButtonTouchTap: PropTypes.func,
-
     /**
      * Callback function for when the right icon is selected via a touch tap.
      *
      * @param {object} event TouchTap event targeting the right `IconButton`.
      */
     onRightIconButtonTouchTap: PropTypes.func,
-
     /**
      * Callback function for when the title text is selected via a touch tap.
      *
      * @param {object} event TouchTap event targeting the `title` node.
      */
     onTitleTouchTap: PropTypes.func,
-
     /**
      * Determines whether or not to display the Menu icon next to the title.
      * Setting this prop to false will hide the icon.
      */
     showMenuIconButton: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * The title to display on the app bar.
      */
     title: PropTypes.node,
-
     /**
      * Override the inline-styles of the app bar's title element.
      */
     titleStyle: PropTypes.object,
-
     /**
      * The zDepth of the component.
      * The shadow of the app bar is also dependent on this property.

--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -47,32 +47,26 @@ class AutoComplete extends Component {
      * Location of the anchor for the auto complete.
      */
     anchorOrigin: propTypes.origin,
-
     /**
      * If true, the auto complete is animated as it is toggled.
      */
     animated: PropTypes.bool,
-
     /**
      * Array of strings or nodes used to populate the list.
      */
     dataSource: PropTypes.array.isRequired,
-
     /**
      * Disables focus ripple when true.
      */
     disableFocusRipple: PropTypes.bool,
-
     /**
      * Override style prop for error.
      */
     errorStyle: PropTypes.object,
-
     /**
      * The error content to display.
      */
     errorText: PropTypes.node,
-
     /**
      * Callback function used to filter the auto complete.
      *
@@ -81,67 +75,55 @@ class AutoComplete extends Component {
      * @returns {boolean} `true` indicates the auto complete list will include `key` when the input is `searchText`.
      */
     filter: PropTypes.func,
-
     /**
      * The content to use for adding floating label element.
      */
     floatingLabelText: PropTypes.node,
-
     /**
      * If true, the field receives the property `width: 100%`.
      */
     fullWidth: PropTypes.bool,
-
     /**
      * The hint content to display.
      */
     hintText: PropTypes.node,
-
     /**
      * Override style for list.
      */
     listStyle: PropTypes.object,
-
     /**
      * The max number of search results to be shown.
      * By default it shows all the items which matches filter.
      */
     maxSearchResults: PropTypes.number,
-
     /**
      * Delay for closing time of the menu.
      */
     menuCloseDelay: PropTypes.number,
-
     /**
      * Props to be passed to menu.
      */
     menuProps: PropTypes.object,
-
     /**
      * Override style for menu.
      */
     menuStyle: PropTypes.object,
-
     /**
      * Callback function that is fired when the `TextField` loses focus.
      *
      * @param {object} event `blur` event targeting the `TextField`.
      */
     onBlur: PropTypes.func,
-
     /**
      * Callback function that is fired when the `TextField` gains focus.
      *
      * @param {object} event `focus` event targeting the `TextField`.
      */
     onFocus: PropTypes.func,
-
     /**
      * Callback function that is fired when the `TextField` receives a keydown event.
      */
     onKeyDown: PropTypes.func,
-
     /**
      * Callback function that is fired when a list item is selected, or enter is pressed in the `TextField`.
      *
@@ -151,7 +133,6 @@ class AutoComplete extends Component {
      * `TextField`.
      */
     onNewRequest: PropTypes.func,
-
     /**
      * Callback function that is fired when the user updates the `TextField`.
      *
@@ -159,32 +140,26 @@ class AutoComplete extends Component {
      * @param {array} dataSource The auto-complete's `dataSource` array.
      */
     onUpdateInput: PropTypes.func,
-
     /**
      * Auto complete menu is open if true.
      */
     open: PropTypes.bool,
-
     /**
      * If true, the list item is showed when a focus event triggers.
      */
     openOnFocus: PropTypes.bool,
-
     /**
      * Text being input to auto complete.
      */
     searchText: PropTypes.string,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * Origin for location of target.
      */
     targetOrigin: propTypes.origin,
-
     /**
      * If true, will update when focus event triggers.
      */

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -49,37 +49,30 @@ class Avatar extends Component {
      * The backgroundColor of the avatar. Does not apply to image avatars.
      */
     backgroundColor: PropTypes.string,
-
     /**
      * Can be used, for instance, to render a letter inside the avatar.
      */
     children: PropTypes.node,
-
     /**
      * The css class name of the root `div` or `img` element.
      */
     className: PropTypes.string,
-
     /**
      * The icon or letter's color.
      */
     color: PropTypes.string,
-
     /**
      * This is the SvgIcon or FontIcon to be used inside the avatar.
      */
     icon: PropTypes.element,
-
     /**
      * This is the size of the avatar in pixels.
      */
     size: PropTypes.number,
-
     /**
      * If passed in, this component will render an img element. Otherwise, a div will be rendered.
      */
     src: PropTypes.string,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -54,32 +54,26 @@ class Badge extends Component {
      * This is the content rendered within the badge.
      */
     badgeContent: PropTypes.node.isRequired,
-
     /**
      * Override the inline-styles of the badge element.
      */
     badgeStyle: PropTypes.object,
-
     /**
      * The badge will be added relativelty to this node.
      */
     children: PropTypes.node,
-
     /**
      * The css class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * If true, the badge will use the primary badge colors.
      */
     primary: PropTypes.bool,
-
     /**
      * If true, the badge will use the secondary badge colors.
      */
     secondary: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/Card/Card.js
+++ b/src/Card/Card.js
@@ -8,36 +8,30 @@ class Card extends Component {
      * If true, a click on this card component expands the card. Can be set on any child of the `Card` component.
      */
     actAsExpander: PropTypes.bool,
-
     /**
      * Can be used to render elements inside the Card.
      */
     children: PropTypes.node,
-
     /**
      * If true, this card component is expandable. Can be set on any child of the `Card` component.
      */
     expandable: PropTypes.bool,
-
     /**
      * Whether this card is expanded.
      * If `true` or `false` the component is controlled.
      * if `null` the component is uncontrolled.
      */
     expanded: PropTypes.bool,
-
     /**
      * Whether this card is initially expanded.
      */
     initiallyExpanded: PropTypes.bool,
-
     /**
      * Callback function fired when the `expandable` state of the card has changed.
      *
      * @param {boolean} newExpandedState Represents the new `expanded` state of the card.
      */
     onExpandChange: PropTypes.func,
-
     /**
      * If true, this card component will include a button to expand the card. `CardTitle`,
      * `CardHeader` and `CardActions` implement `showExpandableButton`. Any child component
@@ -45,7 +39,6 @@ class Card extends Component {
      * component supporting it.
      */
     showExpandableButton: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/Card/CardActions.js
+++ b/src/Card/CardActions.js
@@ -18,22 +18,18 @@ class CardActions extends Component {
      * If true, a click on this card component expands the card.
      */
     actAsExpander: PropTypes.bool,
-
     /**
      * Can be used to render elements inside the Card Action.
      */
     children: PropTypes.node,
-
     /**
      * If true, this card component is expandable.
      */
     expandable: PropTypes.bool,
-
     /**
      * If true, this card component will include a button to expand the card.
      */
     showExpandableButton: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/Card/CardHeader.js
+++ b/src/Card/CardHeader.js
@@ -42,62 +42,50 @@ class CardHeader extends Component {
      * If true, a click on this card component expands the card.
      */
     actAsExpander: PropTypes.bool,
-
     /**
      * This is the [Avatar](/#/components/avatar) element to be displayed on the Card Header.
      */
     avatar: PropTypes.node,
-
     /**
      * Can be used to render elements inside the Card Header.
      */
     children: PropTypes.node,
-
     /**
      * If true, this card component is expandable.
      */
     expandable: PropTypes.bool,
-
     /**
      * If true, this card component will include a button to expand the card.
      */
     showExpandableButton: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * Can be used to render a subtitle in Card Header.
      */
     subtitle: PropTypes.node,
-
     /**
      * Override the subtitle color.
      */
     subtitleColor: PropTypes.string,
-
     /**
      * Override the inline-styles of the subtitle.
      */
     subtitleStyle: PropTypes.object,
-
     /**
      * Override the inline-styles of the text.
      */
     textStyle: PropTypes.object,
-
     /**
      * Can be used to render a title in Card Header.
      */
     title: PropTypes.node,
-
     /**
      * Override the title color.
      */
     titleColor: PropTypes.string,
-
     /**
      * Override the inline-styles of the title.
      */

--- a/src/Card/CardMedia.js
+++ b/src/Card/CardMedia.js
@@ -42,42 +42,34 @@ class CardMedia extends Component {
      * If true, a click on this card component expands the card.
      */
     actAsExpander: PropTypes.bool,
-
     /**
      * Can be used to render elements inside the Card Media.
      */
     children: PropTypes.node,
-
     /**
      * If true, this card component is expandable.
      */
     expandable: PropTypes.bool,
-
     /**
      * Override the inline-styles of the Card Media.
      */
     mediaStyle: PropTypes.object,
-
     /**
      * Can be used to render overlay element in Card Media.
      */
     overlay: PropTypes.node,
-
     /**
      * Override the inline-styles of the overlay container.
      */
     overlayContainerStyle: PropTypes.object,
-
     /**
      * Override the inline-styles of the overlay content.
      */
     overlayContentStyle: PropTypes.object,
-
     /**
      * Override the inline-styles of the overlay element.
      */
     overlayStyle: PropTypes.object,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/Card/CardText.js
+++ b/src/Card/CardText.js
@@ -20,22 +20,18 @@ class CardText extends Component {
      * If true, a click on this card component expands the card.
      */
     actAsExpander: PropTypes.bool,
-
     /**
      * Can be used to render elements inside the Card Text.
      */
     children: PropTypes.node,
-
     /**
      * Override the CardText color.
      */
     color: PropTypes.string,
-
     /**
      * If true, this card component is expandable.
      */
     expandable: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/Card/CardTitle.js
+++ b/src/Card/CardTitle.js
@@ -30,52 +30,42 @@ class CardTitle extends Component {
      * If true, a click on this card component expands the card.
      */
     actAsExpander: PropTypes.bool,
-
     /**
      * Can be used to render elements inside the Card Title.
      */
     children: PropTypes.node,
-
     /**
      * If true, this card component is expandable.
      */
     expandable: PropTypes.bool,
-
     /**
      * If true, this card component will include a button to expand the card.
      */
     showExpandableButton: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * Can be used to render a subtitle in the Card Title.
      */
     subtitle: PropTypes.node,
-
     /**
      * Override the subtitle color.
      */
     subtitleColor: PropTypes.string,
-
     /**
      * Override the inline-styles of the subtitle.
      */
     subtitleStyle: PropTypes.object,
-
     /**
      * Can be used to render a title in the Card Title.
      */
     title: PropTypes.node,
-
     /**
      * Override the title color.
      */
     titleColor: PropTypes.string,
-
     /**
      * Override the inline-styles of the title.
      */

--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -59,13 +59,11 @@ class Checkbox extends Component {
      * Checkbox is checked if true.
      */
     checked: PropTypes.bool,
-
     /**
      * The SvgIcon to use for the checked state.
      * This is useful to create icon toggles.
      */
     checkedIcon: PropTypes.element,
-
     /**
      * The default state of our checkbox component.
      * **Warning:** This cannot be used in conjunction with `checked`.
@@ -73,32 +71,26 @@ class Checkbox extends Component {
      * More info: https://fb.me/react-controlled-components
      */
     defaultChecked: PropTypes.bool,
-
     /**
      * Disabled if true.
      */
     disabled: PropTypes.bool,
-
     /**
      * Overrides the inline-styles of the icon element.
      */
     iconStyle: PropTypes.object,
-
     /**
      * Overrides the inline-styles of the input element.
      */
     inputStyle: PropTypes.object,
-
     /**
      * Where the label will be placed next to the checkbox.
      */
     labelPosition: PropTypes.oneOf(['left', 'right']),
-
     /**
      * Overrides the inline-styles of the Checkbox element label.
      */
     labelStyle: PropTypes.object,
-
     /**
      * Callback function that is fired when the checkbox is checked.
      *
@@ -106,25 +98,21 @@ class Checkbox extends Component {
      * @param {boolean} isInputChecked The `checked` value of the underlying checkbox `input`.
      */
     onCheck: PropTypes.func,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * The SvgIcon to use for the unchecked state.
      * This is useful to create icon toggles.
      */
     unCheckedIcon: deprecated(PropTypes.element,
       'Use uncheckedIcon instead.'),
-
     /**
      * The SvgIcon to use for the unchecked state.
      * This is useful to create icon toggles.
      */
     uncheckedIcon: PropTypes.element,
-
     /**
      * ValueLink for when using controlled checkbox.
      */

--- a/src/CircularProgress/CircularProgress.js
+++ b/src/CircularProgress/CircularProgress.js
@@ -69,38 +69,31 @@ class CircularProgress extends Component {
      * Override the progress's color.
      */
     color: PropTypes.string,
-
     /**
      * Style for inner wrapper div.
      */
     innerStyle: PropTypes.object,
-
     /**
      * The max value of progress, only works in determinate mode.
      */
     max: PropTypes.number,
-
     /**
      * The min value of progress, only works in determinate mode.
      */
     min: PropTypes.number,
-
     /**
      * The mode of show your progress, indeterminate
      * for when there is no value for progress.
      */
     mode: PropTypes.oneOf(['determinate', 'indeterminate']),
-
     /**
      * The size of the progress.
      */
     size: PropTypes.number,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * The value of progress, only works in determinate mode.
      */

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -13,41 +13,34 @@ class DatePicker extends Component {
      * otherwise https://github.com/andyearnshaw/Intl.js is a good polyfill.
      */
     DateTimeFormat: PropTypes.func,
-
     /**
      * If true, automatically accept and close the picker on select a date.
      */
     autoOk: PropTypes.bool,
-
     /**
      * Override the default text of the 'Cancel' button.
      */
     cancelLabel: PropTypes.node,
-
     /**
      * Used to control how the DatePicker will be displayed when a user tries to set a date.
      * `dialog` (default) displays the DatePicker as a dialog with a modal.
      * `inline` displays the DatePicker below the input field (similar to auto complete).
      */
     container: PropTypes.oneOf(['dialog', 'inline']),
-
     /**
      * This is the initial date value of the component.
      * If either `value` or `valueLink` is provided they will override this
      * prop with `value` taking precedence.
      */
     defaultDate: PropTypes.object,
-
     /**
      * Disables the year selection in the date picker.
      */
     disableYearSelection: PropTypes.bool,
-
     /**
      * Disables the DatePicker.
      */
     disabled: PropTypes.bool,
-
     /**
      * Used to change the first day of week. It varies from
      * Saturday to Monday between different locales.
@@ -55,7 +48,6 @@ class DatePicker extends Component {
      * The default is `1`, Monday, as per ISO 8601.
      */
     firstDayOfWeek: PropTypes.number,
-
     /**
      * This function is called to format the date displayed in the input box, and should return a string.
      * By default if no `locale` and `DateTimeFormat` is provided date objects are formatted to ISO 8601 YYYY-MM-DD.
@@ -64,35 +56,29 @@ class DatePicker extends Component {
      * @returns {any} The formatted date.
      */
     formatDate: PropTypes.func,
-
     /**
      * Locale used for formatting the dialog date strings. If you are not using the default value, you
      * have to provide a `DateTimeFormat` that supports it.
      */
     locale: PropTypes.string,
-
     /**
      * The ending of a range of valid dates. The range includes the endDate.
      * The default value is current date + 100 years.
      */
     maxDate: PropTypes.object,
-
     /**
      * The beginning of a range of valid dates. The range includes the startDate.
      * The default value is current date - 100 years.
      */
     minDate: PropTypes.object,
-
     /**
      * Tells the component to display the picker in portrait or landscape mode.
      */
     mode: PropTypes.oneOf(['portrait', 'landscape']),
-
     /**
      * Override the default text of the 'OK' button.
      */
     okLabel: PropTypes.node,
-
     /**
      * Callback function that is fired when the date value changes.
      *
@@ -101,31 +87,26 @@ class DatePicker extends Component {
      * @param {object} date The new date.
      */
     onChange: PropTypes.func,
-
     /**
      * Callback function that is fired when the Date Picker's dialog is dismissed.
      */
     onDismiss: PropTypes.func,
-
     /**
      * Callback function that is fired when the Date Picker's `TextField` gains focus.
      *
      * @param {object} event `focus` event targeting the `TextField`.
      */
     onFocus: PropTypes.func,
-
     /**
      * Callback function that is fired when the Date Picker's dialog is shown.
      */
     onShow: PropTypes.func,
-
     /**
      * Callback function that is fired when a touch tap event occurs on the Date Picker's `TextField`.
      *
      * @param {object} event TouchTap event targeting the `TextField`.
      */
     onTouchTap: PropTypes.func,
-
     /**
      * Callback function used to determine if a day's entry should be disabled on the calendar.
      *
@@ -133,27 +114,22 @@ class DatePicker extends Component {
      * @returns {boolean} Indicates whether the day should be disabled.
      */
     shouldDisableDate: PropTypes.func,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * Override the inline-styles of DatePicker's TextField element.
      */
     textFieldStyle: PropTypes.object,
-
     /**
      * Sets the date for the Date Picker programmatically.
      */
     value: PropTypes.any,
-
     /**
      * Creates a ValueLink with the value of date picker.
      */
     valueLink: PropTypes.object,
-
     /**
      * Wordings used inside the button of the dialog.
      */

--- a/src/DatePicker/DatePickerInline.js
+++ b/src/DatePicker/DatePickerInline.js
@@ -16,7 +16,6 @@ class DatePickerInline extends Component {
     children: PropTypes.node,
     onRequestClose: PropTypes.func.isRequired,
     open: PropTypes.bool.isRequired,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -363,106 +363,86 @@ class Dialog extends Component {
      * This property accepts either a React element, or an array of React elements.
      */
     actions: PropTypes.node,
-
     /**
      * The `className` to add to the actions container's root element.
      */
     actionsContainerClassName: PropTypes.string,
-
     /**
      * Overrides the inline-styles of the actions container's root element.
      */
     actionsContainerStyle: PropTypes.object,
-
     /**
      * If set to true, the height of the `Dialog` will be auto detected. A max height
      * will be enforced so that the content does not extend beyond the viewport.
      */
     autoDetectWindowHeight: PropTypes.bool,
-
     /**
      * If set to true, the body content of the `Dialog` will be scrollable.
      */
     autoScrollBodyContent: PropTypes.bool,
-
     /**
      * The `className` to add to the content's root element under the title.
      */
     bodyClassName: PropTypes.string,
-
     /**
      * Overrides the inline-styles of the content's root element under the title.
      */
     bodyStyle: PropTypes.object,
-
     /**
      * The contents of the `Dialog`.
      */
     children: PropTypes.node,
-
     /**
      * The css class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * The `className` to add to the content container.
      */
     contentClassName: PropTypes.string,
-
     /**
      * Overrides the inline-styles of the content container.
      */
     contentStyle: PropTypes.object,
-
     /**
      * Force the user to use one of the actions in the `Dialog`.
      * Clicking outside the `Dialog` will not trigger the `onRequestClose`.
      */
     modal: PropTypes.bool,
-
     /**
      * Fired when the `Dialog` is requested to be closed by a click outside the `Dialog` or on the buttons.
      *
      * @param {bool} buttonClicked Determines whether a button click triggered this request.
      */
     onRequestClose: PropTypes.func,
-
     /**
      * Controls whether the Dialog is opened or not.
      */
     open: PropTypes.bool.isRequired,
-
     /**
      * The `className` to add to the `Overlay` component that is rendered behind the `Dialog`.
      */
     overlayClassName: PropTypes.string,
-
     /**
      * Overrides the inline-styles of the `Overlay` component that is rendered behind the `Dialog`.
      */
     overlayStyle: PropTypes.object,
-
     /**
      * Determines whether the `Dialog` should be repositioned when it's contents are updated.
      */
     repositionOnUpdate: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * The title to display on the `Dialog`. Could be number, string, element or an array containing these types.
      */
     title: PropTypes.node,
-
     /**
      * The `className` to add to the title's root container element.
      */
     titleClassName: PropTypes.string,
-
     /**
      * Overrides the inline-styles of the title's root container element.
      */

--- a/src/Divider/Divider.js
+++ b/src/Divider/Divider.js
@@ -5,12 +5,10 @@ const propTypes = {
    * The css class name of the root element.
    */
   className: PropTypes.string,
-
   /**
    * If true, the `Divider` will be indented `72px`.
    */
   inset: PropTypes.bool,
-
   /**
    * Override the inline-styles of the root element.
    */

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -16,33 +16,27 @@ class Drawer extends Component {
      * The contents of the `Drawer`
      */
     children: PropTypes.node,
-
     /**
      * The CSS class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * The CSS class name of the container element.
      */
     containerClassName: PropTypes.string,
-
     /**
      * Override the inline-styles of the container element.
      */
     containerStyle: PropTypes.object,
-
     /**
      * If true, swiping sideways when the `Drawer` is closed will not open it.
      */
     disableSwipeToOpen: PropTypes.bool,
-
     /**
      * If true, the `Drawer` will be docked. In this state, the overlay won't show and
      * clicking on a menu item will not close the `Drawer`.
      */
     docked: PropTypes.bool,
-
     /**
      * Callback function fired when the `open` state of the `Drawer` is requested to be changed.
      *
@@ -52,33 +46,27 @@ class Drawer extends Component {
      * 'escape' (on escape key press), and 'swipe' for close requests.
      */
     onRequestChange: PropTypes.func,
-
     /**
      * If true, the `Drawer` is opened.  Providing a value will turn the `Drawer`
      * into a controlled component.
      */
     open: PropTypes.bool,
-
     /**
      * If true, the `Drawer` is positioned to open from the opposite side.
      */
     openSecondary: PropTypes.bool,
-
     /**
      * The CSS class name to add to the `Overlay` component that is rendered behind the `Drawer`.
      */
     overlayClassName: PropTypes.string,
-
     /**
      * Override the inline-styles of the `Overlay` component that is rendered behind the `Drawer`.
      */
     overlayStyle: PropTypes.object,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * The width of the left most (or right most) area in pixels where the `Drawer` can be
      * swiped open from. Setting this to `null` spans that area to the entire page
@@ -86,12 +74,10 @@ class Drawer extends Component {
      * swipeable `Tabs`: use at your own risk).
      */
     swipeAreaWidth: PropTypes.number,
-
     /**
      * The width of the `Drawer` in pixels. Defaults to using the values from theme.
      */
     width: PropTypes.number,
-
     /**
      * The zDepth of the `Drawer`.
      */

--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -79,49 +79,40 @@ class DropDownMenu extends Component {
      * To control this width in css instead, set this prop to `false`.
      */
     autoWidth: PropTypes.bool,
-
     /**
      * The `MenuItem`s to populate the `Menu` with. If the `MenuItems` have the
      * prop `label` that value will be used to render the representation of that
      * item within the field.
      */
     children: PropTypes.node,
-
     /**
      * The css class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * Disables the menu.
      */
     disabled: PropTypes.bool,
-
     /**
      * Overrides the styles of icon element.
      */
     iconStyle: PropTypes.object,
-
     /**
      * Overrides the styles of label when the `DropDownMenu` is inactive.
      */
     labelStyle: PropTypes.object,
-
     /**
      * The style object to use to override underlying list style.
      */
     listStyle: PropTypes.object,
-
     /**
      * The maximum height of the `Menu` when it is displayed.
      */
     maxHeight: PropTypes.number,
-
     /**
      * Overrides the styles of `Menu` when the `DropDownMenu` is displayed.
      */
     menuStyle: PropTypes.object,
-
     /**
      * Callback function fired when a menu item is clicked, other than the one currently selected.
      *
@@ -130,22 +121,18 @@ class DropDownMenu extends Component {
      * @param {any} payload The `value` prop of the clicked menu item.
      */
     onChange: PropTypes.func,
-
     /**
      * Set to true to have the `DropDownMenu` automatically open on mount.
      */
     openImmediately: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * Overrides the inline-styles of the underline.
      */
     underlineStyle: PropTypes.object,
-
     /**
      * The value that is currently selected.
      */

--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -19,7 +19,6 @@ class FlatButton extends Component {
      * Color of button when mouse is not hovering over it.
      */
     backgroundColor: PropTypes.string,
-
     /**
      * This is what will be displayed inside the button.
      * If a label is specified, the text within the label prop will
@@ -30,32 +29,26 @@ class FlatButton extends Component {
      * applies to flat and raised buttons.
      */
     children: PropTypes.node,
-
     /**
      * Disables the button if set to true.
      */
     disabled: PropTypes.bool,
-
     /**
      * Color of button when mouse hovers over.
      */
     hoverColor: PropTypes.string,
-
     /**
      * URL to link to when button clicked if `linkButton` is set to true.
      */
     href: PropTypes.string,
-
     /**
      * Use this property to display an icon.
      */
     icon: PropTypes.node,
-
     /**
      * Label for the button.
      */
     label: validateLabel,
-
     /**
      * Place label before or after the passed children.
      */
@@ -63,17 +56,14 @@ class FlatButton extends Component {
       'before',
       'after',
     ]),
-
     /**
      * Override the inline-styles of the button's label element.
      */
     labelStyle: PropTypes.object,
-
     /**
      * Enables use of `href` property to provide a URL to link to if set to true.
      */
     linkButton: PropTypes.bool,
-
     /**
      * Callback function fired when the element is focused or blurred by the keyboard.
      *
@@ -81,45 +71,38 @@ class FlatButton extends Component {
      * @param {boolean} isKeyboardFocused Indicates whether the element is focused.
      */
     onKeyboardFocus: PropTypes.func,
-
     /**
      * Callback function fired when the mouse enters the element.
      *
      * @param {object} event `mouseenter` event targeting the element.
      */
     onMouseEnter: PropTypes.func,
-
     /**
      * Callback function fired when the mouse leaves the element.
      *
      * @param {object} event `mouseleave` event targeting the element.
      */
     onMouseLeave: PropTypes.func,
-
     /**
      * Callback function fired when the element is touched.
      *
      * @param {object} event `touchstart` event targeting the element.
      */
     onTouchStart: PropTypes.func,
-
     /**
      * If true, colors button according to
      * primaryTextColor from the Theme.
      */
     primary: PropTypes.bool,
-
     /**
      * Color for the ripple after button is clicked.
      */
     rippleColor: PropTypes.string,
-
     /**
      * If true, colors button according to secondaryTextColor from the theme.
      * The primary prop has precendent if set to true.
      */
     secondary: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/FlatButton/FlatButtonLabel.js
+++ b/src/FlatButton/FlatButtonLabel.js
@@ -16,7 +16,6 @@ function getStyles(props, context) {
 class FlatButtonLabel extends Component {
   static propTypes = {
     label: PropTypes.node,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -71,32 +71,26 @@ class FloatingActionButton extends Component {
      * This has to be set separately using the disabledColor attribute.
      */
     backgroundColor: PropTypes.string,
-
     /**
      * This is what displayed inside the floating action button; for example, a SVG Icon.
      */
     children: PropTypes.node,
-
     /**
      * The css class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * Disables the button if set to true.
      */
     disabled: PropTypes.bool,
-
     /**
      * This value will override the default background color for the button when it is disabled.
      */
     disabledColor: PropTypes.string,
-
     /**
      * URL to link to when button clicked if `linkButton` is set to true.
      */
     href: PropTypes.string,
-
     /**
      * The icon within the FloatingActionButton is a FontIcon component.
      * This property is the classname of the icon to be displayed inside the button.
@@ -104,75 +98,63 @@ class FloatingActionButton extends Component {
      * FontIcon component or custom SvgIcon component or as a child of FloatingActionButton.
      */
     iconClassName: PropTypes.string,
-
     /**
      * This is the equivalent to iconClassName except that it is used for
      * overriding the inline-styles of the FontIcon component.
      */
     iconStyle: PropTypes.object,
-
     /**
      * Enables use of `href` property to provide a URL to link to if set to true.
      */
     linkButton: PropTypes.bool,
-
     /**
      * If true, the button will be a small floating action button.
      */
     mini: PropTypes.bool,
-
     /**
      * Callback function fired when a mouse button is pressed down on the elmeent.
      *
      * @param {object} event `mousedown` event targeting the element.
      */
     onMouseDown: PropTypes.func,
-
     /**
      * Callback function fired when the mouse enters the element.
      *
      * @param {object} event `mouseenter` event targeting the element.
      */
     onMouseEnter: PropTypes.func,
-
     /**
      * Callback function fired when the mouse leaves the element.
      *
      * @param {object} event `mouseleave` event targeting the element.
      */
     onMouseLeave: PropTypes.func,
-
     /**
      * Callback function fired when a mouse button is released on the element.
      *
      * @param {object} event `mouseup` event targeting the element.
      */
     onMouseUp: PropTypes.func,
-
     /**
      * Callback function fired when a touch point is removed from the element.
      *
      * @param {object} event `touchend` event targeting the element.
      */
     onTouchEnd: PropTypes.func,
-
     /**
      * Callback function fired when the element is touched.
      *
      * @param {object} event `touchstart` event targeting the element.
      */
     onTouchStart: PropTypes.func,
-
     /**
      * If true, the button will use the secondary button colors.
      */
     secondary: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * The zDepth of the underlying `Paper` component.
      */

--- a/src/FontIcon/FontIcon.js
+++ b/src/FontIcon/FontIcon.js
@@ -32,26 +32,22 @@ class FontIcon extends Component {
      * this component will default to muiTheme.palette.textColor.
      */
     color: PropTypes.string,
-
     /**
      * This is the icon color when the mouse hovers over the icon.
      */
     hoverColor: PropTypes.string,
-
     /**
      * Callback function fired when the mouse enters the element.
      *
      * @param {object} event `mouseenter` event targeting the element.
      */
     onMouseEnter: PropTypes.func,
-
     /**
      * Callback function fired when the mouse leaves the element.
      *
      * @param {object} event `mouseleave` event targeting the element.
      */
     onMouseLeave: PropTypes.func,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/GridList/GridList.js
+++ b/src/GridList/GridList.js
@@ -20,22 +20,18 @@ class GridList extends Component {
      * Number of px for one cell height.
      */
     cellHeight: PropTypes.number,
-
     /**
      * Grid Tiles that will be in Grid List.
      */
     children: PropTypes.node,
-
     /**
      * Number of columns.
      */
     cols: PropTypes.number,
-
     /**
      * Number of px for the padding/spacing between items.
      */
     padding: PropTypes.number,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/GridList/GridTile.js
+++ b/src/GridList/GridTile.js
@@ -64,24 +64,20 @@ class GridTile extends Component {
      * (primary action target is the tile itself).
      */
     actionIcon: PropTypes.element,
-
     /**
      * Position of secondary action IconButton.
      */
     actionPosition: PropTypes.oneOf(['left', 'right']),
-
     /**
      * Theoretically you can pass any node as children, but the main use case is to pass an img,
      * in whichcase GridTile takes care of making the image "cover" available space
      * (similar to background-size: cover or to object-fit:cover).
      */
     children: PropTypes.node,
-
     /**
      * Width of the tile in number of grid cells.
      */
     cols: PropTypes.number,
-
     /**
      * Either a string used as tag name for the tile root element, or a ReactElement.
      * This is useful when you have, for example, a custom implementation of
@@ -93,33 +89,27 @@ class GridTile extends Component {
       PropTypes.string,
       PropTypes.element,
     ]),
-
     /**
      * Height of the tile in number of grid cells.
      */
     rows: PropTypes.number,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * String or element serving as subtitle (support text).
      */
     subtitle: PropTypes.node,
-
     /**
      * Title to be displayed on tile.
      */
     title: PropTypes.node,
-
     /**
      * Style used for title bar background.
      * Useful for setting custom gradients for example
      */
     titleBackground: PropTypes.string,
-
     /**
      * Position of the title bar (container of title, subtitle and action icon).
      */

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -49,44 +49,36 @@ class IconButton extends Component {
      * Can be used to pass a `FontIcon` element as the icon for the button.
      */
     children: PropTypes.node,
-
     /**
      * The CSS class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * If true, the element's ripple effect will be disabled.
      */
     disableTouchRipple: PropTypes.bool,
-
     /**
      * If true, the element will be disabled.
      */
     disabled: PropTypes.bool,
-
     /**
      * The CSS class name of the icon. Used for setting the icon with a stylesheet.
      */
     iconClassName: PropTypes.string,
-
     /**
      * Override the inline-styles of the icon element.
      */
     iconStyle: PropTypes.object,
-
     /**
      * Callback function fired when the element loses focus.
      * @param {object} event `blur` event targeting the element.
      */
     onBlur: PropTypes.func,
-
     /**
      * Callback function fired when the element gains focus.
      * @param {object} event `focus` event targeting the element.
      */
     onFocus: PropTypes.func,
-
     /**
      * Callback function fired when the element is focused or blurred by the keyboard.
      *
@@ -94,21 +86,18 @@ class IconButton extends Component {
      * @param {boolean} keyboardFocused Indicates whether the element is focused.
      */
     onKeyboardFocus: PropTypes.func,
-
     /**
      * Callback function fired when the mouse enters the element.
      *
      * @param {object} event `mouseenter` event targeting the element.
      */
     onMouseEnter: PropTypes.func,
-
     /**
      * Callback function fired when the mouse leaves the element.
      *
      * @param {object} event `mouseleave` event targeting the element.
      */
     onMouseLeave: PropTypes.func,
-
     /**
      * Callback function fired when the mouse leaves the element. Unlike `onMouseLeave`,
      * this callback will fire on disabled icon buttons.
@@ -116,29 +105,24 @@ class IconButton extends Component {
      * @param {object} event `mouseout` event targeting the element.
      */
     onMouseOut: PropTypes.func,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * The text to supply to the element's tooltip.
      */
     tooltip: PropTypes.node,
-
     /**
      * The vertical and horizontal positions, respectively, of the element's tooltip.
      * Possible values are: "bottom-center", "top-center", "bottom-right", "top-right",
      * "bottom-left", and "top-left".
      */
     tooltipPosition: propTypes.cornersAndCenter,
-
     /**
      * Override the inline-styles of the tooltip element.
      */
     tooltipStyles: PropTypes.object,
-
     /**
      * If true, increase the tooltip element's size.  Useful for increasing tooltip
      * readability on mobile devices.

--- a/src/IconMenu/IconMenu.js
+++ b/src/IconMenu/IconMenu.js
@@ -17,37 +17,30 @@ class IconMenu extends Component {
      * horizontal: [left, center, right].
      */
     anchorOrigin: propTypes.origin,
-
     /**
      * Should be used to pass `MenuItem` components.
      */
     children: PropTypes.node,
-
     /**
      * The CSS class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * This is the `IconButton` to render. This button will open the menu.
      */
     iconButtonElement: PropTypes.element.isRequired,
-
     /**
      * Override the inline-styles of the underlying icon element.
      */
     iconStyle: PropTypes.object,
-
     /**
      * Override the inline-styles of the menu element.
      */
     menuStyle: PropTypes.object,
-
     /**
      * If true, the value can an be array and allow the menu to be a multi-select.
      */
     multiple: PropTypes.bool,
-
     /**
      * Callback function fired when a menu item is selected with a touch-tap.
      *
@@ -55,7 +48,6 @@ class IconMenu extends Component {
      * @param {object} child The selected element.
      */
     onItemTouchTap: PropTypes.func,
-
     /**
      * Callback function fired when the `IconButton` element is focused or blurred by the keyboard.
      *
@@ -63,35 +55,30 @@ class IconMenu extends Component {
      * @param {boolean} keyboardFocused If true, the `IconButton` element is focused.
      */
     onKeyboardFocus: PropTypes.func,
-
     /**
      * Callback function fired when a mouse button is pressed down on the `IconButton` element.
      *
      * @param {object} event `mousedown` event targeting the `IconButton` element.
      */
     onMouseDown: PropTypes.func,
-
     /**
      * Callback function fired when the mouse enters the `IconButton` element.
      *
      * @param {object} event `mouseenter` event targeting the `IconButton` element.
      */
     onMouseEnter: PropTypes.func,
-
     /**
      * Callback function fired when the mouse leaves the `IconButton` element.
      *
      * @param {object} event `mouseleave` event targeting the `IconButton` element.
      */
     onMouseLeave: PropTypes.func,
-
     /**
      * Callback function fired when a mouse button is released on the `IconButton` element.
      *
      * @param {object} event `mouseup` event targeting the `IconButton` element.
      */
     onMouseUp: PropTypes.func,
-
     /**
      * Callback function fired when the `open` state of the menu is requested to be changed.
      *
@@ -101,24 +88,20 @@ class IconMenu extends Component {
      * for close requests.
      */
     onRequestChange: PropTypes.func,
-
     /**
      * Callback function fired when the `IconButton` element is touch-tapped.
      *
      * @param {object} event TouchTap event targeting the `IconButton` element.
      */
     onTouchTap: PropTypes.func,
-
     /**
      * If true, the `IconMenu` is opened.
      */
     open: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * This is the point on the menu which will stick to the menu
      * origin.
@@ -127,7 +110,6 @@ class IconMenu extends Component {
      * horizontal: [left, center, right].
      */
     targetOrigin: propTypes.origin,
-
     /**
      * Sets the delay in milliseconds before closing the
      * menu when an item is clicked.
@@ -135,7 +117,6 @@ class IconMenu extends Component {
      * will be disabled.
      */
     touchTapCloseDelay: PropTypes.number,
-
     /**
      * If true, the popover will render on top of an invisible
      * layer, which will prevent clicks to the underlying elements.

--- a/src/LinearProgress/LinearProgress.js
+++ b/src/LinearProgress/LinearProgress.js
@@ -69,28 +69,23 @@ class LinearProgress extends Component {
      * when there is no value for progress.
      */
     color: PropTypes.string,
-
     /**
      * The max value of progress, only works in determinate mode.
      */
     max: PropTypes.number,
-
     /**
      * The min value of progress, only works in determinate mode.
      */
     min: PropTypes.number,
-
     /**
      * The mode of show your progress, indeterminate for when
      * there is no value for progress.
      */
     mode: PropTypes.oneOf(['determinate', 'indeterminate']),
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * The value of progress, only works in determinate mode.
      */

--- a/src/List/List.js
+++ b/src/List/List.js
@@ -11,30 +11,25 @@ class List extends Component {
      * be part of the list.
      */
     children: PropTypes.node,
-
     /**
      * If true, the subheader will be indented by 72px.
      */
     insetSubheader: deprecated(PropTypes.bool,
       'Refer to the `subheader` property.'),
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * The subheader string that will be displayed at the top of the list.
      */
     subheader: deprecated(PropTypes.node,
       'Instead, nest the `Subheader` component directly inside the `List`.'),
-
     /**
      * Override the inline-styles of the subheader element.
      */
     subheaderStyle: deprecated(PropTypes.object,
       'Refer to the `subheader` property.'),
-
     /**
      * @ignore
      * ** Breaking change ** List no longer supports `zDepth`. Instead, wrap it in `Paper`

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -153,17 +153,14 @@ class ListItem extends Component {
      * the element.
      */
     autoGenerateNestedIndicator: PropTypes.bool,
-
     /**
      * Children passed into the `ListItem`.
      */
     children: PropTypes.node,
-
     /**
      * If true, the element will not be able to be focused by the keyboard.
      */
     disableKeyboardFocus: PropTypes.bool,
-
     /**
      * If true, the element will not be clickable
      * and will not display hover effects.
@@ -171,54 +168,44 @@ class ListItem extends Component {
      * or `rightToggle` is set.
      */
     disabled: PropTypes.bool,
-
     /**
      * If true, the nested `ListItem`s are initially displayed.
      */
     initiallyOpen: PropTypes.bool,
-
     /**
      * Override the inline-styles of the inner div element.
      */
     innerDivStyle: PropTypes.object,
-
     /**
      * If true, the children will be indented by 72px.
      * This is useful if there is no left avatar or left icon.
      */
     insetChildren: PropTypes.bool,
-
     /**
      * This is the `Avatar` element to be displayed on the left side.
      */
     leftAvatar: PropTypes.element,
-
     /**
      * This is the `Checkbox` element to be displayed on the left side.
      */
     leftCheckbox: PropTypes.element,
-
     /**
      * This is the `SvgIcon` or `FontIcon` to be displayed on the left side.
      */
     leftIcon: PropTypes.element,
-
     /**
      * An array of `ListItem`s to nest underneath the current `ListItem`.
      */
     nestedItems: PropTypes.arrayOf(PropTypes.element),
-
     /**
      * Controls how deep a `ListItem` appears.
      * This property is automatically managed, so modify at your own risk.
      */
     nestedLevel: PropTypes.number,
-
     /**
      * Override the inline-styles of the nested items' `NestedList`.
      */
     nestedListStyle: PropTypes.object,
-
     /**
      * Callback function fired when the `ListItem` is focused or blurred by the keyboard.
      *
@@ -226,64 +213,54 @@ class ListItem extends Component {
      * @param {boolean} isKeyboardFocused If true, the `ListItem` is focused.
      */
     onKeyboardFocus: PropTypes.func,
-
     /**
      * Callback function fired when the mouse enters the `ListItem`.
      *
      * @param {object} event `mouseenter` event targeting the `ListItem`.
      */
     onMouseEnter: PropTypes.func,
-
     /**
      * Callback function fired when the mouse leaves the `ListItem`.
      *
      * @param {object} event `mouseleave` event targeting the `ListItem`.
      */
     onMouseLeave: PropTypes.func,
-
     /**
      * Callbak function fired when the `ListItem` toggles its nested list.
      *
      * @param {object} listItem The `ListItem`.
      */
     onNestedListToggle: PropTypes.func,
-
     /**
      * Callback function fired when the `ListItem` is touched.
      *
      * @param {object} event `touchstart` event targeting the `ListItem`.
      */
     onTouchStart: PropTypes.func,
-
     /**
      * Callback function fired when the `ListItem` is touch-tapped.
      *
      * @param {object} event TouchTap event targeting the `ListItem`.
      */
     onTouchTap: PropTypes.func,
-
     /**
      * This is the block element that contains the primary text.
      * If a string is passed in, a div tag will be rendered.
      */
     primaryText: PropTypes.node,
-
     /**
      * If true, clicking or tapping the primary text of the `ListItem`
      * toggles the nested list.
      */
     primaryTogglesNestedList: PropTypes.bool,
-
     /**
      * This is the `Avatar` element to be displayed on the right side.
      */
     rightAvatar: PropTypes.element,
-
     /**
      * This is the `SvgIcon` or `FontIcon` to be displayed on the right side.
      */
     rightIcon: PropTypes.element,
-
     /**
      * This is the `IconButton` to be displayed on the right side.
      * Hovering over this button will remove the `ListItem` hover.
@@ -292,24 +269,20 @@ class ListItem extends Component {
      * from bubbling up to cause a `ListItem` click.
      */
     rightIconButton: PropTypes.element,
-
     /**
      * This is the `Toggle` element to display on the right side.
      */
     rightToggle: PropTypes.element,
-
     /**
      * This is the block element that contains the secondary text.
      * If a string is passed in, a div tag will be rendered.
      */
     secondaryText: PropTypes.node,
-
     /**
      * Can be 1 or 2. This is the number of secondary
      * text lines before ellipsis will show.
      */
     secondaryTextLines: PropTypes.oneOf([1, 2]),
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/List/NestedList.js
+++ b/src/List/NestedList.js
@@ -6,7 +6,6 @@ class NestedList extends Component {
     children: PropTypes.node,
     nestedLevel: PropTypes.number,
     open: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -71,7 +71,6 @@ class Menu extends Component {
      * work, wrap the menu inside a `ReactTransitionGroup`.
      */
     animated: deprecated(PropTypes.bool, 'Instead, use a [Popover](/#/components/popover).'),
-
     /**
      * If true, the width of the menu will be set automatically
      * according to the widths of its children,
@@ -79,46 +78,38 @@ class Menu extends Component {
      * 56px otherwise).
      */
     autoWidth: PropTypes.bool,
-
     /**
      * The content of the menu. This is usually used to pass `MenuItem`
      * elements.
      */
     children: PropTypes.node,
-
     /**
      * If true, the menu item will render with compact desktop styles.
      */
     desktop: PropTypes.bool,
-
     /**
      * If true, the menu will not be auto-focused.
      */
     disableAutoFocus: PropTypes.bool,
-
     /**
      * If true, the menu will be keyboard-focused initially.
      */
     initiallyKeyboardFocused: PropTypes.bool,
-
     /**
      * Override the inline-styles of the underlying `List` element.
      */
     listStyle: PropTypes.object,
-
     /**
      * The maximum height of the menu in pixels. If specified,
      * the menu will be scrollable if it is taller than the provided
      * height.
      */
     maxHeight: PropTypes.number,
-
     /**
      * If true, `value` must be an array and the menu will support
      * multiple selections.
      */
     multiple: PropTypes.bool,
-
     /**
      * Callback function fired when a menu item with `value` not
      * equal to the current `value` of the menu is touch-tapped.
@@ -130,7 +121,6 @@ class Menu extends Component {
      * Otherwise, the `value` of the menu item.
      */
     onChange: PropTypes.func,
-
     /**
      * Callback function fired when the menu is focused and the *Esc* key
      * is pressed.
@@ -138,7 +128,6 @@ class Menu extends Component {
      * @param {object} event `keydown` event targeting the menu.
      */
     onEscKeyDown: PropTypes.func,
-
     /**
      * Callback function fired when a menu item is touch-tapped.
      *
@@ -147,7 +136,6 @@ class Menu extends Component {
      * @param {number} index The index of the menu item.
      */
     onItemTouchTap: PropTypes.func,
-
     /**
      * Callback function fired when the menu is focused and a key
      * is pressed.
@@ -155,22 +143,18 @@ class Menu extends Component {
      * @param {object} event `keydown` event targeting the menu.
      */
     onKeyDown: PropTypes.func,
-
     /**
      * This is the placement of the menu relative to the `IconButton`.
      */
     openDirection: deprecated(propTypes.corners, 'Instead, use a [Popover](/#/components/popover).'),
-
     /**
      * Override the inline-styles of selected menu items.
      */
     selectedMenuItemStyle: PropTypes.object,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * If `multiple` is true, an array of the `value`s of the selected
      * menu items. Otherwise, the `value` of the selected menu item.
@@ -178,19 +162,16 @@ class Menu extends Component {
      * This component also supports valueLink.
      */
     value: PropTypes.any,
-
     /**
      * ValueLink for the menu's `value`.
      */
     valueLink: PropTypes.object,
-
     /**
      * The width of the menu. If not specified, the menu's width
      * will be set according to the widths of its children, using
      * proper keyline increments (64px for desktop, 56px otherwise).
      */
     width: propTypes.stringOrNumber,
-
     /**
      * @ignore
      * Menu no longer supports `zDepth`. Instead, wrap it in `Paper`

--- a/src/MenuItem/MenuItem.js
+++ b/src/MenuItem/MenuItem.js
@@ -60,24 +60,20 @@ class MenuItem extends Component {
      * If true, a left check mark will be rendered.
      */
     checked: PropTypes.bool,
-
     /**
      * Elements passed as children to the underlying `ListItem`.
      */
     children: PropTypes.node,
-
     /**
      * @ignore
      * If true, the menu item will render with compact desktop
      * styles.
      */
     desktop: PropTypes.bool,
-
     /**
      * If true, the menu item will be disabled.
      */
     disabled: PropTypes.bool,
-
     /**
      * The focus state of the menu item. This prop is used to set the focus
      * state of the underlying `ListItem`.
@@ -87,55 +83,45 @@ class MenuItem extends Component {
       'focused',
       'keyboard-focused',
     ]),
-
     /**
      * Override the inline-styles of the inner div.
      */
     innerDivStyle: PropTypes.object,
-
     /**
      * If true, the children will be indented.
      * This is only needed when there is no `leftIcon`.
      */
     insetChildren: PropTypes.bool,
-
     /**
      * The `SvgIcon` or `FontIcon` to be displayed on the left side.
      */
     leftIcon: PropTypes.element,
-
     /**
      * `MenuItem` elements to nest within the menu item.
      */
     menuItems: PropTypes.node,
-
     /**
      * Callback function fired when the menu item is touch-tapped.
      *
      * @param {object} event TouchTap event targeting the menu item.
      */
     onTouchTap: PropTypes.func,
-
     /**
      * Can be used to render primary text within the menu item.
      */
     primaryText: PropTypes.node,
-
     /**
      * The `SvgIcon` or `FontIcon` to be displayed on the right side.
      */
     rightIcon: PropTypes.element,
-
     /**
      * Can be used to render secondary text within the menu item.
      */
     secondaryText: PropTypes.node,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * The value of the menu item.
      */

--- a/src/Paper/Paper.js
+++ b/src/Paper/Paper.js
@@ -35,28 +35,23 @@ class Paper extends Component {
      * Children passed into the paper element.
      */
     children: PropTypes.node,
-
     /**
      * Set to true to generate a circlular paper container.
      */
     circle: PropTypes.bool,
-
     /**
      * By default, the paper container will have a border radius.
      * Set this to false to generate a container with sharp corners.
      */
     rounded: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * Set to false to disable CSS transitions for the paper element.
      */
     transitionEnabled: PropTypes.bool,
-
     /**
      * This number represents the zDepth of the paper shadow.
      */

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -14,7 +14,6 @@ class Popover extends Component {
      * popover.
      */
     anchorEl: PropTypes.object,
-
     /**
      * This is the point on the anchor where the popover's
      * `targetOrigin` will attach to.
@@ -23,40 +22,33 @@ class Popover extends Component {
      * horizontal: [left, center, right].
      */
     anchorOrigin: propTypes.origin,
-
     /**
      * If true, the popover will apply transitions when
      * it is added to the DOM.
      */
     animated: PropTypes.bool,
-
     /**
      * Override the default animation component used.
      */
     animation: PropTypes.func,
-
     /**
      * If true, the popover will hide when the anchor is scrolled off the screen.
      */
     autoCloseWhenOffScreen: PropTypes.bool,
-
     /**
      * If true, the popover (potentially) ignores `targetOrigin`
      * and `anchorOrigin` to make itself fit on screen,
      * which is useful for mobile devices.
      */
     canAutoPosition: PropTypes.bool,
-
     /**
      * The content of the popover.
      */
     children: PropTypes.node,
-
     /**
      * The CSS class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * Callback function fired when the popover is requested to be closed.
      *
@@ -64,17 +56,14 @@ class Popover extends Component {
      * are 'clickAway' and 'offScreen'.
      */
     onRequestClose: PropTypes.func,
-
     /**
      * If true, the popover is visible.
      */
     open: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * This is the point on the popover which will attach to
      * the anchor's origin.
@@ -83,14 +72,12 @@ class Popover extends Component {
      * horizontal: [left, center, right].
      */
     targetOrigin: propTypes.origin,
-
     /**
      * If true, the popover will render on top of an invisible
      * layer, which will prevent clicks to the underlying
      * elements, and trigger an `onRequestClose('clickAway')` call.
      */
     useLayerForClickAway: PropTypes.bool,
-
     /**
      * The zDepth of the popover.
      */

--- a/src/Popover/PopoverAnimationDefault.js
+++ b/src/Popover/PopoverAnimationDefault.js
@@ -39,13 +39,11 @@ function getStyles(props, context, state) {
 class PopoverDefaultAnimation extends Component {
   static propTypes = {
     children: PropTypes.node,
-
     /**
      * The css class name of the root element.
      */
     className: PropTypes.string,
     open: PropTypes.bool.isRequired,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/Popover/PopoverAnimationVertical.js
+++ b/src/Popover/PopoverAnimationVertical.js
@@ -27,7 +27,6 @@ class PopoverAnimationVertical extends Component {
     children: PropTypes.node,
     className: PropTypes.string,
     open: PropTypes.bool.isRequired,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/RadioButton/RadioButton.js
+++ b/src/RadioButton/RadioButton.js
@@ -58,39 +58,32 @@ class RadioButton extends Component {
      * Used internally by `RadioButtonGroup`.
      */
     checked: PropTypes.bool,
-
     /**
      * The icon element to show when the radio button is checked.
      */
     checkedIcon: PropTypes.element,
-
     /**
      * If true, the radio button is disabled.
      */
     disabled: PropTypes.bool,
-
     /**
      * Override the inline-styles of the icon element.
      */
     iconStyle: PropTypes.object,
-
     /**
      * Override the inline-styles of the input element.
      */
     inputStyle: PropTypes.object,
-
     /**
      * @ignore
      * Used internally by `RadioButtonGroup`. Use the `labelPosition` property of `RadioButtonGroup` instead.
      * Where the label will be placed next to the radio button.
      */
     labelPosition: PropTypes.oneOf(['left', 'right']),
-
     /**
      * Override the inline-styles of the label element.
      */
     labelStyle: PropTypes.object,
-
     /**
      * @ignore
      * Callback function fired when the radio button is checked. Note that this
@@ -102,17 +95,14 @@ class RadioButton extends Component {
      * @param {string} value The element's `value`.
      */
     onCheck: PropTypes.func,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * The icon element to show when the radio button is unchecked.
      */
     uncheckedIcon: PropTypes.element,
-
     /**
      * The value of the radio button.
      */

--- a/src/RadioButton/RadioButtonGroup.js
+++ b/src/RadioButton/RadioButtonGroup.js
@@ -8,31 +8,26 @@ class RadioButtonGroup extends Component {
      * Should be used to pass `RadioButton` components.
      */
     children: PropTypes.node,
-
     /**
      * The CSS class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * The `value` property (case-sensitive) of the radio button that will be
      * selected by default. This takes precedence over the `checked` property
      * of the `RadioButton` elements.
      */
     defaultSelected: PropTypes.string,
-
     /**
      * Where the label will be placed for all child radio buttons.
      * This takes precedence over the `labelPosition` property of the
      * `RadioButton` elements.
      */
     labelPosition: PropTypes.oneOf(['left', 'right']),
-
     /**
      * The name that will be applied to all child radio buttons.
      */
     name: PropTypes.string.isRequired,
-
     /**
      * Callback function that is fired when a radio button has
      * been checked.
@@ -42,12 +37,10 @@ class RadioButtonGroup extends Component {
      * @param {string} value The `value` of the selected radio button.
      */
     onChange: PropTypes.func,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * The `value` of the currently selected radio button.
      */

--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -119,63 +119,52 @@ class RaisedButton extends Component {
      * (use `disabledBackgroundColor` for this).
      */
     backgroundColor: PropTypes.string,
-
     /**
      * The content of the button.
      * If a label is provided via the `label` prop, the text within the label
      * will be displayed in addition to the content provided here.
      */
     children: PropTypes.node,
-
     /**
      * The CSS class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * If true, the button will be disabled.
      */
     disabled: PropTypes.bool,
-
     /**
      * Override the default background color for the button
      * when it is disabled.
      */
     disabledBackgroundColor: PropTypes.string,
-
     /**
      * The color of the button's label when the button is disabled.
      */
     disabledLabelColor: PropTypes.string,
-
     /**
      * If true, the button will take up the full width of its container.
      */
     fullWidth: PropTypes.bool,
-
     /**
      * If `linkButton` is true, the URL to link to when the button
      * is clicked.
      */
     href: PropTypes.string,
-
     /**
      * An icon to be displayed within the button.
      */
     icon: PropTypes.node,
-
     /**
      * The label to be displayed within the button.
      * If content is provided via the `children` prop, that content will be
      * displayed in addition to the label provided here.
      */
     label: validateLabel,
-
     /**
      * The color of the button's label.
      */
     labelColor: PropTypes.string,
-
     /**
      * The position of the button's label relative to the button's `children`.
      */
@@ -183,18 +172,15 @@ class RaisedButton extends Component {
       'before',
       'after',
     ]),
-
     /**
      * Override the inline-styles of the button's label element.
      */
     labelStyle: PropTypes.object,
-
     /**
      * If true, enable the use of the `href` property to provide
      * a URL to link to.
      */
     linkButton: PropTypes.bool,
-
     /**
      * Callback function fired when a mouse button is pressed down on
      * the element.
@@ -202,59 +188,50 @@ class RaisedButton extends Component {
      * @param {object} event `mousedown` event targeting the element.
      */
     onMouseDown: PropTypes.func,
-
     /**
      * Callback function fired when the mouse enters the element.
      *
      * @param {object} event `mouseenter` event targeting the element.
      */
     onMouseEnter: PropTypes.func,
-
     /**
      * Callback function fired when the mouse leaves the element.
      *
      * @param {object} event `mouseleave` event targeting the element.
      */
     onMouseLeave: PropTypes.func,
-
     /**
      * Callback function fired when a mouse button is released on the element.
      *
      * @param {object} event `mouseup` event targeting the element.
      */
     onMouseUp: PropTypes.func,
-
     /**
      * Callback function fired when a touch point is removed from the element.
      *
      * @param {object} event `touchend` event targeting the element.
      */
     onTouchEnd: PropTypes.func,
-
     /**
      * Callback function fired when the element is touched.
      *
      * @param {object} event `touchstart` event targeting the element.
      */
     onTouchStart: PropTypes.func,
-
     /**
      * If true, the button will use the theme's primary color.
      */
     primary: PropTypes.bool,
-
     /**
      * Override the inline style of the ripple element.
      */
     rippleStyle: PropTypes.object,
-
     /**
      * If true, the button will use the theme's secondary color.
      * If both `secondary` and `primary` are true, the button will use
      * the theme's primary color.
      */
     secondary: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/RefreshIndicator/RefreshIndicator.js
+++ b/src/RefreshIndicator/RefreshIndicator.js
@@ -30,28 +30,23 @@ class RefreshIndicator extends Component {
      * "ready" and it's percentage is less than 100.
      */
     color: PropTypes.string,
-
     /**
      * The absolute left position of the indicator in pixels.
      */
     left: PropTypes.number.isRequired,
-
     /**
      * Override the theme's color of the indicator while
      * it's status is "loading" or when it's percentage is 100.
      */
     loadingColor: PropTypes.string,
-
     /**
      * The confirmation progress to fetch data. Max value is 100.
      */
     percentage: PropTypes.number,
-
     /**
      * Size in pixels.
      */
     size: PropTypes.number,
-
     /**
      * The display status of the indicator. If the status is
      * "ready", the indicator will display the ready state
@@ -60,12 +55,10 @@ class RefreshIndicator extends Component {
      * the indicator will be hidden.
      */
     status: PropTypes.oneOf(['ready', 'loading', 'hide']),
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * The absolute top position of the indicator in pixels.
      */

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -26,7 +26,6 @@ class SelectField extends Component {
      * To control this width in css instead, leave this prop to `false`.
      */
     autoWidth: PropTypes.bool,
-
     /**
      * The `MenuItem` elements to populate the `Menu` with.
      * If the MenuItems have the prop `label` that value will
@@ -34,77 +33,62 @@ class SelectField extends Component {
      * item within the field.
      */
     children: PropTypes.node,
-
     /**
      * Disables the select field if set to true.
      */
     disabled: PropTypes.bool,
-
     /**
      * The style object to use to override error styles.
      */
     errorStyle: PropTypes.object,
-
     /**
      * The error content to display.
      */
     errorText: PropTypes.node,
-
     /**
      * The style object to use to override floating label styles.
      */
     floatingLabelStyle: PropTypes.object,
-
     /**
      * The content to use for the floating label element.
      */
     floatingLabelText: PropTypes.node,
-
     /**
      * If true, the field receives the property width 100%.
      */
     fullWidth: PropTypes.bool,
-
     /**
      * The style object to use to override hint styles.
      */
     hintStyle: PropTypes.object,
-
     /**
      * The hint content to display.
      */
     hintText: PropTypes.node,
-
     /**
      * Overrides the styles of the icon element.
      */
     iconStyle: PropTypes.object,
-
     /**
      * The id prop for the text field.
      */
     id: PropTypes.string,
-
     /**
      * Overrides the styles of label when the `SelectField` is inactive.
      */
     labelStyle: PropTypes.object,
-
     /**
      * Callback function that is fired when the `SelectField` loses focus.
      */
     onBlur: PropTypes.func,
-
     /**
      * Callback function that is fired when the value changes.
      */
     onChange: PropTypes.func,
-
     /**
      * Callback function that is fired when the `SelectField` gains focus.
      */
     onFocus: PropTypes.func,
-
     /**
      * The style object to use to override the `DropDownMenu`.
      */
@@ -114,22 +98,18 @@ class SelectField extends Component {
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * Override the inline-styles of the underline element when disabled.
      */
     underlineDisabledStyle: PropTypes.object,
-
     /**
      * Override the inline-styles of the underline element when focused.
      */
     underlineFocusStyle: PropTypes.object,
-
     /**
      * Overrides the styles of the underline element.
      */
     underlineStyle: PropTypes.object,
-
     /**
      * The value that is currently selected.
      */

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -157,85 +157,69 @@ class Slider extends Component {
      * The default value of the slider.
      */
     defaultValue: valueInRangePropType,
-
     /**
      * Describe the slider.
      */
     description: PropTypes.string,
-
     /**
      * Disables focus ripple if set to true.
      */
     disableFocusRipple: PropTypes.bool,
-
     /**
      * If true, the slider will not be interactable.
      */
     disabled: PropTypes.bool,
-
     /**
      * An error message for the slider.
      */
     error: PropTypes.string,
-
     /**
      * The maximum value the slider can slide to on
      * a scale from 0 to 1 inclusive. Cannot be equal to min.
      */
     max: minMaxPropType,
-
     /**
      * The minimum value the slider can slide to on a scale
      * from 0 to 1 inclusive. Cannot be equal to max.
      */
     min: minMaxPropType,
-
     /**
      * The name of the slider. Behaves like the name attribute
      * of an input element.
      */
     name: PropTypes.string,
-
     /**
      * Callback function that is fired when the focus has left the slider.
      */
     onBlur: PropTypes.func,
-
     /**
      * Callback function that is fired when the user changes the slider's value.
      */
     onChange: PropTypes.func,
-
     /**
      * Callback function that is fired when the slider has begun to move.
      */
     onDragStart: PropTypes.func,
-
     /**
      * Callback function that is fried when the slide has stopped moving.
      */
     onDragStop: PropTypes.func,
-
     /**
      * Callback fired when the user has focused on the slider.
      */
     onFocus: PropTypes.func,
-
     /**
      * Whether or not the slider is required in a form.
      */
     required: PropTypes.bool,
-
     /**
      * The granularity the slider can step through values.
      */
     step: PropTypes.number,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * The value of the slider.
      */

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -72,7 +72,6 @@ const Snackbar = React.createClass({
      * The label for the action on the snackbar.
      */
     action: PropTypes.string,
-
     /**
      * The number of milliseconds to wait before automatically dismissing.
      * If no value is specified the snackbar will dismiss normally.
@@ -80,17 +79,14 @@ const Snackbar = React.createClass({
      * If a snackbar is dismissed before the timer expires, the timer will be cleared.
      */
     autoHideDuration: PropTypes.number,
-
     /**
      * Override the inline-styles of the body element.
      */
     bodyStyle: PropTypes.object,
-
     /**
      * The css class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * The message to be displayed.
      *
@@ -99,14 +95,12 @@ const Snackbar = React.createClass({
      * showing again)
      */
     message: PropTypes.node.isRequired,
-
     /**
      * Fired when the action button is touchtapped.
      *
      * @param {object} event Action button event.
      */
     onActionTouchTap: PropTypes.func,
-
     /**
      * Fired when the `Snackbar` is requested to be closed by a click outside the `Snackbar`, or after the
      * `autoHideDuration` timer expires.
@@ -120,12 +114,10 @@ const Snackbar = React.createClass({
      * @param {string} reason Can be:`"timeout"` (`autoHideDuration` expired) or: `"clickaway"`
      */
     onRequestClose: PropTypes.func,
-
     /**
      * Controls whether the `Snackbar` is opened or not.
      */
     open: PropTypes.bool.isRequired,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/Subheader/Subheader.js
+++ b/src/Subheader/Subheader.js
@@ -5,12 +5,10 @@ const propTypes = {
    * Node that will be placed inside the `Subheader`.
    */
   children: PropTypes.node,
-
   /**
    * If true, the `Subheader` will be indented by `72px`.
    */
   inset: PropTypes.bool,
-
   /**
    * Override the inline-styles of the root element.
    */

--- a/src/SvgIcon/SvgIcon.js
+++ b/src/SvgIcon/SvgIcon.js
@@ -9,34 +9,28 @@ class SvgIcon extends Component {
      * Elements passed into the SVG Icon.
      */
     children: PropTypes.node,
-
     /**
      * This is the fill color of the svg icon.
      * If not specified, this component will default
      * to muiTheme.palette.textColor.
      */
     color: PropTypes.string,
-
     /**
      * This is the icon color when the mouse hovers over the icon.
      */
     hoverColor: PropTypes.string,
-
     /**
      * Function called when mouse enters this element.
      */
     onMouseEnter: PropTypes.func,
-
     /**
      * Function called when mouse leaves this element.
      */
     onMouseLeave: PropTypes.func,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * Allows you to redifine what the coordinates
      * without units mean inside an svg element. For example,

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -34,89 +34,74 @@ class Table extends Component {
      * Set to true to indicate that all rows should be selected.
      */
     allRowsSelected: PropTypes.bool,
-
     /**
      * Override the inline-styles of the body's table element.
      */
     bodyStyle: PropTypes.object,
-
     /**
      * Children passed to table.
      */
     children: PropTypes.node,
-
     /**
      * The css class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * If true, the footer will appear fixed below the table.
      * The default value is true.
      */
     fixedFooter: PropTypes.bool,
-
     /**
      * If true, the header will appear fixed above the table.
      * The default value is true.
      */
     fixedHeader: PropTypes.bool,
-
     /**
      * Override the inline-styles of the footer's table element.
      */
     footerStyle: PropTypes.object,
-
     /**
      * Override the inline-styles of the header's table element.
      */
     headerStyle: PropTypes.object,
-
     /**
      * The height of the table.
      */
     height: PropTypes.string,
-
     /**
      * If true, multiple table rows can be selected.
      * CTRL/CMD+Click and SHIFT+Click are valid actions.
      * The default value is false.
      */
     multiSelectable: PropTypes.bool,
-
     /**
      * Called when a row cell is clicked.
      * rowNumber is the row number and columnId is
      * the column number or the column key.
      */
     onCellClick: PropTypes.func,
-
     /**
      * Called when a table cell is hovered.
      * rowNumber is the row number of the hovered row
      * and columnId is the column number or the column key of the cell.
      */
     onCellHover: PropTypes.func,
-
     /**
      * Called when a table cell is no longer hovered.
      * rowNumber is the row number of the row and columnId
      * is the column number or the column key of the cell.
      */
     onCellHoverExit: PropTypes.func,
-
     /**
      * Called when a table row is hovered.
      * rowNumber is the row number of the hovered row.
      */
     onRowHover: PropTypes.func,
-
     /**
      * Called when a table row is no longer hovered.
      * rowNumber is the row number of the row that is no longer hovered.
      */
     onRowHoverExit: PropTypes.func,
-
     /**
      * Called when a row is selected.
      * selectedRows is an array of all row selections.
@@ -124,19 +109,16 @@ class Table extends Component {
      * will be returned instead to indicate that all rows have been selected.
      */
     onRowSelection: PropTypes.func,
-
     /**
      * If true, table rows can be selected.
      * If multiple row selection is desired, enable multiSelectable.
      * The default value is true.
      */
     selectable: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * Override the inline-styles of the table's wrapper element.
      */

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -12,28 +12,23 @@ class TableBody extends Component {
      * Set to true to indicate that all rows should be selected.
      */
     allRowsSelected: PropTypes.bool,
-
     /**
      * Children passed to table body.
      */
     children: PropTypes.node,
-
     /**
      * The css class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * Controls whether or not to deselect all selected
      * rows after clicking outside the table.
      */
     deselectOnClickaway: PropTypes.bool,
-
     /**
      * Controls the display of the row checkbox. The default value is true.
      */
     displayRowCheckbox: PropTypes.bool,
-
     /**
      * @ignore
      * If true, multiple table rows can be selected.
@@ -41,13 +36,11 @@ class TableBody extends Component {
      * The default value is false.
      */
     multiSelectable: PropTypes.bool,
-
     /**
      * @ignore
      * Callback function for when a cell is clicked.
      */
     onCellClick: PropTypes.func,
-
     /**
      * @ignore
      * Called when a table cell is hovered. rowNumber
@@ -55,7 +48,6 @@ class TableBody extends Component {
      * is the column number or the column key of the cell.
      */
     onCellHover: PropTypes.func,
-
     /**
      * @ignore
      * Called when a table cell is no longer hovered.
@@ -63,14 +55,12 @@ class TableBody extends Component {
      * is the column number or the column key of the cell.
      */
     onCellHoverExit: PropTypes.func,
-
     /**
      * @ignore
      * Called when a table row is hovered.
      * rowNumber is the row number of the hovered row.
      */
     onRowHover: PropTypes.func,
-
     /**
      * @ignore
      * Called when a table row is no longer
@@ -78,7 +68,6 @@ class TableBody extends Component {
      * that is no longer hovered.
      */
     onRowHoverExit: PropTypes.func,
-
     /**
      * @ignore
      * Called when a row is selected. selectedRows is an
@@ -87,14 +76,12 @@ class TableBody extends Component {
      * all rows have been selected.
      */
     onRowSelection: PropTypes.func,
-
     /**
      * Controls whether or not the rows are pre-scanned to determine
      * initial state. If your table has a large number of rows and
      * you are experiencing a delay in rendering, turn off this property.
      */
     preScanRows: PropTypes.bool,
-
     /**
      * @ignore
      * If true, table rows can be selected. If multiple
@@ -102,20 +89,17 @@ class TableBody extends Component {
      * The default value is true.
      */
     selectable: PropTypes.bool,
-
     /**
      * If true, table rows will be highlighted when
      * the cursor is hovering over the row. The default
      * value is false.
      */
     showRowHover: PropTypes.bool,
-
     /**
      * If true, every other table row starting
      * with the first row will be striped. The default value is false.
      */
     stripedRows: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/Table/TableFooter.js
+++ b/src/Table/TableFooter.js
@@ -33,12 +33,10 @@ class TableFooter extends Component {
      * Children passed to table footer.
      */
     children: PropTypes.node,
-
     /**
      * The css class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/Table/TableHeader.js
+++ b/src/Table/TableHeader.js
@@ -26,41 +26,34 @@ class TableHeader extends Component {
      * for manually.
      */
     adjustForCheckbox: PropTypes.bool,
-
     /**
      * Children passed to table header.
      */
     children: PropTypes.node,
-
     /**
      * The css class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * Controls whether or not the select all checkbox is displayed.
      */
     displaySelectAll: PropTypes.bool,
-
     /**
      * If set to true, the select all button will be interactable.
      * If set to false, the button will not be interactable.
      * To hide the checkbox, set displaySelectAll to false.
      */
     enableSelectAll: PropTypes.bool,
-
     /**
      * @ignore
      * Callback when select all has been checked.
      */
     onSelectAll: PropTypes.func,
-
     /**
      * @ignore
      * True when select all has been checked.
      */
     selectAllSelected: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/Table/TableHeaderColumn.js
+++ b/src/Table/TableHeaderColumn.js
@@ -27,35 +27,29 @@ function getStyles(props, context) {
 class TableHeaderColumn extends Component {
   static propTypes = {
     children: PropTypes.node,
-
     /**
      * The css class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * Number to identify the header row. This property
      * is automatically populated when used with TableHeader.
      */
     columnNumber: PropTypes.number,
-
     /**
      * @ignore
      * Callback function for click event.
      */
     onClick: PropTypes.func,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * The string to supply to the tooltip. If not
      * string is supplied no tooltip will be shown.
      */
     tooltip: PropTypes.string,
-
     /**
      * Additional styling that can be applied to the tooltip.
      */

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -30,23 +30,19 @@ class TableRow extends Component {
      * Children passed to table row.
      */
     children: PropTypes.node,
-
     /**
      * The css class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * If true, row border will be displayed for the row.
      * If false, no border will be drawn.
      */
     displayBorder: PropTypes.bool,
-
     /**
      * Controls whether or not the row reponseds to hover events.
      */
     hoverable: PropTypes.bool,
-
     /**
      * Controls whether or not the row should be rendered as being
      * hovered. This property is evaluated in addition to this.state.hovered
@@ -54,7 +50,6 @@ class TableRow extends Component {
      * external events.
      */
     hovered: PropTypes.bool,
-
     /**
      * @ignore
      * Called when a row cell is clicked.
@@ -62,7 +57,6 @@ class TableRow extends Component {
      * the column number or the column key.
      */
     onCellClick: PropTypes.func,
-
     /**
      * @ignore
      * Called when a table cell is hovered.
@@ -70,7 +64,6 @@ class TableRow extends Component {
      * and columnId is the column number or the column key of the cell.
      */
     onCellHover: PropTypes.func,
-
     /**
      * @ignore
      * Called when a table cell is no longer hovered.
@@ -78,51 +71,43 @@ class TableRow extends Component {
      * is the column number or the column key of the cell.
      */
     onCellHoverExit: PropTypes.func,
-
     /**
      * @ignore
      * Called when row is clicked.
      */
     onRowClick: PropTypes.func,
-
     /**
      * @ignore
      * Called when a table row is hovered.
      * rowNumber is the row number of the hovered row.
      */
     onRowHover: PropTypes.func,
-
     /**
      * @ignore
      * Called when a table row is no longer hovered.
      * rowNumber is the row number of the row that is no longer hovered.
      */
     onRowHoverExit: PropTypes.func,
-
     /**
      * Number to identify the row. This property is
      * automatically populated when used with the TableBody component.
      */
     rowNumber: PropTypes.number,
-
     /**
      * If true, table rows can be selected. If multiple row
      * selection is desired, enable multiSelectable.
      * The default value is true.
      */
     selectable: PropTypes.bool,
-
     /**
      * Indicates that a particular row is selected.
      * This property can be used to programmatically select rows.
      */
     selected: PropTypes.bool,
-
     /**
      * Indicates whether or not the row is striped.
      */
     striped: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/Table/TableRowColumn.js
+++ b/src/Table/TableRowColumn.js
@@ -26,43 +26,36 @@ function getStyles(props, context) {
 class TableRowColumn extends Component {
   static propTypes = {
     children: PropTypes.node,
-
     /**
      * The css class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * @ignore
      * Number to identify the header row. This property
      * is automatically populated when used with TableHeader.
      */
     columnNumber: PropTypes.number,
-
     /**
      * @ignore
      * If true, this column responds to hover events.
      */
     hoverable: PropTypes.bool,
-
     /**
      * @ignore
      * Callback function for click event.
      */
     onClick: PropTypes.func,
-
     /**
      * @ignore
      * Callback function for hover event.
      */
     onHover: PropTypes.func,
-
     /**
      * @ignore
      * Callback function for hover exit event.
      */
     onHoverExit: PropTypes.func,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/Tabs/InkBar.js
+++ b/src/Tabs/InkBar.js
@@ -23,7 +23,6 @@ class InkBar extends Component {
   static propTypes = {
     color: PropTypes.string,
     left: PropTypes.string.isRequired,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -31,17 +31,14 @@ class Tab extends Component {
      * The css class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * Sets the icon of the tab, you can pass `FontIcon` or `SvgIcon` elements.
      */
     icon: PropTypes.node,
-
     /**
      * Sets the text value of the tab item to the string specified.
      */
     label: PropTypes.node,
-
     /**
      * Fired when the active tab changes by touch or tap.
      * Use this event to specify any functionality when an active tab changes.
@@ -49,31 +46,26 @@ class Tab extends Component {
      * This function will always recieve the active tab as it\'s first argument.
      */
     onActive: PropTypes.func,
-
     /**
      * @ignore
      * This property is overriden by the Tabs component.
      */
     onTouchTap: PropTypes.func,
-
     /**
      * @ignore
      * Defines if the current tab is selected or not.
      * The Tabs component is responsible for setting this property.
      */
     selected: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * If value prop passed to Tabs component, this value prop is also required.
      * It assigns a value to the tab so that it can be selected by the Tabs.
      */
     value: PropTypes.any,
-
     /**
      * @ignore
      * This property is overriden by the Tabs component.

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -22,22 +22,18 @@ class Tabs extends Component {
      * Should be used to pass `Tab` components.
      */
     children: PropTypes.node,
-
     /**
      * The css class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * The css class name of the content's container.
      */
     contentContainerClassName: PropTypes.string,
-
     /**
      * Override the inline-styles of the content's container.
      */
     contentContainerStyle: PropTypes.object,
-
     /**
      * Specify initial visible tab index.
      * Initial selected index is set by default to 0.
@@ -45,32 +41,26 @@ class Tabs extends Component {
      * initialSelectedIndex will revert back to default.
      */
     initialSelectedIndex: PropTypes.number,
-
     /**
      * Override the inline-styles of the InkBar.
      */
     inkBarStyle: PropTypes.object,
-
     /**
      * Called when the selected value change.
      */
     onChange: PropTypes.func,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * Override the inline-styles of the tab-labels container.
      */
     tabItemContainerStyle: PropTypes.object,
-
     /**
      * Override the default tab template used to wrap the content of each tab element.
      */
     tabTemplate: PropTypes.func,
-
     /**
      * Makes Tabs controllable and selects the tab whose value prop matches this prop.
      */

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -115,162 +115,132 @@ function isValid(value) {
 class TextField extends Component {
   static propTypes = {
     children: PropTypes.node,
-
     /**
      * The css class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * The text string to use for the default value.
      */
     defaultValue: PropTypes.any,
-
     /**
      * Disables the text field if set to true.
      */
     disabled: PropTypes.bool,
-
     /**
      * The style object to use to override error styles.
      */
     errorStyle: PropTypes.object,
-
     /**
      * The error content to display.
      */
     errorText: PropTypes.node,
-
     /**
      * If true, the floating label will float even when there is no value.
      */
     floatingLabelFixed: PropTypes.bool,
-
     /**
      * The style object to use to override floating label styles.
      */
     floatingLabelStyle: PropTypes.object,
-
     /**
      * The content to use for the floating label element.
      */
     floatingLabelText: PropTypes.node,
-
     /**
      * If true, the field receives the property width 100%.
      */
     fullWidth: PropTypes.bool,
-
     /**
      * Override the inline-styles of the TextField's hint text element.
      */
     hintStyle: PropTypes.object,
-
     /**
      * The hint content to display.
      */
     hintText: PropTypes.node,
-
     /**
      * The id prop for the text field.
      */
     id: PropTypes.string,
-
     /**
      * Override the inline-styles of the TextField's input element.
      * When multiLine is false: define the style of the input element.
      * When multiLine is true: define the style of the container of the textarea.
      */
     inputStyle: PropTypes.object,
-
     /**
      * If true, a textarea element will be rendered.
      * The textarea also grows and shrinks according to the number of lines.
      */
     multiLine: PropTypes.bool,
-
     /**
      * Name applied to the input.
      */
     name: PropTypes.string,
-
     /**
      * Callback function that is fired when the textfield loses focus.
      */
     onBlur: PropTypes.func,
-
     /**
      * Callback function that is fired when the textfield's value changes.
      */
     onChange: PropTypes.func,
-
     /**
      * The function to call when the user presses the Enter key.
      */
     onEnterKeyDown: deprecated(PropTypes.func,
       'Use onKeyDown and check for keycode instead.'),
-
     /**
      * Callback function that is fired when the textfield gains focus.
      */
     onFocus: PropTypes.func,
-
     /**
      * Callback function fired when key is pressed down.
      */
     onKeyDown: PropTypes.func,
-
     /**
      * Number of rows to display when multiLine option is set to true.
      */
     rows: PropTypes.number,
-
     /**
      * Maximum number of rows to display when
      * multiLine option is set to true.
      */
     rowsMax: PropTypes.number,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * Override the inline-styles of the TextField's textarea element.
      * The TextField use either a textarea or an input,
      * this property has effects only when multiLine is true.
      */
     textareaStyle: PropTypes.object,
-
     /**
      * Specifies the type of input to display
      * such as "password" or "text".
      */
     type: PropTypes.string,
-
     /**
      * Override the inline-styles of the
      * TextField's underline element when disabled.
      */
     underlineDisabledStyle: PropTypes.object,
-
     /**
      * Override the inline-styles of the TextField's
      * underline element when focussed.
      */
     underlineFocusStyle: PropTypes.object,
-
     /**
      * If true, shows the underline for the text field.
      */
     underlineShow: PropTypes.bool,
-
     /**
      * Override the inline-styles of the TextField's underline element.
      */
     underlineStyle: PropTypes.object,
-
     /**
      * The value of the text field.
      */

--- a/src/TextField/TextFieldHint.js
+++ b/src/TextField/TextFieldHint.js
@@ -7,17 +7,14 @@ const propTypes = {
    * The material-ui theme applied to this component.
    */
   muiTheme: PropTypes.object.isRequired,
-
   /**
    * True if the hint text should be visible.
    */
   show: PropTypes.bool,
-
   /**
    * Override the inline-styles of the root element.
    */
   style: PropTypes.object,
-
   /**
    * The hint text displayed.
    */

--- a/src/TextField/TextFieldLabel.js
+++ b/src/TextField/TextFieldLabel.js
@@ -7,37 +7,30 @@ const propTypes = {
    * The material-ui theme applied to this component.
    */
   muiTheme: PropTypes.object.isRequired,
-
   /**
    * The css class name of the root element.
    */
   className: PropTypes.string,
-
   /**
    * The label contents.
    */
   children: PropTypes.node,
-
   /**
    * Disables the label if set to true.
    */
   disabled: PropTypes.bool,
-
   /**
    * True if the floating label should shrink.
    */
   shrink: PropTypes.bool,
-
   /**
    * The id of the target element that this label should refer to.
    */
   htmlFor: PropTypes.string,
-
   /**
    * Callback function for when the label is selected via a touch tap.
    */
   onTouchTap: PropTypes.func,
-
   /**
    * Override the inline-styles of the root element.
    */

--- a/src/TextField/TextFieldUnderline.js
+++ b/src/TextField/TextFieldUnderline.js
@@ -6,38 +6,31 @@ const propTypes = {
    * True if the parent `TextField` is disabled.
    */
   disabled: PropTypes.bool,
-
   /**
    * Override the inline-styles of the underline when parent `TextField` is disabled.
    */
   disabledStyle: PropTypes.object,
-
   /**
    * True if the parent `TextField` has an error.
    */
   error: PropTypes.bool,
-
   /**
    * Override the inline-styles of the underline when parent `TextField` has an error.
    */
   errorStyle: PropTypes.object,
-
   /**
    * True if the parent `TextField` is focused.
    */
   focus: PropTypes.bool,
-
   /**
    * Override the inline-styles of the underline when parent `TextField` is focused.
    */
   focusStyle: PropTypes.object,
-
   /**
    * @ignore
    * The material-ui theme applied to this component.
    */
   muiTheme: PropTypes.object.isRequired,
-
   /**
    * Override the inline-styles of the root element.
    */

--- a/src/TimePicker/TimePicker.js
+++ b/src/TimePicker/TimePicker.js
@@ -16,59 +16,48 @@ class TimePicker extends Component {
      * If true, automatically accept and close the picker on set minutes.
      */
     autoOk: PropTypes.bool,
-
     /**
      * Override the label of the 'Cancel' button.
      */
     cancelLabel: PropTypes.node,
-
     /**
      * The initial time value of the TimePicker.
      */
     defaultTime: PropTypes.object,
-
     /**
      * If true, the TimePicker is disabled.
      */
     disabled: PropTypes.bool,
-
     /**
      * Tells the component to display the picker in `ampm` (12hr) format or `24hr` format.
      */
     format: PropTypes.oneOf(['ampm', '24hr']),
-
     /**
      * Override the label of the 'OK' button.
      */
     okLabel: PropTypes.node,
-
     /**
      * Callback function that is fired when the time value changes. The time value is passed in a Date Object.
      * Since there is no particular event associated with the change the first argument will always be null
      * and the second argument will be the new Date instance.
      */
     onChange: PropTypes.func,
-
     /**
      * Callback function fired when the TimePicker dialog is dismissed.
      */
     onDismiss: PropTypes.func,
-
     /**
      * Callback function fired when the TimePicker `TextField` gains focus.
      */
     onFocus: PropTypes.func,
-
     /**
      * Callback function fired when the TimePicker dialog is shown.
      */
     onShow: PropTypes.func,
-
     /**
      * Callback function fired when the TimePicker is tapped or clicked.
      */
     onTouchTap: PropTypes.func,
-
     /**
      * If true, uses ("noon" / "midnight") instead of ("12 a.m." / "12 p.m.").
      *
@@ -77,17 +66,14 @@ class TimePicker extends Component {
      * ("12 a.m." / "12 p.m.").
      */
     pedantic: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * Override the inline-styles of TimePicker's TextField element.
      */
     textFieldStyle: PropTypes.object,
-
     /**
      * Sets the time for the Time Picker programmatically.
      */

--- a/src/Toggle/Toggle.js
+++ b/src/Toggle/Toggle.js
@@ -75,72 +75,58 @@ class Toggle extends Component {
      * More info: https://fb.me/react-controlled-components
      */
     defaultToggled: PropTypes.bool,
-
     /**
      * Will disable the toggle if true.
      */
     disabled: PropTypes.bool,
-
     /**
      * Overrides the inline-styles of the Toggle element.
      */
     elementStyle: PropTypes.object,
-
     /**
      * Overrides the inline-styles of the Icon element.
      */
     iconStyle: PropTypes.object,
-
     /**
      * Overrides the inline-styles of the input element.
      */
     inputStyle: PropTypes.object,
-
     /**
      * Label for toggle.
      */
     label: PropTypes.string,
-
     /**
      * Where the label will be placed next to the toggle.
      */
     labelPosition: PropTypes.oneOf(['left', 'right']),
-
     /**
      * Overrides the inline-styles of the Toggle element label.
      */
     labelStyle: PropTypes.object,
-
     /**
      * Callback function that is fired when the toggle switch is toggled.
      */
     onToggle: PropTypes.func,
-
     /**
      * Override style of ripple.
      */
     rippleStyle: PropTypes.object,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * Override style for thumb.
      */
     thumbStyle: PropTypes.object,
-
     /**
      * Toggled if set to true.
      */
     toggled: PropTypes.bool,
-
     /**
      * Override style for track.
      */
     trackStyle: PropTypes.object,
-
     /**
      * ValueLink prop for when using controlled toggle.
      */

--- a/src/Toolbar/Toolbar.js
+++ b/src/Toolbar/Toolbar.js
@@ -27,17 +27,14 @@ class Toolbar extends Component {
      * Can be a `ToolbarGroup` to render a group of related items.
      */
     children: PropTypes.node,
-
     /**
      * The css class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * Do not apply `desktopGutter` to the `Toolbar`.
      */
     noGutter: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/Toolbar/ToolbarGroup.js
+++ b/src/Toolbar/ToolbarGroup.js
@@ -68,29 +68,24 @@ class ToolbarGroup extends Component {
      * Can be any node or number of nodes.
      */
     children: PropTypes.node,
-
     /**
      * The css class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * Set this to true for if the `ToolbarGroup` is the first child of `Toolbar`
      * to prevent setting the left gap.
      */
     firstChild: PropTypes.bool,
-
     /**
      * Determines the side the `ToolbarGroup` will snap to. Either 'left' or 'right'.
      */
     float: PropTypes.oneOf(['left', 'right']),
-
     /**
      * Set this to true for if the `ToolbarGroup` is the last child of `Toolbar`
      * to prevent setting the right gap.
      */
     lastChild: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/Toolbar/ToolbarSeparator.js
+++ b/src/Toolbar/ToolbarSeparator.js
@@ -27,7 +27,6 @@ class ToolbarSeparator extends Component {
      * The css class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/Toolbar/ToolbarTitle.js
+++ b/src/Toolbar/ToolbarTitle.js
@@ -27,12 +27,10 @@ class ToolbarTitle extends Component {
      * The css class name of the root element.
      */
     className: PropTypes.string,
-
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-
     /**
      * The text to be displayed.
      */

--- a/src/internal/BeforeAfterWrapper.js
+++ b/src/internal/BeforeAfterWrapper.js
@@ -48,7 +48,6 @@ class BeforeAfterWrapper extends Component {
     beforeStyle: PropTypes.object,
     children: PropTypes.node,
     elementType: PropTypes.string,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/internal/ClearFix.js
+++ b/src/internal/ClearFix.js
@@ -28,7 +28,6 @@ ClearFix.muiName = 'ClearFix';
 
 ClearFix.propTypes = {
   children: PropTypes.node,
-
   /**
    * Override the inline-styles of the root element.
    */

--- a/src/internal/Overlay.js
+++ b/src/internal/Overlay.js
@@ -42,7 +42,6 @@ class Overlay extends Component {
   static propTypes = {
     autoLockScrolling: PropTypes.bool,
     show: PropTypes.bool.isRequired,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/internal/ScaleIn.js
+++ b/src/internal/ScaleIn.js
@@ -9,7 +9,6 @@ class ScaleIn extends Component {
     enterDelay: PropTypes.number,
     maxScale: PropTypes.number,
     minScale: PropTypes.number,
-
     /**
      * Override the inline-styles of the root element.
      */

--- a/src/internal/Tooltip.js
+++ b/src/internal/Tooltip.js
@@ -86,7 +86,6 @@ class Tooltip extends Component {
     horizontalPosition: PropTypes.oneOf(['left', 'right', 'center']),
     label: PropTypes.node.isRequired,
     show: PropTypes.bool,
-
     /**
      * Override the inline-styles of the root element.
      */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Follow this discusion https://github.com/callemall/material-ui/pull/3903#discussion_r59136936.
