### PR TITLE
[EnhancedButton] Fix not setting focus when keyboardFocused prop set

### DIFF
--- a/src/internal/EnhancedButton.js
+++ b/src/internal/EnhancedButton.js
@@ -94,6 +94,10 @@ class EnhancedButton extends Component {
   componentDidMount() {
     injectStyle();
     listenForTabPresses();
+    if (this.state.isKeyboardFocused) {
+      this.refs.enhancedButton.focus();
+      this.props.onKeyboardFocus(null, true);
+    }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -304,6 +308,7 @@ class EnhancedButton extends Component {
     const buttonProps = {
       ...other,
       style: prepareStyles(mergedStyles),
+      ref: 'enhancedButton',
       disabled: disabled,
       onBlur: this.handleBlur,
       onClick: this.handleClick,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Fixes #4116 calls .focus() on the Enhanced button on initial render as well as calling focus callbacks for parent components.