### PR TITLE
[TableFooter] Fix adjustForCheckbox rendering

### DIFF
--- a/src/Table/TableFooter.js
+++ b/src/Table/TableFooter.js
@@ -72,15 +72,15 @@ class TableFooter extends Component {
         style: Object.assign({}, styles.cell, child.props.style),
       };
 
-      let newDescendants;
-      if (adjustForCheckbox) {
-        newDescendants = [
+      let newDescendants = [
           <TableRowColumn key={`fpcb${rowNumber}`} style={{width: 24}} />,
           ...React.Children.toArray(child.props.children),
         ];
+      if (adjustForCheckbox) {
+        return React.cloneElement(child, newChildProps, newDescendants);
       }
 
-      return React.cloneElement(child, newChildProps, newDescendants);
+      return React.cloneElement(child, newChildProps);
     });
 
     return (

--- a/src/Table/TableFooter.js
+++ b/src/Table/TableFooter.js
@@ -72,10 +72,10 @@ class TableFooter extends Component {
         style: Object.assign({}, styles.cell, child.props.style),
       };
 
-      let newDescendants = [
-          <TableRowColumn key={`fpcb${rowNumber}`} style={{width: 24}} />,
-          ...React.Children.toArray(child.props.children),
-        ];
+      const newDescendants = [
+        <TableRowColumn key={`fpcb${rowNumber}`} style={{width: 24}} />,
+        ...React.Children.toArray(child.props.children),
+      ];
       if (adjustForCheckbox) {
         return React.cloneElement(child, newChildProps, newDescendants);
       }


### PR DESCRIPTION
- [ ] PR has tests / docs demo, and is linted.
- [ ]  Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) 

*Description*
 In the TableFooter, in the render function, having newDescendants as void 0 was breaking the cloneElement method of React.  I instead made it so that the newDescendants are always created but the cloneElement function is conditionally given newDescendants based on the adjustForCheckbox bool.

Before and after shots:
<img width="1125" alt="broken_table_footer" src="https://cloud.githubusercontent.com/assets/9398791/16304321/d77aaa1a-3922-11e6-9be6-9c48996a0272.png">
<img width="1110" alt="working_table_footer" src="https://cloud.githubusercontent.com/assets/9398791/16304326/db28bc06-3922-11e6-8ee6-3e0508fa5a17.png">




