### PR TITLE
[RadioButton] Changed the value type to any

### DIFF
--- a/src/RadioButton/RadioButton.js
+++ b/src/RadioButton/RadioButton.js
@@ -106,7 +106,7 @@ class RadioButton extends Component {
     /**
      * The value of the radio button.
      */
-    value: PropTypes.string,
+    value: PropTypes.any,
   };
 
   static defaultProps = {

--- a/src/internal/EnhancedSwitch.js
+++ b/src/internal/EnhancedSwitch.js
@@ -99,7 +99,7 @@ class EnhancedSwitch extends Component {
     switched: PropTypes.bool.isRequired,
     thumbStyle: PropTypes.object,
     trackStyle: PropTypes.object,
-    value: PropTypes.string,
+    value: PropTypes.any,
   };
 
   static contextTypes = {


### PR DESCRIPTION
- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

This PR changes the type of value for the `RadioButton` from `string` to `any` so that different data types can be used as values for `RadioButton`. Closes #3698

