### PR TITLE
[List] Prefix the style properties

### DIFF
--- a/src/List/List.js
+++ b/src/List/List.js
@@ -1,4 +1,4 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component, PropTypes, Children, isValidElement} from 'react';
 import propTypes from '../utils/propTypes';
 import Subheader from '../Subheader';
 import deprecated from '../utils/deprecatedPropType';
@@ -53,16 +53,18 @@ class List extends Component {
       ...other,
     } = this.props;
 
+    const {prepareStyles} = this.context.muiTheme;
+
     warning((typeof zDepth === 'undefined'), 'List no longer supports `zDepth`. Instead, wrap it in `Paper` ' +
-        'or another component that provides zDepth. It will be removed with v0.16.0.');
+      'or another component that provides zDepth. It will be removed with v0.16.0.');
 
     let hasSubheader = false;
 
     if (subheader) {
       hasSubheader = true;
     } else {
-      const firstChild = React.Children.toArray(children)[0];
-      if (React.isValidElement(firstChild) && firstChild.type === Subheader) {
+      const firstChild = Children.toArray(children)[0];
+      if (isValidElement(firstChild) && firstChild.type === Subheader) {
         hasSubheader = true;
       }
     }
@@ -76,11 +78,12 @@ class List extends Component {
     };
 
     return (
-      <div
-        {...other}
-        style={Object.assign(styles.root, style)}
-      >
-        {subheader && <Subheader inset={insetSubheader} style={subheaderStyle}>{subheader}</Subheader>}
+      <div {...other} style={prepareStyles(Object.assign(styles.root, style))}>
+        {subheader && (
+          <Subheader inset={insetSubheader} style={subheaderStyle}>
+            {subheader}
+          </Subheader>
+        )}
         {children}
       </div>
     );


### PR DESCRIPTION
`prepareStyles` was missing in this component, causing one issue with the `userSelect: 'none'`.
It's working fine now:

![capture d ecran 2016-07-15 a 20 19 07](https://cloud.githubusercontent.com/assets/3165635/16884424/993ea7c0-4ac9-11e6-9407-ebf3362340b0.png)

Address this comment https://github.com/callemall/material-ui/pull/4715#issuecomment-232769759.