### PR TITLE
[RaisedButton] fullWidth fix

### DIFF
--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -61,6 +61,7 @@ function getStyles(props, context, state) {
     root: {
       display: 'inline-block',
       transition: transitions.easeOut(),
+      width: fullWidth ? '100%' : 'auto',
     },
     button: {
       position: 'relative',


### PR DESCRIPTION
The display-inline block wrapper doesn't adapt to the child element's width if it was defined in percentage, because the child element would recognize the width based on the wrapper element.

Fixes #4226
