### PR TITLE
[Docs] Replace name of obsolete repository with new one

### DIFF
--- a/docs/src/app/components/pages/discover-more/related-projects.md
+++ b/docs/src/app/components/pages/discover-more/related-projects.md
@@ -9,7 +9,7 @@ A Formsy compatibility wrapper for Material-UI form components.
 
 - [react-swipeable-views](https://github.com/oliviertassinari/react-swipeable-views)
 A React component for swipeable views. Plays well with the `Tabs` component.
-- [isomorphic-material-relay-starter-kit](https://github.com/codefoundries/isomorphic-material-relay-starter-kit)
-Starter kit for isomorphic applications using React/Relay and Material-UI.
+- [UniversalRelayBoilerplate](https://github.com/codefoundries/UniversalRelayBoilerplate)
+Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Material-UI), Relay, GraphQL, JWT, Node.js, Apache Cassandra.
 - [material-ui-rails](https://github.com/towonzhou/material-ui-rails)
 Material-UI for Rails.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


The isomorphic-material-relay-starter-kit is no longer supported and is superseded by the universal relay boilerplate, which is pretty much the same but modified to also support react native. As before, the web version is entirely based on Material-UI.