### PR TITLE
Time selector for datetime

### DIFF
--- a/docs/src/app/components/pages/components/DatePicker/ExampleInline.js
+++ b/docs/src/app/components/pages/components/DatePicker/ExampleInline.js
@@ -4,6 +4,7 @@ import DatePicker from 'material-ui/DatePicker';
 const DatePickerExampleInline = () => (
   <div>
     <DatePicker hintText="Portrait Inline Dialog" container="inline" />
+    <DatePicker hintText="Portrait Inline With Time" container="inline" timeAware={true} />
     <DatePicker hintText="Landscape Inline Dialog" container="inline" mode="landscape" />
   </div>
 );

--- a/docs/src/app/components/pages/components/DatePicker/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/DatePicker/ExampleSimple.js
@@ -6,6 +6,7 @@ const DatePickerExampleSimple = () => (
     <DatePicker hintText="Portrait Dialog" />
     <DatePicker hintText="Landscape Dialog" mode="landscape" />
     <DatePicker hintText="Dialog Disabled" disabled={true} />
+    <DatePicker hintText="Portrait Dialog With Time" timeAware={true} />
   </div>
 );
 

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -1,5 +1,5 @@
 import React, {Component, PropTypes} from 'react';
-import {formatIso, isEqualDate} from './dateUtils';
+import {formatIso, formatIsoTime, isEqualDate} from './dateUtils';
 import DatePickerDialog from './DatePickerDialog';
 import TextField from '../TextField';
 import deprecated from '../utils/deprecatedPropType';
