### PR TITLE
[FloatingActionButton] Fix invalid 'backgroundColor' prop being passed

### DIFF
--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -234,6 +234,7 @@ class FloatingActionButton extends Component {
 
   render() {
     const {
+      backgroundColor,
       className,
       disabled,
       mini,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

This PR resolves remaining react invalid props warnings for following props:

 * backgroundColor in FloatingActionButton