### PR TITLE
[Popover] Fix documentation page link to Menu component

### DIFF
--- a/docs/src/app/components/pages/components/Popover/Page.js
+++ b/docs/src/app/components/pages/components/Popover/Page.js
@@ -16,7 +16,7 @@ import popoverNoteText from './NOTE';
 import popoverCode from '!raw!material-ui/Popover/Popover';
 
 const descriptions = {
-  simple: 'A simple example showing a Popover containing a [Menu](http://localhost:3000/#/components/menu). ' +
+  simple: 'A simple example showing a Popover containing a [Menu](/#/components/menu). ' +
   'It can be also closed by clicking away from the Popover.',
   animation: 'The default animation style is to animate around the origin. ' +
   'An alternative animation can be applied using the `animation` property. ' +


### PR DESCRIPTION
Minor fix in the Popover documentation that links to the Menu component documentation. Removes hard-coded `http://localhost:3000`.



<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