@@ -123,6 +123,15 @@ class DatePicker extends Component {
      */
     textFieldStyle: PropTypes.object,
     /**
+     * Makes the date picker time aware.  Used for selecting date and time in the datepicker
+     * currently disabled for `landscape` mode
+     */
+    timeAware: PropTypes.bool,
+    /**
+     * Tells the time component to display the picker in `ampm` (12hr) format or `24hr` format.
+     */
+    timeFormat: PropTypes.oneOf(['ampm', '24hr']),
+    /**
      * Sets the date for the Date Picker programmatically.
      */
     value: PropTypes.any,
@@ -140,6 +149,8 @@ class DatePicker extends Component {
     autoOk: false,
     cancelLabel: 'Cancel',
     container: 'dialog',
+    timeAware: false,
+    timeFormat: 'ampm',
     disabled: false,
     disableYearSelection: false,
     firstDayOfWeek: 1,
@@ -242,13 +253,18 @@ class DatePicker extends Component {
 
   formatDate = (date) => {
     if (this.props.locale && this.props.DateTimeFormat) {
-      return new this.props.DateTimeFormat(this.props.locale, {
+      const obj = {
         day: 'numeric',
         month: 'numeric',
         year: 'numeric',
-      }).format(date);
+      };
+      if (this.props.timeAware) {
+        obj.minute = 'numeric';
+        obj.hour = 'numeric';
+      }
+      return new this.props.DateTimeFormat(this.props.locale, obj).format(date);
     } else {
-      return formatIso(date);
+      return this.props.timeAware ? formatIsoTime(date, this.props.timeFormat) : formatIso(date);
     }
   };
 
@@ -258,6 +274,8 @@ class DatePicker extends Component {
       autoOk,
       cancelLabel,
       container,
+      timeAware,
+      timeFormat,
       defaultDate, // eslint-disable-line no-unused-vars
       disableYearSelection,
       firstDayOfWeek,
@@ -303,6 +321,8 @@ class DatePicker extends Component {
           maxDate={maxDate}
           minDate={minDate}
           mode={mode}
+          timeAware={timeAware}
+          timeFormat={timeFormat}
           okLabel={okLabel}
           onAccept={this.handleAccept}
           onShow={onShow}

--- a/src/DatePicker/DatePickerDialog.js
+++ b/src/DatePicker/DatePickerDialog.js
@@ -26,6 +26,8 @@ class DatePickerDialog extends Component {
     onShow: PropTypes.func,
     shouldDisableDate: PropTypes.func,
     style: PropTypes.object,
+    timeAware: PropTypes.bool,
+    timeFormat: PropTypes.oneOf(['ampm', '24hr']),
     wordings: PropTypes.object,
   };
 
@@ -105,6 +107,8 @@ class DatePickerDialog extends Component {
       maxDate,
       shouldDisableDate,
       mode,
+      timeAware,
+      timeFormat,
       disableYearSelection,
       ...other,
     } = this.props;
@@ -158,7 +162,6 @@ class DatePickerDialog extends Component {
         />
       );
     }
-
     // will change later when Popover is available.
     const Container = (container === 'inline' ? DatePickerInline : Dialog);
     return (
@@ -193,6 +196,8 @@ class DatePickerDialog extends Component {
             shouldDisableDate={shouldDisableDate}
             disableYearSelection={disableYearSelection}
             mode={mode}
+            timeAware={timeAware}
+            timeFormat={timeFormat}
           />
         }
       </Container>

--- a/src/DatePicker/DatePickerInline.js
+++ b/src/DatePicker/DatePickerInline.js
@@ -37,7 +37,6 @@ class DatePickerInline extends Component {
       });
     }
   }
-
   render() {
     const {
       actions,

--- a/src/DatePicker/dateUtils.js
+++ b/src/DatePicker/dateUtils.js
@@ -1,5 +1,7 @@
 import warning from 'warning';
 
+import {formatTime} from '../TimePicker/timeUtils';
+
 const dayAbbreviation = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
 const dayList = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const monthList = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep',
@@ -116,6 +118,10 @@ export function localizedWeekday(DateTimeFormat, locale, day, firstDayOfWeek) {
 // Convert date to ISO 8601 (YYYY-MM-DD) date string, accounting for current timezone
 export function formatIso(date) {
   return (new Date(`${date.toDateString()} 12:00:00 +0000`)).toISOString().substring(0, 10);
+}
+
+export function formatIsoTime(date, format = 'ampm') {
+  return `${formatIso(date)} ${formatTime(date, format)}`;
 }
 
 export function isEqualDate(d1, d2) {

--- a/src/TimePicker/Clock.js
+++ b/src/TimePicker/Clock.js
@@ -5,16 +5,21 @@ import ClockMinutes from './ClockMinutes';
 
 class Clock extends Component {
   static propTypes = {
+    clockStyles: PropTypes.object,
+    containerStyle: PropTypes.object,
     format: PropTypes.oneOf(['ampm', '24hr']),
+    hideSelector: PropTypes.bool,
     initialTime: PropTypes.object,
     isActive: PropTypes.bool,
     mode: PropTypes.oneOf(['hour', 'minute']),
     onChangeHours: PropTypes.func,
     onChangeMinutes: PropTypes.func,
+    onTouchTap: PropTypes.func,
   };
 
   static defaultProps = {
     initialTime: new Date(),
+    hideSelector: false,
   };
 
   static contextTypes = {
@@ -23,16 +28,21 @@ class Clock extends Component {
 
   state = {
     selectedTime: this.props.initialTime || new Date(),
+    hideSelector: this.props.hideSelector,
     mode: 'hour',
   };
 
   componentWillReceiveProps(nextProps) {
-    this.setState({
-      selectedTime: nextProps.initialTime || new Date(),
-    });
+    const state = {hideSelector: nextProps.hideSelector};
+    if (!this.state.selectedTime) {
+      state.selectedTime = nextProps.initialTime || new Date();
+    }
+
+    this.setState(state);
   }
 
   setMode = (mode) => {
+    if (this.props.onTouchTap) this.props.onTouchTap();
     setTimeout(() => {
       this.setState({
         mode: mode,
@@ -41,6 +51,8 @@ class Clock extends Component {
   };
 
   handleSelectAffix = (affix) => {
+    if (this.props.onTouchTap) this.props.onTouchTap();
+
     if (affix === this.getAffix()) return;
 
     const hours = this.state.selectedTime.getHours();
@@ -127,6 +139,7 @@ class Clock extends Component {
       container: {
         height: 280,
         padding: 10,
+        margin: 'auto',
         position: 'relative',
       },
       circle: {
@@ -155,7 +168,15 @@ class Clock extends Component {
         />
       );
     }
+    const containerStyle = prepareStyles(styles.container);
 
+    if (this.props.containerStyle) {
+      for (const attr in this.props.containerStyle) {
+        if (this.props.containerStyle.hasOwnProperty(attr)) {
+          containerStyle[attr] = this.props.containerStyle[attr];
+        }
+      }
+    }
     return (
       <div style={prepareStyles(styles.root)}>
         <TimeDisplay
@@ -167,10 +188,12 @@ class Clock extends Component {
           onSelectHour={this.setMode.bind(this, 'hour')}
           onSelectMin={this.setMode.bind(this, 'minute')}
         />
-        <div style={prepareStyles(styles.container)} >
-          <div style={prepareStyles(styles.circle)} />
-          {clock}
-        </div>
+        {!this.props.hideSelector && (
+          <div style={containerStyle} >
+            <div style={prepareStyles(styles.circle)} />
+            {clock}
+          </div>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
DatePicker can be used to pick a date and time. By clicking on the display (time or cal) toggles which component is selected.

Example use case:
`<DatePicker hintText="Portrait Dialog With Time" timeAware={true} />`
Display:

![screen shot 2016-05-02 at 9 21 47 pm](https://cloud.githubusercontent.com/assets/1923059/14973440/c39dd278-10b5-11e6-9bae-e3f567375d3c.png)
![screen shot 2016-05-02 at 9 22 43 pm](https://cloud.githubusercontent.com/assets/1923059/14973439/c39d3ff2-10b5-11e6-9d99-174887490849.png)
![screen shot 2016-05-02 at 10 36 42 pm](https://cloud.githubusercontent.com/assets/1923059/14973491/63ddc3a6-10b6-11e6-9004-2adb80550d17.png)

- [X] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

PS:
Not exactly happy with the leak in the abstraction, looking for feedback.


