### PR TITLE
[TextField] Don't modify error bottom style if we need to override it

### DIFF
--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -92,7 +92,7 @@ const getStyles = (props, context, state) => {
       styles.input.marginTop = 14;
     }
 
-    if (state.errorText) {
+    if (state.errorText && !(props.errorStyle && props.errorStyle.bottom)) {
       styles.error.bottom = !props.multiLine ? styles.error.fontSize + 3 : 3;
     }
   }


### PR DESCRIPTION
If we trying to pass custom bottom style in errorStyle it doesn't apply
![screenshot_1](https://cloud.githubusercontent.com/assets/13744473/17002560/86ea7284-4ed4-11e6-92d9-3f5350a83235.png)

**Sample code**

```jsx
  render() {
    const errorStyle = {
      position: 'absolute',
      bottom: -7
    };
    return (
          <TextField
            id="password"
            hintText="Password here"
            floatingLabelText="Password"
            floatingLabelFixed={true}
            type="password"
            errorText={passwordError}
            errorStyle={errorStyle}
            fullWidth={true}
          />
      </div>
    );
  }
```
