### PR TITLE
[TableBody](Fixes #1345) Respect child (TableRow) props when rendering

### DIFF
--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -165,9 +165,12 @@ class TableBody extends Component {
       if (React.isValidElement(child)) {
         const props = {
           displayRowCheckbox: this.props.displayRowCheckbox,
-          hoverable: this.props.showRowHover,
-          selected: this.isRowSelected(rowNumber),
-          striped: this.props.stripedRows && (rowNumber % 2 === 0),
+          hoverable: (typeof child.props.hoverable !== 'undefined') ?
+            child.props.hoverable : this.props.showRowHover,
+          selected: (typeof child.props.selected !== 'undefined') ?
+            child.props.selected : this.isRowSelected(rowNumber),
+          striped: (typeof child.props.striped !== 'undefined') ?
+            child.props.striped : this.props.stripedRows && rowNumber % 2 === 0,
           rowNumber: rowNumber++,
         };
         const checkboxColumn = this.createRowCheckboxColumn(props);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

The initial issue being fixed here was the select/unselect all button not actually unselecting all of the TableRow checkboxes. This was caused by the TableBody not respecting the value passed in the props for 'selected' when a re-render was caused. Alongside of this, I added checks for the other props that could be passed on the TableRow (hoverable and striped).