### PR TITLE
[DropDownMenu] Do not wrap below dropdown menu.

### DIFF
--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -32,13 +32,16 @@ function getStyles(props, context) {
     label: {
       color: disabled ? palette.disabledColor : palette.textColor,
       lineHeight: `${spacing.desktopToolbarHeight}px`,
+      overflow: 'hidden',
       opacity: 1,
       position: 'relative',
       paddingLeft: spacing.desktopGutter,
       paddingRight: spacing.iconSize +
       spacing.desktopGutterLess +
       spacing.desktopGutterMini,
+      textOverflow: 'ellipsis',
       top: 0,
+      whiteSpace: 'nowrap',
     },
     labelWhenOpen: {
       opacity: 0,


### PR DESCRIPTION
### Problem description

The text is wrapping below the dropdown menu if the text is too long. (This is mostly for the SelectField component.)
### Steps to reproduce
1. Create a dropdown menu with a fixed size.
2. Enter a long string as value.
### Versions

Only tested on...
- Material-UI: 0.15.2
- React: 15.1.0
- Browser: Pretty much all of them!
