### PR TITLE
[SelectField] Implement keyboard tabbing

### DIFF
--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -130,6 +130,11 @@ class DropDownMenu extends Component {
      * @param {any} payload The `value` prop of the clicked menu item.
      */
     onChange: PropTypes.func,
+
+    /**
+     * Callback function fired when menu is closed.
+     */
+    onClose: PropTypes.func,
     /**
      * Set to true to have the `DropDownMenu` automatically open on mount.
      */
@@ -227,6 +232,9 @@ class DropDownMenu extends Component {
       open: false,
       anchorEl: null,
     });
+    if (this.props.onClose) {
+      this.props.onClose();
+    }
   };
 
   handleItemTouchTap = (event, child, index) => {
@@ -236,6 +244,9 @@ class DropDownMenu extends Component {
     }, () => {
       if (this.props.onChange) {
         this.props.onChange(event, index, child.props.value);
+      }
+      if (this.props.onClose) {
+        this.props.onClose();
       }
     });
   };
@@ -252,6 +263,7 @@ class DropDownMenu extends Component {
       listStyle,
       maxHeight,
       menuStyle: menuStyleProp,
+      onClose, // eslint-disable-line no-unused-vars
       openImmediately, // eslint-disable-line no-unused-vars
       style,
       underlineStyle,
@@ -308,16 +320,18 @@ class DropDownMenu extends Component {
           animated={animated}
           onRequestClose={this.handleRequestCloseMenu}
         >
-          <Menu
-            maxHeight={maxHeight}
-            desktop={true}
-            value={value}
-            style={menuStyle}
-            listStyle={listStyle}
-            onItemTouchTap={this.handleItemTouchTap}
-          >
-            {children}
-          </Menu>
+          {open &&
+            <Menu
+              maxHeight={maxHeight}
+              desktop={true}
+              value={value}
+              style={menuStyle}
+              listStyle={listStyle}
+              onItemTouchTap={this.handleItemTouchTap}
+            >
+              {children}
+            </Menu>
+          }
         </Popover>
       </div>
     );

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -1,4 +1,5 @@
 import React, {Component, PropTypes} from 'react';
+import keycode from 'keycode';
 import TextField from '../TextField';
 import DropDownMenu from '../DropDownMenu';
 import deprecated from '../utils/deprecatedPropType';
@@ -19,6 +20,15 @@ function getStyles(props) {
     dropDownMenu: {
       display: 'block',
     },
+    input: {
+      height: 1,
+      width: 1,
+      clip: 'rect(1px, 1px, 1px, 1px)',
+      border: 0,
+      overflow: 'hidden',
+      outline: 'none',
+      position: 'absolute',
+    }
   };
 }
 
@@ -177,39 +187,74 @@ class SelectField extends Component {
     const styles = getStyles(this.props, this.context);
 
     return (
-      <TextField
-        {...other}
-        style={style}
-        disabled={disabled}
-        floatingLabelFixed={floatingLabelFixed}
-        floatingLabelText={floatingLabelText}
-        floatingLabelStyle={floatingLabelStyle}
-        hintStyle={hintStyle}
-        hintText={(!hintText && !floatingLabelText) ? ' ' : hintText}
-        fullWidth={fullWidth}
-        errorText={errorText}
-        underlineStyle={underlineStyle}
-        errorStyle={errorStyle}
-        onFocus={onFocus}
-        onBlur={onBlur}
-        id={id}
-        underlineDisabledStyle={underlineDisabledStyle}
-        underlineFocusStyle={underlineFocusStyle}
+      <div
+        onFocus={
+          function(event) {
+            this.TextField.handleInputFocus(event);
+          }.bind(this)
+        }
+        onBlur={
+          function(event) {
+            this.TextField.handleInputBlur(event);
+          }.bind(this)
+        }
+        onKeyDown={
+          function(event) {
+            if (keycode(event) === 'down') {
+              event.preventDefault();
+              this.TextField.focus();
+            }
+          }.bind(this)
+        }
+        ref={(component) => this.RootNode = component}
       >
-        <DropDownMenu
+        {!disabled &&
+          <input
+            style={styles.input}
+            ref={(component) => this.InputNode = component}
+          />
+        }
+        <TextField
+          {...other}
+          style={style}
           disabled={disabled}
-          style={Object.assign(styles.dropDownMenu, selectFieldRoot, menuStyle)}
-          labelStyle={Object.assign(styles.label, labelStyle)}
-          iconStyle={Object.assign(styles.icon, iconStyle)}
-          underlineStyle={styles.hideDropDownUnderline}
-          autoWidth={autoWidth}
-          value={value}
-          onChange={onChange}
-          maxHeight={maxHeight}
+          floatingLabelFixed={floatingLabelFixed}
+          floatingLabelText={floatingLabelText}
+          floatingLabelStyle={floatingLabelStyle}
+          hintStyle={hintStyle}
+          hintText={(!hintText && !floatingLabelText) ? ' ' : hintText}
+          fullWidth={fullWidth}
+          errorText={errorText}
+          underlineStyle={underlineStyle}
+          errorStyle={errorStyle}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          id={id}
+          underlineDisabledStyle={underlineDisabledStyle}
+          underlineFocusStyle={underlineFocusStyle}
+          ref={(component) => this.TextField = component}
         >
-          {children}
-        </DropDownMenu>
-      </TextField>
+          <DropDownMenu
+            disabled={disabled}
+            style={Object.assign(styles.dropDownMenu, selectFieldRoot, menuStyle)}
+            labelStyle={Object.assign(styles.label, labelStyle)}
+            iconStyle={Object.assign(styles.icon, iconStyle)}
+            underlineStyle={styles.hideDropDownUnderline}
+            autoWidth={autoWidth}
+            value={value}
+            onChange={onChange}
+            onClose={function() {
+              this.InputNode.focus();
+            }.bind(this)}
+            maxHeight={maxHeight}
+            ref={function(component) {
+              this.DropdownMenu = component;
+            }}
+          >
+            {children}
+          </DropDownMenu>
+        </TextField>
+      </div>
     );
   }
 }

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -20,14 +20,8 @@ function getStyles(props) {
     dropDownMenu: {
       display: 'block',
     },
-    input: {
-      height: 1,
-      width: 1,
-      clip: 'rect(1px, 1px, 1px, 1px)',
-      border: 0,
-      overflow: 'hidden',
+    rootNode: {
       outline: 'none',
-      position: 'absolute',
     },
   };
 }
