### PR TITLE
[MenuItem] Add right padding when there is icon.

### DIFF
--- a/src/MenuItem/MenuItem.js
+++ b/src/MenuItem/MenuItem.js
@@ -13,7 +13,7 @@ const nestedMenuStyle = {
 function getStyles(props, context) {
   const disabledColor = context.muiTheme.baseTheme.palette.disabledColor;
   const textColor = context.muiTheme.baseTheme.palette.textColor;
-  const leftIndent = props.desktop ? 64 : 72;
+  const indent = props.desktop ? 64 : 72;
   const sidePadding = props.desktop ? 24 : 16;
 
   const styles = {
@@ -26,8 +26,8 @@ function getStyles(props, context) {
     },
 
     innerDivStyle: {
-      paddingLeft: props.leftIcon || props.insetChildren || props.checked ? leftIndent : sidePadding,
-      paddingRight: sidePadding,
+      paddingLeft: props.leftIcon || props.insetChildren || props.checked ? indent : sidePadding,
+      paddingRight: props.rightIcon ? indent : sidePadding,
       paddingBottom: 0,
       paddingTop: 0,
     },


### PR DESCRIPTION
### Problem description

The text of the menu item is below the right icon.
### Steps to reproduce
1. Create a dropdown menu with a fixed size.
2. Enter a long string as value of the menu item.
3. Add a right icon to the menu item.
### Versions

Only tested on...
- Material-UI: 0.15.2
- React: 15.1.0
- Browser: Pretty much all of them!
