### PR TITLE
[Menu] Stop wheel events from propagating if scroll container is scrollable.

### DIFF
--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -468,6 +468,30 @@ class Menu extends Component {
     }
   }
 
+  cancelScrollEvent(event) {
+    event.stopPropagation();
+    event.preventDefault();
+    return false;
+  }
+
+  handleOnWheel = (event) => {
+    const scrollContainer = this.refs.scrollContainer;
+    // Only scroll lock if the the Menu is scrollable.
+    if (scrollContainer.scrollHeight <= scrollContainer.clientHeight) return;
+
+    const {scrollTop, scrollHeight, clientHeight} = scrollContainer;
+    const wheelDelta = event.deltaY;
+    const isDeltaPositive = wheelDelta > 0;
+
+    if (isDeltaPositive && wheelDelta > scrollHeight - clientHeight - scrollTop) {
+      scrollContainer.scrollTop = scrollHeight;
+      return this.cancelScrollEvent(event);
+    } else if (!isDeltaPositive && -wheelDelta > scrollTop) {
+      scrollContainer.scrollTop = 0;
+      return this.cancelScrollEvent(event);
+    }
+  }
+
   setWidth() {
     const el = ReactDOM.findDOMNode(this);
     const listEl = ReactDOM.findDOMNode(this.refs.list);
@@ -563,6 +587,7 @@ class Menu extends Component {
       <ClickAwayListener onClickAway={this.handleClickAway}>
         <div
           onKeyDown={this.handleKeyDown}
+          onWheel={this.handleOnWheel}
           style={prepareStyles(mergedRootStyles)}
           ref="scrollContainer"
         >


### PR DESCRIPTION
Fixes #4154 by preventing bubbling of wheel events from the Menu component's scroll container, if the container is scrollable.

Followed @mbrookes opinion in that this is implemented as the default behaviour, and not hidden behind a prop flag.

It now behaves so:
![](https://thumbs.gfycat.com/MaleCloseJanenschia-size_restricted.gif)
