### PR TITLE
[DatePicker] Fix calendar year child div

### DIFF
--- a/src/DatePicker/CalendarYear.js
+++ b/src/DatePicker/CalendarYear.js
@@ -76,20 +76,25 @@ class CalendarYear extends Component {
     const years = this.getYears();
     const backgroundColor = this.context.muiTheme.datePicker.calendarYearBackgroundColor;
     const styles = {
-      backgroundColor: backgroundColor,
-      height: 'inherit',
-      lineHeight: '35px',
-      overflowX: 'hidden',
-      overflowY: 'scroll',
-      position: 'relative',
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'center',
+      root: {
+        backgroundColor: backgroundColor,
+        height: 'inherit',
+        lineHeight: '35px',
+        overflowX: 'hidden',
+        overflowY: 'scroll',
+        position: 'relative',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+      },
+      child: {
+        height: 'inherit'
+      }
     };
 
     return (
-      <div style={styles}>
-        <div>
+      <div style={styles.root}>
+        <div style={styles.child}>
           {years}
         </div>
       </div>

--- a/src/DatePicker/CalendarYear.js
+++ b/src/DatePicker/CalendarYear.js
@@ -88,8 +88,8 @@ class CalendarYear extends Component {
         justifyContent: 'center',
       },
       child: {
-        height: 'inherit'
-      }
+        height: 'inherit',
+      },
     };
 
     return (


### PR DESCRIPTION
Added style to div child of the component to show all the years inside the minDate and maxDate range, it set the div style to inherit the height from its parent div.

fixes #4317 