### PR TITLE
[Themes][ListItem] Secondary Text color is incorrect fix

### DIFF
--- a/src/styles/baseThemes/darkBaseTheme.js
+++ b/src/styles/baseThemes/darkBaseTheme.js
@@ -18,6 +18,7 @@ export default {
     accent2Color: pinkA400,
     accent3Color: pinkA100,
     textColor: fullWhite,
+    secondaryTextColor: fade(fullWhite, 0.7),
     alternateTextColor: '#303030',
     canvasColor: '#303030',
     borderColor: fade(fullWhite, 0.3),

--- a/src/styles/baseThemes/lightBaseTheme.js
+++ b/src/styles/baseThemes/lightBaseTheme.js
@@ -27,6 +27,7 @@ export default {
     accent2Color: grey100,
     accent3Color: grey500,
     textColor: darkBlack,
+    secondaryTextColor: fade(darkBlack, 0.54),
     alternateTextColor: white,
     canvasColor: white,
     borderColor: grey300,

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -140,7 +140,7 @@ export default function getMuiTheme(muiTheme, ...more) {
     },
     listItem: {
       nestedLevelDepth: 18,
-      secondaryTextColor: lightBlack,
+      secondaryTextColor: palette.secondaryTextColor,
       leftIconColor: grey600,
       rightIconColor: grey600,
     },


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ListItem], and are in imperative form: "[Themes][ListItem] Secondary Text color is incorrect".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

resolves #4469 
