### PR TITLE
[Checkbox]Add Type check to avoid alway false condition

### DIFF
--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -141,11 +141,13 @@ class Checkbox extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState({
-      switched: this.props.checked !== nextProps.checked ?
-        nextProps.checked :
-        this.state.switched,
-    });
+    if (nextProps.checked !== undefined) {
+      this.setState({
+        switched: this.props.checked !== nextProps.checked ?
+          nextProps.checked :
+          this.state.switched,
+      });
+    }
   }
 
   isChecked() {


### PR DESCRIPTION
- [ ] PR has tests / docs demo, and is linted.

- [x]  Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".

- [x]  Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

This fixes #4653 
This also enable a temporary solution to leave the Checkbox uncontrolled #2832 
when setting onCheck without checked prop, the
`this.props.checked !== nextProps.checked` always return false cause
setState in WillReceiveProps which should be checked in
componeentDidUpdate
This cause unexpected behavior in #2983  which was not resolved correctly