### PR TITLE
[Icon Builder] Add muiName to generated SvgIcons

### DIFF
--- a/packages/icon-builder/README.md
+++ b/packages/icon-builder/README.md
@@ -1,24 +1,26 @@
 # Material-UI-Icons
 
-This tool crawls the [material-design-icons](https://github.com/google/material-design-icons) repo
-and generates react svg icon components for each icon.
+This tool generates Material-UI SvgIcon components for a set of svg icons.
 
 ## Running the build
+The npm script builds the [material-design-icons](https://github.com/google/material-design-icons) 
+that are included with Material-UI.
+
 ```sh
 npm install
 npm run build
 ```
 
 ## Generated folders
-The build script walks through all of the svg icons in the material-design-icons folder and generates the appropriate
-`.jsx` files in the `./jsx` folder. It'll also compile the `.jsx` files and create the cooresponding `.js` equivalent
-in the `./js` folder.
+The npm build script walks through all of the svg icons in the material-design-icons package
+ and generates the appropriate `.js` files in the `svg-icons` folder.
 
 ## Advanced usage and Custom builds
 
 `node build.js --help` can be used to pull up options available for building.
 
-You can build your own SVG icons as well as collections like [game-icons](http://game-icons.net/) through environmental variables.
+You can build your own SVG icons as well as collections like [game-icons](http://game-icons.net/) 
+through environmental variables.
 
 * `--output-dir` - directory to output jsx components
 * `--svg-dir` - SVG directory

--- a/packages/icon-builder/build.js
+++ b/packages/icon-builder/build.js
@@ -52,10 +52,7 @@ function parseArgs() {
     describe: `Load material-ui dependencies (SvgIcon) relatively or absolutely.
       (absolute|relative).
       For material-ui distributions, relative, for anything else, you probably want absolute.`,
-  })
-  .describe('mui-icons-opts', 'Shortcut to use MUI icons options')
-  .boolean('mui-icons-opts')
-  .argv;
+  }).argv;
 }
 
 function main(options, cb) {
@@ -100,7 +97,7 @@ function main(options, cb) {
   }
 }
 
-/*
+/**
  * @param {string} svgPath
  * Absolute path to svg file to process.
  *
@@ -152,17 +149,16 @@ function getJsxString(svgPath, destPath, options) {
     encoding: 'utf8',
   });
 
-  //Extract the paths from the svg string
+  // Extract the paths from the svg string
   let paths = data.slice(data.indexOf('>') + 1);
   paths = paths.slice(0, -6);
-  //clean xml paths
+  // Clean xml paths
   paths = paths.replace(/xlink:href="#a"/g, '');
   paths = paths.replace(/xlink:href="#c"/g, '');
   paths = paths.replace(/fill-opacity=/g, 'fillOpacity=');
   paths = paths.replace(/\s?fill=".*?"/g, '');
 
-  // Node acts wierd if we put this directly into string concatenation
-
+  // Node acts weird if we put this directly into string concatenation
   const muiRequireStmt = options.muiRequire === 'relative' ? SVG_ICON_RELATIVE_REQUIRE : SVG_ICON_ABSOLUTE_REQUIRE;
 
   return Mustache.render(

--- a/packages/icon-builder/package.json
+++ b/packages/icon-builder/package.json
@@ -5,8 +5,7 @@
   "private": "true",
   "scripts": {
     "prebuild": "rimraf js jsx",
-    "createMuiIconsJsx": "node build.js --output-dir jsx --svg-dir ./node_modules/material-design-icons --glob '/**/production/*_24px.svg' --mui-require relative --renameFilter ./filters/rename/material-design-icons.js",
-    "build": "npm run createMuiIconsJsx && babel --stage 1 ./jsx --out-dir ./js",
+    "build": "node build.js --output-dir ../../src/svg-icons --svg-dir ./node_modules/material-design-icons --glob '/**/production/*_24px.svg' --mui-require relative --renameFilter ./filters/rename/material-design-icons.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [

--- a/packages/icon-builder/tpl/SvgIcon.js
+++ b/packages/icon-builder/tpl/SvgIcon.js
@@ -9,5 +9,6 @@ let {{className}} = (props) => (
 );
 {{className}} = pure({{className}});
 {{className}}.displayName = '{{className}}';
+{{className}}.muiName = 'SvgIcon';
 
 export default {{className}};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

~~Adding `muiName` necessitated switching to class syntax to support `shouldComponentUpdate`~~

Edit: Removed `pure()` from the template, and added `shouldComponentUpdate` to `SvgIcon`.
