### PR TITLE
[TextField] Fix server-side rendering

### DIFF
--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -287,12 +287,20 @@ class TextField extends Component {
       hasValue: isValid(propsLeaf.value) || isValid(propsLeaf.defaultValue),
     });
 
-    warning(name || hintText || floatingLabelText || id, `We don't have enough information
-      to build a robust unique id for the TextField component. Please provide an id or a name.`);
+    if (!id) {
+      let uniqueId;
 
-    const uniqueId = `${name}-${hintText}-${floatingLabelText}-${
-      Math.floor(Math.random() * 0xFFFF)}`;
-    this.uniqueId = uniqueId.replace(/[^A-Za-z0-9-]/gi, '');
+      if (name || hintText || floatingLabelText) {
+        uniqueId = `${name}-${hintText}-${floatingLabelText}`;
+      } else {
+        warning(false, `We don't have enough information
+          to build a robust unique id for the TextField component. Please provide an id or a name.`);
+
+        uniqueId = Math.floor(Math.random() * 0xFFFF).toString();
+      }
+
+      this.uniqueId = uniqueId.replace(/[^A-Za-z0-9-]/gi, '');
+    }
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/TextField/TextField.spec.js
+++ b/src/TextField/TextField.spec.js
@@ -62,4 +62,48 @@ describe('<TextField />', () => {
     assert.strictEqual(wrapper.state().isClean, false);
     assert.strictEqual(wrapper.find(TextFieldLabel).props().shrink, false, 'should not shrink TextFieldLabel');
   });
+
+  // Server side rendering
+  describe('deterministic id', () => {
+    it('should use the id', () => {
+      const wrapper = shallowWithContext(<TextField id="foo" />);
+
+      assert.strictEqual(wrapper.find('input').props().id, 'foo',
+        'It should use the id property'
+      );
+    });
+
+    it('should use the name', () => {
+      const wrapper = shallowWithContext(<TextField name="foo" />);
+
+      assert.strictEqual(wrapper.find('input').props().id, 'foo-undefined-undefined',
+        'It should use the id property'
+      );
+    });
+
+    it('should use the hintText', () => {
+      const wrapper = shallowWithContext(<TextField hintText="foo" />);
+
+      assert.strictEqual(wrapper.find('input').props().id, 'undefined-foo-undefined',
+        'It should use the id property'
+      );
+    });
+
+    it('should use the floatingLabelText', () => {
+      const wrapper = shallowWithContext(<TextField floatingLabelText="foo" />);
+
+      assert.strictEqual(wrapper.find('input').props().id, 'undefined-undefined-foo',
+        'It should use the id property'
+      );
+    });
+
+    it('should use a random hash', () => {
+      const wrapper1 = shallowWithContext(<TextField />);
+      const wrapper2 = shallowWithContext(<TextField />);
+
+      assert.notStrictEqual(wrapper1.find('input').props().id, wrapper2.find('input').props().id,
+        'It should use a random hash'
+      );
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Closes https://github.com/callemall/material-ui/issues/3757.
Closes https://github.com/callemall/material-ui/pull/4253.

I have added some tests. I should have added them the first time. That would have same me this PR 😁 .

@AJIh What do you think about this change instead?
