### PR TITLE
[Slider] Pass this.state.value into onDragStop & onDragStart

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -632,7 +632,7 @@ class Slider extends Component {
     });
 
     if (this.props.onDragStart) {
-      this.props.onDragStart(event);
+      this.props.onDragStart(event, this.state.value);
     }
   }
 
@@ -643,7 +643,7 @@ class Slider extends Component {
     });
 
     if (this.props.onDragStop) {
-      this.props.onDragStop(event);
+      this.props.onDragStop(event, this.state.value);
     }
   }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


Someone I know was having issues getting the slider value back when the user stops sliding. It was being passed back whilst sliding (`onChange`) but that's now what they were after.

From what I can see, the only way of getting that value is creating a ref on the Slider component and accessing `this.refs.slider.getValue()` within the `onDragStop` method. Like the `onChange` method, the second param is now the slider value. I also added the same to `onDragStart` for consistency.