### PR TITLE
[TableBody] Add clickAsSelect prop and default

### DIFF
--- a/docs/src/app/components/pages/components/Table/ExampleComplex.js
+++ b/docs/src/app/components/pages/components/Table/ExampleComplex.js
@@ -54,6 +54,7 @@ export default class TableExampleComplex extends React.Component {
     super(props);
 
     this.state = {
+      clickAsSelect: false,
       fixedHeader: true,
       fixedFooter: true,
       stripedRows: false,
@@ -104,6 +105,7 @@ export default class TableExampleComplex extends React.Component {
             </TableRow>
           </TableHeader>
           <TableBody
+            clickAsSelect={this.state.clickAsSelect}
             displayRowCheckbox={this.state.showCheckboxes}
             deselectOnClickaway={this.state.deselectOnClickaway}
             showRowHover={this.state.showRowHover}
@@ -112,7 +114,9 @@ export default class TableExampleComplex extends React.Component {
             {tableData.map( (row, index) => (
               <TableRow key={index} selected={row.selected}>
                 <TableRowColumn>{index}</TableRowColumn>
-                <TableRowColumn>{row.name}</TableRowColumn>
+                <TableRowColumn>
+                  <a target="_blank" href="#">{row.name}</a>
+                </TableRowColumn>
                 <TableRowColumn>{row.status}</TableRowColumn>
               </TableRow>
               ))}
@@ -176,6 +180,12 @@ export default class TableExampleComplex extends React.Component {
             label="Deselect On Clickaway"
             onToggle={this.handleToggle}
             defaultToggled={this.state.deselectOnClickaway}
+          />
+          <Toggle
+            name="clickAsSelect"
+            label="Click as Select"
+            onToggle={this.handleToggle}
+            defaultToggled={this.state.clickAsSelect}
           />
           <Toggle
             name="stripedRows"

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -21,6 +21,12 @@ class TableBody extends Component {
      */
     className: PropTypes.string,
     /**
+     * If true, table rows will be selected or not after clicking
+     * the row. If this is false but selectable is true, table
+     * rows will be selected only by clicking the checkbox.
+     */
+    clickAsSelect: React.PropTypes.bool,
+    /**
      * Controls whether or not to deselect all selected
      * rows after clicking outside the table.
      */
@@ -108,6 +114,7 @@ class TableBody extends Component {
 
   static defaultProps = {
     allRowsSelected: false,
+    clickAsSelect: false,
     deselectOnClickaway: true,
     displayRowCheckbox: true,
     multiSelectable: false,
@@ -198,6 +205,7 @@ class TableBody extends Component {
         value="selected"
         disabled={disabled}
         checked={rowProps.selected}
+        onClick={this.processCheckboxEvent(rowProps)}
       />
     );
 
@@ -213,6 +221,15 @@ class TableBody extends Component {
         {checkbox}
       </TableRowColumn>
     );
+  }
+
+  processCheckboxEvent(rowProps) {
+    return (event) => {
+      if (this.props.clickAsSelect) return null; // will fire onRowClick event
+      event.stopPropagation();
+      event.ctrlKey = true;
+      this.processRowSelection(event, rowProps.rowNumber);
+    };
   }
 
   calculatePreselectedRows(props) {
@@ -266,14 +283,14 @@ class TableBody extends Component {
   onRowClick = (event, rowNumber) => {
     event.stopPropagation();
 
-    if (this.props.selectable) {
-      // Prevent text selection while selecting rows.
-      window.getSelection().removeAllRanges();
+    if (this.props.clickAsSelect) {
       this.processRowSelection(event, rowNumber);
     }
   };
 
   processRowSelection(event, rowNumber) {
+    if (!this.props.selectable) return null;
+
     let selectedRows = this.state.selectedRows;
 
     if (event.shiftKey && this.props.multiSelectable && selectedRows.length) {


### PR DESCRIPTION
An updated version of: https://github.com/callemall/material-ui/pull/3455

This is necessary in order for anything clickable (dropdown, link, input field, etc) to be used in a table row when it is selectable. There was a long discussion on the previous PR regarding this and nothing has changed in this implementation (just updated for 0.15.x).

There was discuss about it only being a band-aid, but until the Table component is rewritten, a band-aid is quite necessary so that a Table can be used. We can gladly rip out the band-aid once the component is rewritten in a better way.

Closes #3453
