### PR TITLE
[Docs] Don't document standard DOM events

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -118,21 +118,11 @@ class AutoComplete extends Component {
      * Override style for menu.
      */
     menuStyle: PropTypes.object,
-    /**
-     * Callback function that is fired when the `TextField` loses focus.
-     *
-     * @param {object} event `blur` event targeting the `TextField`.
-     */
+    /** @ignore */
     onBlur: PropTypes.func,
-    /**
-     * Callback function that is fired when the `TextField` gains focus.
-     *
-     * @param {object} event `focus` event targeting the `TextField`.
-     */
+    /** @ignore */
     onFocus: PropTypes.func,
-    /**
-     * Callback function that is fired when the `TextField` receives a keydown event.
-     */
+    /** @ignore */
     onKeyDown: PropTypes.func,
     /**
      * Callback function that is fired when a list item is selected, or enter is pressed in the `TextField`.

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -99,8 +99,6 @@ class DatePicker extends Component {
     onDismiss: PropTypes.func,
     /**
      * Callback function that is fired when the Date Picker's `TextField` gains focus.
-     *
-     * @param {object} event `focus` event targeting the `TextField`.
      */
     onFocus: PropTypes.func,
     /**

--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -69,23 +69,11 @@ class FlatButton extends Component {
      * @param {boolean} isKeyboardFocused Indicates whether the element is focused.
      */
     onKeyboardFocus: PropTypes.func,
-    /**
-     * Callback function fired when the mouse enters the element.
-     *
-     * @param {object} event `mouseenter` event targeting the element.
-     */
+    /** @ignore */
     onMouseEnter: PropTypes.func,
-    /**
-     * Callback function fired when the mouse leaves the element.
-     *
-     * @param {object} event `mouseleave` event targeting the element.
-     */
+    /** @ignore */
     onMouseLeave: PropTypes.func,
-    /**
-     * Callback function fired when the element is touched.
-     *
-     * @param {object} event `touchstart` event targeting the element.
-     */
+    /** @ignore */
     onTouchStart: PropTypes.func,
     /**
      * If true, colors button according to

--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -107,41 +107,17 @@ class FloatingActionButton extends Component {
      * If true, the button will be a small floating action button.
      */
     mini: PropTypes.bool,
-    /**
-     * Callback function fired when a mouse button is pressed down on the element.
-     *
-     * @param {object} event `mousedown` event targeting the element.
-     */
+    /** @ignore */
     onMouseDown: PropTypes.func,
-    /**
-     * Callback function fired when the mouse enters the element.
-     *
-     * @param {object} event `mouseenter` event targeting the element.
-     */
+    /** @ignore */
     onMouseEnter: PropTypes.func,
-    /**
-     * Callback function fired when the mouse leaves the element.
-     *
-     * @param {object} event `mouseleave` event targeting the element.
-     */
+    /** @ignore */
     onMouseLeave: PropTypes.func,
-    /**
-     * Callback function fired when a mouse button is released on the element.
-     *
-     * @param {object} event `mouseup` event targeting the element.
-     */
+    /** @ignore */
     onMouseUp: PropTypes.func,
-    /**
-     * Callback function fired when a touch point is removed from the element.
-     *
-     * @param {object} event `touchend` event targeting the element.
-     */
+    /** @ignore */
     onTouchEnd: PropTypes.func,
-    /**
-     * Callback function fired when the element is touched.
-     *
-     * @param {object} event `touchstart` event targeting the element.
-     */
+    /** @ignore */
     onTouchStart: PropTypes.func,
     /**
      * If true, the button will use the secondary button colors.

--- a/src/FontIcon/FontIcon.js
+++ b/src/FontIcon/FontIcon.js
@@ -36,17 +36,9 @@ class FontIcon extends Component {
      * This is the icon color when the mouse hovers over the icon.
      */
     hoverColor: PropTypes.string,
-    /**
-     * Callback function fired when the mouse enters the element.
-     *
-     * @param {object} event `mouseenter` event targeting the element.
-     */
+    /** @ignore */
     onMouseEnter: PropTypes.func,
-    /**
-     * Callback function fired when the mouse leaves the element.
-     *
-     * @param {object} event `mouseleave` event targeting the element.
-     */
+    /** @ignore */
     onMouseLeave: PropTypes.func,
     /**
      * Override the inline-styles of the root element.

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -73,15 +73,9 @@ class IconButton extends Component {
      * Override the inline-styles of the icon element.
      */
     iconStyle: PropTypes.object,
-    /**
-     * Callback function fired when the element loses focus.
-     * @param {object} event `blur` event targeting the element.
-     */
+    /** @ignore */
     onBlur: PropTypes.func,
-    /**
-     * Callback function fired when the element gains focus.
-     * @param {object} event `focus` event targeting the element.
-     */
+    /** @ignore */
     onFocus: PropTypes.func,
     /**
      * Callback function fired when the element is focused or blurred by the keyboard.
@@ -90,24 +84,11 @@ class IconButton extends Component {
      * @param {boolean} keyboardFocused Indicates whether the element is focused.
      */
     onKeyboardFocus: PropTypes.func,
-    /**
-     * Callback function fired when the mouse enters the element.
-     *
-     * @param {object} event `mouseenter` event targeting the element.
-     */
+    /** @ignore */
     onMouseEnter: PropTypes.func,
-    /**
-     * Callback function fired when the mouse leaves the element.
-     *
-     * @param {object} event `mouseleave` event targeting the element.
-     */
+    /** @ignore */
     onMouseLeave: PropTypes.func,
-    /**
-     * Callback function fired when the mouse leaves the element. Unlike `onMouseLeave`,
-     * this callback will fire on disabled icon buttons.
-     *
-     * @param {object} event `mouseout` event targeting the element.
-     */
+    /** @ignore */
     onMouseOut: PropTypes.func,
     /**
      * Override the inline-styles of the root element.

--- a/src/IconMenu/IconMenu.js
+++ b/src/IconMenu/IconMenu.js
@@ -55,29 +55,13 @@ class IconMenu extends Component {
      * @param {boolean} keyboardFocused If true, the `IconButton` element is focused.
      */
     onKeyboardFocus: PropTypes.func,
-    /**
-     * Callback function fired when a mouse button is pressed down on the `IconButton` element.
-     *
-     * @param {object} event `mousedown` event targeting the `IconButton` element.
-     */
+    /** @ignore */
     onMouseDown: PropTypes.func,
-    /**
-     * Callback function fired when the mouse enters the `IconButton` element.
-     *
-     * @param {object} event `mouseenter` event targeting the `IconButton` element.
-     */
+    /** @ignore */
     onMouseEnter: PropTypes.func,
-    /**
-     * Callback function fired when the mouse leaves the `IconButton` element.
-     *
-     * @param {object} event `mouseleave` event targeting the `IconButton` element.
-     */
+    /** @ignore */
     onMouseLeave: PropTypes.func,
-    /**
-     * Callback function fired when a mouse button is released on the `IconButton` element.
-     *
-     * @param {object} event `mouseup` event targeting the `IconButton` element.
-     */
+    /** @ignore */
     onMouseUp: PropTypes.func,
     /**
      * Callback function fired when the `open` state of the menu is requested to be changed.

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -213,17 +213,9 @@ class ListItem extends Component {
      * @param {boolean} isKeyboardFocused If true, the `ListItem` is focused.
      */
     onKeyboardFocus: PropTypes.func,
-    /**
-     * Callback function fired when the mouse enters the `ListItem`.
-     *
-     * @param {object} event `mouseenter` event targeting the `ListItem`.
-     */
+    /** @ignore */
     onMouseEnter: PropTypes.func,
-    /**
-     * Callback function fired when the mouse leaves the `ListItem`.
-     *
-     * @param {object} event `mouseleave` event targeting the `ListItem`.
-     */
+    /** @ignore */
     onMouseLeave: PropTypes.func,
     /**
      * Callbak function fired when the `ListItem` toggles its nested list.
@@ -231,17 +223,9 @@ class ListItem extends Component {
      * @param {object} listItem The `ListItem`.
      */
     onNestedListToggle: PropTypes.func,
-    /**
-     * Callback function fired when the `ListItem` is touched.
-     *
-     * @param {object} event `touchstart` event targeting the `ListItem`.
-     */
+    /** @ignore */
     onTouchStart: PropTypes.func,
-    /**
-     * Callback function fired when the `ListItem` is touch-tapped.
-     *
-     * @param {object} event TouchTap event targeting the `ListItem`.
-     */
+    /** @ignore */
     onTouchTap: PropTypes.func,
     /**
      * This is the block element that contains the primary text.

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -136,12 +136,7 @@ class Menu extends Component {
      * @param {number} index The index of the menu item.
      */
     onItemTouchTap: PropTypes.func,
-    /**
-     * Callback function fired when the menu is focused and a key
-     * is pressed.
-     *
-     * @param {object} event `keydown` event targeting the menu.
-     */
+    /** @ignore */
     onKeyDown: PropTypes.func,
     /**
      * This is the placement of the menu relative to the `IconButton`.

--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -176,42 +176,17 @@ class RaisedButton extends Component {
      * Override the inline-styles of the button's label element.
      */
     labelStyle: PropTypes.object,
-    /**
-     * Callback function fired when a mouse button is pressed down on
-     * the element.
-     *
-     * @param {object} event `mousedown` event targeting the element.
-     */
+    /** @ignore */
     onMouseDown: PropTypes.func,
-    /**
-     * Callback function fired when the mouse enters the element.
-     *
-     * @param {object} event `mouseenter` event targeting the element.
-     */
+    /** @ignore */
     onMouseEnter: PropTypes.func,
-    /**
-     * Callback function fired when the mouse leaves the element.
-     *
-     * @param {object} event `mouseleave` event targeting the element.
-     */
+    /** @ignore */
     onMouseLeave: PropTypes.func,
-    /**
-     * Callback function fired when a mouse button is released on the element.
-     *
-     * @param {object} event `mouseup` event targeting the element.
-     */
+    /** @ignore */
     onMouseUp: PropTypes.func,
-    /**
-     * Callback function fired when a touch point is removed from the element.
-     *
-     * @param {object} event `touchend` event targeting the element.
-     */
+    /** @ignore */
     onTouchEnd: PropTypes.func,
-    /**
-     * Callback function fired when the element is touched.
-     *
-     * @param {object} event `touchstart` event targeting the element.
-     */
+    /** @ignore */
     onTouchStart: PropTypes.func,
     /**
      * If true, the button will use the theme's primary color.

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -88,11 +88,7 @@ class SelectField extends Component {
      * Override the inline-styles of the underlying `DropDownMenu` element.
      */
     menuStyle: PropTypes.object,
-    /**
-     * Callback function fired when the select field loses focus.
-     *
-     * @param {object} event `blur` event targeting the select field.
-     */
+    /** @ignore */
     onBlur: PropTypes.func,
     /**
      * Callback function fired when a menu item is selected.
@@ -103,11 +99,7 @@ class SelectField extends Component {
      * @param {any} payload The `value` prop of the selected menu item.
      */
     onChange: PropTypes.func,
-    /**
-     * Callback function fired when the select field gains focus.
-     *
-     * @param {object} event `focus` event targeting the select field.
-     */
+    /** @ignore */
     onFocus: PropTypes.func,
     /**
      * Override the inline-styles of the underlying `DropDownMenu` element.

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -188,9 +188,7 @@ class Slider extends Component {
      * of an input element.
      */
     name: PropTypes.string,
-    /**
-     * Callback function that is fired when the focus has left the slider.
-     */
+    /** @ignore */
     onBlur: PropTypes.func,
     /**
      * Callback function that is fired when the user changes the slider's value.
@@ -204,9 +202,7 @@ class Slider extends Component {
      * Callback function that is fried when the slide has stopped moving.
      */
     onDragStop: PropTypes.func,
-    /**
-     * Callback fired when the user has focused on the slider.
-     */
+    /** @ignore */
     onFocus: PropTypes.func,
     /**
      * Whether or not the slider is required in a form.

--- a/src/Stepper/StepButton.js
+++ b/src/Stepper/StepButton.js
@@ -53,23 +53,11 @@ class StepButton extends Component {
       PropTypes.string,
       PropTypes.number,
     ]),
-    /**
-     * Callback function fired when the mouse enters the element.
-     *
-     * @param {object} event `mouseenter` event targeting the element.
-     */
+    /** @ignore */
     onMouseEnter: PropTypes.func,
-    /**
-     * Callback function fired when the mouse leaves the element.
-     *
-     * @param {object} event `mouseleave` event targeting the element.
-     */
+    /** @ignore */
     onMouseLeave: PropTypes.func,
-    /**
-     * Callback function fired when the element is touched.
-     *
-     * @param {object} event `touchstart` event targeting the element.
-     */
+    /** @ignore */
     onTouchStart: PropTypes.func,
     /**
      * Override the inline-style of the root element.

--- a/src/SvgIcon/SvgIcon.js
+++ b/src/SvgIcon/SvgIcon.js
@@ -19,13 +19,9 @@ class SvgIcon extends Component {
      * This is the icon color when the mouse hovers over the icon.
      */
     hoverColor: PropTypes.string,
-    /**
-     * Function called when mouse enters this element.
-     */
+    /** @ignore */
     onMouseEnter: PropTypes.func,
-    /**
-     * Function called when mouse leaves this element.
-     */
+    /** @ignore */
     onMouseLeave: PropTypes.func,
     /**
      * Override the inline-styles of the root element.

--- a/src/Table/TableHeaderColumn.js
+++ b/src/Table/TableHeaderColumn.js
@@ -36,10 +36,7 @@ class TableHeaderColumn extends Component {
      * is automatically populated when used with TableHeader.
      */
     columnNumber: PropTypes.number,
-    /**
-     * @ignore
-     * Callback function for click event.
-     */
+    /** @ignore */
     onClick: PropTypes.func,
     /**
      * Override the inline-styles of the root element.

--- a/src/Table/TableRowColumn.js
+++ b/src/Table/TableRowColumn.js
@@ -41,15 +41,9 @@ class TableRowColumn extends Component {
      * If true, this column responds to hover events.
      */
     hoverable: PropTypes.bool,
-    /**
-     * @ignore
-     * Callback function for click event.
-     */
+    /** @ignore */
     onClick: PropTypes.func,
-    /**
-     * @ignore
-     * Callback function for hover event.
-     */
+    /** @ignore */
     onHover: PropTypes.func,
     /**
      * @ignore

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -181,9 +181,7 @@ class TextField extends Component {
      * Name applied to the input.
      */
     name: PropTypes.string,
-    /**
-     * Callback function that is fired when the textfield loses focus.
-     */
+    /** @ignore */
     onBlur: PropTypes.func,
     /**
      * Callback function that is fired when the textfield's value changes.
@@ -194,13 +192,9 @@ class TextField extends Component {
      */
     onEnterKeyDown: deprecated(PropTypes.func,
       'Use onKeyDown and check for keycode instead.'),
-    /**
-     * Callback function that is fired when the textfield gains focus.
-     */
+    /** @ignore */
     onFocus: PropTypes.func,
-    /**
-     * Callback function fired when key is pressed down.
-     */
+    /** @ignore */
     onKeyDown: PropTypes.func,
     /**
      * Number of rows to display when multiLine option is set to true.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Per [previous discussion](https://github.com/callemall/material-ui/issues/3172#issuecomment-216901922), we don't need to document standard DOM events just because they happen to have been used internally by the component and bubbled up.

