### PR TITLE
[DropDownMenu] Remove Synthetic Event from pooling when used asynchronously

### DIFF
--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -226,6 +226,7 @@ class DropDownMenu extends Component {
   };
 
   handleItemTouchTap = (event, child, index) => {
+    event.persist();
     this.setState({
       open: false,
     }, () => {


### PR DESCRIPTION
calling event.persist()  is needed as noted here  https://facebook.github.io/react/docs/events.html#event-pooling