### PR TITLE
[RadioButtonGroup] Move state definition inside constructor

### DIFF
--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -306,14 +306,18 @@ class ListItem extends Component {
     muiTheme: PropTypes.object.isRequired,
   };
 
-  state = {
-    hovered: false,
-    isKeyboardFocused: false,
-    open: this.props.initiallyOpen,
-    rightIconButtonHovered: false,
-    rightIconButtonKeyboardFocused: false,
-    touch: false,
-  };
+  constructor(props, context) {
+    super(props, context);
+
+    this.state = {
+      hovered: false,
+      isKeyboardFocused: false,
+      open: props.initiallyOpen,
+      rightIconButtonHovered: false,
+      rightIconButtonKeyboardFocused: false,
+      touch: false,
+    };
+  }
 
   shouldComponentUpdate(nextProps, nextState, nextContext) {
     return (

--- a/src/RadioButton/RadioButtonGroup.js
+++ b/src/RadioButton/RadioButtonGroup.js
@@ -55,10 +55,14 @@ class RadioButtonGroup extends Component {
     muiTheme: PropTypes.object.isRequired,
   };
 
-  state = {
-    numberCheckedRadioButtons: 0,
-    selected: this.props.valueSelected || this.props.defaultSelected || '',
-  };
+  constructor(props, context) {
+    super(props, context);
+
+    this.state = {
+      numberCheckedRadioButtons: 0,
+      selected: props.valueSelected || props.defaultSelected || '',
+    };
+  }
 
   componentWillMount() {
     let cnt = 0;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


Fixes #4223

An exception is raised in IE9/10 when a RadioButtonGroup is used.
It looks like this might be a transpilation issue with babel.