### PR TITLE
[PopOver] Fix Animation vertical

### DIFF
--- a/src/Popover/PopoverAnimationVertical.js
+++ b/src/Popover/PopoverAnimationVertical.js
@@ -8,12 +8,13 @@ function getStyles(props, context, state) {
   const {open} = state;
   const {muiTheme} = context;
   const horizontal = targetOrigin.horizontal.replace('middle', 'vertical');
+  const vertical = targetOrigin.vertical.replace('top', 'bottom');
 
   return {
     root: {
       opacity: open ? 1 : 0,
       transform: open ? 'scaleY(1)' : 'scaleY(0)',
-      transformOrigin: `${horizontal} ${targetOrigin.vertical}`,
+      transformOrigin: `${horizontal} ${vertical}`,
       position: 'fixed',
       zIndex: muiTheme.zIndex.popover,
       transition: transitions.easeOut('450ms', ['transform', 'opacity']),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


Fixes the popover animation origin issue. 

Animation starts from the point of click.

Closes : #4219 

Current Issue:
![old](https://cloud.githubusercontent.com/assets/15271922/15130659/cfab6012-160f-11e6-9f6c-5a524a9f6e6f.gif)

Fix:
![hbdmqrwdpl](https://cloud.githubusercontent.com/assets/15271922/15130634/a0f24bc8-160f-11e6-9b36-f59d7f229318.gif)

Also, the popover position looks alright to me, it scrolls correctly and closes when it should. @mbrookes  and I were discussing it.Updating the `react-event-listner` solves the issue.

![popover](https://cloud.githubusercontent.com/assets/15271922/15130739/58e84ed0-1610-11e6-80cd-9de931260d8e.gif)
