### PR TITLE
[AutoComplete] Add text and value field keys for objects list dataSource

### DIFF
--- a/docs/src/app/components/pages/components/AutoComplete/ExampleDataSources.js
+++ b/docs/src/app/components/pages/components/AutoComplete/ExampleDataSources.js
@@ -26,9 +26,13 @@ const dataSource1 = [
 const dataSource2 = ['12345', '23456', '34567'];
 
 const dataSource3 = [
-  {text: 'Some Text', value: 'someFirstValue'},
-  {text: 'Some Text', value: 'someSecondValue'},
+  {textKey: 'Some Text', valueKey: 'someFirstValue'},
+  {textKey: 'Some Text', valueKey: 'someSecondValue'},
 ];
+const dataSourceConfig = {
+  text: 'textKey',
+  value: 'valueKey',
+};
 
 const AutoCompleteExampleNoFilter = () => (
   <div>
@@ -48,6 +52,7 @@ const AutoCompleteExampleNoFilter = () => (
       filter={AutoComplete.noFilter}
       openOnFocus={true}
       dataSource={dataSource3}
+      dataSourceConfig={dataSourceConfig}
     />
   </div>
 );


### PR DESCRIPTION
Sometimes we have no option to change `dataSource` fields so that they always had `text` and `value` without clumsy modifications.
It is more reasonable to have special props to map appropriate keys in `dataSource` to be used for search and results instead of hard-coded names (though I left them as the default values). E.g.

```jsx
const dataSource = [
  {txt: 'Some Text', val: 'someFirstValue'},
  {txt: 'Some Text', val: 'someSecondValue'},
];

<AutoComplete
  sourceTextKey='txt'
  sourceValueKey='val'
  dataSource={dataSource}
  ...
/>
```