### PR TITLE
[DatePicker] Added a clear date example

### DIFF
--- a/docs/src/app/components/pages/components/DatePicker/ExampleClearDate.js
+++ b/docs/src/app/components/pages/components/DatePicker/ExampleClearDate.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import DatePicker from 'material-ui/DatePicker';
+
+/**
+ * This example allows you to clear a selected date using `clearSelection`
+ */
+
+
+const DatePickerExampleClear = () => (
+  <div>
+    <DatePicker hintText="Clear Date Date Picker" clearSelection={true} />
+    <DatePicker hintText="Clear Date with Custom Label" clearSelection={true} cancelLabel="Custom Label" />
+  </div>
+);
+
+export default DatePickerExampleClear;

--- a/docs/src/app/components/pages/components/DatePicker/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/DatePicker/ExampleSimple.js
@@ -5,6 +5,8 @@ import DatePicker from 'material-ui/DatePicker';
  * The Date Picker defaults to a portrait dialog. The `mode` property can be set to `landscape`.
  * You can also disable the Dialog passing `true` to the `disabled` property.
  */
+
+
 const DatePickerExampleSimple = () => (
   <div>
     <DatePicker hintText="Portrait Dialog" />

--- a/docs/src/app/components/pages/components/DatePicker/Page.js
+++ b/docs/src/app/components/pages/components/DatePicker/Page.js
@@ -10,6 +10,8 @@ import DatePickerExampleSimple from './ExampleSimple';
 import datePickerExampleSimpleCode from '!raw!./ExampleSimple';
 import DatePickerExampleInline from './ExampleInline';
 import datePickerExampleInlineCode from '!raw!./ExampleInline';
+import DatePickerExampleClear from './ExampleClearDate';
+import datePickerExampleClear from '!raw!./ExampleClearDate';
 import DatePickerExampleToggle from './ExampleToggle';
 import datePickerExampleToggleCode from '!raw!./ExampleToggle';
 import DatePickerExampleControlled from './ExampleControlled';
@@ -35,6 +37,12 @@ const DatePickerPage = () => (
       code={datePickerExampleInlineCode}
     >
       <DatePickerExampleInline />
+    </CodeExample>
+    <CodeExample
+      title="Clear Date example"
+      code={datePickerExampleClear}
+    >
+      <DatePickerExampleClear />
     </CodeExample>
     <CodeExample
       title="Ranged example"

--- a/src/DatePicker/Calendar.js
+++ b/src/DatePicker/Calendar.js
@@ -30,6 +30,7 @@ class Calendar extends Component {
     DateTimeFormat: PropTypes.func.isRequired,
     autoOk: PropTypes.bool,
     cancelLabel: PropTypes.node,
+    clearSelection: PropTypes.bool,
     disableYearSelection: PropTypes.bool,
     firstDayOfWeek: PropTypes.number,
     initialDate: PropTypes.object,
@@ -361,6 +362,7 @@ class Calendar extends Component {
             <CalendarActionButtons
               autoOk={this.props.autoOk}
               cancelLabel={cancelLabel}
+              clearSelection={this.props.clearSelection}
               okLabel={okLabel}
               onTouchTapCancel={onTouchTapCancel}
               onTouchTapOk={onTouchTapOk}

--- a/src/DatePicker/CalendarActionButtons.js
+++ b/src/DatePicker/CalendarActionButtons.js
@@ -5,6 +5,8 @@ class CalendarActionButton extends Component {
   static propTypes = {
     autoOk: PropTypes.bool,
     cancelLabel: PropTypes.node,
+    clearSelection: PropTypes.bool,
+    handleCancelLabel: PropTypes.func,
     okLabel: PropTypes.node,
     onTouchTapCancel: PropTypes.func,
     onTouchTapOk: PropTypes.func,
@@ -35,7 +37,7 @@ class CalendarActionButton extends Component {
     return (
       <div style={styles.root} >
         <FlatButton
-          label={wordings ? wordings.cancel : cancelLabel}
+          label={(this.props.clearSelection && this.props.cancelLabel === 'Cancel') ? 'Clear' : cancelLabel}
           onTouchTap={this.props.onTouchTapCancel}
           primary={true}
           style={styles.flatButtons}

--- a/src/DatePicker/CalendarMonth.js
+++ b/src/DatePicker/CalendarMonth.js
@@ -5,6 +5,7 @@ import DayButton from './DayButton';
 class CalendarMonth extends Component {
   static propTypes = {
     autoOk: PropTypes.bool,
+    clearSelection: PropTypes.bool,
     displayDate: PropTypes.object.isRequired,
     firstDayOfWeek: PropTypes.number,
     maxDate: PropTypes.object,

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -20,13 +20,18 @@ class DatePicker extends Component {
      */
     autoOk: PropTypes.bool,
     /**
-     * Override the default text of the 'Cancel' button.
+     * Override the default text of the 'Cancel' / 'Clear' button.
      */
     cancelLabel: PropTypes.node,
     /**
      * The css class name of the root element.
      */
     className: PropTypes.string,
+    /**
+     * If true, will replace the cancel button with clear button. This button will clear the selected value
+     * upon clicking.
+     */
+    clearSelection: PropTypes.bool,
     /**
      * Used to control how the Date Picker will be displayed when the input field is focused.
      * `dialog` (default) displays the DatePicker as a dialog with a modal.
@@ -143,6 +148,7 @@ class DatePicker extends Component {
 
   static defaultProps = {
     autoOk: false,
+    clearSelection: false,
     container: 'dialog',
     disabled: false,
     disableYearSelection: false,
@@ -265,6 +271,7 @@ class DatePicker extends Component {
       autoOk,
       cancelLabel,
       className,
+      clearSelection,
       container,
       defaultDate, // eslint-disable-line no-unused-vars
       dialogContainerStyle,
@@ -304,6 +311,7 @@ class DatePicker extends Component {
           DateTimeFormat={DateTimeFormat}
           autoOk={autoOk}
           cancelLabel={cancelLabel}
+          clearSelection={clearSelection}
           container={container}
           containerStyle={dialogContainerStyle}
           disableYearSelection={disableYearSelection}

--- a/src/DatePicker/DatePickerDialog.js
+++ b/src/DatePicker/DatePickerDialog.js
@@ -12,6 +12,7 @@ class DatePickerDialog extends Component {
     DateTimeFormat: PropTypes.func,
     autoOk: PropTypes.bool,
     cancelLabel: PropTypes.node,
+    clearSelection: PropTypes.bool,
     container: PropTypes.oneOf(['dialog', 'inline']),
     containerStyle: PropTypes.object,
     disableYearSelection: PropTypes.bool,
@@ -44,6 +45,7 @@ class DatePickerDialog extends Component {
   };
 
   state = {
+    clearSelection: this.props.clearSelection,
     open: false,
   };
 
@@ -74,6 +76,9 @@ class DatePickerDialog extends Component {
   };
 
   handleTouchTapCancel = () => {
+    if (this.state.clearSelection) {
+      this.props.onAccept(undefined);
+    }
     this.dismiss();
   };
 
@@ -104,6 +109,7 @@ class DatePickerDialog extends Component {
       DateTimeFormat,
       autoOk,
       cancelLabel,
+      clearSelection,
       container,
       containerStyle,
       disableYearSelection,
@@ -159,6 +165,7 @@ class DatePickerDialog extends Component {
             autoOk={autoOk}
             DateTimeFormat={DateTimeFormat}
             cancelLabel={cancelLabel}
+            clearSelection={clearSelection}
             disableYearSelection={disableYearSelection}
             firstDayOfWeek={firstDayOfWeek}
             initialDate={initialDate}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Added `clearSelection` property, which when set to true will change the cancel button to a clear button and can be used to clear a selected date in DatePicker.

Closes #2204 

