### PR TITLE
[ListItem] New property open to toggle nested list

### DIFF
--- a/docs/src/app/components/pages/components/List/ExampleNested.js
+++ b/docs/src/app/components/pages/components/List/ExampleNested.js
@@ -64,7 +64,6 @@ export default class ListExampleNested extends React.Component {
                 <ListItem
                   key={3}
                   primaryText="Inbox"
-                  className="TESTTESTT"
                   leftIcon={<ContentInbox />}
                   open={this.state.open}
                   onNestedListToggle={this.handleNestedListToggle}

--- a/docs/src/app/components/pages/components/List/ExampleNested.js
+++ b/docs/src/app/components/pages/components/List/ExampleNested.js
@@ -1,42 +1,80 @@
 import React from 'react';
 import MobileTearSheet from '../../../MobileTearSheet';
-import {List, ListItem} from 'material-ui/List';
+import { List, ListItem } from 'material-ui/List';
 import ActionGrade from 'material-ui/svg-icons/action/grade';
 import ContentInbox from 'material-ui/svg-icons/content/inbox';
 import ContentDrafts from 'material-ui/svg-icons/content/drafts';
 import ContentSend from 'material-ui/svg-icons/content/send';
 import Subheader from 'material-ui/Subheader';
+import Toggle from 'material-ui/Toggle'
 
-const ListExampleNested = () => (
-  <MobileTearSheet>
-    <List>
-      <Subheader>Nested List Items</Subheader>
-      <ListItem primaryText="Sent mail" leftIcon={<ContentSend />} />
-      <ListItem primaryText="Drafts" leftIcon={<ContentDrafts />} />
-      <ListItem
-        primaryText="Inbox"
-        leftIcon={<ContentInbox />}
-        initiallyOpen={true}
-        primaryTogglesNestedList={true}
-        nestedItems={[
-          <ListItem
-            key={1}
-            primaryText="Starred"
-            leftIcon={<ActionGrade />}
-          />,
-          <ListItem
-            key={2}
-            primaryText="Sent Mail"
-            leftIcon={<ContentSend />}
-            disabled={true}
-            nestedItems={[
-              <ListItem key={1} primaryText="Drafts" leftIcon={<ContentDrafts />} />,
-            ]}
-          />,
-        ]}
-      />
-    </List>
-  </MobileTearSheet>
-);
+export default class ListExampleNested extends React.Component {
 
-export default ListExampleNested;
+  state = {
+    open: false
+  };
+
+  handleToggle = () => {
+    this.setState({
+      open: !this.state.open
+    });
+  };
+
+  syncState = (item) => {
+    this.setState({
+      open: item.state.open
+    });
+  };
+
+  render() {
+    return (
+      <div>
+        <Toggle
+          toggled={this.state.open}
+          onToggle={this.handleToggle}
+          labelPosition="right"
+          label="This toggle controls the expanded state of the submenu item."
+        /><br/>
+        <MobileTearSheet>
+          <List>
+            <Subheader>Nested List Items</Subheader>
+            <ListItem primaryText="Sent mail" leftIcon={<ContentSend />} />
+            <ListItem primaryText="Drafts" leftIcon={<ContentDrafts />} />
+            <ListItem
+              primaryText="Inbox"
+              leftIcon={<ContentInbox />}
+              initiallyOpen={true}
+              primaryTogglesNestedList={true}
+              nestedItems={[
+                <ListItem
+                  key={1}
+                  primaryText="Starred"
+                  leftIcon={<ActionGrade />}
+                />,
+                <ListItem
+                  key={2}
+                  primaryText="Sent Mail"
+                  leftIcon={<ContentSend />}
+                  disabled={true}
+                  nestedItems={[
+                    <ListItem key={1} primaryText="Drafts" leftIcon={<ContentDrafts />} />,
+                  ]}
+                />,
+                <ListItem
+                  key={3}
+                  primaryText="Inbox"
+                  leftIcon={<ContentInbox />}
+                  open={this.state.open}
+                  onNestedListToggle={this.syncState}
+                  nestedItems={[
+                    <ListItem key={1} primaryText="Drafts" leftIcon={<ContentDrafts />} />,
+                  ]}
+                />
+              ]}
+            />
+          </List>
+        </MobileTearSheet>
+      </div>
+    );
+  }
+}

--- a/docs/src/app/components/pages/components/List/ExampleNested.js
+++ b/docs/src/app/components/pages/components/List/ExampleNested.js
@@ -64,6 +64,7 @@ export default class ListExampleNested extends React.Component {
                 <ListItem
                   key={3}
                   primaryText="Inbox"
+                  className="TESTTESTT"
                   leftIcon={<ContentInbox />}
                   open={this.state.open}
                   onNestedListToggle={this.handleNestedListToggle}

--- a/docs/src/app/components/pages/components/List/ExampleNested.js
+++ b/docs/src/app/components/pages/components/List/ExampleNested.js
@@ -1,28 +1,28 @@
 import React from 'react';
 import MobileTearSheet from '../../../MobileTearSheet';
-import { List, ListItem } from 'material-ui/List';
+import {List, ListItem} from 'material-ui/List';
 import ActionGrade from 'material-ui/svg-icons/action/grade';
 import ContentInbox from 'material-ui/svg-icons/content/inbox';
 import ContentDrafts from 'material-ui/svg-icons/content/drafts';
 import ContentSend from 'material-ui/svg-icons/content/send';
 import Subheader from 'material-ui/Subheader';
-import Toggle from 'material-ui/Toggle'
+import Toggle from 'material-ui/Toggle';
 
 export default class ListExampleNested extends React.Component {
 
   state = {
-    open: false
+    open: false,
   };
 
   handleToggle = () => {
     this.setState({
-      open: !this.state.open
+      open: !this.state.open,
     });
   };
 
-  syncState = (item) => {
+  handleNestedListToggle = (item) => {
     this.setState({
-      open: item.state.open
+      open: item.state.open,
     });
   };
 
@@ -34,7 +34,8 @@ export default class ListExampleNested extends React.Component {
           onToggle={this.handleToggle}
           labelPosition="right"
           label="This toggle controls the expanded state of the submenu item."
-        /><br/>
+        />
+        <br />
         <MobileTearSheet>
           <List>
             <Subheader>Nested List Items</Subheader>
@@ -65,11 +66,11 @@ export default class ListExampleNested extends React.Component {
                   primaryText="Inbox"
                   leftIcon={<ContentInbox />}
                   open={this.state.open}
-                  onNestedListToggle={this.syncState}
+                  onNestedListToggle={this.handleNestedListToggle}
                   nestedItems={[
                     <ListItem key={1} primaryText="Drafts" leftIcon={<ContentDrafts />} />,
                   ]}
-                />
+                />,
               ]}
             />
           </List>

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -286,6 +286,7 @@ class ListItem extends Component {
     onMouseLeave: () => {},
     onNestedListToggle: () => {},
     onTouchStart: () => {},
+    open: null,
     primaryTogglesNestedList: false,
     secondaryTextLines: 1,
   };
@@ -304,15 +305,15 @@ class ListItem extends Component {
   };
 
   componentWillMount() {
-    if (this.props.initiallyOpen) {
-      this.setState({open: true});
-    }
+    this.setState({
+      open: this.props.open === null ? this.props.initiallyOpen === true : this.props.open,
+    });
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.open !== nextProps.open) {
+    // update the state when the component is controlled.
+    if (nextProps.open !== null)
       this.setState({open: nextProps.open});
-    }
   }
 
   shouldComponentUpdate(nextProps, nextState, nextContext) {

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -224,6 +224,10 @@ class ListItem extends Component {
     /** @ignore */
     onTouchTap: PropTypes.func,
     /**
+     * Control toggle state of nested list.
+     */
+    open: PropTypes.bool,
+    /**
      * This is the block element that contains the primary text.
      * If a string is passed in, a div tag will be rendered.
      */
@@ -302,6 +306,12 @@ class ListItem extends Component {
   componentWillMount() {
     if (this.props.initiallyOpen) {
       this.setState({open: true});
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.open !== nextProps.open) {
+      this.setState({open: nextProps.open});
     }
   }
 

--- a/src/List/ListItem.spec.js
+++ b/src/List/ListItem.spec.js
@@ -73,4 +73,43 @@ describe('<ListItem />', () => {
     assert.ok(wrapper.find('.test-checkbox').length);
     assert.strictEqual(wrapper.find(`.${testClass}`).length, 1, 'should have a div with the test class');
   });
+
+  it('should initially open nested list', () => {
+    const testClass = 'test-class';
+    const wrapper = shallowWithContext(
+      <ListItem
+        className={testClass}
+        initiallyOpen={true}
+        nestedItems={[
+          <ListItem
+            key={1}
+          />,
+        ]}
+      />
+    );
+
+    assert.ok(wrapper.find('NestedList').length);
+    assert.ok(wrapper.find('.test-class').parent().children().nodes[1].props.open === true);
+  });
+
+  it('should toggle nested list', () => {
+    const testClass = 'test-class';
+    const wrapper = shallowWithContext(
+      <ListItem
+        className={testClass}
+        open={false}
+        nestedItems={[
+          <ListItem
+            key={1}
+          />,
+        ]}
+      />
+    );
+
+    assert.ok(wrapper.find('.test-class').parent().children().nodes[1].props.open === false);
+    wrapper.setProps({
+      open: true,
+    });
+    assert.ok(wrapper.find('.test-class').parent().children().nodes[1].props.open === true);
+  });
 });


### PR DESCRIPTION
This PR resolves #4803. With the new property `open` one can toggle the nested list, even when the component already did mount.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).