### PR TITLE
[TextField] Take bottom position value from props styles 

### DIFF
--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -90,7 +90,9 @@ const getStyles = (props, context, state) => {
     }
 
     if (state.errorText) {
-      styles.error.bottom = !props.multiLine ? styles.error.fontSize + 3 : 3;
+      if (!styles.error.bottom) {
+        styles.error.bottom = !props.multiLine ? styles.error.fontSize + 3 : 3;
+      }
     }
   }
 


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

I have use-case with making absolute position to errorText...but bottom value is hardcoded.
`if (state.errorText) {
   styles.error.bottom = !props.multiLine ? styles.error.fontSize + 3 : 3;
}`
This is my way to solve this problem – if you set your own bottom value through props styles.error.bottom - take this value and ignore logic with calc value by fontSize.

It looks like this: http://cl.ly/2B3B2c2T1f04