### PR TITLE
[TimePicker] Fix auto reset of time on window resize

### DIFF
--- a/src/TimePicker/Clock.js
+++ b/src/TimePicker/Clock.js
@@ -26,12 +26,6 @@ class Clock extends Component {
     mode: 'hour',
   };
 
-  componentWillReceiveProps(nextProps) {
-    this.setState({
-      selectedTime: nextProps.initialTime || new Date(),
-    });
-  }
-
   setMode = (mode) => {
     setTimeout(() => {
       this.setState({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Closes https://github.com/callemall/material-ui/issues/1592

![timepicker-reset](https://cloud.githubusercontent.com/assets/15271922/15230405/17635232-185b-11e6-96e2-5e383e298046.gif)

The updating of selectedTime was causing the issue because it was setting it to new Date() every time, so I removed it.




