### PR TITLE
[ListItem] Trigger onNestedListToggle callback after state update

### DIFF
--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -419,8 +419,9 @@ class ListItem extends Component {
 
   handleNestedListToggle = (event) => {
     event.stopPropagation();
-    this.setState({open: !this.state.open});
-    this.props.onNestedListToggle(this);
+    this.setState({open: !this.state.open}, () => {
+      this.props.onNestedListToggle(this);
+    });
   };
 
   handleRightIconButtonKeyboardFocus = (event, isKeyboardFocused) => {


### PR DESCRIPTION
Before the fix, `onNestedListToggle` callback was fired right after `this.setState`.  And when the callback is executed, the toggle state has not changed and you will get the wrong `item.state.open` state due to async state update.

After the fix, the callback is fired *after* state change to make sure the callback get the correct toggle open state.