### PR TITLE
[InlineStylePrefixer] Update to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-tap-event-plugin": "^1.0.0"
   },
   "dependencies": {
-    "inline-style-prefixer": "^1.0.3",
+    "inline-style-prefixer": "^2.0.0",
     "keycode": "^2.1.1",
     "lodash": "^4.13.1",
     "react-addons-create-fragment": "^15.2.0",


### PR DESCRIPTION
A new version of inline-style-prefixer has been released a day ago. Updating the dependency to that version fixes an issue in Chromium where styles like `display: flex` or `height: calc(100% - 20px)` would just disappear.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


Fixes #4419