### PR TITLE
[RadioButton] Fix IE double click disabled RadioButton

### DIFF
--- a/src/RadioButton/RadioButton.js
+++ b/src/RadioButton/RadioButton.js
@@ -123,8 +123,8 @@ class RadioButton extends Component {
   };
 
   // Only called when selected, not when unselected.
-  handleSwitch = (event) => {
-    if (this.props.onCheck) this.props.onCheck(event, this.props.value);
+  handleSwitch = (event, isInputChecked) => {
+    if (this.props.onCheck && isInputChecked) this.props.onCheck(event, this.props.value);
   };
 
   isChecked() {


### PR DESCRIPTION
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


Fixes #3382
In React + IE, a handleChange event is incorrectly fired on a disabled
radio button double click. Added a guard in RadioButton to leverage the
isInputChecked argument sent from EnhancedSwitch.