### PR TITLE
[TimePicker] Add a Fade-in component for hours-minute change transition

### DIFF
--- a/src/TimePicker/Clock.js
+++ b/src/TimePicker/Clock.js
@@ -2,6 +2,8 @@ import React, {Component, PropTypes} from 'react';
 import TimeDisplay from './TimeDisplay';
 import ClockHours from './ClockHours';
 import ClockMinutes from './ClockMinutes';
+import FadeIn from '../internal/FadeIn';
+
 
 class Clock extends Component {
   static propTypes = {
@@ -144,7 +146,7 @@ class Clock extends Component {
     if ( this.state.mode === 'hour') {
       clock = (
         <ClockHours
-          key="hours"
+          key={0}
           format={this.props.format}
           onChange={this.handleChangeHours}
           initialHours={this.state.selectedTime.getHours()}
@@ -153,7 +155,7 @@ class Clock extends Component {
     } else {
       clock = (
         <ClockMinutes
-          key="minutes"
+          key={1}
           onChange={this.handleChangeMinutes}
           initialMinutes={this.state.selectedTime.getMinutes()}
         />
@@ -173,7 +175,9 @@ class Clock extends Component {
         />
         <div style={prepareStyles(styles.container)} >
           <div style={prepareStyles(styles.circle)} />
-          {clock}
+          <FadeIn enterDelay={200} >
+            {clock}
+          </FadeIn>
         </div>
       </div>
     );

--- a/src/TimePicker/Clock.js
+++ b/src/TimePicker/Clock.js
@@ -145,20 +145,24 @@ class Clock extends Component {
 
     if ( this.state.mode === 'hour') {
       clock = (
-        <ClockHours
-          key={0}
-          format={this.props.format}
-          onChange={this.handleChangeHours}
-          initialHours={this.state.selectedTime.getHours()}
-        />
+        <FadeIn enterDelay={200} leaveDelay={500}>
+          <ClockHours
+            key={0}
+            format={this.props.format}
+            onChange={this.handleChangeHours}
+            initialHours={this.state.selectedTime.getHours()}
+          />
+        </FadeIn>
       );
     } else {
       clock = (
-        <ClockMinutes
-          key={1}
-          onChange={this.handleChangeMinutes}
-          initialMinutes={this.state.selectedTime.getMinutes()}
-        />
+        <FadeIn enterDelay={200} leaveDelay={500}>
+          <ClockMinutes
+            key={1}
+            onChange={this.handleChangeMinutes}
+            initialMinutes={this.state.selectedTime.getMinutes()}
+          />
+        </FadeIn>
       );
     }
 
@@ -175,9 +179,7 @@ class Clock extends Component {
         />
         <div style={prepareStyles(styles.container)} >
           <div style={prepareStyles(styles.circle)} />
-          <FadeIn enterDelay={200} >
             {clock}
-          </FadeIn>
         </div>
       </div>
     );

--- a/src/internal/FadeIn.js
+++ b/src/internal/FadeIn.js
@@ -7,11 +7,13 @@ class FadeIn extends Component {
     childStyle: PropTypes.object,
     children: PropTypes.node,
     enterDelay: PropTypes.number,
+    leaveDelay: PropTypes.number,
     style: PropTypes.object,
   };
 
   static defaultProps = {
     enterDelay: 0,
+    leaveDelay: 0,
   };
 
   static contextTypes = {
@@ -23,6 +25,7 @@ class FadeIn extends Component {
       enterDelay,
       children,
       childStyle,
+      leaveDelay,
       style,
       ...other,
     } = this.props;
@@ -40,6 +43,7 @@ class FadeIn extends Component {
         <FadeInChild
           key={child.key}
           enterDelay={enterDelay}
+          leaveDelay={leaveDelay}
           style={childStyle}
         >
           {child}

--- a/src/internal/FadeIn.js
+++ b/src/internal/FadeIn.js
@@ -1,0 +1,62 @@
+import React, {Component, PropTypes} from 'react';
+import ReactTransitionGroup from 'react-addons-transition-group';
+import FadeInChild from './FadeInChild';
+
+class FadeIn extends Component {
+  static propTypes = {
+    childStyle: PropTypes.object,
+    children: PropTypes.node,
+    enterDelay: PropTypes.number,
+    style: PropTypes.object,
+  };
+
+  static defaultProps = {
+    enterDelay: 0,
+  };
+
+  static contextTypes = {
+    muiTheme: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const {
+      enterDelay,
+      children,
+      childStyle,
+      style,
+      ...other,
+    } = this.props;
+
+    const {prepareStyles} = this.context.muiTheme;
+
+    const mergedRootStyles = Object.assign({}, {
+      position: 'relative',
+      overflow: 'hidden',
+      height: '100%',
+    }, style);
+
+    const newChildren = React.Children.map(children, (child) => {
+      return (
+        <FadeInChild
+          key={child.key}
+          enterDelay={enterDelay}
+          style={childStyle}
+        >
+          {child}
+        </FadeInChild>
+      );
+    }, this);
+
+    return (
+      <ReactTransitionGroup
+        {...other}
+        style={prepareStyles(mergedRootStyles)}
+        component="div"
+      >
+        {newChildren}
+      </ReactTransitionGroup>
+    );
+  }
+}
+
+export default FadeIn;

--- a/src/internal/FadeInChild.js
+++ b/src/internal/FadeInChild.js
@@ -1,0 +1,73 @@
+import React, {Component, PropTypes} from 'react';
+import ReactDOM from 'react-dom';
+import autoPrefix from '../utils/autoPrefix';
+import transitions from '../styles/transitions';
+
+class FadeInChild extends Component {
+  static propTypes = {
+    children: PropTypes.node,
+    direction: PropTypes.string,
+    enterDelay: PropTypes.number,
+    style: PropTypes.object,
+  };
+
+  static defaultProps = {
+    enterDelay: 0,
+  };
+
+  static contextTypes = {
+    muiTheme: PropTypes.object.isRequired,
+  };
+
+  componentWillUnmount() {
+    clearTimeout(this.enterTimer);
+    clearTimeout(this.leaveTimer);
+  }
+
+  componentWillEnter(callback) {
+    const style = ReactDOM.findDOMNode(this).style;
+    style.opacity = '0';
+    autoPrefix.set(style, 'transition', 'opacity ease-out');
+    this.enterTimer = setTimeout(callback, this.props.enterDelay);
+  }
+
+  componentDidEnter() {
+    const style = ReactDOM.findDOMNode(this).style;
+    style.opacity = '1';
+    autoPrefix.set(style, 'transition', 'opacity 0.5s ease-out');
+  }
+
+  componentWillLeave(callback) {
+    const style = ReactDOM.findDOMNode(this).style;
+    style.opacity = '0';
+    autoPrefix.set(style, 'transition', 'opacity ease-out');
+    this.leaveTimer = setTimeout(callback, 0);
+  }
+
+  render() {
+    const {
+      children,
+      style,
+      ...other,
+    } = this.props;
+
+    const {prepareStyles} = this.context.muiTheme;
+
+    const mergedRootStyles = Object.assign({}, {
+      position: 'relative',
+      height: '100%',
+      width: '100%',
+      top: 0,
+      left: 0,
+      transition: transitions.easeOut(null, ['opacity']),
+    }, style);
+
+    return (
+      <div {...other} style={prepareStyles(mergedRootStyles)}>
+        {children}
+      </div>
+    );
+  }
+}
+
+export default FadeInChild;

--- a/src/internal/FadeInChild.js
+++ b/src/internal/FadeInChild.js
@@ -8,6 +8,7 @@ class FadeInChild extends Component {
     children: PropTypes.node,
     direction: PropTypes.string,
     enterDelay: PropTypes.number,
+    leaveDelay: PropTypes.number,
     style: PropTypes.object,
   };
 
@@ -24,25 +25,32 @@ class FadeInChild extends Component {
     clearTimeout(this.leaveTimer);
   }
 
+  componentDidAppear() {
+    const style = ReactDOM.findDOMNode(this).style;
+    style.opacity = '1';
+    autoPrefix.set(style, 'transition', 'opacity 0.5s ease-in');
+  }
+
   componentWillEnter(callback) {
     const style = ReactDOM.findDOMNode(this).style;
     style.opacity = '0';
-    autoPrefix.set(style, 'transition', 'opacity ease-out');
-    this.enterTimer = setTimeout(callback, this.props.enterDelay);
+    autoPrefix.set(style, 'transition', 'opacity 0.5s ease-in');
+    setTimeout(callback, this.props.enterDelay);
   }
 
   componentDidEnter() {
     const style = ReactDOM.findDOMNode(this).style;
     style.opacity = '1';
-    autoPrefix.set(style, 'transition', 'opacity 0.5s ease-out');
+    autoPrefix.set(style, 'transition', 'opacity 0.5s ease-in');
   }
 
   componentWillLeave(callback) {
     const style = ReactDOM.findDOMNode(this).style;
     style.opacity = '0';
-    autoPrefix.set(style, 'transition', 'opacity ease-out');
-    this.leaveTimer = setTimeout(callback, 0);
+    autoPrefix.set(style, 'transition', 'opacity 0.5s ease-in');
+    setTimeout(callback, this.props.leaveDelay);
   }
+
 
   render() {
     const {
@@ -54,7 +62,7 @@ class FadeInChild extends Component {
     const {prepareStyles} = this.context.muiTheme;
 
     const mergedRootStyles = Object.assign({}, {
-      position: 'relative',
+      position: 'absolute',
       height: '100%',
       width: '100%',
       top: 0,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Added a Fade-In Component which internally uses ReactTransitionGroup Component to add a fade-in transition effect to the hours/ minute transition.

![transition](https://cloud.githubusercontent.com/assets/15271922/15169207/76f9e890-16fe-11e6-8a8a-1daffbc0a131.gif)


Closes https://github.com/callemall/material-ui/issues/1943

