### PR TITLE
[MenuItem] Allow styles on lefticon in non-desktop mode

### DIFF
--- a/src/MenuItem/MenuItem.js
+++ b/src/MenuItem/MenuItem.js
@@ -238,8 +238,9 @@ class MenuItem extends Component {
 
     // Left Icon
     let leftIconElement = leftIcon ? leftIcon : checked ? <CheckIcon /> : null;
-    if (leftIconElement && desktop) {
-      const mergedLeftIconStyles = Object.assign(styles.leftIconDesktop, leftIconElement.props.style);
+    if (leftIconElement) {
+      const mergedLeftIconStyles = desktop ?
+        Object.assign(styles.leftIconDesktop, leftIconElement.props.style) : leftIconElement.props.style;
       leftIconElement = React.cloneElement(leftIconElement, {style: mergedLeftIconStyles});
     }
 


### PR DESCRIPTION
Currently it is only possible to style the icon if the entire MenuItem is in desktop mode. Be consistent with the right icon and allow styling.