### PR TITLE
[DropDownMenu] Add check if there is onChange prop before calling it.

### DIFF
--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -220,10 +220,12 @@ class DropDownMenu extends Component {
   };
 
   handleItemTouchTap = (event, child, index) => {
-    this.props.onChange(event, index, child.props.value);
-
     this.setState({
       open: false,
+    }, () => {
+      if (this.props.onChange) {
+        this.props.onChange(event, index, child.props.value);
+      }
     });
   };
 


### PR DESCRIPTION
A component doesn't check if there is `onChange` prop passed (and that prop is not required) so it causes errors when using this component without such callback. This PR adds such check so it shouldn't happen now.