### PR TITLE
[FloatingActionButton] Fix SvgIcon fill color

### DIFF
--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -53,7 +53,7 @@ function getStyles(props, context) {
     icon: {
       height: floatingActionButton.buttonSize,
       lineHeight: `${floatingActionButton.buttonSize}px`,
-      fill: floatingActionButton.iconColor,
+      fill: iconColor,
       color: iconColor,
     },
     iconWhenMini: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

#### Before (0.15.0 and prior)
![image](https://cloud.githubusercontent.com/assets/357702/15442793/3068c326-1edb-11e6-9d77-ff07bfb9693b.png)

#### After
![image](https://cloud.githubusercontent.com/assets/357702/15442801/3a69b6f0-1edb-11e6-9594-cedc079ca9c7.png)

This now matches the behaviour with a `FontIcon`.
