### PR TITLE
[IconMenu] Add `animated` prop for internal `Popover`

### DIFF
--- a/src/IconMenu/IconMenu.js
+++ b/src/IconMenu/IconMenu.js
@@ -18,6 +18,10 @@ class IconMenu extends Component {
      */
     anchorOrigin: propTypes.origin,
     /**
+     * If false, disables the `Popover` animation on close.
+     */
+    animated: PropTypes.bool,
+    /**
      * Should be used to pass `MenuItem` components.
      */
     children: PropTypes.node,
@@ -129,6 +133,7 @@ class IconMenu extends Component {
       vertical: 'top',
       horizontal: 'left',
     },
+    animated: true,
     multiple: false,
     open: null,
     onItemTouchTap: () => {},
@@ -233,6 +238,7 @@ class IconMenu extends Component {
   render() {
     const {
       anchorOrigin,
+      animated,
       className,
       iconButtonElement,
       iconStyle,
@@ -303,6 +309,7 @@ class IconMenu extends Component {
         {iconButton}
         <Popover
           anchorOrigin={anchorOrigin}
+          animated={animated}
           targetOrigin={targetOrigin}
           open={open}
           anchorEl={anchorEl}


### PR DESCRIPTION
Previously, usages of `IconMenu` provided no control over its internal `Popover` components animation. The default option (`animation: true`) was the only option available to `IconMenu`. An 'animation' prop was added to `IconMenu` which is passed to the `Popover`, allowing users to disable animations if desired.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [X] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


