### PR TITLE
[AutoComplete] Use dataSourceConfig.text instead of value when rendering MenuItems from objects

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -449,7 +449,7 @@ class AutoComplete extends Component {
                 value: (
                   <MenuItem
                     innerDivStyle={styles.innerDiv}
-                    primaryText={itemValue}
+                    primaryText={itemText}
                     disableFocusRipple={disableFocusRipple}
                     key={index}
                   />),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

We were using itemValue instead of itemText which made the AutoComplete menu render the wrong property as primaryText when using arrays of objects as a data source.

Using this dataSource config...
```
dataSourceConfig = {
	text: 'name',
	value: 'id',
}
```

... and an array with simple id + name objects rendered this

![screen shot 2016-07-07 at 14 55 35](https://cloud.githubusercontent.com/assets/437760/16654220/0cf83e86-4455-11e6-8b77-9d34e70fec54.png)

With this PR we now render

![screen shot 2016-07-07 at 14 54 05](https://cloud.githubusercontent.com/assets/437760/16654224/14ff6712-4455-11e6-9d2f-3629712a97cb.png)



