### PR TITLE
[Icon Builder] Fix SvgIcon require path to icons generated with --mui-require absolute

### DIFF
--- a/packages/icon-builder/build.js
+++ b/packages/icon-builder/build.js
@@ -20,7 +20,7 @@ const glob = require('glob');
 const mkdirp = require('mkdirp');
 
 const SVG_ICON_RELATIVE_REQUIRE = '../../SvgIcon';
-const SVG_ICON_ABSOLUTE_REQUIRE = 'material-ui/lib/SvgIcon';
+const SVG_ICON_ABSOLUTE_REQUIRE = 'material-ui/SvgIcon';
 const RENAME_FILTER_DEFAULT = './filters/rename/default';
 const RENAME_FILTER_MUI = './filters/rename/material-design-icons';
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


