### PR TITLE
[Timepicker] Add explicit box-sizing to Clock component

### DIFF
--- a/src/TimePicker/Clock.js
+++ b/src/TimePicker/Clock.js
@@ -125,6 +125,7 @@ class Clock extends Component {
         height: 280,
         padding: 10,
         position: 'relative',
+        boxSizing: 'content-box',
       },
       circle: {
         position: 'absolute',


### PR DESCRIPTION
- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

### Hey, folks!
I've found difference between in clock's look while [using `box-size: border-box` for all elements on the page](http://www.paulirish.com/2012/box-sizing-border-box-ftw/).

#### With `box-sizing: border-box`
![image](https://cloud.githubusercontent.com/assets/1788245/15670548/c9a50ea4-272e-11e6-8b4d-beac6e7f6c66.png)
#### Without (compare hour's arrow)
![image](https://cloud.githubusercontent.com/assets/1788245/15670564/da358f6e-272e-11e6-88cc-fef81dd91489.png)

Also I suggest a solution for that. What do you think?

Closes #4406.