### PR TITLE
[FlatButton] Add a condition to check for zero in the label warning

### DIFF
--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -7,7 +7,7 @@ import FlatButtonLabel from './FlatButtonLabel';
 
 function validateLabel(props, propName, componentName) {
   if (process.env.NODE_ENV !== 'production') {
-    if (!props.children && !props.label && !props.icon) {
+    if (!props.children && (props.label !== 0 && !props.label) && !props.icon) {
       return new Error(`Required prop label or children or icon was not specified in ${componentName}.`);
     }
   }


### PR DESCRIPTION

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Got a warning on passing the number 0 in the label property like <FlatButton label={0} />

Updated condition to prevent warning show if 0 passed to label.

Closes #4592 



