### PR TITLE
[SvgIcon] Add support for color attribute

### DIFF
--- a/src/SvgIcon/SvgIcon.js
+++ b/src/SvgIcon/SvgIcon.js
@@ -81,11 +81,13 @@ class SvgIcon extends Component {
 
     const offColor = color ? color :
       style && style.fill ? style.fill :
-      baseTheme.palette.textColor;
+        'currentColor';
+
     const onColor = hoverColor ? hoverColor : offColor;
 
     const mergedStyles = Object.assign({
       display: 'inline-block',
+      color: baseTheme.palette.textColor,
       fill: this.state.hovered ? onColor : offColor,
       height: 24,
       width: 24,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

This PR allows users to supply the icon color using the `color` attribute but is fully backwards compatible with current default color and `fill` behaviour.
