### PR TITLE
[SvgIcon] Remove unused style assignment

### DIFF
--- a/src/SvgIcon/SvgIcon.js
+++ b/src/SvgIcon/SvgIcon.js
@@ -79,10 +79,7 @@ class SvgIcon extends Component {
       prepareStyles,
     } = this.context.muiTheme;
 
-    const offColor = color ? color :
-      style && style.fill ? style.fill :
-        'currentColor';
-
+    const offColor = color ? color : 'currentColor';
     const onColor = hoverColor ? hoverColor : offColor;
 
     const mergedStyles = Object.assign({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

If `fill` is set with the `style` prop it will always override `fill` in the `mergedStyles` object due to `Object.assign`. Therefore conditionally applying it to `fill` in the assignment is redundant.
