### PR TITLE
[Dialog] Do not mix padding and padding top

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
   "private": true,
   "scripts": {
     "start": "npm run browser:development",
-    "browser:development": "webpack-dev-server --config webpack-dev-server.config.js --progress --colors --inline --host=",
+    "browser:development": "webpack-dev-server --config webpack-dev-server.config.js --progress --colors --inline",
     "browser:build": "NODE_ENV=docs-production webpack --config webpack-production.config.js --progress --colors --profile",
     "browser:prd": "NODE_ENV=docs-production webpack-dev-server --config webpack-production.config.js --progress --colors",
     "gh-pages:build": "node ./gh-pages-build.js",

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -140,8 +140,8 @@ function getStyles(props, context) {
     body: {
       fontSize: dialog.bodyFontSize,
       color: dialog.bodyColor,
-      padding: gutter,
-      paddingTop: props.title ? 0 : gutter,
+      padding: `${props.title ? 0 : gutter}px ${gutter}px ${gutter}px`,
+      boxSizing: 'border-box',
       overflowY: autoScrollBodyContent ? 'auto' : 'hidden',
     },
   };
@@ -223,7 +223,7 @@ class DialogInline extends Component {
     if (autoDetectWindowHeight || autoScrollBodyContent) {
       const styles = getStyles(this.props, this.context);
       styles.body = Object.assign(styles.body, bodyStyle);
-      let maxDialogContentHeight = clientHeight - 2 * (styles.body.padding + 64);
+      let maxDialogContentHeight = clientHeight - 2 * 64;
 
       if (title) maxDialogContentHeight -= dialogContent.previousSibling.offsetHeight;
 


### PR DESCRIPTION
- Fix https://github.com/callemall/material-ui/issues/4081. The `DatePickerDialog` is resetting the padding with `padding: 0`. But that has no impact on the `paddingTop` property.
- Revert https://github.com/callemall/material-ui/pull/4072
