### PR TITLE
[ListItem] with disableKeyboardFocus=true does not get keyboard focus

### DIFF
--- a/src/internal/EnhancedButton.js
+++ b/src/internal/EnhancedButton.js
@@ -89,7 +89,6 @@ class EnhancedButton extends Component {
     onTouchEnd: () => {},
     onTouchStart: () => {},
     onTouchTap: () => {},
-    tabIndex: 0,
     type: 'button',
   };
 


### PR DESCRIPTION
- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

---

The ListItem gets keyboard focus even though `disableKeyboardFocus` property turn to `true`. Because it have `tabindex` property and the value is `0`. Do not set `tabindex` property to refuse getting keyboard focus.
