### PR TITLE
[Tabs] Property description of initialSelectedValue updated for no initial selected tab

### DIFF
--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -36,9 +36,9 @@ class Tabs extends Component {
     contentContainerStyle: PropTypes.object,
     /**
      * Specify initial visible tab index.
-     * Initial selected index is set by default to 0.
-     * If initialSelectedIndex is set but larger than the total amount of specified tabs,
-     * initialSelectedIndex will revert back to default.
+     * If `initialSelectedIndex` is set but larger than the total amount of specified tabs,
+     * `initialSelectedIndex` will revert back to default.
+     * If `initialSlectedIndex` is set to any negative value, no tab will be selected intially.
      */
     initialSelectedIndex: PropTypes.number,
     /**


### PR DESCRIPTION
- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

[Tabs] Property description of initialSelectedValue updated for no initial selected tab.
Closes #4369 