### PR TITLE
[Stepper] Register clicks in Safari for Vertical non-linear example

### DIFF
--- a/docs/src/app/components/pages/components/Stepper/VerticalNonLinearStepper.js
+++ b/docs/src/app/components/pages/components/Stepper/VerticalNonLinearStepper.js
@@ -65,7 +65,7 @@ class VerticalNonLinear extends React.Component {
           orientation="vertical"
         >
           <Step>
-            <StepButton onClick={() => this.setState({stepIndex: 0})}>
+            <StepButton onTouchTap={() => this.setState({stepIndex: 0})}>
               Select campaign settings
             </StepButton>
             <StepContent>
@@ -78,7 +78,7 @@ class VerticalNonLinear extends React.Component {
             </StepContent>
           </Step>
           <Step>
-            <StepButton onClick={() => this.setState({stepIndex: 1})}>
+            <StepButton onTouchTap={() => this.setState({stepIndex: 1})}>
               Create an ad group
             </StepButton>
             <StepContent>
@@ -87,7 +87,7 @@ class VerticalNonLinear extends React.Component {
             </StepContent>
           </Step>
           <Step>
-            <StepButton onClick={() => this.setState({stepIndex: 2})}>
+            <StepButton onTouchTap={() => this.setState({stepIndex: 2})}>
               Create an ad
             </StepButton>
             <StepContent>


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

[Stepper] Now a single click works for stepper example in Safari. `onClick` was replaced with `onTouchTap` as it works on both Safari and Chrome. Closes issue #4421
