### PR TITLE
[Drawer] Allow string widths

### DIFF
--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -75,9 +75,12 @@ class Drawer extends Component {
      */
     swipeAreaWidth: PropTypes.number,
     /**
-     * The width of the `Drawer` in pixels. Defaults to using the values from theme.
+     * The width of the `Drawer`. Defaults to using the values from theme.
      */
-    width: PropTypes.number,
+    width: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
     /**
      * The zDepth of the `Drawer`.
      */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

There doesn't seem to be any reason that a non-numeric width can't be allowed. Example: '30%', '45vw', etc.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).
