### PR TITLE
[ListItem] Fix incorrect `nestedLevel`

### DIFF
--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -624,7 +624,7 @@ class ListItem extends Component {
     }
 
     const nestedList = nestedItems.length ? (
-      <NestedList nestedLevel={nestedLevel + 1} open={this.state.open} style={nestedListStyle}>
+      <NestedList nestedLevel={nestedLevel} open={this.state.open} style={nestedListStyle}>
         {nestedItems}
       </NestedList>
     ) : undefined;


### PR DESCRIPTION
The `nestedLevel` is already added in `NestedList`, so no more `+ 1` here.
```jsx
class NestedList extends Component {
    //...
    return (
      <List style={Object.assign({}, styles.root, style)}>
        {
          React.Children.map(children, (child) => {
            return React.isValidElement(child) ? (
              React.cloneElement(child, {
                nestedLevel: nestedLevel + 1,
              })
            ) : child;
          })
        }
      </List>
    );
}
```