### PR TITLE
[TextField] Keep spreading properties when children is set

### DIFF
--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -181,6 +181,7 @@ class SelectField extends Component {
 
     return (
       <TextField
+        {...other}
         style={style}
         floatingLabelFixed={floatingLabelFixed}
         floatingLabelText={floatingLabelText}
@@ -196,7 +197,6 @@ class SelectField extends Component {
         id={id}
         underlineDisabledStyle={underlineDisabledStyle}
         underlineFocusStyle={underlineFocusStyle}
-        {...other}
       >
         <DropDownMenu
           disabled={disabled}

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -384,6 +384,7 @@ class TextField extends Component {
 
   render() {
     const {
+      children,
       className,
       disabled,
       errorStyle,
@@ -445,12 +446,12 @@ class TextField extends Component {
     const inputStyleMerged = Object.assign(styles.input, inputStyle);
 
     let inputElement;
-    if (this.props.children) {
-      inputElement = React.cloneElement(this.props.children,
+    if (children) {
+      inputElement = React.cloneElement(children,
         {
           ...inputProps,
-          ...this.props.children.props,
-          style: Object.assign(inputStyleMerged, this.props.children.props.style),
+          ...children.props,
+          style: Object.assign(inputStyleMerged, children.props.style),
         });
     } else {
       inputElement = multiLine ? (
@@ -473,8 +474,18 @@ class TextField extends Component {
       );
     }
 
+    let rootProps = {};
+
+    if (children) {
+      rootProps = other;
+    }
+
     return (
-      <div className={className} style={prepareStyles(Object.assign(styles.root, style))}>
+      <div
+        {...rootProps}
+        className={className}
+        style={prepareStyles(Object.assign(styles.root, style))}
+      >
         {floatingLabelTextElement}
         {hintText ?
           <TextFieldHint

--- a/src/TextField/TextField.spec.js
+++ b/src/TextField/TextField.spec.js
@@ -48,7 +48,7 @@ describe('<TextField />', () => {
         defaultValue="default value"
         value={null}
       />
-      );
+    );
     assert.strictEqual(wrapper.find(TextFieldLabel).props().shrink, true, 'should shrink TextFieldLabel');
 
     // make input change
@@ -61,5 +61,20 @@ describe('<TextField />', () => {
     wrapper.setProps({value: null});
     assert.strictEqual(wrapper.state().isClean, false);
     assert.strictEqual(wrapper.find(TextFieldLabel).props().shrink, false, 'should not shrink TextFieldLabel');
+  });
+
+  describe('props: children', () => {
+    it('should forward any property to the root', () => {
+      const wrapper = shallowWithContext(
+        <TextField data-test="hello">
+          <div />
+        </TextField>
+      );
+
+      assert.strictEqual(
+        wrapper.is('[data-test="hello"]'), true,
+        'The root element should receive any additional properties'
+      );
+    });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

To put some context, I'm using the `data-test` properties for my end to end tests.
It was broken by https://github.com/callemall/material-ui/pull/4392.