### PR TITLE
[TextField] False should be a valid value

### DIFF
--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -113,7 +113,7 @@ const getStyles = (props, context, state) => {
  * @returns True if the string provided is valid, false otherwise.
  */
 function isValid(value) {
-  return Boolean(value || value === 0);
+  return value !== '' && value !== undefined && value !== null;
 }
 
 class TextField extends Component {

--- a/src/TextField/TextField.spec.js
+++ b/src/TextField/TextField.spec.js
@@ -77,4 +77,40 @@ describe('<TextField />', () => {
       );
     });
   });
+
+  describe('isValid', () => {
+    it('should consider the input as empty', () => {
+      const values = [
+        undefined,
+        null,
+        '',
+      ];
+
+      values.forEach((value) => {
+        const wrapper = shallowWithContext(
+          <TextField id="isValid" value={value} />
+        );
+
+        assert.strictEqual(wrapper.state().hasValue, false,
+          `Should consider '${value}' as empty`);
+      });
+    });
+
+    it('should consider the input as not empty', () => {
+      const values = [
+        ' ',
+        0,
+        false,
+      ];
+
+      values.forEach((value) => {
+        const wrapper = shallowWithContext(
+          <TextField id="isValid" value={value} />
+        );
+
+        assert.strictEqual(wrapper.state().hasValue, true,
+          `Should consider '${value}' as not empty`);
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

@crudh Thanks for raising this issue. I have added some tests and cleared the implementation.
Could you have a look at this PR?

The issue:
```js
        <TextField
          value={false}
          hintText="This is an hint text"
        />
```
![capture d ecran 2016-07-16 a 13 10 06](https://cloud.githubusercontent.com/assets/3165635/16894452/a81acf5c-4b56-11e6-99e1-2a6c6f9984c4.png)


Closes #4491.

For the full history of this method, #1080, #1090, #2073.

