### PR TITLE
[Snackbar] Fix consecutive updates leading to displaying old message

### DIFF
--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -115,13 +115,14 @@ class Snackbar extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
+    clearTimeout(this.timerOneAtTheTimeId);
+
     if (this.state.open && nextProps.open === this.props.open &&
         (nextProps.message !== this.props.message || nextProps.action !== this.props.action)) {
       this.setState({
         open: false,
       });
 
-      clearTimeout(this.timerOneAtTheTimeId);
       this.timerOneAtTheTimeId = setTimeout(() => {
         this.setState({
           message: nextProps.message,

--- a/src/Snackbar/Snackbar.spec.js
+++ b/src/Snackbar/Snackbar.spec.js
@@ -34,4 +34,22 @@ describe('<Snackbar />', () => {
       );
     });
   });
+
+  it('should show the latest message of consecutive updates', (done) => {
+    const wrapper = shallowWithContext(
+      <Snackbar open={true} message="First message"/>
+    );
+
+    wrapper.setProps({open: true, message: 'Second message'});
+    wrapper.setProps({open: true, message: 'Third message'});
+
+    setTimeout(() => {
+      assert.equal(
+        wrapper.state('message'),
+        'Third message'
+      );
+
+      done();
+    }, 500);
+  });
 });

--- a/src/Snackbar/Snackbar.spec.js
+++ b/src/Snackbar/Snackbar.spec.js
@@ -37,7 +37,7 @@ describe('<Snackbar />', () => {
 
   it('should show the latest message of consecutive updates', (done) => {
     const wrapper = shallowWithContext(
-      <Snackbar open={true} message="First message"/>
+      <Snackbar open={true} message="First message" />
     );
 
     wrapper.setProps({open: true, message: 'Second message'});


### PR DESCRIPTION
When multiple updates to `Snackbar` props are done instantaneously, the latest one gets lost due to non-cleared timeout.