### PR TITLE
[FlatButton][RaisedButton] Fix label validation for 0 (number data-type)

### DIFF
--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -6,7 +6,7 @@ import EnhancedButton from '../internal/EnhancedButton';
 import FlatButtonLabel from './FlatButtonLabel';
 
 function validateLabel(props, propName, componentName) {
-  if (!props.children && !props.label && !props.icon) {
+  if (!props.children && (!props.label && props.label !== 0) && !props.icon) {
     return new Error(`Required prop label or children or icon was not specified in ${componentName}.`);
   }
 }

--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -6,7 +6,7 @@ import EnhancedButton from '../internal/EnhancedButton';
 import Paper from '../Paper';
 
 function validateLabel(props, propName, componentName) {
-  if (!props.children && !props.label && !props.icon) {
+  if (!props.children && (!props.label && props.label !== 0) && !props.icon) {
     return new Error(`Required prop label or children or icon was not specified in ${componentName}.`);
   }
 }


### PR DESCRIPTION
FlatButton throw an error when label is zero (numeric data-type). This is special case, so we should handle it in validation function.

