### PR TITLE
[DatePicker] Fix year view for ranges that overflow

### DIFF
--- a/src/DatePicker/CalendarYear.js
+++ b/src/DatePicker/CalendarYear.js
@@ -76,19 +76,22 @@ class CalendarYear extends Component {
     const years = this.getYears();
     const backgroundColor = this.context.muiTheme.datePicker.calendarYearBackgroundColor;
     const styles = {
-      backgroundColor: backgroundColor,
-      height: 'inherit',
-      lineHeight: '35px',
-      overflowX: 'hidden',
-      overflowY: 'scroll',
-      position: 'relative',
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'center',
+      default: {
+        backgroundColor: backgroundColor,
+        height: 'inherit',
+        lineHeight: '35px',
+        overflowX: 'hidden',
+        overflowY: 'auto',
+        position: 'relative',
+      },
+      noOverflow: {
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+      },
     };
-
     return (
-      <div style={styles}>
+      <div style={years.length < 7 ? Object.assign(styles.default, styles.noOverflow) : styles.default}>
         <div>
           {years}
         </div>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

There might be a better solution, but this seems to fix overflowed ranges in the datepicker while still keeping vertical alignment.

closes #4317 
