### PR TITLE
[Tests] Fix sourcemap bug in mocha error stack traces

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,7 @@
   ],
   "env": {
     "test": {
-      "sourceMaps": "inline"
+      "sourceMaps": "both"
     },
     "docs-production": {
       "plugins": [


### PR DESCRIPTION
Fixes a regression I introduced in the test updates today. I just encountered it when writing a failing test and saw the error stack trace output had incorrect line numbers 🔥 🚒 

