### PR TITLE
[GitHub] Update the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,35 +1,22 @@
-<!-- 
+### Problem description
 
-Sorry to hear you're having trouble! If you have a question, please ask in 
-[StackOverflow or gitter](http://tr.im/77pVj)
+### Steps to reproduce
 
-If you are having an issue with click events, please re-read the 
-[README](http://tr.im/410Fg) (you did read the README, right?).
-
-Questions, or issues that don't provide sufficient information, may be closed without comment. 
-(We're sure you'd rather we work on improving Material-UI than chasing ghost issues!)
-
-If you think you have found a _new_ issue that hasn't already been reported, please complete the template below.
-
--->
-
-Problem Description
--------------------
-<!-- Please include steps to reproduce the problem, code sample, screenshots as appropriate. -->
-
-Versions
---------
-<!-- Versions affected. (Please test with Material-UI HEAD.) -->
+### Versions
 
 - Material-UI: 
 - React: 
 - Browser: 
 
-<!--
+<!-- Have a QUESTION? Please ask in [StackOverflow or gitter](http://tr.im/77pVj before opening an issue.
 
-For feature requests, please delete the template above, 
-and include a link to the relevant section of Material Design spec, 
-or a screenshot showing your proposed feature, 
-and enough information to understand your suggestion.
+If you are having an issue with click events, please re-read the [README](http://tr.im/410Fg) (you did read the README, right? :-) ).
+
+If you think you have found a _new_ issue that hasn't already been reported or fixed in HEAD, please complete the template above.
+
+For feature requests, please delete the template above and use this one instead:
+
+### Description
+### Images & references
 
 -->


### PR DESCRIPTION
Here's what it looks like now:

### Problem description

Some people ignore the issue template. Maybe it isn't clear that it's a template?

### Steps to reproduce

Look at some recent issues on GitHub.

https://github.com/callemall/material-ui/issues

### Versions

- Material-UI: Any before this update
- React: N/A
- Browser: Any

<!-- Have a QUESTION? Please ask in [StackOverflow or gitter](http://tr.im/77pVj before opening an issue.

If you are having an issue with click events, please re-read the [README](http://tr.im/410Fg) (you did read the README, right? :-) ).

If you think you have found a _new_ issue that hasn't already been reported or fixed in HEAD, please complete the template above.

For feature requests, please delete the template above and use this one instead:

### Description
### Images & references

-->

