### PR TITLE
[Avatar] Use inner shadow for border

### DIFF
--- a/docs/src/app/components/pages/components/Avatar/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/Avatar/ExampleSimple.js
@@ -16,12 +16,16 @@ purple500,
 
 const style = {margin: 5};
 
+/**
+ * Examples of `Avatar` using an image, [Font Icon](/#/components/font-icon), [SVG Icon](/#/components/svg-icon)
+ * and "Letter" (string), with and without custom colors at the default size (`40dp`) and an alternate size (`30dp`).
+ */
 const AvatarExampleSimple = () => (
   <List>
     <ListItem
       disabled={true}
       leftAvatar={
-        <Avatar src="images/uxceo-128.jpg" />
+        <Avatar src="images/kerem-128.jpg" />
       }
     >
       Image Avatar
@@ -30,7 +34,7 @@ const AvatarExampleSimple = () => (
       disabled={true}
       leftAvatar={
         <Avatar
-          src="images/uxceo-128.jpg"
+          src="images/kerem-128.jpg"
           size={30}
           style={style}
         />

--- a/docs/src/app/components/pages/components/Avatar/Page.js
+++ b/docs/src/app/components/pages/components/Avatar/Page.js
@@ -10,9 +10,6 @@ import AvatarExampleSimple from './ExampleSimple';
 import avatarExampleSimpleCode from '!raw!./ExampleSimple';
 import avatarCode from '!raw!material-ui/Avatar/Avatar';
 
-const description = 'Examples of `Avatar` using an image, [Font Icon](/#/components/font-icon), ' +
-  '[SVG Icon](/#/components/svg-icon) and "Letter" (string), with and without custom colors.';
-
 const AvatarsPage = () => (
   <div>
     <Title render={(previousTitle) => `Avatar - ${previousTitle}`} />
@@ -20,7 +17,6 @@ const AvatarsPage = () => (
     <CodeExample
       code={avatarExampleSimpleCode}
       title="Examples"
-      description={description}
     >
       <AvatarExampleSimple />
     </CodeExample>

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -22,6 +22,7 @@ function getStyles(props, context) {
       borderRadius: '50%',
       height: size,
       width: size,
+      boxShadow: src ? `inset 0px 0px 0px 1px ${avatar.borderColor}` : 'none',
     },
     icon: {
       color: color || avatar.color,
@@ -31,17 +32,6 @@ function getStyles(props, context) {
       margin: size * 0.2,
     },
   };
-
-  if (src && avatar.borderColor) {
-    Object.assign(styles.root, {
-      background: `url(${src})`,
-      backgroundSize: size,
-      backgroundOrigin: 'border-box',
-      border: `solid 1px ${avatar.borderColor}`,
-      height: size - 2,
-      width: size - 2,
-    });
-  }
 
   return styles;
 }
@@ -106,8 +96,9 @@ class Avatar extends Component {
 
     if (src) {
       return (
-        <div
+        <img
           {...other}
+          src={src}
           style={prepareStyles(Object.assign(styles.root, style))}
           className={className}
         />

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -5,24 +5,40 @@ function getStyles(props, context) {
     backgroundColor,
     color,
     size,
-    src,
   } = props;
 
   const {avatar} = context.muiTheme;
 
   const styles = {
     root: {
+      position: 'absolute',
       color: color || avatar.color,
       backgroundColor: backgroundColor || avatar.backgroundColor,
       userSelect: 'none',
-      display: 'inline-block',
-      textAlign: 'center',
-      lineHeight: `${size}px`,
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
       fontSize: size / 2,
       borderRadius: '50%',
       height: size,
       width: size,
-      boxShadow: src ? `inset 0px 0px 0px 1px ${avatar.borderColor}` : 'none',
+    },
+    image: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      height: '100%',
+      width: '100%',
+      borderRadius: '50%',
+    },
+    border: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      borderRadius: '50%',
+      boxShadow: `inset 0px 0px 0px 0.5px ${avatar.borderColor}`,
+      height: '100%',
+      width: '100%',
     },
     icon: {
       color: color || avatar.color,
@@ -96,12 +112,15 @@ class Avatar extends Component {
 
     if (src) {
       return (
-        <img
-          {...other}
-          src={src}
-          style={prepareStyles(Object.assign(styles.root, style))}
-          className={className}
-        />
+        <div style={prepareStyles(Object.assign(styles.root, style))}>
+          <img
+            style={prepareStyles(styles.image)}
+            {...other}
+            src={src}
+            className={className}
+          />
+          <div style={prepareStyles(styles.border)}></div>
+        </div>
       );
     } else {
       return (

--- a/src/Avatar/Avatar.spec.js
+++ b/src/Avatar/Avatar.spec.js
@@ -36,10 +36,10 @@ describe('<Avatar />', () => {
     );
 
     assert.notOk(!wrapper.contains(testChildren), 'should not contain the children');
-    assert.ok(wrapper.is('div'), 'should be a div');
-    assert.ok(wrapper.is({style: {background: 'url(face.jpg)'}}), 'should set background url');
+    assert.ok(wrapper.is('img'), 'should be an image');
+    assert.ok(wrapper.is({src: 'face.jpg'}), 'should have the src passed into props');
 
     wrapper.setProps({src: 'meow.jpg'});
-    assert.ok(wrapper.is({style: {background: 'url(meow.jpg)'}}), 'should have changed the background url');
+    assert.ok(wrapper.is({src: 'meow.jpg'}), 'should have changed the src');
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Use an inner shadow for the border to allow the image to be an `<img>` not `backgroundImage`.

Closes #4254.
