### PR TITLE
[AutoComplete] Fix bug with onNewRequest

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -260,7 +260,7 @@ class AutoComplete extends Component {
     const chosenRequest = dataSource[index];
     const searchText = typeof chosenRequest === 'string' ? chosenRequest : chosenRequest.text;
 
-    this.props.onNewRequest(chosenRequest, index);
+    this.props.onNewRequest(searchText, index);
 
     this.timerTouchTapCloseId = setTimeout(() => {
       this.setState({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


The docs say it should consistently return a string, however when an item is tapped, it returns the menu object. Alternatively, I could update the docs to show that onNewRequest will give different values depending on how its selected, but i think multiple type arguments are a bad idea.