### PR TITLE
[travis] Update travis config to exit early on errors and only run codemod tests when needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,4 @@ cache:
   directories:
     - node_modules
 script:
-  - npm run lint
-  - npm run test:coverage
-  - cat ./test/coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
-  - npm run test:karma
-  - cd packages/material-ui-codemod && npm install && npm test
+  - ./scripts/run-travis-tests.sh

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build:babel": "babel ./src --ignore *.spec.js --out-dir ./build",
     "build:copy-files": "babel-node ./scripts/copy-files.js",
     "clean:build": "rimraf build",
-    "lint": "eslint src docs/src test/browser test/unit && echo \"eslint: no lint errors\"",
+    "lint": "eslint src docs/src test/integration && echo \"eslint: no lint errors\"",
     "prebuild": "npm run clean:build",
     "test": "cross-env NODE_ENV=test babel-node test/index.js",
     "test:coverage": "cross-env NODE_ENV=test babel-node ./node_modules/istanbul/lib/cli.js cover test/index.js",

--- a/scripts/run-travis-tests.sh
+++ b/scripts/run-travis-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ev
+npm run lint
+npm run test:coverage
+npm run test:karma
+cat ./test/coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+if git log ${TRAVIS_COMMIT_RANGE} | grep -Ei '\[codemod\]'; then
+  cd packages/material-ui-codemod && npm install && npm test
+fi

--- a/test/integration/fixtures/react-stub-context.js
+++ b/test/integration/fixtures/react-stub-context.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prefer-es6-class */
 // "react-stub-context": "^0.3.0",
 
 const React = require('react');

--- a/test/integration/theming.js
+++ b/test/integration/theming.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/prefer-es6-class */
+
 // NOTE: all these tests depend on DarkRawTheme, and Colors
 // Modifying any of the above files will break these tests!
 


### PR DESCRIPTION
This PR changes our travis setup so that travis will exit early when a command errors instead of continuing to run the entire suite.

For example, this build would stop after the lint step failed: https://travis-ci.org/callemall/material-ui/builds/131384921

This is to prevent CI time being wasted. 

An additional change I've made is to only run the codemod tests if `[codemod]` (case insensitive) is present in any of the commit messages. This will also reduce build times and prevent CI time being wasted.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).