### PR TITLE
FloatingActionButton Fix styling

### DIFF
--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -45,7 +45,14 @@ function getStyles(props, context) {
     },
     overlay: {
       transition: transitions.easeOut(),
+      position: 'absolute',
       top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
     },
     overlayWhenHovered: {
       backgroundColor: fade(iconColor, 0.4),


### PR DESCRIPTION
The button animation didn't fill the whole button, because the div had the size of the svg icon.
I therefore made the containing div fill the whole button. I then centered the svg icon both vertically and horizontally.

![screen shot 2016-06-01 at 12 35 47](https://cloud.githubusercontent.com/assets/11021818/15706764/79b03d34-27f5-11e6-9cf5-cbab250d4b00.png)
![screen shot 2016-06-01 at 12 36 07](https://cloud.githubusercontent.com/assets/11021818/15706765/79b40522-27f5-11e6-8c86-a12a1ae365e5.png)