### PR TITLE
[AppBar] Fix a styling regression

### DIFF
--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -218,8 +218,8 @@ class AppBar extends Component {
 
       if (iconElementLeft) {
         if (iconElementLeft.type.muiName === 'IconButton') {
-          const iconButtonIconStyle = !iconElementLeft.props.children &&
-            iconElementLeft.props.children.props.color ? styles.iconButtonIconStyle : null;
+          const iconButtonIconStyle = !(iconElementLeft.props.children &&
+            iconElementLeft.props.children.props.color) ? styles.iconButtonIconStyle : null;
 
           iconElementLeftNode = React.cloneElement(iconElementLeft, {
             iconStyle: Object.assign({}, iconButtonIconStyle, iconElementLeft.props.iconStyle),

--- a/src/AppBar/AppBar.spec.js
+++ b/src/AppBar/AppBar.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import React from 'react';
-import sinon from 'sinon';
+import {spy} from 'sinon';
 import {shallow} from 'enzyme';
 import {assert} from 'chai';
 import AppBar, {getStyles} from './AppBar';
@@ -12,7 +12,7 @@ describe('<AppBar />', () => {
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
 
   it('renders children by default', () => {
-    const testChildren = <div className="unique">Hello World</div>;
+    const testChildren = <div />;
     const wrapper = shallowWithContext(
       <AppBar>{testChildren}</AppBar>
     );
@@ -34,7 +34,7 @@ describe('<AppBar />', () => {
       <AppBar iconClassNameLeft={iconClassName} />
     );
 
-    assert.equal(wrapper.find('IconButton').get(0).props.iconClassName, iconClassName,
+    assert.strictEqual(wrapper.find(IconButton).get(0).props.iconClassName, iconClassName,
       'should contain iconClassNameLeft');
   });
 
@@ -44,7 +44,7 @@ describe('<AppBar />', () => {
       <AppBar iconClassNameRight={iconClassName} />
     );
 
-    assert.equal(wrapper.find('IconButton').get(1).props.iconClassName, iconClassName,
+    assert.strictEqual(wrapper.find(IconButton).get(1).props.iconClassName, iconClassName,
       'should contain iconClassNameRight');
   });
 
@@ -55,18 +55,32 @@ describe('<AppBar />', () => {
       <AppBar iconClassNameLeft={iconClassNameLeft} iconClassNameRight={iconClassNameRight} />
     );
 
-    assert.equal(wrapper.find('IconButton').get(0).props.iconClassName, iconClassNameLeft,
+    assert.strictEqual(wrapper.find(IconButton).get(0).props.iconClassName, iconClassNameLeft,
       'should contain iconClassNameLeft');
-    assert.equal(wrapper.find('IconButton').get(1).props.iconClassName, iconClassNameRight,
+    assert.strictEqual(wrapper.find(IconButton).get(1).props.iconClassName, iconClassNameRight,
       'should contain iconClassNameRight');
   });
 
-  it('renders iconElementLeft', () => {
-    const wrapper = shallowWithContext(
-      <AppBar iconElementLeft={<span className="icon" />} />
-    );
+  describe('iconElementLeft', () => {
+    it('renders the node', () => {
+      const wrapper = shallowWithContext(
+        <AppBar iconElementLeft={<span className="icon" />} />
+      );
 
-    assert.equal(wrapper.find('.icon').length, 1, 'should contain iconElementLeft');
+      assert.strictEqual(wrapper.find('.icon').length, 1, 'should contain iconElementLeft');
+    });
+
+    it('renders the IconButton with a correct style', () => {
+      const wrapper = shallowWithContext(
+        <AppBar iconElementLeft={<IconButton><div /></IconButton>} />
+      );
+
+      assert.strictEqual(
+        Object.keys(wrapper.find(IconButton).get(0).props.iconStyle).length > 0,
+        true,
+        'should add some properties to the iconStyle'
+      );
+    });
   });
 
   it('renders iconElementRight', () => {
@@ -74,11 +88,11 @@ describe('<AppBar />', () => {
       <AppBar iconElementRight={<span className="icon" />} />
     );
 
-    assert.equal(wrapper.find('.icon').length, 1, 'should contain iconElementRight');
+    assert.strictEqual(wrapper.find('.icon').length, 1, 'should contain iconElementRight');
   });
 
   it('call onLeftIconButtonTouchTap callback', () => {
-    const onLeftIconButtonTouchTap = sinon.spy();
+    const onLeftIconButtonTouchTap = spy();
     const iconClassNameLeft = 'muidocs-icon-action-home';
     const wrapper = shallowWithContext(
       <AppBar
@@ -87,13 +101,13 @@ describe('<AppBar />', () => {
       />
     );
 
-    wrapper.find('IconButton').simulate('touchTap');
-    assert.equal(onLeftIconButtonTouchTap.calledOnce, true,
+    wrapper.find(IconButton).simulate('touchTap');
+    assert.strictEqual(onLeftIconButtonTouchTap.calledOnce, true,
       'should have called onLeftIconButtonTouchTap callback function');
   });
 
   it('call onRightIconButtonTouchTap callback', () => {
-    const onRightIconButtonTouchTap = sinon.spy();
+    const onRightIconButtonTouchTap = spy();
     const iconClassNameRight = 'muidocs-icon-action-home';
     const wrapper = shallowWithContext(
       <AppBar
@@ -102,34 +116,28 @@ describe('<AppBar />', () => {
       />
     );
 
-    wrapper.find('IconButton').at(1).simulate('touchTap');
-    assert.equal(onRightIconButtonTouchTap.calledOnce, true,
+    wrapper.find(IconButton).at(1).simulate('touchTap');
+    assert.strictEqual(onRightIconButtonTouchTap.calledOnce, true,
       'should have called onRightIconButtonTouchTap callback function');
   });
 
   it('call onTitleTouchTap callback', () => {
-    const onTitleTouchTap = sinon.spy();
+    const onTitleTouchTap = spy();
     const wrapper = shallowWithContext(
-      <AppBar
-        title="Title"
-        onTitleTouchTap={onTitleTouchTap}
-      />
+      <AppBar title="Title" onTitleTouchTap={onTitleTouchTap} />
     );
 
     wrapper.find('h1').simulate('touchTap');
-    assert.equal(onTitleTouchTap.calledOnce, true,
+    assert.strictEqual(onTitleTouchTap.calledOnce, true,
       'should have called onTitleTouchTap callback function');
   });
 
   it('hide menu icon when showMenuIconButton is false', () => {
     const wrapper = shallowWithContext(
-      <AppBar
-        title="Title"
-        showMenuIconButton={false}
-      />
+      <AppBar title="Title" showMenuIconButton={false} />
     );
 
-    assert.equal(wrapper.find('IconButton').length, 0, 'should not have menu icon');
+    assert.strictEqual(wrapper.find(IconButton).length, 0, 'should not have menu icon');
   });
 
   it('renders AppBar and overwrite styles', () => {
@@ -140,7 +148,7 @@ describe('<AppBar />', () => {
       <AppBar title="Title" style={style} />
     );
 
-    assert.equal(wrapper.get(0).props.style.backgroundColor, style.backgroundColor,
+    assert.strictEqual(wrapper.get(0).props.style.backgroundColor, style.backgroundColor,
       'should have backgroundColor to red');
   });
 
@@ -149,7 +157,7 @@ describe('<AppBar />', () => {
       <AppBar title="Title" />
     );
 
-    assert.equal(wrapper.find('h1').length, 1, 'should have title');
+    assert.strictEqual(wrapper.find('h1').length, 1, 'should have title');
   });
 
   it('renders title and overwrite title styles', () => {
@@ -160,8 +168,8 @@ describe('<AppBar />', () => {
       <AppBar title="Title" titleStyle={titleStyle} />
     );
 
-    assert.equal(wrapper.find('h1').length, 1, 'should have title');
-    assert.equal(wrapper.find('h1').get(0).props.style.backgroundColor,
+    assert.strictEqual(wrapper.find('h1').length, 1, 'should have title');
+    assert.strictEqual(wrapper.find('h1').get(0).props.style.backgroundColor,
       titleStyle.backgroundColor, 'should have backgroundColor to red');
   });
 
@@ -170,7 +178,7 @@ describe('<AppBar />', () => {
       <AppBar title="Title" zDepth={2} />
     );
 
-    assert.equal(wrapper.find('Paper').get(0).props.zDepth, 2, 'should have zDepth to 2');
+    assert.strictEqual(wrapper.find('Paper').get(0).props.zDepth, 2, 'should have zDepth to 2');
   });
 
   it('menuElementLeft\'s style should be iconButtonStyle', () => {

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -201,6 +201,7 @@ class IconButton extends Component {
     const {
       disabled,
       disableTouchRipple,
+      children,
       iconClassName,
       tooltip,
       touch,
@@ -241,7 +242,7 @@ class IconButton extends Component {
           )}
           color={this.context.muiTheme.baseTheme.palette.textColor}
         >
-          {this.props.children}
+          {children}
         </FontIcon>
       );
     }
@@ -265,7 +266,7 @@ class IconButton extends Component {
       >
         {tooltipElement}
         {fonticon}
-        {extendChildren(this.props.children, {
+        {extendChildren(children, {
           style: childrenStyle,
         })}
       </EnhancedButton>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

https://github.com/callemall/material-ui/pull/4025 has introduced a visual regression:
![capture d ecran 2016-06-10 a 21 58 59](https://cloud.githubusercontent.com/assets/3165635/15978428/32adf618-2f5e-11e6-9c34-1aac082475ea.png).
It's a simple typo, we miss the `()` as we use for the *right* properties.


