### PR TITLE
[Styles] Check for nulls for RTL

### DIFF
--- a/src/utils/rtl.js
+++ b/src/utils/rtl.js
@@ -50,6 +50,7 @@ export default function rtl(muiTheme) {
             break;
 
           case 'transform':
+            if (!value) break;
             let matches;
             if ((matches = value.match(reTranslate))) {
               value = value.replace(matches[0], matches[1] + (-parseFloat(matches[4])) );
@@ -62,6 +63,7 @@ export default function rtl(muiTheme) {
             break;
 
           case 'transformOrigin':
+            if (!value) break;
             if (value.indexOf('right') > -1) {
               value = value.replace('right', 'left');
             } else if (value.indexOf('left') > -1) {


### PR DESCRIPTION
some values of a style can be nulls and doesnt need a replacement. we need to keep them.
Plese note that in the cases like 'direction' (#L44) we want replacment for null anyway.
So only when we invoke function we check for null.

Fix for this issue:
https://github.com/callemall/material-ui/issues/4364