### PR TITLE
[TextField][MultiLine] Fix bug with multiLine cursor position on height change

### DIFF
--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -72,6 +72,11 @@ const getStyles = (props, context, state) => {
     font: 'inherit',
   });
 
+  // If rowsMax property exists, calc max height value for textarea
+  if (props.rowsMax) {
+    styles.textarea.maxHeight = 24 * props.rowsMax;
+  }
+
   if (state.hasValue) {
     styles.floatingLabel.color = fade(props.disabled ? disabledTextColor : floatingLabelColor, 0.5);
   }

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -11,6 +11,9 @@ import TextFieldLabel from './TextFieldLabel';
 import TextFieldUnderline from './TextFieldUnderline';
 import warning from 'warning';
 
+// Input line height
+const fieldLineHeight = 24;
+
 const getStyles = (props, context, state) => {
   const {
     baseTheme,
@@ -28,9 +31,9 @@ const getStyles = (props, context, state) => {
   const styles = {
     root: {
       fontSize: 16,
-      lineHeight: '24px',
+      lineHeight: `${fieldLineHeight}px`,
       width: props.fullWidth ? '100%' : 256,
-      height: (props.rows - 1) * 24 + (props.floatingLabelText ? 72 : 48),
+      height: (props.rows - 1) * fieldLineHeight + (props.floatingLabelText ? 72 : 48),
       display: 'inline-block',
       position: 'relative',
       backgroundColor: backgroundColor,
@@ -74,7 +77,7 @@ const getStyles = (props, context, state) => {
 
   // If rowsMax property exists, calc max height value for textarea
   if (props.rowsMax) {
-    styles.textarea.maxHeight = 24 * props.rowsMax;
+    styles.textarea.maxHeight = fieldLineHeight * props.rowsMax;
   }
 
   if (state.hasValue) {
@@ -375,9 +378,9 @@ class TextField extends Component {
   };
 
   handleHeightChange = (event, height) => {
-    let newHeight = height + 24;
+    let newHeight = height + fieldLineHeight;
     if (this.props.floatingLabelText) {
-      newHeight += 24;
+      newHeight += fieldLineHeight;
     }
     ReactDOM.findDOMNode(this).style.height = `${newHeight}px`;
   };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Fixed bug, described here #4276 

To fix this problem, I did init textarea maxHeight in function getStyles() If maxRows value were sent in props. Also I put standard input lineHeight value to the const, because it's used several times in component

PR doesn't have a new tests, but I did lint and run the test (npm run lint && npm run test) and everything was fine