### PR TITLE
[AutoComplete] use sublime text like search instead of Levenshtein Distance for fuzzy search

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -539,14 +539,17 @@ AutoComplete.levenshteinDistanceFilter = (distanceLessThan) => {
 };
 
 AutoComplete.fuzzyFilter = (searchText, key) => {
-  if (searchText.length === 0) {
-    return false;
+  const compareString = key.toLowerCase();
+  searchText = searchText.toLowerCase();
+
+  let searchTextIndex = 0;
+  for (let index = 0; index < key.length; index++) {
+    if (compareString[index] === searchText[searchTextIndex]) {
+      searchTextIndex += 1;
+    }
   }
 
-  const subMatchKey = key.substring(0, searchText.length);
-  const distance = AutoComplete.levenshteinDistance(searchText.toLowerCase(), subMatchKey.toLowerCase());
-
-  return searchText.length > 3 ? distance < 2 : distance === 0;
+  return searchTextIndex === searchText.length;
 };
 
 AutoComplete.Item = MenuItem;

--- a/src/AutoComplete/AutoComplete.spec.js
+++ b/src/AutoComplete/AutoComplete.spec.js
@@ -1,0 +1,33 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import AutoComplete from './AutoComplete';
+
+describe('<AutoComplete />', () => {
+  it('search using fuzzy filter', () => {
+    assert.strictEqual(AutoComplete.fuzzyFilter('ea', 'Peach'), true, 'should match Peach with ea');
+    assert.strictEqual(AutoComplete.fuzzyFilter('pah', 'Peach'), true, 'should match Peach with pah');
+    assert.strictEqual(AutoComplete.fuzzyFilter('peach', 'Peach'), true, 'should match Peach with peach');
+
+    assert.strictEqual(AutoComplete.fuzzyFilter('phc', 'Peach'), false, 'should not match Peach with phc');
+    assert.strictEqual(AutoComplete.fuzzyFilter('pp', 'Peach'), false, 'should not match Peach with pp');
+    assert.strictEqual(AutoComplete.fuzzyFilter('pb', 'Peach'), false, 'should not match Peach with pb');
+
+    // testing longer string
+    const test_string = 'The best thing about a Boolean is even if you are wrong, you are only off by a bit.';
+
+    let search_result = AutoComplete.fuzzyFilter('bOOLEAN', test_string);
+    assert.strictEqual(search_result, true, 'should match with case insensitive');
+
+    search_result = AutoComplete.fuzzyFilter('The a Boolean if wrong', test_string);
+    assert.strictEqual(search_result, true, 'should match pattern with spaces');
+
+    search_result = AutoComplete.fuzzyFilter(' if ,bit.', test_string);
+    assert.strictEqual(search_result, true, 'should match pattern with comma and period');
+
+    search_result = AutoComplete.fuzzyFilter('the best q', test_string);
+    assert.strictEqual(search_result, false, 'should not match pattern with letter is not contained in search text');
+
+    search_result = AutoComplete.fuzzyFilter('off bit by', 'off by a bit');
+    assert.strictEqual(search_result, false, 'should not match pattern when can not find letters in order ');
+  });
+});


### PR DESCRIPTION
The problem was that fuzzy search used Levenshtein Distance for matching.
It resulted that Peach was not matched by ea.

So i use search similar to the sublime text fuzzy search in ctrl + p also inspired by [https://github.com/mattyork/fuzzy](https://github.com/mattyork/fuzzy)

Basically pattern will match if you will get it from search text by deleting some letters.

If someone would like Levenshtein Distance there is still filter for them.