### PR TITLE
[DatePicker] Fix layout when used with border-box

### DIFF
--- a/src/DatePicker/Calendar.js
+++ b/src/DatePicker/Calendar.js
@@ -8,7 +8,6 @@ import CalendarYear from './CalendarYear';
 import CalendarToolbar from './CalendarToolbar';
 import DateDisplay from './DateDisplay';
 import SlideInTransitionGroup from '../internal/SlideIn';
-import ClearFix from '../internal/ClearFix';
 
 import {
   addDays,
@@ -262,7 +261,6 @@ class Calendar extends Component {
         fontWeight: 400,
         padding: '0px 8px',
         transition: transitions.easeOut(),
-        width: isLandscape ? 294 : 'auto',
       },
       yearContainer: {
         display: 'flex',
@@ -272,12 +270,6 @@ class Calendar extends Component {
         marginTop: 10,
         overflow: 'hidden',
         width: 310,
-      },
-      dateDisplay: {
-        width: isLandscape ? 125 : 270,
-        height: isLandscape ? 290 : 'auto',
-        float: isLandscape ? 'left' : 'none',
-        fontWeight: 'bolder',
       },
       weekTitle: {
         display: 'flex',
@@ -297,10 +289,12 @@ class Calendar extends Component {
       },
     };
 
-    const weekTitleDayStyle = prepareStyles(styles.weekTitleDay);
-    const weekTitleStyle = prepareStyles(styles.weekTitle);
-    const calendarContainerStyle = prepareStyles(styles.calendarContainer);
-    const yearContainerStyle = prepareStyles(styles.yearContainer);
+    prepareStyles(styles.root);
+    prepareStyles(styles.calendar);
+    prepareStyles(styles.calendarContainer);
+    prepareStyles(styles.weekTitle);
+    prepareStyles(styles.weekTitleDay);
+    prepareStyles(styles.yearContainer);
 
     const {
       cancelLabel,
@@ -314,7 +308,7 @@ class Calendar extends Component {
     } = this.props;
 
     return (
-      <ClearFix style={styles.root}>
+      <div style={styles.root}>
         <EventListener
           target="window"
           onKeyDown={this.handleWindowKeyDown}
@@ -332,7 +326,7 @@ class Calendar extends Component {
         />
         <div style={styles.calendar}>
           {this.state.displayMonthDay &&
-            <div style={calendarContainerStyle}>
+            <div style={styles.calendarContainer}>
               <CalendarToolbar
                 DateTimeFormat={DateTimeFormat}
                 locale={locale}
@@ -341,9 +335,9 @@ class Calendar extends Component {
                 prevMonth={toolbarInteractions.prevMonth}
                 nextMonth={toolbarInteractions.nextMonth}
               />
-              <div style={weekTitleStyle}>
+              <div style={styles.weekTitle}>
                 {daysArray.map((event, i) => (
-                  <span key={i} style={weekTitleDayStyle}>
+                  <span key={i} style={styles.weekTitleDay}>
                     {localizedWeekday(DateTimeFormat, locale, i, firstDayOfWeek)}
                   </span>
                 ))}
@@ -364,7 +358,7 @@ class Calendar extends Component {
             </div>
           }
           {!this.state.displayMonthDay &&
-            <div style={yearContainerStyle}>
+            <div style={styles.yearContainer}>
               {this.yearSelector()}
             </div>
           }
@@ -379,7 +373,7 @@ class Calendar extends Component {
             />
           }
         </div>
-      </ClearFix>
+      </div>
     );
   }
 }

--- a/src/DatePicker/Calendar.js
+++ b/src/DatePicker/Calendar.js
@@ -289,13 +289,6 @@ class Calendar extends Component {
       },
     };
 
-    prepareStyles(styles.root);
-    prepareStyles(styles.calendar);
-    prepareStyles(styles.calendarContainer);
-    prepareStyles(styles.weekTitle);
-    prepareStyles(styles.weekTitleDay);
-    prepareStyles(styles.yearContainer);
-
     const {
       cancelLabel,
       DateTimeFormat,
@@ -308,7 +301,7 @@ class Calendar extends Component {
     } = this.props;
 
     return (
-      <div style={styles.root}>
+      <div style={prepareStyles(styles.root)}>
         <EventListener
           target="window"
           onKeyDown={this.handleWindowKeyDown}
@@ -324,9 +317,9 @@ class Calendar extends Component {
           selectedDate={this.state.selectedDate}
           weekCount={weekCount}
         />
-        <div style={styles.calendar}>
+        <div style={prepareStyles(styles.calendar)}>
           {this.state.displayMonthDay &&
-            <div style={styles.calendarContainer}>
+            <div style={prepareStyles(styles.calendarContainer)}>
               <CalendarToolbar
                 DateTimeFormat={DateTimeFormat}
                 locale={locale}
@@ -335,9 +328,9 @@ class Calendar extends Component {
                 prevMonth={toolbarInteractions.prevMonth}
                 nextMonth={toolbarInteractions.nextMonth}
               />
-              <div style={styles.weekTitle}>
+              <div style={prepareStyles(styles.weekTitle)}>
                 {daysArray.map((event, i) => (
-                  <span key={i} style={styles.weekTitleDay}>
+                  <span key={i} style={prepareStyles(styles.weekTitleDay)}>
                     {localizedWeekday(DateTimeFormat, locale, i, firstDayOfWeek)}
                   </span>
                 ))}
@@ -358,7 +351,7 @@ class Calendar extends Component {
             </div>
           }
           {!this.state.displayMonthDay &&
-            <div style={styles.yearContainer}>
+            <div style={prepareStyles(styles.yearContainer)}>
               {this.yearSelector()}
             </div>
           }

--- a/src/DatePicker/DateDisplay.js
+++ b/src/DatePicker/DateDisplay.js
@@ -9,8 +9,8 @@ function getStyles(props, context, state) {
 
   const styles = {
     root: {
-      width: isLandscape ? 125 : 270,
-      height: isLandscape ? 290 : 'auto',
+      width: isLandscape ? 165 : '100%',
+      height: isLandscape ? 330 : 'auto',
       float: isLandscape ? 'left' : 'none',
       fontWeight: 700,
       display: 'inline-block',
@@ -20,6 +20,7 @@ function getStyles(props, context, state) {
       borderBottomLeftRadius: isLandscape ? 2 : 0,
       color: datePicker.textColor,
       padding: 20,
+      boxSizing: 'border-box',
     },
     monthDay: {
       display: 'block',
@@ -119,9 +120,15 @@ class DateDisplay extends Component {
   render() {
     const {
       DateTimeFormat,
+      disableYearSelection, // eslint-disable-line no-unused-vars
       locale,
-      selectedDate,
+      mode, // eslint-disable-line no-unused-vars
+      monthDaySelected, // eslint-disable-line no-unused-vars
+      onTouchTapMonthDay, // eslint-disable-line no-unused-vars
+      onTouchTapYear, // eslint-disable-line no-unused-vars
+      selectedDate, // eslint-disable-line no-unused-vars
       style,
+      weekCount, // eslint-disable-line no-unused-vars
       ...other,
     } = this.props;
 

--- a/src/DatePicker/DatePickerDialog.js
+++ b/src/DatePicker/DatePickerDialog.js
@@ -126,6 +126,7 @@ class DatePickerDialog extends Component {
     };
 
     const Container = (container === 'inline' ? Popover : Dialog);
+
     return (
       <div {...other} ref="root">
         <Container


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

DatePicker would display incorrectly when used with `box-sizing: border-box` as described in #4422.

Also remove an unnecessary `Clearfix`.
Also remove unnecessary assignment of `prepareStyles` (arguably these could go right into the style prop like in every other component).
Also add some props to the destructure in `DateDisplay` to prevent them being passed down.

Closes #4259.
