### PR TITLE
[svg-icons] Fix windows build by replacing back to forward slashes in icon paths.

### DIFF
--- a/scripts/icon-index-generator.js
+++ b/scripts/icon-index-generator.js
@@ -13,7 +13,7 @@ rrs(svgIconPath).forEach((file) => {
     while (found === false && index < fileLines.length) {
       if (fileLines[index].indexOf('export default') > -1) {
         const moduleName = fileLines[index].split(' ')[2].replace(';', '').trim();
-        const modulePath = file.substring(0, file.length - 3).replace(svgIconPath, '');
+        const modulePath = file.substring(0, file.length - 3).replace(/\\/g, '/').replace(svgIconPath, '');
 
         outArray.push(`export ${moduleName} from './${modulePath}';\n`);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

In windows, build fails because of backslashes in icon paths. This simply replaces all backslash characters to slash in icon index generator.
