### PR TITLE
[DatePicker] Expose dialog container style

### DIFF
--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -40,6 +40,10 @@ class DatePicker extends Component {
      */
     defaultDate: PropTypes.object,
     /**
+     * Override the inline-styles of DatePickerDialog's Container element.
+     */
+    dialogContainerStyle: PropTypes.object,
+    /**
      * Disables the year selection in the date picker.
      */
     disableYearSelection: PropTypes.bool,
@@ -264,6 +268,7 @@ class DatePicker extends Component {
       className,
       container,
       defaultDate, // eslint-disable-line no-unused-vars
+      dialogContainerStyle,
       disableYearSelection,
       firstDayOfWeek,
       locale,
@@ -300,6 +305,7 @@ class DatePicker extends Component {
           autoOk={autoOk}
           cancelLabel={cancelLabel}
           container={container}
+          containerStyle={dialogContainerStyle}
           disableYearSelection={disableYearSelection}
           firstDayOfWeek={firstDayOfWeek}
           initialDate={this.state.dialogDate}

--- a/src/DatePicker/DatePickerDialog.js
+++ b/src/DatePicker/DatePickerDialog.js
@@ -13,6 +13,7 @@ class DatePickerDialog extends Component {
     autoOk: PropTypes.bool,
     cancelLabel: PropTypes.node,
     container: PropTypes.oneOf(['dialog', 'inline']),
+    containerStyle: PropTypes.object,
     disableYearSelection: PropTypes.bool,
     firstDayOfWeek: PropTypes.number,
     initialDate: PropTypes.object,
@@ -95,6 +96,7 @@ class DatePickerDialog extends Component {
       DateTimeFormat,
       cancelLabel,
       container,
+      containerStyle,
       disableYearSelection,
       initialDate,
       firstDayOfWeek,
@@ -127,7 +129,6 @@ class DatePickerDialog extends Component {
     return (
       <div {...other} ref="root">
         <Container
-          {...other}
           anchorEl={this.refs.root} // For Popover
           animation={PopoverAnimationFromTop} // For Popover
           bodyStyle={styles.dialogBodyContent}
@@ -136,7 +137,7 @@ class DatePickerDialog extends Component {
           repositionOnUpdate={true}
           open={open}
           onRequestClose={this.handleRequestClose}
-          style={styles.dialogBodyContent}
+          style={Object.assign(styles.dialogBodyContent, containerStyle)}
         >
           <EventListener
             target="window"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

As a possible workaround for https://github.com/callemall/material-ui/issues/1261, allow people to set the DatePicker's Dialog body content style. In particular, setting it's overflow to 'auto' will bring up a scroll bar for small screens.

With this change in place you can just do the following to get scroll bars on small screens:
```
<DatePicker
    dialogStyle={{overflowY: 'auto'}}
/>
```

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).
