### PR TITLE
[Docs] Added ES Instructions to Docs

### DIFF
--- a/docs/src/app/components/pages/get-started/installation.md
+++ b/docs/src/app/components/pages/get-started/installation.md
@@ -27,3 +27,7 @@ font in mind.
 So be sure to include it in your project.
 Here are [some instructions](http://www.google.com/fonts#UsePlace:use/Collection:Roboto:400,300,500)
 on how to do so.
+
+### ES Compiling
+
+The examples in this documentation use the ```stage-1``` features of the ECMAScript specification. Be sure if you are testing these examples in your own project that you have the proper plugins installed in your compiler. Here are [some instructions](http://babeljs.io/docs/plugins/preset-stage-1/) on how to install the plugin for Babel.   


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Added ES instructions to the Docs site. This explains that the examples use ```stage 1```of ES and how to install that plugin. Resolves #4862 confusion

