### PR TITLE
[AutoComplete and other Popover based elements] Animation property added to Popover based elements

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -52,6 +52,10 @@ class AutoComplete extends Component {
      */
     animated: PropTypes.bool,
     /**
+     * Override the default animation component used.
+     */
+    animation: PropTypes.func,
+    /**
      * Array of strings or nodes used to populate the list.
      */
     dataSource: PropTypes.array.isRequired,
@@ -375,6 +379,7 @@ class AutoComplete extends Component {
     const {
       anchorOrigin,
       animated,
+      animation,
       dataSource,
       dataSourceConfig, // eslint-disable-line no-unused-vars
       disableFocusRipple,
@@ -511,6 +516,7 @@ class AutoComplete extends Component {
           useLayerForClickAway={false}
           onRequestClose={this.handleRequestClose}
           animated={animated}
+          animation={animation}
         >
           {menu}
         </Popover>

--- a/src/DatePicker/DatePickerDialog.js
+++ b/src/DatePicker/DatePickerDialog.js
@@ -10,6 +10,7 @@ import {dateTimeFormat} from './dateUtils';
 class DatePickerDialog extends Component {
   static propTypes = {
     DateTimeFormat: PropTypes.func,
+    animation: PropTypes.func,
     autoOk: PropTypes.bool,
     cancelLabel: PropTypes.node,
     container: PropTypes.oneOf(['dialog', 'inline']),
@@ -120,6 +121,7 @@ class DatePickerDialog extends Component {
       shouldDisableDate,
       style, // eslint-disable-line no-unused-vars
       wordings,
+      animation,
       ...other,
     } = this.props;
 
@@ -142,7 +144,7 @@ class DatePickerDialog extends Component {
       <div {...other} ref="root">
         <Container
           anchorEl={this.refs.root} // For Popover
-          animation={PopoverAnimationFromTop} // For Popover
+          animation={animation || PopoverAnimationFromTop} // For Popover
           bodyStyle={styles.dialogBodyContent}
           contentStyle={styles.dialogContent}
           ref="dialog"

--- a/src/DatePicker/DatePickerDialog.js
+++ b/src/DatePicker/DatePickerDialog.js
@@ -4,7 +4,7 @@ import keycode from 'keycode';
 import Calendar from './Calendar';
 import Dialog from '../Dialog';
 import Popover from '../Popover/Popover';
-import PopoverAnimationFromTop from '../Popover/PopoverAnimationVertical';
+import PopoverAnimationVertical from '../Popover/PopoverAnimationVertical';
 import {dateTimeFormat} from './dateUtils';
 
 class DatePickerDialog extends Component {
@@ -144,7 +144,7 @@ class DatePickerDialog extends Component {
       <div {...other} ref="root">
         <Container
           anchorEl={this.refs.root} // For Popover
-          animation={animation || PopoverAnimationFromTop} // For Popover
+          animation={animation || PopoverAnimationVertical} // For Popover
           bodyStyle={styles.dialogBodyContent}
           contentStyle={styles.dialogContent}
           ref="dialog"

--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -80,6 +80,10 @@ class DropDownMenu extends Component {
      */
     animated: PropTypes.bool,
     /**
+     * Override the default animation component used.
+     */
+    animation: PropTypes.func,
+    /**
      * The width will automatically be set according to the items inside the menu.
      * To control this width in css instead, set this prop to `false`.
      */
@@ -239,6 +243,7 @@ class DropDownMenu extends Component {
   render() {
     const {
       animated,
+      animation,
       autoWidth,
       children,
       className,
@@ -298,7 +303,7 @@ class DropDownMenu extends Component {
         <Popover
           anchorOrigin={anchorOrigin}
           anchorEl={anchorEl}
-          animation={PopoverAnimationFromTop}
+          animation={animation || PopoverAnimationFromTop}
           open={open}
           animated={animated}
           onRequestClose={this.handleRequestCloseMenu}

--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -4,7 +4,7 @@ import DropDownArrow from '../svg-icons/navigation/arrow-drop-down';
 import Menu from '../Menu/Menu';
 import ClearFix from '../internal/ClearFix';
 import Popover from '../Popover/Popover';
-import PopoverAnimationFromTop from '../Popover/PopoverAnimationVertical';
+import PopoverAnimationVertical from '../Popover/PopoverAnimationVertical';
 
 const anchorOrigin = {
   vertical: 'top',
@@ -303,7 +303,7 @@ class DropDownMenu extends Component {
         <Popover
           anchorOrigin={anchorOrigin}
           anchorEl={anchorEl}
-          animation={animation || PopoverAnimationFromTop}
+          animation={animation || PopoverAnimationVertical}
           open={open}
           animated={animated}
           onRequestClose={this.handleRequestCloseMenu}

--- a/src/IconMenu/IconMenu.js
+++ b/src/IconMenu/IconMenu.js
@@ -23,6 +23,10 @@ class IconMenu extends Component {
      */
     animated: PropTypes.bool,
     /**
+     * Override the default animation component used.
+     */
+    animation: PropTypes.func,
+    /**
      * Should be used to pass `MenuItem` components.
      */
     children: PropTypes.node,
@@ -225,6 +229,7 @@ class IconMenu extends Component {
       anchorOrigin,
       className,
       animated,
+      animation,
       iconButtonElement,
       iconStyle,
       onItemTouchTap, // eslint-disable-line no-unused-vars
@@ -302,6 +307,7 @@ class IconMenu extends Component {
           useLayerForClickAway={useLayerForClickAway}
           onRequestClose={this.handleRequestClose}
           animated={animated}
+          animation={animation}
           context={this.context}
         >
           {menu}

--- a/src/MenuItem/MenuItem.js
+++ b/src/MenuItem/MenuItem.js
@@ -58,6 +58,10 @@ class MenuItem extends Component {
 
   static propTypes = {
     /**
+     * Override the default animation component used.
+     */
+    animation: PropTypes.func,
+    /**
      * If true, a left check mark will be rendered.
      */
     checked: PropTypes.bool,
@@ -228,6 +232,7 @@ class MenuItem extends Component {
       rightIcon,
       secondaryText,
       style,
+      animation,
       value, // eslint-disable-line no-unused-vars
       ...other,
     } = this.props;
@@ -268,6 +273,7 @@ class MenuItem extends Component {
     if (menuItems) {
       childMenuPopover = (
         <Popover
+          animation={animation}
           anchorOrigin={{horizontal: 'right', vertical: 'top'}}
           anchorEl={this.state.anchorEl}
           open={this.state.open}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

For some cases animation have to be customised. Right now there are now way to customise animations of Popover-based elements, since animation is not transferred to property. This PR adds `animation` property to Popover based elements. This property is added to documentation. I don't see that any additional tests are needed, but if they are, please let me know.
