### PR TITLE
[Button] Never allow a disabled button to be in a hovered state.

### DIFF
--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -117,6 +117,14 @@ class FlatButton extends Component {
     touch: false,
   };
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.disabled && this.state.hovered) {
+      this.setState({
+        hovered: false,
+      });
+    }
+  }
+
   handleKeyboardFocus = (event, isKeyboardFocused) => {
     this.setState({isKeyboardFocused: isKeyboardFocused});
     this.props.onKeyboardFocus(event, isKeyboardFocused);

--- a/src/FlatButton/FlatButton.spec.js
+++ b/src/FlatButton/FlatButton.spec.js
@@ -166,4 +166,19 @@ describe('<FlatButton />', () => {
       }, 'label', 'FlatButton'), undefined);
     });
   });
+
+  describe('hover state', () => {
+    it('should reset the hover state when disabled', () => {
+      const wrapper = shallowWithContext(
+        <FlatButton label="foo" />
+      );
+
+      wrapper.simulate('mouseEnter');
+      assert.strictEqual(wrapper.state().hovered, true, 'should respond to the event');
+      wrapper.setProps({
+        disabled: true,
+      });
+      assert.strictEqual(wrapper.state().hovered, false, 'should reset the state');
+    });
+  });
 });

--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -238,10 +238,16 @@ class RaisedButton extends Component {
 
   componentWillReceiveProps(nextProps) {
     const zDepth = nextProps.disabled ? 0 : 1;
-    this.setState({
+    const nextState = {
       zDepth: zDepth,
       initialZDepth: zDepth,
-    });
+    };
+
+    if (nextProps.disabled && this.state.hovered) {
+      nextState.hovered = false;
+    }
+
+    this.setState(nextState);
   }
 
   handleMouseDown = (event) => {
@@ -279,7 +285,9 @@ class RaisedButton extends Component {
 
   handleMouseEnter = (event) => {
     if (!this.state.keyboardFocused && !this.state.touched) {
-      this.setState({hovered: true});
+      this.setState({
+        hovered: true,
+      });
     }
     if (this.props.onMouseEnter) {
       this.props.onMouseEnter(event);

--- a/src/RaisedButton/RaisedButton.spec.js
+++ b/src/RaisedButton/RaisedButton.spec.js
@@ -131,4 +131,19 @@ describe('<RaisedButton />', () => {
       }, 'label', 'RaisedButton'), undefined);
     });
   });
+
+  describe('hover state', () => {
+    it('should reset the hover state when disabled', () => {
+      const wrapper = shallowWithContext(
+        <RaisedButton label="foo" />
+      );
+
+      wrapper.children().simulate('mouseEnter');
+      assert.strictEqual(wrapper.state().hovered, true, 'should respond to the event');
+      wrapper.setProps({
+        disabled: true,
+      });
+      assert.strictEqual(wrapper.state().hovered, false, 'should reset the state');
+    });
+  });
 });


### PR DESCRIPTION
Continuation of #4531. Thanks @mhahn for raising the issue.

There are several cases where `onMouseLeave` (which normally unsets
the `hovered` state won't be called). One of those is if you disable a
button within the `onTouchTap` method.

This check ensures that a button will never be disabled but have an
internal hovered state.

Closes #4531.