### PR TITLE
[Docs] Update build scripts

### DIFF
--- a/docs/gh-pages-build.js
+++ b/docs/gh-pages-build.js
@@ -66,21 +66,46 @@ function lastCommitIsHead() {
 }
 
 /**
+ * Add new version number to versions.js
+ * The checks for HEAD can be removed once HEAD builds are automated, as the first entry will always be HEAD.
+ */
+function addMenuVersion(version) {
+  var versions = JSON.parse(fs.readFileSync(versionsFile, 'utf8'));
+  var position = 0;
+
+  // If the first version in the array is HEAD, set the insert position to 1
+  if (versions[0] === 'HEAD') {
+    position = 1;
+  }
+
+  // If not a new HEAD version, splice it in, otherwise only add it if HEAD is not already present
+  if (version !== 'HEAD' || (version === 'HEAD' && !position)) {
+    versions.splice(position, 0, version);
+  
+    // Write the file
+    fs.writeFileSync(versionsFile, JSON.stringify(versions, null, 2));
+
+  // Commit it (on master branch)
+    execho('git add ' + versionsFile + ' && git commit -m ' + '\'[Docs] Add ' + version + ' to versions.json\'');
+  }
+}
+
+/**
  * Build the docs site on a detached branch, commit it on gh-pages branch.
  */
 function buildDocs() {
   // Ensure we're starting in the docs dir
   process.chdir(__dirname);
 
-  // Checkout the tag 'version'
-  execho('git checkout gh-pages');
+  // Checkout the `gh-pages` branch and update from upstream
+  execho('git checkout gh-pages && git pull upstream gh-pages');
 
-  // Delete last HEAD commit to keep the history clean
-  if (lastCommitIsHead()) {
+  // Delete last HEAD commit to keep the history clean, unless we're commiting a new HEAD version
+  if (lastCommitIsHead() && version !== 'HEAD') {
     execho('git reset --hard HEAD~1');
   }
 
-  // Checkout the tag 'version'
+  // Checkout the tag `version` or master for HEAD
   if (version === 'HEAD') {
     execho('git checkout --detach master');
   } else {
@@ -96,50 +121,25 @@ function buildDocs() {
   // Move to the gh-pages branch
   execho('git checkout gh-pages');
 
-  // Symbolic link 'release' to latest version
+  // Symbolic link `release` to latest version
   if (!preRelease(version)) {
-    execho('ln -sfh ../' + version + ' ../release');
+    execho('ln -sfh ./' + version + ' ../release');
   }
 
+  // Symbolic link `versions.json` to latest version
+  execho('ln -sfh ./' + version + '/versions.json ../versions.json');
+  
   // Commit the new version
-  execho('git add .. && git commit -m \'' + version + '\'');
+  if (version === 'HEAD') {
+    execho('git commit --amend --no-edit');
+  } else {
+    execho('git add .. && git commit -m \'' + version + '\'');
+  }
 
   if (args[3] === '-p') {
     execho('git push -f');
   }
 }
 
-/**
- * Add new version number to versions.js
- * The checks for HEAD can be removed once HEAD builds are automated, as the first entry will always be HEAD.
- */
-function addMenuVersion(version) {
-  // Return to master
-  execho('git checkout master');
-
-  var versions = JSON.parse(fs.readFileSync(versionsFile, 'utf8'));
-  var head;
-
-  // If HEAD is first in the array, shift it off.
-  if (versions[0] === 'HEAD') {
-    head = versions.shift()
-  }
-
-  // Add the new version
-  versions.unshift(version);
-
-  // If the array had a HEAD version, and we didn't just add one, put it back.
-  if (head && version !== 'HEAD') {
-    versions.unshift('HEAD');
-  }
-
-  fs.writeFileSync(versionsFile, JSON.stringify(versions, null, 2));
-
-  // If we're adding a new version, or first instance of 'HEAD', commit it (on master branch)
-  if (version !=='HEAD' || (version === 'HEAD' && !head)) {
-    execho('git add ' + versionsFile + ' && git commit -m ' + '\'Add ' + version + ' to versions.json\'');
-  }
-}
-
-buildDocs(version);
 addMenuVersion(version);
+buildDocs(version);

--- a/docs/package.json
+++ b/docs/package.json
@@ -33,7 +33,6 @@
     "eslint-plugin-react": "^5.0.1",
     "highlight.js": "^9.0.0",
     "history": "^2.0.0",
-    "html-webpack-plugin": "^2.8.1",
     "intl": "^1.0.1",
     "intl-locales-supported": "^1.0.0",
     "json-loader": "^0.5.4",

--- a/docs/package.json
+++ b/docs/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^6.0.0",
+    "copy-webpack-plugin": "^2.1.3",
     "css-loader": "^0.23.0",
     "doctrine": "^1.1.0",
     "eslint": "^2.5.1",
@@ -47,7 +48,6 @@
     "react-swipeable-views": "^0.5.0",
     "recast": "^0.11.4",
     "style-loader": "0.13.1",
-    "transfer-webpack-plugin": "^0.1.4",
     "webpack": "^1.11.0",
     "webpack-dev-server": "^1.10.1"
   }

--- a/docs/webpack-production.config.js
+++ b/docs/webpack-production.config.js
@@ -2,7 +2,7 @@ const webpack = require('webpack');
 const path = require('path');
 const buildPath = path.resolve(__dirname, 'build');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const TransferWebpackPlugin = require('transfer-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const config = {
   // Entry point to the project
@@ -51,10 +51,11 @@ const config = {
     // Allows error warninggs but does not stop compiling. Will remove when eslint is added
     new webpack.NoErrorsPlugin(),
     // Transfer Files
-    new TransferWebpackPlugin([
-      {from: 'www/css', to: 'css'},
-      {from: 'www/images', to: 'images'},
-    ], path.resolve(__dirname, 'src')),
+    new CopyWebpackPlugin([
+      {from: 'src/www/css', to: 'css'},
+      {from: 'src/www/images', to: 'images'},
+      {from: 'src/www/versions.json', to: 'versions.json'},
+    ]),
   ],
   externals: {
     fs: 'fs', // To remove once https://github.com/benjamn/recast/pull/238 is released

--- a/docs/webpack-production.config.js
+++ b/docs/webpack-production.config.js
@@ -1,7 +1,6 @@
 const webpack = require('webpack');
 const path = require('path');
 const buildPath = path.resolve(__dirname, 'build');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const config = {
@@ -44,17 +43,15 @@ const config = {
         NODE_ENV: JSON.stringify('production'),
       },
     }),
-    new HtmlWebpackPlugin({
-      inject: false,
-      template: path.join(__dirname, '/src/www/index.html'),
-    }),
+
     // Allows error warninggs but does not stop compiling. Will remove when eslint is added
     new webpack.NoErrorsPlugin(),
     // Transfer Files
     new CopyWebpackPlugin([
       {from: 'src/www/css', to: 'css'},
       {from: 'src/www/images', to: 'images'},
-      {from: 'src/www/versions.json', to: 'versions.json'},
+      {from: 'src/www/index.html'},
+      {from: 'src/www/versions.json'},
     ]),
   ],
   externals: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has docs demo, ~~and is linted~~.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

To simplify the docs build process, the build directory now includes the `versions.json` file.

The `gh-pages-build` has bee updated to symlink to the version of this file in the current build.

The script has also been updated to use `git commit amend` for HEAD updates, in theory to prevent repository bloat.

Finally the `html-webpack-plugin` has been removed, as it was only being used to copy the index.html file, which `copy-webpack-plugin` can handle.