### PR TITLE
[DatePicker] Add support for built-in en-US locale

### DIFF
--- a/docs/src/app/components/pages/components/DatePicker/ExampleControlled.js
+++ b/docs/src/app/components/pages/components/DatePicker/ExampleControlled.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import DatePicker from 'material-ui/DatePicker';
 
+/**
+ * DatePicker` can be implemented as a controlled input,
+ * where `value` is handled by state in the parent component.
+ */
 export default class DatePickerExampleControlled extends React.Component {
 
   constructor(props) {

--- a/docs/src/app/components/pages/components/DatePicker/ExampleDisableDates.js
+++ b/docs/src/app/components/pages/components/DatePicker/ExampleDisableDates.js
@@ -8,7 +8,9 @@ function disableWeekends(date) {
 function disableRandomDates() {
   return Math.random() > 0.7;
 }
-
+/**
+ * `DatePicker` can disable specific dates based on the return value of a callback.
+ */
 const DatePickerExampleDisableDates = () => (
   <div>
     <DatePicker hintText="Weekends Disabled" shouldDisableDate={disableWeekends} />

--- a/docs/src/app/components/pages/components/DatePicker/ExampleInline.js
+++ b/docs/src/app/components/pages/components/DatePicker/ExampleInline.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import DatePicker from 'material-ui/DatePicker';
 
+/**
+ * Inline Date Pickers are displayed below the input, rather than as a modal dialog.
+ */
 const DatePickerExampleInline = () => (
   <div>
     <DatePicker hintText="Portrait Inline Dialog" container="inline" />

--- a/docs/src/app/components/pages/components/DatePicker/ExampleInternational.js
+++ b/docs/src/app/components/pages/components/DatePicker/ExampleInternational.js
@@ -7,15 +7,24 @@ let DateTimeFormat;
 /**
  * Use the native Intl.DateTimeFormat if available, or a polyfill if not.
  */
-if (areIntlLocalesSupported(['fr', 'en-US'])) {
+if (areIntlLocalesSupported(['fr'])) {
   DateTimeFormat = global.Intl.DateTimeFormat;
 } else {
   const IntlPolyfill = require('intl');
   DateTimeFormat = IntlPolyfill.DateTimeFormat;
   require('intl/locale-data/jsonp/fr');
-  require('intl/locale-data/jsonp/en-US');
 }
 
+/**
+ *  localised: '`DatePicker` can be localised using the `locale` property. The first example is localised in French.
+ *  Note that the buttons must be separately localised using the `cancelLabel` and `okLabel` properties.
+ *
+ *  The second example shows `firstDayOfWeek` set to `0`, (Sunday), and `locale` to `en-US` which matches the
+ *  behavior of the Date Picker prior to 0.15.0. Note that the 'en-US' locale is built in, and so does not require
+ *  `DateTimeFormat' to be supplied.
+ *
+ *  The final example displays the resulting date in a custom format using the `formatDate` property.',
+ */
 const DatePickerExampleInternational = () => (
   <div>
     <DatePicker
@@ -27,7 +36,6 @@ const DatePickerExampleInternational = () => (
     />
     <DatePicker
       hintText="en-US locale"
-      DateTimeFormat={DateTimeFormat}
       locale="en-US"
       firstDayOfWeek={0}
     />

--- a/docs/src/app/components/pages/components/DatePicker/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/DatePicker/ExampleSimple.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import DatePicker from 'material-ui/DatePicker';
 
+/**
+ * The Date Picker defaults to a portrait dialog. The `mode` property can be set to `landscape`.
+ * You can also disable the Dialog passing `true` to the `disabled` property.
+ */
 const DatePickerExampleSimple = () => (
   <div>
     <DatePicker hintText="Portrait Dialog" />

--- a/docs/src/app/components/pages/components/DatePicker/ExampleToggle.js
+++ b/docs/src/app/components/pages/components/DatePicker/ExampleToggle.js
@@ -8,8 +8,10 @@ const optionsStyle = {
   marginRight: 'auto',
 };
 
+/**
+ * This example allows you to set a date range, and to toggle `autoOk`, and `disableYearSelection`.
+ */
 export default class DatePickerExampleToggle extends React.Component {
-
   constructor(props) {
     super(props);
 
@@ -70,7 +72,7 @@ export default class DatePickerExampleToggle extends React.Component {
           <Toggle
             name="autoOk"
             value="autoOk"
-            label="Auto Accept"
+            label="Auto Ok"
             toggled={this.state.autoOk}
             onToggle={this.handleToggle}
           />

--- a/docs/src/app/components/pages/components/DatePicker/Page.js
+++ b/docs/src/app/components/pages/components/DatePicker/Page.js
@@ -20,64 +20,42 @@ import DatePickerExampleInternational from './ExampleInternational';
 import datePickerExampleInternationalCode from '!raw!./ExampleInternational';
 import datePickerCode from '!raw!material-ui/DatePicker/DatePicker';
 
-const descriptions = {
-  simple: 'The Date Picker defaults to a portrait dialog. The `mode` property can be set to `landscape`. You can ' +
-  'also disable the Dialog passing `true` to the `disabled` property.',
-  inline: 'Inline Date Pickers are displayed below the input, rather than as a modal dialog. ',
-  ranged: 'This example allows you to set a date range, and to toggle `autoOk`, and `disableYearSelection`.',
-  controlled: '`DatePicker` can be implemented as a controlled input, where `value` is handled by state in the ' +
-  'parent component.',
-  disabledDates: '`DatePicker` can disable specific dates based on the return value of a callback.',
-  localised: '`DatePicker` can be localised using the `locale` property. The first example is localised in French. ' +
-  'Note that the buttons must be separately localised using the `cancelLabel` and `okLabel` properties. \n\n' +
-  'The `firstDayOfWeek` property defaults to `1`, (Monday), so may also need to be set for the target locale. ' +
-  'The second example shows `firstDayOfWeek` set to `0`, (Sunday), and `locale` to `en-US` which matches the ' +
-  'bahavior of the Date Picker prior to 0.15.0.\n\n' +
-  'The final example displays the resulting date in a custom format using the `formatDate` property.',
-};
-
 const DatePickerPage = () => (
   <div>
     <Title render={(previousTitle) => `Date Picker - ${previousTitle}`} />
     <MarkdownElement text={datePickerReadmeText} />
     <CodeExample
       title="Simple examples"
-      description={descriptions.simple}
       code={datePickerExampleSimpleCode}
     >
       <DatePickerExampleSimple />
     </CodeExample>
     <CodeExample
       title="Inline examples"
-      description={descriptions.inline}
       code={datePickerExampleInlineCode}
     >
       <DatePickerExampleInline />
     </CodeExample>
     <CodeExample
       title="Ranged example"
-      description={descriptions.ranged}
       code={datePickerExampleToggleCode}
     >
       <DatePickerExampleToggle />
     </CodeExample>
     <CodeExample
       title="Controlled example"
-      description={descriptions.controlled}
       code={datePickerExampleControlledCode}
     >
       <DatePickerExampleControlled />
     </CodeExample>
     <CodeExample
       title="Disabled dates example"
-      description={descriptions.disabledDates}
       code={datePickerExampleDisableDatesCode}
     >
       <DatePickerExampleDisableDates />
     </CodeExample>
     <CodeExample
       title="Localised example"
-      description={descriptions.localised}
       code={datePickerExampleInternationalCode}
     >
       <DatePickerExampleInternational />

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -1,5 +1,5 @@
 import React, {Component, PropTypes} from 'react';
-import {formatIso, isEqualDate} from './dateUtils';
+import {dateTimeFormat, formatIso, isEqualDate} from './dateUtils';
 import DatePickerDialog from './DatePickerDialog';
 import TextField from '../TextField';
 import deprecated from '../utils/deprecatedPropType';
@@ -11,6 +11,8 @@ class DatePicker extends Component {
      * The constructor must follow this specification: ECMAScript Internationalization API 1.0 (ECMA-402).
      * `Intl.DateTimeFormat` is supported by most modern browsers, see http://caniuse.com/#search=intl,
      * otherwise https://github.com/andyearnshaw/Intl.js is a good polyfill.
+     *
+     * By default, a built-in `DateTimeFormat` is used which supports the 'en-US' `locale`.
      */
     DateTimeFormat: PropTypes.func,
     /**
@@ -22,7 +24,7 @@ class DatePicker extends Component {
      */
     cancelLabel: PropTypes.node,
     /**
-     * Used to control how the DatePicker will be displayed when a user tries to set a date.
+     * Used to control how the Date Picker will be displayed when the input field is focused.
      * `dialog` (default) displays the DatePicker as a dialog with a modal.
      * `inline` displays the DatePicker below the input field (similar to auto complete).
      */
@@ -49,7 +51,7 @@ class DatePicker extends Component {
      */
     firstDayOfWeek: PropTypes.number,
     /**
-     * This function is called to format the date displayed in the input box, and should return a string.
+     * This function is called to format the date displayed in the input field, and should return a string.
      * By default if no `locale` and `DateTimeFormat` is provided date objects are formatted to ISO 8601 YYYY-MM-DD.
      *
      * @param {object} date Date object to be formatted.
@@ -57,8 +59,8 @@ class DatePicker extends Component {
      */
     formatDate: PropTypes.func,
     /**
-     * Locale used for formatting the dialog date strings. If you are not using the default value, you
-     * have to provide a `DateTimeFormat` that supports it.
+     * Locale used for formatting the `DatePicker` date strings. Other than for 'en-US', you
+     * must provide a `DateTimeFormat` that supports the chosen `locale`.
      */
     locale: PropTypes.string,
     /**
@@ -241,8 +243,9 @@ class DatePicker extends Component {
   }
 
   formatDate = (date) => {
-    if (this.props.locale && this.props.DateTimeFormat) {
-      return new this.props.DateTimeFormat(this.props.locale, {
+    if (this.props.locale) {
+      const DateTimeFormat = this.props.DateTimeFormat || dateTimeFormat;
+      return new DateTimeFormat(this.props.locale, {
         day: 'numeric',
         month: 'numeric',
         year: 'numeric',

--- a/src/DatePicker/dateUtils.js
+++ b/src/DatePicker/dateUtils.js
@@ -8,23 +8,21 @@ const monthLongList = ['January', 'February', 'March', 'April', 'May', 'June',
   'July', 'August', 'September', 'October', 'November', 'December'];
 
 export function dateTimeFormat(locale, options) {
-  warning(locale === 'en-US', `Wrong usage of DateTimeFormat.
-    The ${locale} locale is not supported.`);
+  warning(locale === 'en-US', `The ${locale} locale is not supported by the built-in DateTimeFormat.
+  Use the \`DateTimeFormat\` prop to supply an alternative implementation.`);
 
   this.format = function(date) {
-    let output;
-
     if (options.month === 'short' && options.weekday === 'short' && options.day === '2-digit') {
-      output = `${dayList[date.getDay()]}, ${monthList[date.getMonth()]} ${date.getDate()}`;
+      return `${dayList[date.getDay()]}, ${monthList[date.getMonth()]} ${date.getDate()}`;
+    } else if (options.day === 'numeric' && options.month === 'numeric' && options.year === 'numeric') {
+      return `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
     } else if (options.month === 'long' && options.year === 'numeric') {
-      output = `${monthLongList[date.getMonth()]} ${date.getFullYear()}`;
+      return `${monthLongList[date.getMonth()]} ${date.getFullYear()}`;
     } else if (options.weekday === 'narrow') {
-      output = dayAbbreviation[date.getDay()];
+      return dayAbbreviation[date.getDay()];
     } else {
       warning(false, 'Wrong usage of DateTimeFormat');
     }
-
-    return output;
   };
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


0.15.0-alpha.1 introduced a breaking change to support ISO 8601 as the default date format.
This PR makes reverting to the previous behavior of displaying a US formatted date simpler, 
by allowing the 'en-US' `locale`, without requiring `DateTimeFormat` to be provided.

In addition, the example descriptions are moved to code comments.