### PR TITLE
[SelectableList] Allow nested/wrapped ListItems

### DIFF
--- a/docs/src/app/components/pages/components/List/ExampleSelectable.js
+++ b/docs/src/app/components/pages/components/List/ExampleSelectable.js
@@ -28,6 +28,7 @@ function wrapState(ComposedComponent) {
     render() {
       return (
         <ComposedComponent
+          {...this.props}
           value={this.state.selectedIndex}
           onChange={this.handleRequestChange}
         >

--- a/docs/src/app/components/pages/components/List/ExampleSelectable.js
+++ b/docs/src/app/components/pages/components/List/ExampleSelectable.js
@@ -43,35 +43,40 @@ SelectableList = wrapState(SelectableList);
 
 const ListExampleSelectable = () => (
   <MobileTearSheet>
-    <SelectableList defaultValue={3}>
+    <SelectableList
+      defaultValue={3}
+      traverse={['div']}
+    >
       <Subheader>Selectable Contacts</Subheader>
-      <ListItem
-        value={1}
-        primaryText="Brendan Lim"
-        leftAvatar={<Avatar src="images/ok-128.jpg" />}
-        nestedItems={[
-          <ListItem
-            value={2}
-            primaryText="Grace Ng"
-            leftAvatar={<Avatar src="images/uxceo-128.jpg" />}
-          />,
-        ]}
-      />
-      <ListItem
-        value={3}
-        primaryText="Kerem Suer"
-        leftAvatar={<Avatar src="images/kerem-128.jpg" />}
-      />
-      <ListItem
-        value={4}
-        primaryText="Eric Hoffman"
-        leftAvatar={<Avatar src="images/kolage-128.jpg" />}
-      />
-      <ListItem
-        value={5}
-        primaryText="Raquel Parrado"
-        leftAvatar={<Avatar src="images/raquelromanp-128.jpg" />}
-      />
+      <div>
+        <ListItem
+          value={1}
+          primaryText="Brendan Lim"
+          leftAvatar={<Avatar src="images/ok-128.jpg" />}
+          nestedItems={[
+            <ListItem
+              value={2}
+              primaryText="Grace Ng"
+              leftAvatar={<Avatar src="images/uxceo-128.jpg" />}
+            />,
+          ]}
+        />
+        <ListItem
+          value={3}
+          primaryText="Kerem Suer"
+          leftAvatar={<Avatar src="images/kerem-128.jpg" />}
+        />
+        <ListItem
+          value={4}
+          primaryText="Eric Hoffman"
+          leftAvatar={<Avatar src="images/kolage-128.jpg" />}
+        />
+        <ListItem
+          value={5}
+          primaryText="Raquel Parrado"
+          leftAvatar={<Avatar src="images/raquelromanp-128.jpg" />}
+        />
+      </div>
     </SelectableList>
   </MobileTearSheet>
 );

--- a/src/List/List.js
+++ b/src/List/List.js
@@ -31,6 +31,11 @@ class List extends Component {
     subheaderStyle: deprecated(PropTypes.object,
       'Refer to the `subheader` property.'),
     /**
+     * For selectable lists, this array specifies component
+     * type names that are searched for nested ListItem components.
+     */
+    traverse: PropTypes.array,
+    /**
      * @ignore
      * ** Breaking change ** List no longer supports `zDepth`. Instead, wrap it in `Paper`
      * or another component that provides zDepth.

--- a/src/List/MakeSelectable.js
+++ b/src/List/MakeSelectable.js
@@ -8,6 +8,7 @@ export const MakeSelectable = (Component) => {
       children: PropTypes.node,
       onChange: PropTypes.func,
       selectedItemStyle: PropTypes.object,
+      traverse: PropTypes.array,
       value: PropTypes.any,
       valueLink: deprecated(PropTypes.shape({
         value: PropTypes.any,
@@ -50,6 +51,16 @@ export const MakeSelectable = (Component) => {
           nestedItems: child.props.nestedItems.map((child) => this.extendChild(child, styles, selectedItemStyle)),
           initiallyOpen: this.isInitiallyOpen(child),
         });
+      
+      } else if (child && child.type && this.props.traverse &&
+                 this.props.traverse.indexOf(child.type.name || child.type) >= 0) {
+
+        return React.cloneElement(child, undefined,
+          React.Children.map(child.props.children, (child) => (
+            this.extendChild(child, styles, selectedItemStyle)
+          ))
+        );
+
       } else {
         return child;
       }


### PR DESCRIPTION
This closes #4432, which was discussed in #3103

Allows wrappers inside `SelectableList`s. This is useful for adding additional libraries, e.g. ones that could provide drag and drop functionality to the `ListItem`s. Previously, `ListItems` needed to be directly descended from the `SelectableList` for the selection functionality to work.

<!-- Thanks so much for your PR, your contribution is appreciated! -->
- [ ] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).
