### PR TITLE
[Snackbar] change the action's PropType to node

### DIFF
--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -42,7 +42,7 @@ class Snackbar extends Component {
     /**
      * The label for the action on the snackbar.
      */
-    action: PropTypes.string,
+    action: PropTypes.node,
     /**
      * The number of milliseconds to wait before automatically dismissing.
      * If no value is specified the snackbar will dismiss normally.

--- a/src/Snackbar/SnackbarBody.js
+++ b/src/Snackbar/SnackbarBody.js
@@ -95,7 +95,7 @@ SnackbarBody.propTypes = {
   /**
    * The label for the action on the snackbar.
    */
-  action: PropTypes.string,
+  action: PropTypes.node,
   /**
    * The message to be displayed.
    *


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Snackbar's action should accept a node rather than a string for i18n.

I'm using [react-intl](https://github.com/yahoo/react-intl) for i18n.
The component is expressed like `<FormattedMessage id="dismiss" defaultMessage="Dismiss"/>`
I'd like to pass that to Snackbar's action without getting a warning.

I think it's a common use case for apps with i18n since react-intl is the most popular library for i18n and a component in the other libraries like [i18n-react](https://github.com/alexdrel/i18n-react) is also expressed like that.
So it would be better if Snackbar's action accepts a node rather than a string.

Let me know if I'm missing something.

Thanks!