### PR TITLE
[AutoComplete] Allow to replace searchText after item selected

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -259,13 +259,18 @@ class AutoComplete extends Component {
     const index = parseInt(child.key, 10);
     const chosenRequest = dataSource[index];
     const searchText = typeof chosenRequest === 'string' ? chosenRequest : chosenRequest.text;
+    const prevSearchText = this.props.searchText;
 
     this.props.onNewRequest(chosenRequest, index);
 
     this.timerTouchTapCloseId = setTimeout(() => {
-      this.setState({
-        searchText: searchText,
-      });
+      // Replace 'searchText' only if there were no changes since the item was selected.
+      if (prevSearchText === this.props.searchText) {
+        this.setState({
+          searchText: searchText,
+        });
+      }
+
       this.close();
       this.timerTouchTapCloseId = null;
     }, this.props.menuCloseDelay);


### PR DESCRIPTION
After an item is selected, the value of the selected item is automatically set as the displayed text (aka `searchText`). There is no _easy way_ to change that value if needed.

For example, one use-case to change this default behavior is if we wanted to clear the text after an item is selected.