### PR TITLE
[TextField] False should be a valid value

### DIFF
--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -109,7 +109,7 @@ const getStyles = (props, context, state) => {
  * @returns True if the string provided is valid, false otherwise.
  */
 function isValid(value) {
-  return Boolean(value || value === 0);
+  return Boolean(value || value === 0 || value === false);
 }
 
 class TextField extends Component {


### PR DESCRIPTION
`isValid` in `TextField` has a special case for `0` as a valid value. This PR adds `false` as a valid value too.

For example using a `SelectField` with the following `MenuItems`:
```
<MenuItem value={true} primaryText="Yes"/>
<MenuItem value={false} primaryText="No"/>
```
Before this PR the `floatingLabelText` would overlap the `primaryText` when `No` was selected. After it works as expected.

This is related to issue #4275 