### PR TITLE
[Themes] Make shadows general, and use in place of Paper

### DIFF
--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -3,12 +3,11 @@ import transitions from '../styles/transitions';
 import {fade} from '../utils/colorManipulator';
 import EnhancedButton from '../internal/EnhancedButton';
 import FontIcon from '../FontIcon';
-import Paper from '../Paper';
 import {extendChildren} from '../utils/childUtils';
 import warning from 'warning';
 import propTypes from '../utils/propTypes';
 
-function getStyles(props, context) {
+function getStyles(props, context, state) {
   const {floatingActionButton} = context.muiTheme;
 
   let backgroundColor = props.backgroundColor || floatingActionButton.color;
@@ -26,6 +25,8 @@ function getStyles(props, context) {
     root: {
       transition: transitions.easeOut(),
       display: 'inline-block',
+      boxShadow: floatingActionButton.zDepthShadows[state.zDepth],
+      borderRadius: '50%',
     },
     container: {
       backgroundColor,
@@ -255,7 +256,7 @@ class FloatingActionButton extends Component {
       ...other} = this.props;
 
     const {prepareStyles} = this.context.muiTheme;
-    const styles = getStyles(this.props, this.context);
+    const styles = getStyles(this.props, this.context, this.state);
 
     let iconElement;
     if (iconClassName) {
@@ -288,11 +289,9 @@ class FloatingActionButton extends Component {
     };
 
     return (
-      <Paper
+      <div
         className={className}
         style={Object.assign(styles.root, this.props.style)}
-        zDepth={this.state.zDepth}
-        circle={true}
       >
         <EnhancedButton
           {...other}
@@ -318,7 +317,7 @@ class FloatingActionButton extends Component {
             {children}
           </div>
         </EnhancedButton>
-      </Paper>
+      </div>
     );
   }
 }

--- a/src/Paper/Paper.js
+++ b/src/Paper/Paper.js
@@ -23,7 +23,7 @@ function getStyles(props, context) {
       boxSizing: 'border-box',
       fontFamily: baseTheme.fontFamily,
       WebkitTapHighlightColor: 'rgba(0,0,0,0)', // Remove mobile color flashing (deprecated)
-      boxShadow: paper.zDepthShadows[zDepth - 1], // No shadow for 0 depth papers
+      boxShadow: paper.zDepthShadows[zDepth],
       borderRadius: circle ? '50%' : rounded ? '2px' : '0px',
     },
   };

--- a/src/Paper/Paper.spec.js
+++ b/src/Paper/Paper.spec.js
@@ -84,7 +84,7 @@ describe('<Paper />', () => {
     );
 
     assert.ok(wrapper.contains(testChildren), 'should contain the children');
-    assert.strictEqual(wrapper.prop('style').boxShadow, muiTheme.paper.zDepthShadows[zDepth - 1],
+    assert.strictEqual(wrapper.prop('style').boxShadow, muiTheme.paper.zDepthShadows[zDepth],
       'should have good zDepthShadows');
   });
 });

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom';
 import EventListener from 'react-event-listener';
 import RenderToLayer from '../internal/RenderToLayer';
 import propTypes from '../utils/propTypes';
-import Paper from '../Paper';
 import throttle from 'lodash.throttle';
 import PopoverAnimationDefault from './PopoverAnimationDefault';
 
@@ -164,16 +163,6 @@ class Popover extends Component {
 
     let Animation = animation || PopoverAnimationDefault;
     let styleRoot = style;
-
-    if (!Animation) {
-      Animation = Paper;
-      styleRoot = {
-        position: 'fixed',
-      };
-      if (!this.state.open) {
-        return null;
-      }
-    }
 
     return (
       <Animation {...other} style={styleRoot} open={this.state.open && !this.state.closing}>

--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -3,7 +3,6 @@ import transitions from '../styles/transitions';
 import {fade} from '../utils/colorManipulator';
 import {createChildFragment} from '../utils/childUtils';
 import EnhancedButton from '../internal/EnhancedButton';
-import Paper from '../Paper';
 
 function validateLabel(props, propName, componentName) {
   if (!props.children && !props.label && !props.icon) {
@@ -61,6 +60,7 @@ function getStyles(props, context, state) {
     root: {
       display: 'inline-block',
       transition: transitions.easeOut(),
+      boxShadow: raisedButton.zDepthShadows[state.zDepth],
     },
     button: {
       position: 'relative',
@@ -394,7 +394,7 @@ class RaisedButton extends Component {
     const enhancedButtonChildren = createChildFragment(childrenFragment);
 
     return (
-      <Paper
+      <div
         className={className}
         style={Object.assign(styles.root, this.props.style)}
         zDepth={this.state.zDepth}
@@ -417,7 +417,7 @@ class RaisedButton extends Component {
             {enhancedButtonChildren}
           </div>
         </EnhancedButton>
-      </Paper>
+      </div>
     );
   }
 }

--- a/src/RaisedButton/RaisedButton.spec.js
+++ b/src/RaisedButton/RaisedButton.spec.js
@@ -14,11 +14,11 @@ describe('<RaisedButton />', () => {
   const mountWithContext = (node) => mount(node, {context: {muiTheme}});
   const testChildren = <span className="unique">Hello World</span>;
 
-  it('renders an enhanced button inside paper', () => {
+  it('renders an enhanced button inside a div', () => {
     const wrapper = shallowWithContext(
       <RaisedButton>Button</RaisedButton>
     );
-    assert.ok(wrapper.is('Paper'));
+    assert.ok(wrapper.is('div'));
     assert.ok(wrapper.childAt(0).is('EnhancedButton'));
   });
 

--- a/src/RefreshIndicator/RefreshIndicator.js
+++ b/src/RefreshIndicator/RefreshIndicator.js
@@ -1,12 +1,13 @@
 import React, {Component, PropTypes} from 'react';
 import autoPrefix from '../utils/autoPrefix';
 import transitions from '../styles/transitions';
-import Paper from '../Paper';
 
 const VIEWBOX_SIZE = 32;
 
-function getStyles(props) {
+function getStyles(props, context) {
   const padding = props.size * 0.1; // same implementation of `this.getPaddingSize()`
+  const {refreshIndicator} = context.muiTheme;
+
   return {
     root: {
       position: 'absolute',
@@ -19,6 +20,9 @@ function getStyles(props) {
       transform: `translate3d(${10000 + props.left}px, ${10000 + props.top}px, 0)`,
       opacity: props.status === 'hide' ? 0 : 1,
       transition: props.status === 'hide' ? transitions.create('all', '.3s', 'ease-out') : 'none',
+      boxShadow: refreshIndicator.shadow,
+      borderRadius: 90,
+      boxSizing: 'border-box',
     },
   };
 }
@@ -306,13 +310,12 @@ class RefreshIndicator extends Component {
     const styles = getStyles(this.props, this.context);
 
     return (
-      <Paper
-        circle={true}
+      <div
         style={Object.assign(styles.root, style)}
         ref="indicatorCt"
       >
         {this.renderChildren()}
-      </Paper>
+      </div>
     );
   }
 }

--- a/src/Toggle/Toggle.js
+++ b/src/Toggle/Toggle.js
@@ -1,6 +1,5 @@
 import React, {Component, PropTypes} from 'react';
 import transitions from '../styles/transitions';
-import Paper from '../Paper';
 import EnhancedSwitch from '../internal/EnhancedSwitch';
 
 function getStyles(props, context, state) {
@@ -23,9 +22,6 @@ function getStyles(props, context, state) {
       left: -10,
       color: state.switched ? toggle.thumbOnColor : baseTheme.palette.textColor,
     },
-    toggleElement: {
-      width: toggleTrackWidth,
-    },
     track: {
       transition: transitions.easeOut(),
       width: '100%',
@@ -43,6 +39,7 @@ function getStyles(props, context, state) {
       lineHeight: '24px',
       borderRadius: '50%',
       backgroundColor: toggle.thumbOffColor,
+      boxShadow: toggle.shadow,
     },
     trackWhenSwitched: {
       backgroundColor: toggle.trackOnColor,
@@ -177,7 +174,6 @@ class Toggle extends Component {
       ...other,
     } = this.props;
 
-    const {prepareStyles} = this.context.muiTheme;
     const styles = getStyles(this.props, this.context, this.state);
 
     const trackStyles = Object.assign({},
@@ -198,18 +194,6 @@ class Toggle extends Component {
       thumbStyles.marginLeft = 0 - thumbStyles.width;
     }
 
-    const toggleElementStyles = Object.assign({},
-      styles.toggleElement,
-      this.props.elementStyle
-    );
-
-    const toggleElement = (
-      <div style={prepareStyles(Object.assign({}, toggleElementStyles))}>
-        <div style={prepareStyles(Object.assign({}, trackStyles))} />
-        <Paper style={thumbStyles} circle={true} zDepth={1} />
-      </div>
-    );
-
     const rippleStyle = Object.assign({},
       styles.ripple,
       this.props.rippleStyle
@@ -228,7 +212,7 @@ class Toggle extends Component {
     const enhancedSwitchProps = {
       ref: 'enhancedSwitch',
       inputType: 'checkbox',
-      switchElement: toggleElement,
+      switchElement: <div />,
       rippleStyle: rippleStyle,
       rippleColor: rippleStyle.color,
       iconStyle: iconStyle,

--- a/src/internal/EnhancedSwitch.js
+++ b/src/internal/EnhancedSwitch.js
@@ -4,7 +4,6 @@ import keycode from 'keycode';
 import transitions from '../styles/transitions';
 import FocusRipple from './FocusRipple';
 import TouchRipple from './TouchRipple';
-import Paper from './../Paper';
 import warning from 'warning';
 
 function getStyles(props, context) {
@@ -354,7 +353,7 @@ class EnhancedSwitch extends Component {
     ) : (
       <div style={prepareStyles(wrapStyles)}>
         <div style={prepareStyles(Object.assign({}, trackStyle))} />
-        <Paper style={thumbStyle} zDepth={1} circle={true}> {ripples} </Paper>
+        <div style={thumbStyle}> {ripples} </div>
       </div>
     );
 

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -7,6 +7,7 @@ import callOnce from '../utils/callOnce';
 import rtl from '../utils/rtl';
 import compose from 'recompose/compose';
 import typography from './typography';
+import zDepthShadows from './zDepthShadows';
 import {
   red500, grey400, grey500, grey600, grey700,
   transparent, lightWhite, white, darkWhite, lightBlack, black,
@@ -27,6 +28,7 @@ export default function getMuiTheme(muiTheme, ...more) {
 
   const {spacing, fontFamily, palette} = muiTheme;
   const baseTheme = {spacing, fontFamily, palette};
+  const shadows = zDepthShadows(palette.shadowColor);
 
   muiTheme = merge({
     appBar: {
@@ -83,8 +85,7 @@ export default function getMuiTheme(muiTheme, ...more) {
       textColor: fade(palette.textColor, 0.87),
       fontSize: 14,
       fontWeight: typography.fontWeightNormal,
-      shadow: `0 1px 6px ${fade(palette.shadowColor, 0.12)},
-        0 1px 4px ${fade(palette.shadowColor, 0.12)}`,
+      shadow: shadows[1],
     },
     datePicker: {
       color: palette.primary1Color,
@@ -124,6 +125,7 @@ export default function getMuiTheme(muiTheme, ...more) {
       secondaryIconColor: palette.alternateTextColor,
       disabledTextColor: palette.disabledColor,
       disabledColor: emphasize(palette.canvasColor, 0.12),
+      zDepthShadows: shadows,
     },
     gridTile: {
       textColor: white,
@@ -168,16 +170,7 @@ export default function getMuiTheme(muiTheme, ...more) {
     paper: {
       color: palette.textColor,
       backgroundColor: palette.canvasColor,
-      zDepthShadows: [
-        [1, 6, 0.12, 1, 4, 0.12],
-        [3, 10, 0.16, 3, 10, 0.23],
-        [10, 30, 0.19, 6, 10, 0.23],
-        [14, 45, 0.25, 10, 18, 0.22],
-        [19, 60, 0.30, 15, 20, 0.22],
-      ].map((d) => (
-        `0 ${d[0]}px ${d[1]}px ${fade(palette.shadowColor, d[2])},
-         0 ${d[3]}px ${d[4]}px ${fade(palette.shadowColor, d[5])}`
-      )),
+      zDepthShadows: shadows,
     },
     radioButton: {
       borderColor: palette.textColor,
@@ -200,10 +193,12 @@ export default function getMuiTheme(muiTheme, ...more) {
       disabledTextColor: fade(palette.textColor, 0.3),
       fontSize: typography.fontStyleButtonFontSize,
       fontWeight: typography.fontWeightMedium,
+      zDepthShadows: shadows,
     },
     refreshIndicator: {
       strokeColor: palette.borderColor,
       loadingStrokeColor: palette.primary1Color,
+      shadow: shadows[1],
     },
     ripple: {
       color: fade(palette.textColor, 0.87),
@@ -302,6 +297,7 @@ export default function getMuiTheme(muiTheme, ...more) {
       labelColor: palette.textColor,
       labelDisabledColor: palette.disabledColor,
       trackRequiredColor: fade(palette.primary1Color, 0.5),
+      shadow: shadows[1],
     },
     toolbar: {
       color: fade(palette.textColor, 0.54),

--- a/src/styles/zDepthShadows.js
+++ b/src/styles/zDepthShadows.js
@@ -1,0 +1,15 @@
+import {fade} from '../utils/colorManipulator';
+
+export default function zDepthShadows(color) {
+  return [
+    'none',
+    [1, 6, 0.12, 1, 4, 0.12],
+    [3, 10, 0.16, 3, 10, 0.23],
+    [10, 30, 0.19, 6, 10, 0.23],
+    [14, 45, 0.25, 10, 18, 0.22],
+    [19, 60, 0.30, 15, 20, 0.22],
+  ].map((d) => (
+    `0 ${d[0]}px ${d[1]}px ${fade(color, d[2])},
+         0 ${d[3]}px ${d[4]}px ${fade(color, d[5])}`
+  ));
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

I was originally holding off from this in anticipation of the new themes (so just gave Chip it's own shadow), but making shadows more general, and removing Paper will carry over to new theme however and whenever that happens, so no reason to wait.

* Remove Paper from: RaisedButton, FloatingActionButton, RefreshIndicator & Toggle.
* Use new shadow in Chip.
* Remove some dead-code from Toggle & Popover.