### PR TITLE
[Table] Fixing selectAll functionality a bit

### DIFF
--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -142,6 +142,14 @@ class Table extends Component {
     allRowsSelected: this.props.allRowsSelected,
   };
 
+  componentWillReceiveProps(nextProps) {
+    if (typeof nextProps.allRowsSelected !== 'undefined' && this.props.allRowsSelected !== nextProps.allRowsSelected) {
+      this.setState({
+        allRowsSelected: nextProps.selectAllSelected,
+      });
+    }
+  }
+
   isScrollbarVisible() {
     const tableDivHeight = this.refs.tableDiv.clientHeight;
     const tableBodyHeight = this.refs.tableBody.clientHeight;

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -125,7 +125,11 @@ class TableBody extends Component {
   };
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.allRowsSelected && !nextProps.allRowsSelected) {
+    if (!this.props.allRowsSelected && nextProps.allRowsSelected) {
+      this.setState({
+        selectedRows: [],
+      });
+    } else if (this.props.allRowsSelected && !nextProps.allRowsSelected) {
       this.setState({
         selectedRows: this.state.selectedRows.length > 0 ?
           [this.state.selectedRows[this.state.selectedRows.length - 1]] : [],
@@ -139,7 +143,7 @@ class TableBody extends Component {
   }
 
   handleClickAway = () => {
-    if (this.props.deselectOnClickaway && this.state.selectedRows.length) {
+    if (this.props.deselectOnClickaway && (this.state.selectedRows.length || this.props.allRowsSelected)) {
       this.setState({
         selectedRows: [],
       });


### PR DESCRIPTION
This PR is for improvements made to the Table component's functionality. There are quite a few issues that basically render the component unusable if you were to want to use the `selectable` property. Although this PR does not fix every issue out there, it does appear to fix #1345, as well as improves handling of selecting/unselecting rows.

For example, when using select all, it would not uncheck all rows after unselecting the check all box (when 'deselect on clickaway' is disabled).

Another example is when using select all and you have all the boxes checked and then click on one, it will change to only have that single one selected. Currently, when you have rows that were preselected (like the complex example), it incorrectly leaves the wrong one checked (if you try checking one of the preselected rows).

Basically, my goal is to get this component to a point where we can use it in our project. The way it stands right now with how the `select all` functionality works, we'd have to do some hacking to get it working. This PR should fix the major issues with that functionality.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Closes #1345 
