### PR TITLE
[core] Get rid of the all the propTypes in production

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -15,6 +15,11 @@
         "transform-react-constant-elements",
         "transform-react-inline-elements"
       ]
+    },
+    "release": {
+      "plugins": [
+        ["transform-react-remove-prop-types", {"mode": "wrap"}]
+      ],
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Examples:
 <CircularProgress size={119} thickness={7} style={{margin: 10.5}} />
 ```
 (#4705)
+- [core] Wrap the `propTypes` definitions so they can be removed in production (#4872)
 
 ## 0.15.3
 ###### _Jul 31, 2016_

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "npm run build:icon-index && npm run build:babel && npm run build:copy-files",
     "build:icon-index": "babel-node ./scripts/icon-index-generator.js",
-    "build:babel": "babel ./src --ignore *.spec.js --out-dir ./build",
+    "build:babel": "NODE_ENV=release babel ./src --ignore *.spec.js --out-dir ./build",
     "build:copy-files": "babel-node ./scripts/copy-files.js",
     "clean:build": "rimraf build",
     "lint": "eslint src docs/src test/integration && echo \"eslint: no lint errors\"",

--- a/src/Stepper/Step.js
+++ b/src/Stepper/Step.js
@@ -19,8 +19,7 @@ const getStyles = ({index}, {stepper}) => {
   return styles;
 };
 
-export default class Step extends Component {
-
+class Step extends Component {
   static propTypes = {
     /**
      * Sets the step as active. Is passed to child components.
@@ -98,3 +97,5 @@ export default class Step extends Component {
     );
   }
 }
+
+export default Step;

--- a/src/internal/AutoLockScrolling.js
+++ b/src/internal/AutoLockScrolling.js
@@ -3,15 +3,15 @@ import {Component, PropTypes} from 'react';
 let originalBodyOverflow = null;
 let lockingCounter = 0;
 
-export default class AutoLockScrolling extends Component {
-
+class AutoLockScrolling extends Component {
   static propTypes = {
     lock: PropTypes.bool.isRequired,
   };
 
   componentDidMount() {
-    if (this.props.lock === true)
+    if (this.props.lock === true) {
       this.preventScrolling();
+    }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -32,8 +32,10 @@ export default class AutoLockScrolling extends Component {
   locked = false;
 
   preventScrolling() {
-    if (this.locked === true)
+    if (this.locked === true) {
       return;
+    }
+
     lockingCounter = lockingCounter + 1;
     this.locked = true;
 
@@ -61,5 +63,6 @@ export default class AutoLockScrolling extends Component {
   render() {
     return null;
   }
-
 }
+
+export default AutoLockScrolling;

--- a/src/internal/ClickAwayListener.js
+++ b/src/internal/ClickAwayListener.js
@@ -13,8 +13,7 @@ const clickAwayEvents = ['mouseup', 'touchend'];
 const bind = (callback) => clickAwayEvents.forEach((event) => events.on(document, event, callback));
 const unbind = (callback) => clickAwayEvents.forEach((event) => events.off(document, event, callback));
 
-export default class ClickAwayListener extends Component {
-
+class ClickAwayListener extends Component {
   static propTypes = {
     children: PropTypes.node,
     onClickAway: PropTypes.any,
@@ -60,3 +59,5 @@ export default class ClickAwayListener extends Component {
     return this.props.children;
   }
 }
+
+export default ClickAwayListener;


### PR DESCRIPTION
### TL;DR

This new [babel plugin](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types) is wrapping all the `propTypes` definitions around the following block:
```js
process.env.NODE_ENV !== "production"
```

Expect a **20%+** size reduction win in production 🎈 .

That's exactly how React is allowing users to remove some part of the lib not needed in production.

E.g. with the `AppBar`:
```js
process.env.NODE_ENV !== "production" ? AppBar.propTypes = {
  /**
   * Can be used to render a tab inside an app bar for instance.
   */
  children: _react.PropTypes.node,
  /**
   * Applied to the app bar's root element.
   */
  className: _react.PropTypes.string,

...
```

*P.S:*
- That's a breaking change for anyone using those `propTypes` in production. However, that's considered as a bad practice. React is know displaying a warning when you try to do so.
- I had an issue with the plugin, where using
```js
export default class AppBar extends Component {
```
didn't work. [I'm on it](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types/pull/45). The good part is that it's a hard break and it's making us more consistent 😁 .