### PR TITLE
[React] Fix the warning of the latest release v15.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "babel-runtime": "^6.6.1",
     "chai": "^3.5.0",
     "coveralls": "^2.11.9",
-    "cross-env": "^1.0.7",
+    "cross-env": "^2.0.0",
     "enzyme": "^2.4.1",
     "eslint": "^3.0.1",
     "eslint-find-rules": "^1.11.0",

--- a/src/utils/deprecatedPropType.js
+++ b/src/utils/deprecatedPropType.js
@@ -1,11 +1,32 @@
+/**
+ * This module is taken from https://github.com/react-bootstrap/react-prop-types.
+ * It's not a dependency to reduce build size / install time.
+ * It should be pretty stable.
+ */
 import warning from 'warning';
 
-export default function deprecated(propType, explanation) {
-  return function validate(props, propName, componentName) {
+const warned = {};
+
+export default function deprecated(validator, reason) {
+  return function validate(
+    props, propName, componentName, location, propFullName, ...args
+  ) {
+    const componentNameSafe = componentName || '<<anonymous>>';
+    const propFullNameSafe = propFullName || propName;
+
     if (props[propName] != null) {
-      warning(false, `"${propName}" property of "${componentName}" has been deprecated.\n${explanation}`);
+      const messageKey = `${componentName}.${propName}`;
+
+      warning(warned[messageKey],
+        `The ${location} \`${propFullNameSafe}\` of ` +
+        `\`${componentNameSafe}\` is deprecated. ${reason}.`
+      );
+
+      warned[messageKey] = true;
     }
 
-    return propType(props, propName, componentName);
+    return validator(
+      props, propName, componentName, location, propFullName, ...args
+    );
   };
 }


### PR DESCRIPTION
React has documented this issue: [fixing-the-false-positive](https://facebook.github.io/react/warnings/dont-call-proptypes.html#fixing-the-false-positive-in-third-party-proptypes).

Closes #4854.