### PR TITLE
Switch to loose mode

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["es2015", "stage-1", "react"],
+  "presets": ["es2015-loose", "stage-1", "react"],
   "plugins": [
     ["transform-replace-object-assign", "simple-assign"],
     "transform-dev-warning"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "babel-plugin-transform-replace-object-assign": "^0.2.1",
     "babel-polyfill": "^6.7.4",
     "babel-preset-es2015": "^6.6.0",
+    "babel-preset-es2015-loose": "^7.0.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-1": "^6.5.0",
     "babel-runtime": "^6.6.1",


### PR DESCRIPTION
Hi!

Some components (e.g. #4212) doesn't work in IE9.
[Switching on loose mode](http://www.2ality.com/2015/12/babel6-loose-mode.html) solves this problem.