### PR TITLE
[TableBody] Don't set childrens' hoverable prop to false when showRow…

### DIFF
--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -165,7 +165,6 @@ class TableBody extends Component {
       if (React.isValidElement(child)) {
         const props = {
           displayRowCheckbox: this.props.displayRowCheckbox,
-          hoverable: this.props.showRowHover,
           selected: this.isRowSelected(rowNumber),
           striped: this.props.stripedRows && (rowNumber % 2 === 0),
           rowNumber: rowNumber++,
@@ -174,6 +173,10 @@ class TableBody extends Component {
 
         if (rowNumber === numChildren) {
           props.displayBorder = false;
+        }
+
+        if (this.props.showRowHover) {
+          props.hoverable = true;
         }
 
         const children = [checkboxColumn];

--- a/src/Table/TableBody.spec.js
+++ b/src/Table/TableBody.spec.js
@@ -1,0 +1,45 @@
+/* eslint-env mocha */
+import React from 'react';
+import {shallow} from 'enzyme';
+import {assert} from 'chai';
+import TableBody from './TableBody';
+import TableRow from './TableRow';
+import getMuiTheme from '../styles/getMuiTheme';
+
+describe('<TableBody />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
+  it("does not set child TableRow's hoverable prop to false when showRowHover prop is not specified", () => {
+    const wrapper = shallowWithContext(
+      <TableBody>
+        <TableRow hoverable={true} />
+      </TableBody>
+    );
+    const tableRow = wrapper.find(TableRow);
+
+    assert.isTrue(tableRow.props().hoverable, 'tableRow hoverable should be true');
+  });
+
+  it("does not set child TableRow's hoverable prop to false when showRowHover prop is set to false", () => {
+    const wrapper = shallowWithContext(
+      <TableBody showRowHover={false}>
+        <TableRow hoverable={true} />
+      </TableBody>
+    );
+    const tableRow = wrapper.find(TableRow);
+
+    assert.isTrue(tableRow.props().hoverable, 'tableRow hoverable should be true');
+  });
+
+  it("sets child TableRow's hoverable prop to true when showRowHover prop is set to true", () => {
+    const wrapper = shallowWithContext(
+      <TableBody showRowHover={true}>
+        <TableRow />
+      </TableBody>
+    );
+    const tableRow = wrapper.find(TableRow);
+
+    assert.isTrue(tableRow.props().hoverable, 'tableRow hoverable should be true');
+  });
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


…Hover is falsy

Hey, I was working on finishing the callback signatures for the Docs, and I noticed that the `onCellHover` callback of the `Table` component wasn't being called, even when `hoverable` was set to `true` on all the child elements.

The problem is that when `showRowHover` isn't specified on `TableBody`, it will render its child `TableRow` elements with `hoverable` set to `false`, even if I specify it as `true`.  For example, 

~~~
 <TableBody>
        <TableRow hoverable={true} />
 </TableBody>
~~~

would be rendered as if `hoverable` was `false`.

I think `onCellHover` callbacks should still be able to fire regardless of the value of  `showRowHover`, and this PR allows that.