### PR TITLE
[TextField] Fix multi-line textarea height override

### DIFF
--- a/docs/src/app/components/AppNavDrawer.js
+++ b/docs/src/app/components/AppNavDrawer.js
@@ -369,7 +369,7 @@ class AppNavDrawer extends Component {
               <ListItem
                 primaryText="Tabs"
                 value="/components/tabs"
-                href="/#/components/auto-complete"
+                href="/#/components/tabs"
               />,
               <ListItem
                 primaryText="Text Field"

--- a/src/LinearProgress/LinearProgress.js
+++ b/src/LinearProgress/LinearProgress.js
@@ -4,7 +4,7 @@ import transitions from '../styles/transitions';
 function getRelativeValue(value, min, max) {
   const clampedValue = Math.min(Math.max(min, value), max);
   const rangeValue = max - min;
-  const relValue = Math.round(clampedValue / rangeValue * 10000) / 10000;
+  const relValue = Math.round((clampedValue - min) / rangeValue * 10000) / 10000;
   return relValue * 100;
 }
 

--- a/src/LinearProgress/LinearProgress.spec.js
+++ b/src/LinearProgress/LinearProgress.spec.js
@@ -1,0 +1,55 @@
+/* eslint-env mocha */
+import React from 'react';
+import {shallow} from 'enzyme';
+import {assert} from 'chai';
+import LinearProgress from './LinearProgress';
+import getMuiTheme from '../styles/getMuiTheme';
+
+describe('<LinearProgress />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
+  describe('props: min', () => {
+    it('should work when min equal zero', () => {
+      const wrapper = shallowWithContext(
+        <LinearProgress
+          mode="determinate"
+          value={50}
+          min={0}
+          max={100}
+        />
+      );
+
+      assert.strictEqual(wrapper.children().props().style.width, '50%',
+        'should compute the width correctly');
+    });
+
+    it('should work when min is different to zero', () => {
+      const wrapper = shallowWithContext(
+        <LinearProgress
+          mode="determinate"
+          value={75}
+          min={50}
+          max={100}
+        />
+      );
+
+      assert.strictEqual(wrapper.children().props().style.width, '50%',
+        'should compute the width correctly');
+    });
+
+    it('should work when value equal min', () => {
+      const wrapper = shallowWithContext(
+        <LinearProgress
+          mode="determinate"
+          value={50}
+          min={50}
+          max={100}
+        />
+      );
+
+      assert.strictEqual(wrapper.children().props().style.width, '0%',
+        'should compute the width correctly');
+    });
+  });
+});

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -290,6 +290,10 @@ class Slider extends Component {
      */
     required: PropTypes.bool,
     /**
+     * Override the inline-styles of the inner slider element.
+     */
+    sliderStyle: PropTypes.object,
+    /**
      * The granularity the slider can step through values.
      */
     step: PropTypes.number,
@@ -690,6 +694,7 @@ class Slider extends Component {
       onDragStop, // eslint-disable-line no-unused-vars
       onFocus, // eslint-disable-line no-unused-vars
       required,
+      sliderStyle,
       step,
       style,
       ...other,
@@ -697,7 +702,6 @@ class Slider extends Component {
 
     const {prepareStyles} = this.context.muiTheme;
     const styles = getStyles(this.props, this.context, this.state);
-    const sliderStyles = styles.slider;
 
     let handleStyles = {};
     let percent = this.state.percent;
@@ -763,7 +767,7 @@ class Slider extends Component {
         <span>{description}</span>
         <span>{error}</span>
         <div
-          style={prepareStyles(sliderStyles)}
+          style={prepareStyles(Object.assign(styles.slider, sliderStyle))}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
           onMouseDown={this.handleMouseDown}

--- a/src/SvgIcon/SvgIcon.js
+++ b/src/SvgIcon/SvgIcon.js
@@ -75,7 +75,7 @@ class SvgIcon extends Component {
     } = this.props;
 
     const {
-      baseTheme,
+      svgIcon,
       prepareStyles,
     } = this.context.muiTheme;
 
@@ -84,7 +84,7 @@ class SvgIcon extends Component {
 
     const mergedStyles = Object.assign({
       display: 'inline-block',
-      color: baseTheme.palette.textColor,
+      color: svgIcon.color,
       fill: this.state.hovered ? onColor : offColor,
       height: 24,
       width: 24,

--- a/src/TextField/EnhancedTextarea.js
+++ b/src/TextField/EnhancedTextarea.js
@@ -3,13 +3,12 @@ import EventListener from 'react-event-listener';
 
 const rowsHeight = 24;
 
-function getStyles(props, context, state) {
+function getStyles(props) {
   return {
     root: {
       position: 'relative', // because the shadow has position: 'absolute'
     },
     textarea: {
-      height: state.height,
       width: '100%',
       resize: 'none',
       font: 'inherit',
@@ -134,9 +133,11 @@ class EnhancedTextarea extends Component {
     } = this.props;
 
     const {prepareStyles} = this.context.muiTheme;
-    const styles = getStyles(this.props, this.context, this.state);
+    const styles = getStyles(this.props);
     const rootStyles = Object.assign({}, styles.root, style);
-    const textareaStyles = Object.assign({}, styles.textarea, textareaStyle);
+    const textareaStyles = Object.assign({}, styles.textarea, textareaStyle, {
+      height: this.state.height,
+    });
     const shadowStyles = Object.assign({}, textareaStyles, styles.shadow, shadowStyle);
 
     if (this.props.hasOwnProperty('valueLink')) {

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -238,6 +238,9 @@ export default function getMuiTheme(muiTheme, ...more) {
       disabledTextColor: fade(black, 0.26),
       connectorLineColor: grey400,
     },
+    svgIcon: {
+      color: palette.textColor,
+    },
     table: {
       backgroundColor: palette.canvasColor,
     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Currently the height property of the textarea is overridden by the value received in props from the TextField parent component and the result is this:

![textarea](https://cloud.githubusercontent.com/assets/6530577/16551025/f01060fc-41aa-11e6-98a2-e0b8f0f221a1.png)

Closes #4276.
Closes #4331.
