### PR TITLE
[Avatar] Remove the border

### DIFF
--- a/docs/src/app/components/pages/components/Avatar/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/Avatar/ExampleSimple.js
@@ -16,6 +16,10 @@ purple500,
 
 const style = {margin: 5};
 
+/**
+ * Examples of `Avatar` using an image, [Font Icon](/#/components/font-icon), [SVG Icon](/#/components/svg-icon)
+ * and "Letter" (string), with and without custom colors at the default size (`40dp`) and an alternate size (`30dp`).
+ */
 const AvatarExampleSimple = () => (
   <List>
     <ListItem

--- a/docs/src/app/components/pages/components/Avatar/Page.js
+++ b/docs/src/app/components/pages/components/Avatar/Page.js
@@ -10,9 +10,6 @@ import AvatarExampleSimple from './ExampleSimple';
 import avatarExampleSimpleCode from '!raw!./ExampleSimple';
 import avatarCode from '!raw!material-ui/Avatar/Avatar';
 
-const description = 'Examples of `Avatar` using an image, [Font Icon](/#/components/font-icon), ' +
-  '[SVG Icon](/#/components/svg-icon) and "Letter" (string), with and without custom colors.';
-
 const AvatarsPage = () => (
   <div>
     <Title render={(previousTitle) => `Avatar - ${previousTitle}`} />
@@ -20,7 +17,6 @@ const AvatarsPage = () => (
     <CodeExample
       code={avatarExampleSimpleCode}
       title="Examples"
-      description={description}
     >
       <AvatarExampleSimple />
     </CodeExample>

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -5,19 +5,19 @@ function getStyles(props, context) {
     backgroundColor,
     color,
     size,
-    src,
   } = props;
 
   const {avatar} = context.muiTheme;
 
   const styles = {
     root: {
+      position: 'absolute',
       color: color || avatar.color,
       backgroundColor: backgroundColor || avatar.backgroundColor,
       userSelect: 'none',
-      display: 'inline-block',
-      textAlign: 'center',
-      lineHeight: `${size}px`,
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
       fontSize: size / 2,
       borderRadius: '50%',
       height: size,
@@ -31,17 +31,6 @@ function getStyles(props, context) {
       margin: size * 0.2,
     },
   };
-
-  if (src && avatar.borderColor) {
-    Object.assign(styles.root, {
-      background: `url(${src})`,
-      backgroundSize: size,
-      backgroundOrigin: 'border-box',
-      border: `solid 1px ${avatar.borderColor}`,
-      height: size - 2,
-      width: size - 2,
-    });
-  }
 
   return styles;
 }
@@ -106,9 +95,10 @@ class Avatar extends Component {
 
     if (src) {
       return (
-        <div
-          {...other}
+        <img
           style={prepareStyles(Object.assign(styles.root, style))}
+          {...other}
+          src={src}
           className={className}
         />
       );

--- a/src/Avatar/Avatar.spec.js
+++ b/src/Avatar/Avatar.spec.js
@@ -36,10 +36,10 @@ describe('<Avatar />', () => {
     );
 
     assert.notOk(!wrapper.contains(testChildren), 'should not contain the children');
-    assert.ok(wrapper.is('div'), 'should be a div');
-    assert.ok(wrapper.is({style: {background: 'url(face.jpg)'}}), 'should set background url');
+    assert.ok(wrapper.is('img'), 'should be an image');
+    assert.ok(wrapper.is({src: 'face.jpg'}), 'should have the src passed into props');
 
     wrapper.setProps({src: 'meow.jpg'});
-    assert.ok(wrapper.is({style: {background: 'url(meow.jpg)'}}), 'should have changed the background url');
+    assert.ok(wrapper.is({src: 'meow.jpg'}), 'should have changed the src');
   });
 });

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -39,7 +39,6 @@ export default function getMuiTheme(muiTheme, ...more) {
     avatar: {
       color: palette.canvasColor,
       backgroundColor: emphasize(palette.canvasColor, 0.26),
-      borderColor: 'rgba(128, 128, 128, 0.15)',
     },
     badge: {
       color: palette.alternateTextColor,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

While #4261 does solve the issue of using of an `<img>` tag for the for the Avatar image, and with a semi-transparent overlay border, the consensus was that the border is only marginally useful, and that it should just be removed, rather than add the complexity of an overlay div; and the rendering performance overhead of a shadow as a border.

Closes #4254.
