### PR TITLE
[Table] Row selectable prop fix

### DIFF
--- a/docs/src/app/components/pages/components/Table/ExampleComplex.js
+++ b/docs/src/app/components/pages/components/Table/ExampleComplex.js
@@ -110,7 +110,7 @@ export default class TableExampleComplex extends React.Component {
             stripedRows={this.state.stripedRows}
           >
             {tableData.map( (row, index) => (
-              <TableRow key={index} selected={row.selected}>
+              <TableRow key={index} selected={row.selected} selectable={row.selectable}>
                 <TableRowColumn>{index}</TableRowColumn>
                 <TableRowColumn>{row.name}</TableRowColumn>
                 <TableRowColumn>{row.status}</TableRowColumn>

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -166,7 +166,8 @@ class TableBody extends Component {
         const props = {
           displayRowCheckbox: this.props.displayRowCheckbox,
           hoverable: this.props.showRowHover,
-          selected: this.isRowSelected(rowNumber),
+          selected: this.isRowSelected(rowNumber, child.props),
+          selectable: this.isRowSelectable(this.props, child.props),
           striped: this.props.stripedRows && (rowNumber % 2 === 0),
           rowNumber: rowNumber++,
         };
@@ -190,7 +191,7 @@ class TableBody extends Component {
     if (!this.props.displayRowCheckbox) return null;
 
     const key = `${rowProps.rowNumber}-cb`;
-    const disabled = !this.props.selectable;
+    const disabled = !rowProps.selectable;
     const checkbox = (
       <Checkbox
         ref="rowSelectCB"
@@ -235,8 +236,10 @@ class TableBody extends Component {
     return preSelectedRows;
   }
 
-  isRowSelected(rowNumber) {
+  isRowSelected(rowNumber, childProps) {
     if (this.props.allRowsSelected) {
+      if (typeof childProps.selectable !== 'undefined' && !childProps.selectable) return false;
+
       return true;
     }
 
@@ -248,6 +251,16 @@ class TableBody extends Component {
       } else {
         if (selection === rowNumber) return true;
       }
+    }
+
+    return false;
+  }
+
+  isRowSelectable(tableProps, rowProps) {
+    if (tableProps.selectable) {
+      if (typeof rowProps.selectable !== 'undefined' && !rowProps.selectable) return false;
+
+      return true;
     }
 
     return false;


### PR DESCRIPTION
Individual rows did not respect the `selectable` property if the table had `selectable = true` set on it. This is an issue if you need to dynamically set the `selectable` property on a row within a table where all of the rows originally start off as selectable.

This PR fixes issue #4543.
