### PR TITLE
[FlatButton] Fix Icon color prop issue

### DIFF
--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -221,7 +221,7 @@ class FlatButton extends Component {
 
     if (icon) {
       iconCloned = React.cloneElement(icon, {
-        color: mergedRootStyles.color,
+        color: icon.props.color || mergedRootStyles.color,
         style: {
           verticalAlign: 'middle',
           marginLeft: label && labelPosition !== 'before' ? 12 : 0,

--- a/src/FlatButton/FlatButton.spec.js
+++ b/src/FlatButton/FlatButton.spec.js
@@ -4,6 +4,7 @@ import {shallow} from 'enzyme';
 import {assert} from 'chai';
 import FlatButton from './FlatButton';
 import getMuiTheme from '../styles/getMuiTheme';
+import ActionAndroid from '../svg-icons/action/android';
 
 describe('<FlatButton />', () => {
   const muiTheme = getMuiTheme();
@@ -90,6 +91,19 @@ describe('<FlatButton />', () => {
     }));
     assert.ok(icon.is('span'));
     assert.ok(icon.is({color: flatButtonTheme.primaryTextColor}));
+  });
+
+  it('colors the icon with the passed color in prop', () => {
+    const color = 'white';
+    const wrapper = shallowWithContext(
+      <FlatButton
+        backgroundColor="#a4c639"
+        hoverColor="#8AA62F"
+        icon={<ActionAndroid color={color} />}
+      />
+    );
+    const icon = wrapper.find('ActionAndroid');
+    assert.strictEqual(icon.prop('color'), color, 'icon should have same color as that of color prop');
   });
 
   it('colors the button the secondary theme color', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Resolves: https://github.com/callemall/material-ui/issues/4144

color prop of icon was not being passed to the icon used within a flat-button

Replaced `color: mergedRootStyles.color,` with `color: icon.props.color,` and that fixed it.

```
    <FlatButton
      backgroundColor="#a4c639"
      hoverColor="#8AA62F"
      icon={<ActionAndroid color={fullWhite} />}
      style={style}
    />
```
![screen shot 2016-05-04 at 2 22 38 pm](https://cloud.githubusercontent.com/assets/15271922/15026677/379b6564-1205-11e6-96fc-a20ccccf1f60.png)