### PR TITLE
[Picker] Disable userSelect on TimePicker and DatePicker

### DIFF
--- a/src/DatePicker/Calendar.js
+++ b/src/DatePicker/Calendar.js
@@ -246,6 +246,7 @@ class Calendar extends Component {
     const styles = {
       root: {
         color: calendarTextColor,
+        userSelect: 'none',
         width: isLandscape ? 479 : 310,
       },
       calendar: {

--- a/src/TimePicker/Clock.js
+++ b/src/TimePicker/Clock.js
@@ -123,7 +123,9 @@ class Clock extends Component {
     const {prepareStyles} = this.context.muiTheme;
 
     const styles = {
-      root: {},
+      root: {
+        userSelect: 'none',
+      },
       container: {
         height: 280,
         padding: 10,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Disables user-select on both the picker components.

Resolves #1981

With this in place, the user won't be able to select any text in both the pickers.

![userselect](https://cloud.githubusercontent.com/assets/15271922/15099553/d6db3e86-151d-11e6-9d4e-4f1772615f3e.gif)

![userselect1](https://cloud.githubusercontent.com/assets/15271922/15099554/df94d348-151d-11e6-8765-4420bd8138f4.gif)

