### PR TITLE
[Popover] Fix typo from innerWith to innerWidth

### DIFF
--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -272,7 +272,7 @@ class Popover extends Component {
     if (anchorPosition.top < 0 ||
       anchorPosition.top > window.innerHeight ||
       anchorPosition.left < 0 ||
-      anchorPosition.left > window.innerWith) {
+      anchorPosition.left > window.innerWidth) {
       this.requestClose('offScreen');
     }
   }


### PR DESCRIPTION
To be honest, I haven't tested this, but seems like an obvious problem.

Fixes #4324 


