### PR TITLE
[Docs] Fix color swatch label text contrast ratio

### DIFF
--- a/docs/src/app/components/pages/customization/Colors.js
+++ b/docs/src/app/components/pages/customization/Colors.js
@@ -98,11 +98,11 @@ class ColorsPage extends Component {
   getColorBlock(styles, colorName, colorValue, colorTitle) {
     const bgColorText = colorName + colorValue;
     const bgColor = colors[bgColorText];
-    let fgColor = colors.fullBlack;
-    const contrastRatio = getContrastRatio(bgColor, fgColor);
     let blockTitle;
 
-    if (contrastRatio < 7) fgColor = colors.fullWhite;
+    const fgColor = getContrastRatio(bgColor, colors.fullWhite) > getContrastRatio(bgColor, colors.fullBlack) ?
+      colors.fullWhite : colors.fullBlack;
+
     if (colorTitle) {
       blockTitle = (
         <span style={styles.name}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

In the current implementation, we switch to white if the contrast ratio of black is < 7 (WCAG AAA), but white doesn't always have a higher contrast ratio than black.
