### PR TITLE
[TableFooter] Fix when adjustForCheckbox is false

### DIFF
--- a/src/Table/TableFooter.js
+++ b/src/Table/TableFooter.js
@@ -75,7 +75,7 @@ class TableFooter extends Component {
       let newDescendants;
       if (adjustForCheckbox) {
         newDescendants = [
-          <TableRowColumn key={`fpcb${rowNumber}`} style={{width: 24}} />
+          <TableRowColumn key={`fpcb${rowNumber}`} style={{width: 24}} />,
         ];
       }
       newDescendants.push(...React.Children.toArray(child.props.children));

--- a/src/Table/TableFooter.js
+++ b/src/Table/TableFooter.js
@@ -75,10 +75,10 @@ class TableFooter extends Component {
       let newDescendants;
       if (adjustForCheckbox) {
         newDescendants = [
-          <TableRowColumn key={`fpcb${rowNumber}`} style={{width: 24}} />,
-          ...React.Children.toArray(child.props.children),
+          <TableRowColumn key={`fpcb${rowNumber}`} style={{width: 24}} />
         ];
       }
+      newDescendants.push(...React.Children.toArray(child.props.children));
 
       return React.cloneElement(child, newChildProps, newDescendants);
     });


### PR DESCRIPTION
TableFooter is not displaying its children when adjustForCheckbox is set to false.