### PR TITLE
[EnhancedButton] Fix invalid `labelColor` prop being passed

### DIFF
--- a/src/internal/EnhancedButton.js
+++ b/src/internal/EnhancedButton.js
@@ -261,6 +261,7 @@ class EnhancedButton extends Component {
       centerRipple, // eslint-disable-line no-unused-vars
       children,
       containerElement,
+      labelColor, // eslint-disable-line no-unused-vars
       disabled,
       disableFocusRipple,
       disableKeyboardFocus, // eslint-disable-line no-unused-vars


### PR DESCRIPTION
Just updated to v0.15.2 and caught this prop still being passed down to `<button>` :smile: