### PR TITLE
[FlatButton] Fix label validation for 0 (number data-type)

### DIFF
--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -6,7 +6,7 @@ import EnhancedButton from '../internal/EnhancedButton';
 import FlatButtonLabel from './FlatButtonLabel';
 
 function validateLabel(props, propName, componentName) {
-  if (!props.children && !props.label && !props.icon) {
+  if (!props.children && (!props.label && props.label !== 0) && !props.icon) {
     return new Error(`Required prop label or children or icon was not specified in ${componentName}.`);
   }
 }


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) 


FlatButton throw an error when label is zero (numeric data-type). This is special case, so we should handle it in validation function.


