### PR TITLE
[Tabs] Fixes tabindex

### DIFF
--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -149,14 +149,14 @@ class Tabs extends Component {
 
   handleTabTouchTap = (value, event, tab) => {
     const valueLink = this.getValueLink(this.props);
-    const tabIndex = tab.props.tabIndex;
+    const index = tab.props.index;
 
     if ((valueLink.value && valueLink.value !== value) ||
-      this.state.selectedIndex !== tabIndex) {
+      this.state.selectedIndex !== index) {
       valueLink.requestChange(value, event, tab);
     }
 
-    this.setState({selectedIndex: tabIndex});
+    this.setState({selectedIndex: index});
 
     if (tab.props.onActive) {
       tab.props.onActive(tab);
@@ -206,8 +206,8 @@ class Tabs extends Component {
 
       return React.cloneElement(tab, {
         key: index,
+        index: index,
         selected: this.getSelected(tab, index),
-        tabIndex: index,
         width: `${width}%`,
         onTouchTap: this.handleTabTouchTap,
       });


### PR DESCRIPTION
- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Visiting http://www.material-ui.com/#/components/tabs shows the strange tab behavior.
With tabs in this layout:
```
ITEM ONE | ITEM TWO | ITEM THREE
TAB A | TAB B
TAB ONE | TAB TWO | TAB THREE
```

Currently pressing tab will focus the elements in the following order:
- ITEM TWO
- TAB B
- TAB TWO
- ITEM THREE
- TAB THREE
- normal tabbing continues at this point

Expected behavior: (after my change)
- normal tabbing
- ITEM ONE
- ITEM TWO
- ITEM THREE
- TAB A
- TAB B
- ...

Currently the tab index increments by 1 from 0 for each `Tab`. Therefore, the 2nd `Tab` for each `Tabs` component are the first focusable elements, then the 3rd `Tab` for each `Tabs`, and so on. After exhausting all of the `Tab`s tabbing continues as expected.