### PR TITLE
[SvgIcon] Add themeable color

### DIFF
--- a/src/SvgIcon/SvgIcon.js
+++ b/src/SvgIcon/SvgIcon.js
@@ -75,7 +75,7 @@ class SvgIcon extends Component {
     } = this.props;
 
     const {
-      baseTheme,
+      svgIcon,
       prepareStyles,
     } = this.context.muiTheme;
 
@@ -84,7 +84,7 @@ class SvgIcon extends Component {
 
     const mergedStyles = Object.assign({
       display: 'inline-block',
-      color: baseTheme.palette.textColor,
+      color: svgIcon.color,
       fill: this.state.hovered ? onColor : offColor,
       height: 24,
       width: 24,

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -238,6 +238,9 @@ export default function getMuiTheme(muiTheme, ...more) {
       disabledTextColor: fade(black, 0.26),
       connectorLineColor: grey400,
     },
+    svgIcon: {
+      color: palette.textColor,
+    },
     table: {
       backgroundColor: palette.canvasColor,
     },


### PR DESCRIPTION
This PR tends to reapply #4561 which was mistakenly applied on `0.15-stable` instead of `master`. I also conflicted with #4487 which I had to manually fix.

@mbrookes @hhaidar @oliviertassinari Please take a look at these changes and make sure everything is in place.