### PR TITLE
[Menu] Add basic hotkey-focusing feature

### DIFF
--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -10,6 +10,7 @@ import propTypes from '../utils/propTypes';
 import List from '../List/List';
 import deprecated from '../utils/deprecatedPropType';
 import warning from 'warning';
+import {HotKeyHolder} from './menuUtils';
 
 function getStyles(props, context) {
   const {
@@ -207,6 +208,8 @@ class Menu extends Component {
       isKeyboardFocused: props.initiallyKeyboardFocused,
       keyWidth: props.desktop ? 64 : 56,
     };
+
+    this.hotKeyHolder = new HotKeyHolder();
   }
 
   componentDidMount() {
@@ -376,7 +379,8 @@ class Menu extends Component {
 
   handleKeyDown = (event) => {
     const filteredChildren = this.getFilteredChildren(this.props.children);
-    switch (keycode(event)) {
+    const key = keycode(event);
+    switch (key) {
       case 'down':
         event.preventDefault();
         this.incrementKeyboardFocusIndex(filteredChildren);
@@ -396,9 +400,34 @@ class Menu extends Component {
         event.preventDefault();
         this.decrementKeyboardFocusIndex();
         break;
+      default:
+        if (key.length === 1) {
+          const hotKeys = this.hotKeyHolder.append(key);
+          if (this.setFocusIndexStartsWith(hotKeys)) {
+            event.preventDefault();
+          }
+        }
     }
     this.props.onKeyDown(event);
   };
+
+  setFocusIndexStartsWith(keys) {
+    let foundIndex = -1;
+    React.Children.forEach(this.props.children, (child, index) => {
+      if (foundIndex >= 0) {
+        return;
+      }
+      const {primaryText} = child.props;
+      if (typeof primaryText === 'string' && new RegExp(`^${keys}`, 'i').test(primaryText)) {
+        foundIndex = index;
+      }
+    });
+    if (foundIndex >= 0) {
+      this.setFocusIndex(foundIndex, true);
+      return true;
+    }
+    return false;
+  }
 
   handleMenuItemTouchTap(event, item, index) {
     const children = this.props.children;

--- a/src/Menu/menuUtils.js
+++ b/src/Menu/menuUtils.js
@@ -1,0 +1,11 @@
+export class HotKeyHolder {
+  append(key) {
+    clearTimeout(this.timerId);
+    this.timerId = setTimeout(this.clear, 500);
+    return this.lastKeys = (this.lastKeys || '') + key;
+  }
+  clear = () => {
+    this.timerId = null;
+    this.lastKeys = null;
+  }
+}

--- a/src/Menu/menuUtils.spec.js
+++ b/src/Menu/menuUtils.spec.js
@@ -1,0 +1,42 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import * as Utils from './menuUtils';
+
+describe('Menu Utils', () => {
+  describe('HotKeyHolder', () => {
+    let hotKeyHolder;
+    beforeEach(() => {
+      hotKeyHolder = new Utils.HotKeyHolder();
+    });
+    afterEach(() => {
+      hotKeyHolder = null;
+    });
+    it('returns the key appended', () => {
+      assert.strictEqual(hotKeyHolder.append('k'), 'k');
+    });
+    it('holds keys within 500ms and dispose these afterwards', () => {
+      hotKeyHolder.append('k');
+      return timeout(100)
+        .then(() => {
+          assert.strictEqual(hotKeyHolder.append('o'), 'ko');
+          assert.strictEqual(hotKeyHolder.append('k'), 'kok');
+          assert.strictEqual(hotKeyHolder.append('o'), 'koko');
+          assert.strictEqual(hotKeyHolder.append('s'), 'kokos');
+        })
+        .then(() => timeout(400))
+        .then(() => {
+          assert.strictEqual(hotKeyHolder.append('a'), 'kokosa');
+          assert.strictEqual(hotKeyHolder.append('k'), 'kokosak');
+          assert.strictEqual(hotKeyHolder.append('e'), 'kokosake');
+        })
+        .then(() => timeout(600))
+        .then(() => {
+          assert.isNull(hotKeyHolder.lastKeys);
+          assert.strictEqual(hotKeyHolder.append('k'), 'k');
+        });
+    });
+    function timeout(ms) {
+      return new Promise((resolve) => setTimeout(resolve, ms));
+    }
+  });
+});


### PR DESCRIPTION
fix #4181 

What I did:
- When a user types keys serially, `Menu` tries to focus the first item whose
  `primaryText` starts with the keys.
- After 500ms, keys are disposed.

What I didn't do:
- Performance. `primaryText` can be cached with lowerCased because it is expensive to search with regex every time.
- Browser native `<select>` can handle `DELETE` key to erase the last key in hotkeys.
- When browser (Chrome) cannot find an item, it seems to focus the one
  selected when the dropdown gets opened.

----

- [ - ] PR has tests / docs demo, and is linted.
  - No test. It's kind of hard to test keyboard operation without webdriver.
- [ v ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ v ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).