### PR TITLE
[DatePicker] Fix docs descriptions

### DIFF
--- a/docs/src/app/components/pages/components/DatePicker/ExampleControlled.js
+++ b/docs/src/app/components/pages/components/DatePicker/ExampleControlled.js
@@ -2,7 +2,7 @@ import React from 'react';
 import DatePicker from 'material-ui/DatePicker';
 
 /**
- * DatePicker` can be implemented as a controlled input,
+ * `DatePicker` can be implemented as a controlled input,
  * where `value` is handled by state in the parent component.
  */
 export default class DatePickerExampleControlled extends React.Component {

--- a/docs/src/app/components/pages/components/DatePicker/ExampleInternational.js
+++ b/docs/src/app/components/pages/components/DatePicker/ExampleInternational.js
@@ -16,14 +16,14 @@ if (areIntlLocalesSupported(['fr'])) {
 }
 
 /**
- *  localised: '`DatePicker` can be localised using the `locale` property. The first example is localised in French.
+ *  `DatePicker` can be localised using the `locale` property. The first example is localised in French.
  *  Note that the buttons must be separately localised using the `cancelLabel` and `okLabel` properties.
  *
  *  The second example shows `firstDayOfWeek` set to `0`, (Sunday), and `locale` to `en-US` which matches the
  *  behavior of the Date Picker prior to 0.15.0. Note that the 'en-US' locale is built in, and so does not require
- *  `DateTimeFormat' to be supplied.
+ *  `DateTimeFormat` to be supplied.
  *
- *  The final example displays the resulting date in a custom format using the `formatDate` property.',
+ *  The final example displays the resulting date in a custom format using the `formatDate` property.
  */
 const DatePickerExampleInternational = () => (
   <div>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has ~~tests~~ / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Fix a couple of issues from conversion of example descriptions to code comments.

Closes #4390.