### PR TITLE
[RaisedButton] Fix the fullWidth regression

### DIFF
--- a/docs/src/app/components/pages/components/RaisedButton/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/RaisedButton/ExampleSimple.js
@@ -11,6 +11,9 @@ const RaisedButtonExampleSimple = () => (
     <RaisedButton label="Primary" primary={true} style={style} />
     <RaisedButton label="Secondary" secondary={true} style={style} />
     <RaisedButton label="Disabled" disabled={true} style={style} />
+    <br />
+    <br />
+    <RaisedButton label="Full width" fullWidth={true} />
   </div>
 );
 

--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -63,10 +63,10 @@ function getStyles(props, context, state) {
     root: {
       display: 'inline-block',
       transition: transitions.easeOut(),
+      minWidth: fullWidth ? '100%' : button.minWidth,
     },
     button: {
       position: 'relative',
-      minWidth: fullWidth ? '100%' : button.minWidth,
       height: buttonHeight,
       lineHeight: `${buttonHeight}px`,
       width: '100%',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Alternately, here is my shot at solving https://github.com/callemall/material-ui/pull/4225.
@leonuh could you have a look at this?

Closes https://github.com/callemall/material-ui/issues/4226.