### PR TITLE
[DatePicker] Add a default text value

### DIFF
--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -40,6 +40,12 @@ class DatePicker extends Component {
      */
     defaultDate: PropTypes.object,
     /**
+     * This is the initial value of the TextField component.
+     * If `value`, `valueLink`, or `defaultDate` is provided they will override
+     * this prop with `value` taking precedence.
+     */
+    defaultTextFieldValue: PropTypes.string,
+    /**
      * Disables the year selection in the date picker.
      */
     disableYearSelection: PropTypes.bool,
@@ -141,6 +147,7 @@ class DatePicker extends Component {
   static defaultProps = {
     autoOk: false,
     container: 'dialog',
+    defaultTextFieldValue: '',
     disabled: false,
     disableYearSelection: false,
     firstDayOfWeek: 1,
@@ -264,6 +271,7 @@ class DatePicker extends Component {
       className,
       container,
       defaultDate, // eslint-disable-line no-unused-vars
+      defaultTextFieldValue,
       disableYearSelection,
       firstDayOfWeek,
       locale,
@@ -293,7 +301,7 @@ class DatePicker extends Component {
           onTouchTap={this.handleTouchTap}
           ref="input"
           style={textFieldStyle}
-          value={this.state.date ? formatDate(this.state.date) : ''}
+          value={this.state.date ? formatDate(this.state.date) : defaultTextFieldValue}
         />
         <DatePickerDialog
           DateTimeFormat={DateTimeFormat}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

The Default Text Field Value is like the Default Date, except that it can be any string rather than just a date object. It has lower priority than the Default Date, so when both are specified the Default Date will be shown.

The use case that I came across was a need to have both the floatingTextField and a non-date initial value for the TextField as seen in the following screenshot next to a similarly modified TimePicker:
![screenshot from 2016-05-26 14-03-49](https://cloud.githubusercontent.com/assets/2854149/15588362/c5509bb2-234a-11e6-9a39-9674aad35219.png)
In this screenshot, "Today" is the text passed as the defaultTextFieldValue. It could also have been something like "Pick a date" or "None". The styling in the screenshot for the date component is just because it is set to disabled and unrelated to this PR.

The implementation approach for this PR is to just pass this field as the value of the TextField when nothing else is specified.

I can think of two alternate approaches that could achieve the same thing:
1. Without making any changes to the existing components, you could start with a regular TextField with an onTouchTap function that sets some state to indicate that a DatePicker should be rendered instead of the TextField. This would produce more verbose code since an entire additional TextField component and the conditional logic for when to display it would be needed.

2. Allow the defaultDate property to accept strings as well as dates. When it is a string, don't try to parse it as a date when the DatePicker is first opened. This approach could confuse developers who think they could put a string representation of a date in this field and have its value respected when they open the date picker.

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

If the current approach sounds better than the two alternative approaches, I'll go ahead and write the related tests and update the docs with an example.