### PR TITLE
[FlatButton] Never allow a disabled button to be in a hovered state.

### DIFF
--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -117,6 +117,12 @@ class FlatButton extends Component {
     touch: false,
   };
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.disabled && this.state.hovered) {
+      this.setState({hovered: false});
+    }
+  }
+
   handleKeyboardFocus = (event, isKeyboardFocused) => {
     this.setState({isKeyboardFocused: isKeyboardFocused});
     this.props.onKeyboardFocus(event, isKeyboardFocused);


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

There are several cases where `onMouseLeave` (which normally unsets
the `hovered` state won't be called). One of those is if you disable a
button within the `onTouchTap` method.

This check ensures that a button will never be disabled but have an
internal hovered state.

I believe: https://github.com/callemall/material-ui/issues/1495 is related.