### PR TITLE
[Popover] Making sure Popover has correct position

### DIFF
--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -148,6 +148,10 @@ class Popover extends Component {
   componentDidUpdate() {
     this.setPlacement();
   }
+  
+  componentDidMount() {
+    this.setPlacement();
+  }
 
   componentWillUnmount() {
     clearTimeout(this.timeout);

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -120,6 +120,10 @@ class Popover extends Component {
     };
   }
 
+  componentDidMount() {
+    this.setPlacement();
+  }
+
   componentWillReceiveProps(nextProps) {
     if (nextProps.open !== this.state.open) {
       if (nextProps.open) {
@@ -146,10 +150,6 @@ class Popover extends Component {
   }
 
   componentDidUpdate() {
-    this.setPlacement();
-  }
-  
-  componentDidMount() {
     this.setPlacement();
   }
 


### PR DESCRIPTION
When Popover gets initially rendered with `this.props.open = true`, the positioning is incorrect (as the logic never gets run). This is because this.componentDidUpdate() is handling the placement when it renders, but that method doesn't get called on the initial render. (https://facebook.github.io/react/docs/component-specs.html#updating-componentdidupdate) To fix this I added this.componentDidMount().