### PR TITLE
[Docs] Fix incorrect imports in ServerRendering.md

### DIFF
--- a/docs/src/app/components/pages/get-started/serverRendering.md
+++ b/docs/src/app/components/pages/get-started/serverRendering.md
@@ -19,8 +19,8 @@ We rely on the [muiTheme](/#/customization/themes) context to spread the user ag
 For instance, you can provide it like this:
 
 ```js
-import getMuiTheme from 'material-ui/getMuiTheme';
-import MuiThemeProvider from 'material-ui/MuiThemeProvider';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import {green100, green500, green700} from 'material-ui/styles/colors';
 
 const muiTheme = getMuiTheme({


### PR DESCRIPTION
The imports of `getMuiTheme` and `MuiThemeProvider` don't work because they are missing the `styles/` part of path. I assume these changes are correct since they work for me.

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


