### PR TITLE
[TimePicker] Expose two TimePickerDialog style props

### DIFF
--- a/src/TimePicker/TimePicker.js
+++ b/src/TimePicker/TimePicker.js
@@ -25,6 +25,14 @@ class TimePicker extends Component {
      */
     defaultTime: PropTypes.object,
     /**
+     * Override the inline-styles of TimePickerDialog's body element.
+     */
+    dialogBodyStyle: PropTypes.object,
+    /**
+     * Override the inline-styles of TimePickerDialog's root element.
+     */
+    dialogStyle: PropTypes.object,
+    /**
      * If true, the TimePicker is disabled.
      */
     disabled: PropTypes.bool,
@@ -187,6 +195,8 @@ class TimePicker extends Component {
     const {
       autoOk,
       cancelLabel,
+      dialogBodyStyle,
+      dialogStyle,
       format,
       okLabel,
       onFocus, // eslint-disable-line no-unused-vars
@@ -214,6 +224,7 @@ class TimePicker extends Component {
         />
         <TimePickerDialog
           ref="dialogWindow"
+          bodyStyle={dialogBodyStyle}
           initialTime={this.state.dialogTime}
           onAccept={this.handleAcceptDialog}
           onShow={onShow}
@@ -222,6 +233,7 @@ class TimePicker extends Component {
           okLabel={okLabel}
           cancelLabel={cancelLabel}
           autoOk={autoOk}
+          style={dialogStyle}
         />
       </div>
     );

--- a/src/TimePicker/TimePickerDialog.js
+++ b/src/TimePicker/TimePickerDialog.js
@@ -8,6 +8,7 @@ import FlatButton from '../FlatButton';
 class TimePickerDialog extends Component {
   static propTypes = {
     autoOk: PropTypes.bool,
+    bodyStyle: PropTypes.object,
     cancelLabel: PropTypes.node,
     format: PropTypes.oneOf(['ampm', '24hr']),
     initialTime: PropTypes.object,
@@ -15,6 +16,7 @@ class TimePickerDialog extends Component {
     onAccept: PropTypes.func,
     onDismiss: PropTypes.func,
     onShow: PropTypes.func,
+    style: PropTypes.object,
   };
 
   static defaultProps = {
@@ -69,12 +71,14 @@ class TimePickerDialog extends Component {
 
   render() {
     const {
+      bodyStyle,
       initialTime,
       onAccept, // eslint-disable-line no-unused-vars
       format,
       autoOk,
       okLabel,
       cancelLabel,
+      style,
       ...other,
     } = this.props;
 
@@ -112,8 +116,8 @@ class TimePickerDialog extends Component {
     return (
       <Dialog
         {...other}
-        style={styles.root}
-        bodyStyle={styles.body}
+        style={Object.assign(styles.root, style)}
+        bodyStyle={Object.assign(styles.body, bodyStyle)}
         actions={actions}
         contentStyle={styles.dialogContent}
         repositionOnUpdate={false}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

As a possible workaround for https://github.com/callemall/material-ui/issues/1261, allow people to set the TimePicker's Dialog body style. In particular, setting it's overflow to 'auto' will bring up a scroll bar for small screens.

With this change in place you can just do the following to get scroll bars on small screens:
```
<TimePicker
    dialogBodyStyle={{overflowY: 'auto'}}
/>
```

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


