### PR TITLE
[IconButton] Fix children styles for IconButton

### DIFF
--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -265,7 +265,7 @@ class IconButton extends Component {
         {tooltipElement}
         {fonticon}
         {extendChildren(this.props.children, {
-          style: childrenStyle,
+          style: Object.assign({}, childrenStyle, this.props.style),
         })}
       </EnhancedButton>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Resolves #2454 

Styles applied to child component is rendered correctly now.

```
<IconButton>
  <ActionDelete
    style={{backgroundColor: 'magenta', height: 30, width: 30}}
    color="cyan"
    hoverColor="#000"
  />
</IconButton>
```

<img width="282" alt="screen shot 2016-05-11 at 7 38 56 pm" src="https://cloud.githubusercontent.com/assets/15271922/15204128/c2e83ef6-17cf-11e6-921a-12f121cd7441.png">


The styles component of children was not being included in Object.Assign(), so included that.


