### PR TITLE
[Snackbar] textAlign 'center' by default

### DIFF
--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -26,6 +26,7 @@ function getStyles(props, context, state) {
       bottom: 0,
       zIndex: zIndex.snackbar,
       visibility: open ? 'visible' : 'hidden',
+      textAlign: 'center',
       transform: open ?
         'translate3d(0, 0, 0)' :
         `translate3d(0, ${desktopSubheaderHeight}px, 0)`,


### PR DESCRIPTION
This is purely a personal preference, but I feel like it is a responsible default to center the Snackbar content by default (text-align: center).