### PR TITLE
[Drawer] Fix muiTheme key name

### DIFF
--- a/docs/src/app/components/AppNavDrawer.js
+++ b/docs/src/app/components/AppNavDrawer.js
@@ -118,7 +118,7 @@ class AppNavDrawer extends Component {
         docked={docked}
         open={open}
         onRequestChange={onRequestChangeNavDrawer}
-        containerStyle={{zIndex: zIndex.navDrawer - 100}}
+        containerStyle={{zIndex: zIndex.drawer - 100}}
       >
         <div style={styles.logo} onTouchTap={this.handleTouchTapHeader}>
           Material-UI

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -139,7 +139,7 @@ class Drawer extends Component {
 
   getStyles() {
     const muiTheme = this.context.muiTheme;
-    const theme = muiTheme.navDrawer;
+    const theme = muiTheme.drawer;
 
     const x = this.getTranslateMultiplier() * (this.state.open ? 0 : this.getMaxTranslateX());
 
@@ -148,7 +148,7 @@ class Drawer extends Component {
         height: '100%',
         width: this.props.width || theme.width,
         position: 'fixed',
-        zIndex: muiTheme.zIndex.navDrawer,
+        zIndex: muiTheme.zIndex.drawer,
         left: 0,
         top: 0,
         transform: `translate3d(${x}px, 0, 0)`,
@@ -198,7 +198,7 @@ class Drawer extends Component {
   };
 
   getMaxTranslateX() {
-    const width = this.props.width || this.context.muiTheme.navDrawer.width;
+    const width = this.props.width || this.context.muiTheme.drawer.width;
     return width + 10;
   }
 

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -126,7 +126,7 @@ export default function getMuiTheme(muiTheme, ...more) {
     inkBar: {
       backgroundColor: palette.accent1Color,
     },
-    navDrawer: {
+    drawer: {
       width: spacing.desktopKeylineIncrement * 4,
       color: palette.canvasColor,
     },

--- a/src/styles/zIndex.js
+++ b/src/styles/zIndex.js
@@ -2,7 +2,7 @@ export default {
   menu: 1000,
   appBar: 1100,
   drawerOverlay: 1200,
-  navDrawer: 1300,
+  drawer: 1300,
   dialogOverlay: 1400,
   dialog: 1500,
   layer: 2000,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has ~~tests / docs demo, and~~ is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

key was navDrawer instead of Drawer

Close #4190.