### PR TITLE
[DropDownMenu] Display the first item in case there's no one with the corresponding value

### DIFF
--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -267,9 +267,9 @@ class DropDownMenu extends Component {
     const {prepareStyles} = this.context.muiTheme;
     const styles = getStyles(this.props, this.context);
 
-    let displayValue = '';
+    let displayValue;
     React.Children.forEach(children, (child) => {
-      if (value === child.props.value) {
+      if (!displayValue || value === child.props.value) {
         // This will need to be improved (in case primaryText is a node)
         displayValue = child.props.label || child.props.primaryText;
       }

--- a/src/DropDownMenu/DropDownMenu.spec.js
+++ b/src/DropDownMenu/DropDownMenu.spec.js
@@ -11,7 +11,19 @@ describe('<DropDownMenu />', () => {
 
   it('displays the text field of menuItems prop at index x when value prop is x', () => {
     const wrapper = shallowWithContext(
-      <DropDownMenu value={1}>
+      <DropDownMenu value={2}>
+        <div value={1} primaryText="Never" />
+        <div value={2} primaryText="Every Night" />
+        <div value={3} primaryText="Weeknights" />
+      </DropDownMenu>
+    );
+
+    assert.strictEqual(wrapper.childAt(0).childAt(0).childAt(0).node, 'Every Night');
+  });
+
+  it('displays the text field of the first menuItems prop when value prop isn\'t found', () => {
+    const wrapper = shallowWithContext(
+      <DropDownMenu value={4}>
         <div value={1} primaryText="Never" />
         <div value={2} primaryText="Every Night" />
         <div value={3} primaryText="Weeknights" />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Like for html select tag, display the first option in case there's no one with the corresponding value. Useful for migrating from vanilla `<select value=.../>`, also when having dynamic options it wouldn't be effective to traverse the array twice to identify if the value in present. Just displaying an empty element as before doesn't look like a reasonable solution.