### PR TITLE
[DatePicker] Added className prop to DatePicker

### DIFF
--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -24,6 +24,10 @@ class DatePicker extends Component {
      */
     cancelLabel: PropTypes.node,
     /**
+     * The css class name of the root element.
+     */
+    className: PropTypes.string,
+    /**
      * Used to control how the Date Picker will be displayed when the input field is focused.
      * `dialog` (default) displays the DatePicker as a dialog with a modal.
      * `inline` displays the DatePicker below the input field (similar to auto complete).
@@ -251,6 +255,7 @@ class DatePicker extends Component {
       DateTimeFormat,
       autoOk,
       cancelLabel,
+      className,
       container,
       defaultDate, // eslint-disable-line no-unused-vars
       disableYearSelection,
@@ -275,7 +280,7 @@ class DatePicker extends Component {
     const formatDate = this.props.formatDate || this.formatDate;
 
     return (
-      <div style={prepareStyles(Object.assign({}, style))}>
+      <div className={className} style={prepareStyles(Object.assign({}, style))}>
         <TextField
           {...other}
           onFocus={this.handleFocus}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


Now able to specify className of the root element of a DatePicker.