### PR TITLE
[Proof-of-Concept] react-mixout Demonstration

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "react-addons-create-fragment": "^15.0.1",
     "react-addons-transition-group": "^15.0.1",
     "react-event-listener": "^0.2.1",
+    "react-mixout": "^0.3.1",
+    "react-mixout-forward-context": "^0.3.0",
+    "react-mixout-pure": "^0.3.0",
     "recompose": "^0.19.0",
     "simple-assign": "^0.1.0",
     "warning": "^2.1.0"

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -1,13 +1,13 @@
 import React, {Component, PropTypes} from 'react';
+import {mixout, remix, muiMixout} from '../utils/muiMixout';
 
-function getStyles(props, context) {
+function getStyles(props) {
   const {
     backgroundColor,
     color,
     size,
+    muiTheme: {avatar},
   } = props;
-
-  const {avatar} = context.muiTheme;
 
   const styles = {
     root: {
@@ -34,89 +34,86 @@ function getStyles(props, context) {
   return styles;
 }
 
-class Avatar extends Component {
-  static muiName = 'Avatar';
+const propTypes = {
+  /**
+   * The backgroundColor of the avatar. Does not apply to image avatars.
+   */
+  backgroundColor: PropTypes.string,
+  /**
+   * Can be used, for instance, to render a letter inside the avatar.
+   */
+  children: PropTypes.node,
+  /**
+   * The css class name of the root `div` or `img` element.
+   */
+  className: PropTypes.string,
+  /**
+   * The icon or letter's color.
+   */
+  color: PropTypes.string,
+  /**
+   * This is the SvgIcon or FontIcon to be used inside the avatar.
+   */
+  icon: PropTypes.element,
+  /**
+   * This is the size of the avatar in pixels.
+   */
+  size: PropTypes.number,
+  /**
+   * If passed in, this component will render an img element. Otherwise, a div will be rendered.
+   */
+  src: PropTypes.string,
+  /**
+   * Override the inline-styles of the root element.
+   */
+  style: PropTypes.object,
+};
 
-  static propTypes = {
-    /**
-     * The backgroundColor of the avatar. Does not apply to image avatars.
-     */
-    backgroundColor: PropTypes.string,
-    /**
-     * Can be used, for instance, to render a letter inside the avatar.
-     */
-    children: PropTypes.node,
-    /**
-     * The css class name of the root `div` or `img` element.
-     */
-    className: PropTypes.string,
-    /**
-     * The icon or letter's color.
-     */
-    color: PropTypes.string,
-    /**
-     * This is the SvgIcon or FontIcon to be used inside the avatar.
-     */
-    icon: PropTypes.element,
-    /**
-     * This is the size of the avatar in pixels.
-     */
-    size: PropTypes.number,
-    /**
-     * If passed in, this component will render an img element. Otherwise, a div will be rendered.
-     */
-    src: PropTypes.string,
-    /**
-     * Override the inline-styles of the root element.
-     */
-    style: PropTypes.object,
-  };
+const defaultProps = {
+  size: 40,
+};
 
-  static defaultProps = {
-    size: 40,
-  };
+let Avatar = (props) => {
+  const {
+    icon,
+    src,
+    style,
+    className,
+    muiTheme: {prepareStyles},
+    ...other,
+  } = props;
 
-  static contextTypes = {
-    muiTheme: PropTypes.object.isRequired,
-  };
+  const styles = getStyles(props);
 
-  render() {
-    const {
-      icon,
-      src,
-      style,
-      className,
-      ...other,
-    } = this.props;
-
-    const {prepareStyles} = this.context.muiTheme;
-    const styles = getStyles(this.props, this.context);
-
-    if (src) {
-      return (
-        <img
-          style={prepareStyles(Object.assign(styles.root, style))}
-          {...other}
-          src={src}
-          className={className}
-        />
-      );
-    } else {
-      return (
-        <div
-          {...other}
-          style={prepareStyles(Object.assign(styles.root, style))}
-          className={className}
-        >
-          {icon && React.cloneElement(icon, {
-            color: styles.icon.color,
-            style: Object.assign(styles.icon, icon.props.style),
-          })}
-          {this.props.children}
-        </div>
-      );
-    }
+  if (src) {
+    return (
+      <img
+        style={prepareStyles(Object.assign(styles.root, style))}
+        {...other}
+        src={src}
+        className={className}
+      />
+    );
+  } else {
+    return (
+      <div
+        {...other}
+        style={prepareStyles(Object.assign(styles.root, style))}
+        className={className}
+      >
+        {icon && React.cloneElement(icon, {
+          color: styles.icon.color,
+          style: Object.assign(styles.icon, icon.props.style),
+        })}
+        {props.children}
+      </div>
+    );
   }
 }
+
+Avatar = mixout(muiMixout)(remix('Avatar', Avatar));
+Avatar.propTypes = propTypes;
+Avatar.defaultProps = defaultProps;
+Avatar.muiName = 'Avatar';
 
 export default Avatar;

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -1,4 +1,4 @@
-import React, {Component, PropTypes} from 'react';
+import React, {PropTypes} from 'react';
 import {mixout, remix, muiMixout} from '../utils/muiMixout';
 
 function getStyles(props) {
@@ -67,6 +67,10 @@ const propTypes = {
    * Override the inline-styles of the root element.
    */
   style: PropTypes.object,
+  /**
+   * @ignore
+   */
+  muiTheme: PropTypes.object,
 };
 
 const defaultProps = {
@@ -109,7 +113,7 @@ let Avatar = (props) => {
       </div>
     );
   }
-}
+};
 
 Avatar = mixout(muiMixout)(remix('Avatar', Avatar));
 Avatar.propTypes = propTypes;

--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -1,8 +1,8 @@
 import React, {Component, PropTypes} from 'react';
+import {mixout, remix, muiMixout} from '../utils/muiMixout';
 
-function getStyles(props, context) {
-  const {primary, secondary} = props;
-  const {badge} = context.muiTheme;
+function getStyles(props) {
+  const {primary, secondary, muiTheme:{badge}} = props;
 
   let badgeBackgroundColor;
   let badgeTextColor;
@@ -48,68 +48,66 @@ function getStyles(props, context) {
   };
 }
 
-class Badge extends Component {
-  static propTypes = {
-    /**
-     * This is the content rendered within the badge.
-     */
-    badgeContent: PropTypes.node.isRequired,
-    /**
-     * Override the inline-styles of the badge element.
-     */
-    badgeStyle: PropTypes.object,
-    /**
-     * The badge will be added relativelty to this node.
-     */
-    children: PropTypes.node,
-    /**
-     * The css class name of the root element.
-     */
-    className: PropTypes.string,
-    /**
-     * If true, the badge will use the primary badge colors.
-     */
-    primary: PropTypes.bool,
-    /**
-     * If true, the badge will use the secondary badge colors.
-     */
-    secondary: PropTypes.bool,
-    /**
-     * Override the inline-styles of the root element.
-     */
-    style: PropTypes.object,
-  };
+const propTypes = {
+  /**
+   * This is the content rendered within the badge.
+   */
+  badgeContent: PropTypes.node.isRequired,
+  /**
+   * Override the inline-styles of the badge element.
+   */
+  badgeStyle: PropTypes.object,
+  /**
+   * The badge will be added relativelty to this node.
+   */
+  children: PropTypes.node,
+  /**
+   * The css class name of the root element.
+   */
+  className: PropTypes.string,
+  /**
+   * If true, the badge will use the primary badge colors.
+   */
+  primary: PropTypes.bool,
+  /**
+   * If true, the badge will use the secondary badge colors.
+   */
+  secondary: PropTypes.bool,
+  /**
+   * Override the inline-styles of the root element.
+   */
+  style: PropTypes.object,
+};
 
-  static defaultProps = {
-    primary: false,
-    secondary: false,
-  };
+const defaultProps = {
+  primary: false,
+  secondary: false,
+};
 
-  static contextTypes = {
-    muiTheme: PropTypes.object.isRequired,
-  };
+let Badge = (props) => {
+  const {
+    style,
+    children,
+    badgeContent,
+    badgeStyle,
+    muiTheme: {prepareStyles},
+    ...other,
+  } = props;
 
-  render() {
-    const {
-      style,
-      children,
-      badgeContent,
-      badgeStyle,
-      ...other,
-    } = this.props;
+  const styles = getStyles(props);
 
-    const {prepareStyles} = this.context.muiTheme;
-    const styles = getStyles(this.props, this.context);
-
-    return (
-      <div {...other} style={prepareStyles(Object.assign({}, styles.root, style))}>
-        {children}
-        <span style={prepareStyles(Object.assign({}, styles.badge, badgeStyle))}>
-          {badgeContent}
-        </span>
-      </div>
-    );
-  }
+  return (
+    <div {...other} style={prepareStyles(Object.assign({}, styles.root, style))}>
+      {children}
+      <span style={prepareStyles(Object.assign({}, styles.badge, badgeStyle))}>
+        {badgeContent}
+      </span>
+    </div>
+  );
 }
+
+Badge = mixout(muiMixout)(remix('Badge', Badge));
+Badge.propTypes = propTypes;
+Badge.defaultProps = defaultProps;
 
 export default Badge;

--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -1,8 +1,8 @@
-import React, {Component, PropTypes} from 'react';
+import React, {PropTypes} from 'react';
 import {mixout, remix, muiMixout} from '../utils/muiMixout';
 
 function getStyles(props) {
-  const {primary, secondary, muiTheme:{badge}} = props;
+  const {primary, secondary, muiTheme: {badge}} = props;
 
   let badgeBackgroundColor;
   let badgeTextColor;
@@ -77,6 +77,10 @@ const propTypes = {
    * Override the inline-styles of the root element.
    */
   style: PropTypes.object,
+  /**
+   * @ignore
+   */
+  muiTheme: PropTypes.object,
 };
 
 const defaultProps = {
@@ -104,7 +108,7 @@ let Badge = (props) => {
       </span>
     </div>
   );
-}
+};
 
 Badge = mixout(muiMixout)(remix('Badge', Badge));
 Badge.propTypes = propTypes;

--- a/src/Divider/Divider.js
+++ b/src/Divider/Divider.js
@@ -1,4 +1,5 @@
 import React, {PropTypes} from 'react';
+import {mixout, remix, muiMixout} from '../utils/muiMixout';
 
 const propTypes = {
   /**
@@ -19,19 +20,14 @@ const defaultProps = {
   inset: false,
 };
 
-const contextTypes = {
-  muiTheme: PropTypes.object.isRequired,
-};
-
-const Divider = (props, context) => {
+let Divider = (props) => {
   const {
     inset,
     style,
+    muiTheme,
+    muiTheme: {prepareStyles},
     ...other,
   } = props;
-
-  const {muiTheme} = context;
-  const {prepareStyles} = muiTheme;
 
   const styles = {
     root: {
@@ -49,9 +45,8 @@ const Divider = (props, context) => {
   );
 };
 
-Divider.muiName = 'Divider';
+Divider = mixout(muiMixout)(remix('Divider', Divider));
 Divider.propTypes = propTypes;
 Divider.defaultProps = defaultProps;
-Divider.contextTypes = contextTypes;
 
 export default Divider;

--- a/src/Divider/Divider.js
+++ b/src/Divider/Divider.js
@@ -14,6 +14,10 @@ const propTypes = {
    * Override the inline-styles of the root element.
    */
   style: PropTypes.object,
+  /**
+   * @ignore
+   */
+  muiTheme: PropTypes.object,
 };
 
 const defaultProps = {

--- a/src/Subheader/Subheader.js
+++ b/src/Subheader/Subheader.js
@@ -1,4 +1,5 @@
 import React, {PropTypes} from 'react';
+import {mixout, remix, muiMixout} from '../utils/muiMixout';
 
 const propTypes = {
   /**
@@ -19,19 +20,14 @@ const defaultProps = {
   inset: false,
 };
 
-const contextTypes = {
-  muiTheme: PropTypes.object.isRequired,
-};
-
-const Subheader = (props, context) => {
+let Subheader = (props) => {
   const {
     children,
     inset,
     style,
+    muiTheme: {prepareStyles, subheader},
     ...other,
   } = props;
-
-  const {prepareStyles, subheader} = context.muiTheme;
 
   const styles = {
     root: {
@@ -52,9 +48,8 @@ const Subheader = (props, context) => {
   );
 };
 
-Subheader.muiName = 'Subheader';
+Subheader = mixout(muiMixout)(remix('Subheader', Subheader));
 Subheader.propTypes = propTypes;
 Subheader.defaultProps = defaultProps;
-Subheader.contextTypes = contextTypes;
 
 export default Subheader;

--- a/src/Subheader/Subheader.js
+++ b/src/Subheader/Subheader.js
@@ -14,6 +14,10 @@ const propTypes = {
    * Override the inline-styles of the root element.
    */
   style: PropTypes.object,
+  /**
+   * @ignore
+   */
+  muiTheme: PropTypes.object,
 };
 
 const defaultProps = {

--- a/src/utils/muiMixout.js
+++ b/src/utils/muiMixout.js
@@ -1,0 +1,12 @@
+import {PropTypes} from 'react';
+import mixout, {remix, combine} from 'react-mixout';
+import pure from 'react-mixout-pure';
+import forwardContext from 'react-mixout-forward-context';
+
+export {mixout, remix, combine, pure, forwardContext};
+
+export const forwardTheme = forwardContext('muiTheme', {
+  validator: PropTypes.object.isRequired,
+});
+
+export const muiMixout = combine(pure, forwardTheme);


### PR DESCRIPTION
After spending quiet a long time working on react-mixout it's finally ready (to demonstrate :sweat_smile:).

This is just the tip of the iceberg. A lot of things can go into mixouts without introducing another layer of HOCs. In this PR I kept things simple. Here you can see how easy it is to implement `pure-render`, `forward-context` for a component.

Components that are simple enough that can be turned into function components can be `remix`ed. That means they can be called directly by `Mixout`'s render function. In other words, here `Avatar`, `Badge`, `Divider` and `Subheader` are a single component! no chain. you can use react devtool to see it. they also get theme from context and implement pure render. neat :grin: 

There are many other things that can be done with them ([forward-methods, proxy, listen, uncontrol, memoize, etc...](https://github.com/alitaheri/react-mixout#included-features)) and having all these features will result in **one** HOC no more! 

Another good thing about it is that we can export the raw component, the necessary mixout and have users add their own, effectively extending the library in their own way :grin: 

big thanks to @nathanmarks for all the advice and helps :+1: 
