### PR TITLE
[Select] Docs code highlighting overreached.

### DIFF
--- a/docs/src/app/components/pages/components/SelectField/Page.js
+++ b/docs/src/app/components/pages/components/SelectField/Page.js
@@ -26,7 +26,7 @@ const descriptions = {
   label: 'With a `label` applied to each `MenuItem`, `SelectField` displays a complementary description of the ' +
   'selected item.',
   floating: '`SelectField` supports a floating label with the `floatingLabelText` property. This can be customised ' +
-  'with `the floatingLabelText` property.',
+  'with the `floatingLabelText` property.',
   errorText: 'The `errorText` property displays an error message below the Select Field. This can be customised with ' +
   'the `errorStyle` property.',
 };


### PR DESCRIPTION
- [ ] PR has tests / docs demo, and is linted. (n/a)
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Tiny swap for `the floatingLabelText` property, to the `floatingLabelText`, because "the" shouldn't be part of the inline code tag.

