### PR TITLE
[AutoComplete] Add a textFieldStyle property

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -122,6 +122,10 @@ class AutoComplete extends Component {
      * Override style for menu.
      */
     menuStyle: PropTypes.object,
+    /**
+     * Override style for TextField
+     */
+    textFieldStyle: PropTypes.object,
     /** @ignore */
     onBlur: PropTypes.func,
     /** @ignore */
@@ -391,6 +395,7 @@ class AutoComplete extends Component {
       hintText,
       maxSearchResults,
       menuCloseDelay, // eslint-disable-line no-unused-vars
+      textFieldStyle,
       menuStyle,
       menuProps,
       listStyle,
@@ -505,6 +510,7 @@ class AutoComplete extends Component {
           fullWidth={fullWidth}
           multiLine={false}
           errorStyle={errorStyle}
+          style={textFieldStyle}
         />
         <Popover
           style={styles.popover}

--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -165,7 +165,7 @@ class AutoComplete extends Component {
      */
     targetOrigin: propTypes.origin,
     /**
-     * Override style for TextField
+     * Override the inline-styles of AutoComplete's TextField element.
      */
     textFieldStyle: PropTypes.object,
     /**

--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -122,10 +122,6 @@ class AutoComplete extends Component {
      * Override style for menu.
      */
     menuStyle: PropTypes.object,
-    /**
-     * Override style for TextField
-     */
-    textFieldStyle: PropTypes.object,
     /** @ignore */
     onBlur: PropTypes.func,
     /** @ignore */
@@ -168,6 +164,10 @@ class AutoComplete extends Component {
      * Origin for location of target.
      */
     targetOrigin: propTypes.origin,
+    /**
+     * Override style for TextField
+     */
+    textFieldStyle: PropTypes.object,
     /**
      * If true, will update when focus event triggers.
      */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


there is no way to change
```js
{ font-size: 16px; line-height: 24px; width: 100%; height: 72px; display: inline-block; position: relative; font-family: Roboto, sans-serif; transition: height 200ms cubic-bezier(0.23, 1, 0.32, 1) 0ms; background-color: transparent; }
```

except pass fullWidth