### PR TITLE
[Stepper] Set height to "auto" in componentDidAppear and componentDidEnter

### DIFF
--- a/src/internal/ExpandTransitionChild.js
+++ b/src/internal/ExpandTransitionChild.js
@@ -31,28 +31,37 @@ class ExpandTransitionChild extends Component {
     callback();
   }
 
+  componentDidAppear() {
+    var style = ReactDOM.findDOMNode(this).style;
+    style.height = 'auto';
+  }
+
   componentWillEnter(callback) {
     const {enterDelay} = this.props;
     const {style} = ReactDOM.findDOMNode(this);
     style.height = 0;
 
     if (enterDelay) {
-      this.enterTimer = setTimeout(() => callback(), 450);
+      this.open();
+      this.enterTimer = setTimeout(() => callback(), enterDelay);
       return;
     }
 
+    this.open();
     callback();
   }
 
   componentDidEnter() {
-    this.open();
+    var style = ReactDOM.findDOMNode(this).style;
+    style.height = 'auto';
   }
 
   componentWillLeave(callback) {
+    const {enterDelay} = this.props;
     const style = ReactDOM.findDOMNode(this).style;
     style.height = this.refs.wrapper.clientHeight;
     style.height = 0;
-    this.leaveTimer = setTimeout(() => callback(), 450);
+    this.leaveTimer = setTimeout(() => callback(), enterDelay);
   }
 
   open() {

--- a/src/internal/ExpandTransitionChild.js
+++ b/src/internal/ExpandTransitionChild.js
@@ -32,7 +32,7 @@ class ExpandTransitionChild extends Component {
   }
 
   componentDidAppear() {
-    var style = ReactDOM.findDOMNode(this).style;
+    const style = ReactDOM.findDOMNode(this).style;
     style.height = 'auto';
   }
 
@@ -52,7 +52,7 @@ class ExpandTransitionChild extends Component {
   }
 
   componentDidEnter() {
-    var style = ReactDOM.findDOMNode(this).style;
+    const style = ReactDOM.findDOMNode(this).style;
     style.height = 'auto';
   }
 


### PR DESCRIPTION
This PR addresses the following points all in the ExpandTransitionChildComponent (with respect to the vertical stepper):

- Fixed height is causing problems when StepContent's children are updated. After animation is completed (componentDidAppear & componentDidEnter) height is changed to 'auto' so that StepContent can accomodate dynamic children with arbitrary height.
- this.open() in componentDidEnter was starting animation after the callback is called, and therefore _after_ the animation delay. I have moved this.open() call to componentWillEnter. This changes the way how the vertical stepper animates. In this PR collapsing and expanding animation happen simultaneously, while originally because of the "double" delay, expanding animation takes place after the previously active step collapses.
- Hard-coded 450ms animation delay is replaced with the enterDelay variable.