### PR TITLE
[Pickers] Add some test regarding the expect value property

### DIFF
--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -131,7 +131,7 @@ class DatePicker extends Component {
     /**
      * Sets the date for the Date Picker programmatically.
      */
-    value: PropTypes.any,
+    value: PropTypes.object,
     /**
      * Wordings used inside the button of the dialog.
      */
@@ -146,7 +146,6 @@ class DatePicker extends Component {
     firstDayOfWeek: 1,
     style: {},
   };
-
 
   static contextTypes = {
     muiTheme: PropTypes.object.isRequired,
@@ -210,21 +209,28 @@ class DatePicker extends Component {
         date: date,
       });
     }
-    if (this.props.onChange) this.props.onChange(null, date);
+    if (this.props.onChange) {
+      this.props.onChange(null, date);
+    }
   };
 
   handleFocus = (event) => {
     event.target.blur();
-    if (this.props.onFocus) this.props.onFocus(event);
+    if (this.props.onFocus) {
+      this.props.onFocus(event);
+    }
   };
 
   handleTouchTap = (event) => {
-    if (this.props.onTouchTap) this.props.onTouchTap(event);
+    if (this.props.onTouchTap) {
+      this.props.onTouchTap(event);
+    }
 
-    if (!this.props.disabled)
+    if (!this.props.disabled) {
       setTimeout(() => {
         this.openDialog();
       }, 0);
+    }
   };
 
   isControlled() {

--- a/src/DatePicker/DatePicker.spec.js
+++ b/src/DatePicker/DatePicker.spec.js
@@ -1,0 +1,42 @@
+/* eslint-env mocha */
+import React from 'react';
+import {shallow} from 'enzyme';
+import {assert} from 'chai';
+import {stub} from 'sinon';
+import DatePicker from './DatePicker';
+import getMuiTheme from '../styles/getMuiTheme';
+
+describe('<DatePicker />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
+  describe('propTypes', () => {
+    let consoleStub;
+
+    beforeEach(() => {
+      consoleStub = stub(console, 'error');
+    });
+
+    afterEach(() => {
+      console.error.restore(); // eslint-disable-line no-console
+    });
+
+    it('should throw when using wrong properties', () => {
+      shallowWithContext(
+        <DatePicker value="2016-03-21" />
+      );
+      assert.strictEqual(consoleStub.callCount, 1);
+      assert.strictEqual(
+        consoleStub.args[0][0],
+        'Warning: Failed propType: Invalid prop `value` of type `string` supplied to `DatePicker`, expected `object`.'
+      );
+    });
+
+    it('should not throw when using a valid properties', () => {
+      shallowWithContext(
+        <DatePicker value={new Date()} />
+      );
+      assert.strictEqual(consoleStub.callCount, 0);
+    });
+  });
+});

--- a/src/TimePicker/TimePicker.js
+++ b/src/TimePicker/TimePicker.js
@@ -78,7 +78,6 @@ class TimePicker extends Component {
      * Sets the time for the Time Picker programmatically.
      */
     value: PropTypes.object,
-
   };
 
   static defaultProps = {
@@ -155,15 +154,21 @@ class TimePicker extends Component {
 
   handleFocusInput = (event) => {
     event.target.blur();
-    if (this.props.onFocus) this.props.onFocus(event);
+    if (this.props.onFocus) {
+      this.props.onFocus(event);
+    }
   };
 
   handleTouchTapInput = (event) => {
     event.preventDefault();
 
-    if (!this.props.disabled) this.openDialog();
+    if (!this.props.disabled) {
+      this.openDialog();
+    }
 
-    if (this.props.onTouchTap) this.props.onTouchTap(event);
+    if (this.props.onTouchTap) {
+      this.props.onTouchTap(event);
+    }
   };
 
   isControlled() {

--- a/src/TimePicker/TimePicker.test.js
+++ b/src/TimePicker/TimePicker.test.js
@@ -1,0 +1,42 @@
+/* eslint-env mocha */
+import React from 'react';
+import {shallow} from 'enzyme';
+import {assert} from 'chai';
+import {stub} from 'sinon';
+import TimePicker from './TimePicker';
+import getMuiTheme from '../styles/getMuiTheme';
+
+describe('<TimePicker />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
+  describe('propTypes', () => {
+    let consoleStub;
+
+    beforeEach(() => {
+      consoleStub = stub(console, 'error');
+    });
+
+    afterEach(() => {
+      console.error.restore(); // eslint-disable-line no-console
+    });
+
+    it('should throw when using wrong properties', () => {
+      shallowWithContext(
+        <TimePicker value="2016-03-21" />
+      );
+      assert.strictEqual(consoleStub.callCount, 1);
+      assert.strictEqual(
+        consoleStub.args[0][0],
+        'Warning: Failed propType: Invalid prop `value` of type `string` supplied to `TimePicker`, expected `object`.'
+      );
+    });
+
+    it('should not throw when using a valid properties', () => {
+      shallowWithContext(
+        <TimePicker value={new Date()} />
+      );
+      assert.strictEqual(consoleStub.callCount, 0);
+    });
+  });
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Following https://github.com/callemall/material-ui/pull/4304, we should make sure that the `value` isn't *too far* from a `Date` object.

