### PR TITLE
[ListItem][RadioButtonGroup] Fix error with props access in state assignment for ie9/10

### DIFF
--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -293,11 +293,17 @@ class ListItem extends Component {
   state = {
     hovered: false,
     isKeyboardFocused: false,
-    open: this.props.initiallyOpen,
+    open: false,
     rightIconButtonHovered: false,
     rightIconButtonKeyboardFocused: false,
     touch: false,
   };
+
+  componentWillMount() {
+    if (this.props.initiallyOpen) {
+      this.setState({open: true});
+    }
+  }
 
   shouldComponentUpdate(nextProps, nextState, nextContext) {
     return (

--- a/src/RadioButton/RadioButtonGroup.js
+++ b/src/RadioButton/RadioButtonGroup.js
@@ -57,7 +57,7 @@ class RadioButtonGroup extends Component {
 
   state = {
     numberCheckedRadioButtons: 0,
-    selected: this.props.valueSelected || this.props.defaultSelected || '',
+    selected: '',
   };
 
   componentWillMount() {
@@ -67,7 +67,10 @@ class RadioButtonGroup extends Component {
       if (this.hasCheckAttribute(option)) cnt++;
     }, this);
 
-    this.setState({numberCheckedRadioButtons: cnt});
+    this.setState({
+      numberCheckedRadioButtons: cnt,
+      selected: this.props.valueSelected || this.props.defaultSelected || '',
+    });
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
Currently, not even the docs home page will load in ie9/10. Some have had luck with polyfills, but accessing props in state initialization is an anti-pattern anyways, it should be set in `componentWillMount` which is a cleaner solution than polyfills or constructors.

This issue is also affecting some other components as mentioned by @hhaidar in #4593. I haven't done a full scan yet to take a look.

@hhaidar want to follow my lead here and get the rest shored up?

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