@@ -154,6 +148,29 @@ class SelectField extends Component {
     muiTheme: PropTypes.object.isRequired,
   };
 
+  constructor(props) {
+    super(props);
+    this.handleFocus = this.handleFocus.bind(this);
+    this.handleBlur = this.handleBlur.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+  }
+
+  handleFocus(event) {
+    this.TextField.handleInputFocus(event);
+  }
+
+  handleBlur(event) {
+    this.TextField.handleInputBlur(event);
+  }
+
+  handleKeyDown(event) {
+    if (keycode(event) === 'down') {
+      event.preventDefault();
+      this.TextField.focus();
+    }
+  }
+
+
   render() {
     const {
       autoWidth,
@@ -188,32 +205,13 @@ class SelectField extends Component {
 
     return (
       <div
-        onFocus={
-          function(event) {
-            this.TextField.handleInputFocus(event);
-          }.bind(this)
-        }
-        onBlur={
-          function(event) {
-            this.TextField.handleInputBlur(event);
-          }.bind(this)
-        }
-        onKeyDown={
-          function(event) {
-            if (keycode(event) === 'down') {
-              event.preventDefault();
-              this.TextField.focus();
-            }
-          }.bind(this)
-        }
+        tabIndex={disabled ? -1 : 0}
+        onFocus={this.handleFocus}
+        onBlur={this.handleBlur}
+        onKeyDown={this.handleKeyDown}
         ref={(component) => this.RootNode = component}
+        style={styles.rootNode}
       >
-        {!disabled &&
-          <input
-            style={styles.input}
-            ref={(component) => this.InputNode = component}
-          />
-        }
         <TextField
           {...other}
           style={style}
@@ -244,12 +242,9 @@ class SelectField extends Component {
             value={value}
             onChange={onChange}
             onClose={function() {
-              this.InputNode.focus();
+              this.RootNode.focus();
             }.bind(this)}
             maxHeight={maxHeight}
-            ref={function(component) {
-              this.DropdownMenu = component;
-            }}
           >
             {children}
           </DropDownMenu>

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -28,7 +28,7 @@ function getStyles(props) {
       overflow: 'hidden',
       outline: 'none',
       position: 'absolute',
-    }
+    },
   };
 }
 


### PR DESCRIPTION
As discussed in #2654...

This PR enhances the accessibility of the `SelectField` component.

Use case: Support keyboard navigation. Tab between components, and use the down key to open the `DropDownMenu`.

GIF example here:

![selectfield_tab](https://cloud.githubusercontent.com/assets/1571918/17308945/2e2cec8c-57f1-11e6-8d0b-d5ed8c117a0c.gif)

Implementation:

~~An empty `<input>` element (that is purposefully not visually apparent) was added for keyboard navigation purposes.~~ A wrapper div uses `tabIndex` to manage keyboard navigation. Disabled elements are skipped. Adds a new property to DropDownMenu (onClose) in order to return focus to the `SelectField` (which in turn focuses the `TextField`).

Project maintainers: If you'd like to see anything changed with this specific implementation, work with me. I view it as valuable to get this functionality in. Thanks! :)