### PR TITLE
[CardHeader] Removed the unnecessary right padding

### DIFF
--- a/src/Card/CardHeader.js
+++ b/src/Card/CardHeader.js
@@ -16,7 +16,6 @@ function getStyles(props, context) {
       display: 'inline-block',
       verticalAlign: 'top',
       whiteSpace: 'normal',
-      paddingRight: '90px',
     },
     avatar: {
       marginRight: 16,


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Removed the unnecessary right padding from the title style. Doesn't affect desktop, but makes the title look a lot better on smaller screens. Closes #4695 
