### PR TITLE
[ClickAwayListener] Add better support for IE11

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -20,6 +20,7 @@
     "android:setup-port": "adb reverse tcp:8081 tcp:8081"
   },
   "dependencies": {
+    "babel-polyfill": "^6.9.1",
     "react-title-component": "^1.0.1",
     "simple-assign": "^0.1.0"
   },

--- a/docs/webpack-dev-server.config.js
+++ b/docs/webpack-dev-server.config.js
@@ -8,6 +8,7 @@ const config = {
   entry: [
     'webpack/hot/dev-server',
     'webpack/hot/only-dev-server',
+    './node_modules/babel-polyfill/lib/index.js',
     path.resolve(__dirname, 'src/app/app.js'),
   ],
   // Webpack config options on how to obtain modules
@@ -44,9 +45,6 @@ const config = {
       {from: 'src/www/index.html'},
     ]),
   ],
-  externals: {
-    fs: 'js', // To remove once https://github.com/benjamn/recast/pull/238 is released
-  },
   module: {
     // Allow loading of non-es
     loaders: [

--- a/docs/webpack-production.config.js
+++ b/docs/webpack-production.config.js
@@ -6,6 +6,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const config = {
   // Entry point to the project
   entry: [
+    './node_modules/babel-polyfill/lib/index.js',
     path.resolve(__dirname, 'src/app/app.js'),
   ],
   // Webpack config options on how to obtain modules
@@ -56,9 +57,6 @@ const config = {
       {from: 'src/www/versions.json'},
     ]),
   ],
-  externals: {
-    fs: 'fs', // To remove once https://github.com/benjamn/recast/pull/238 is released
-  },
   module: {
     // Allow loading of non-es5 js files.
     loaders: [

--- a/src/internal/ClickAwayListener.js
+++ b/src/internal/ClickAwayListener.js
@@ -21,6 +21,7 @@ export default class ClickAwayListener extends Component {
   };
 
   componentDidMount() {
+    this.isCurrentlyMounted = true;
     if (this.props.onClickAway) {
       bind(this.handleClickAway);
     }
@@ -36,6 +37,7 @@ export default class ClickAwayListener extends Component {
   }
 
   componentWillUnmount() {
+    this.isCurrentlyMounted = false;
     unbind(this.handleClickAway);
   }
 
@@ -44,10 +46,13 @@ export default class ClickAwayListener extends Component {
       return;
     }
 
-    const el = ReactDOM.findDOMNode(this);
+    // IE11 support, which trigger the handleClickAway even after the unbind
+    if (this.isCurrentlyMounted) {
+      const el = ReactDOM.findDOMNode(this);
 
-    if (document.documentElement.contains(event.target) && !isDescendant(el, event.target)) {
-      this.props.onClickAway(event);
+      if (document.documentElement.contains(event.target) && !isDescendant(el, event.target)) {
+        this.props.onClickAway(event);
+      }
     }
   };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


In IE11, even if we call `removeEventListener` during the event, the currently propagating event calls all listeners. It means that `ClickAwayListener` calls `unbind` on `componentWillUnmount`, then IE calls the `handleClickAway` listener that was previously bound, even if `unbind` was called.
The solution is a bit hackish, but fixes the error `findDOMNode was called on an unmounted component.` in IE11.

Also, add a polyfill for IE11 for Array.find added in `react-docgen v2.8` (https://github.com/reactjs/react-docgen/issues/88).
![image](https://cloud.githubusercontent.com/assets/1634993/16241222/bc01a16c-37ba-11e6-8c45-b9610900afa6.png)

BTW, this is probably another issue, but I had to comment out `CopyWebpackPlugin` from webpack on Windows. Its was triggering an infinite loop of rebuilding because `docs/src/www/index.html` is watched and was refreshed by webpack itself on every rebuild.