### PR TITLE
[FlatButton] Merge styles prop for FontIcon node

### DIFF
--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -213,13 +213,14 @@ class FlatButton extends Component {
     const labelStyleIcon = {};
 
     if (icon) {
+      const iconStyles = Object.assign({
+        verticalAlign: 'middle',
+        marginLeft: label && labelPosition !== 'before' ? 12 : 0,
+        marginRight: label && labelPosition === 'before' ? 12 : 0,
+      }, icon.props.style);
       iconCloned = React.cloneElement(icon, {
         color: icon.props.color || mergedRootStyles.color,
-        style: {
-          verticalAlign: 'middle',
-          marginLeft: label && labelPosition !== 'before' ? 12 : 0,
-          marginRight: label && labelPosition === 'before' ? 12 : 0,
-        },
+        style: iconStyles,
       });
 
       if (labelPosition === 'before') {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

At the moment, a few default styles are merged into the icon node passed to FlatButton, overriding any styles the user passes. This resolves that by reordering the merge to favor the user's styles. Fixes #4632.

