### PR TITLE
[Snackbar] Add a fontFamily

### DIFF
--- a/src/Snackbar/SnackbarBody.js
+++ b/src/Snackbar/SnackbarBody.js
@@ -16,6 +16,7 @@ function getStyles(props, context) {
           desktopGutter,
           desktopSubheaderHeight,
         },
+        fontFamily,
       },
       snackbar: {
         backgroundColor,
@@ -29,6 +30,7 @@ function getStyles(props, context) {
 
   const styles = {
     root: {
+      fontFamily: fontFamily,
       backgroundColor: backgroundColor,
       padding: `0 ${desktopGutter}px`,
       height: desktopSubheaderHeight,


### PR DESCRIPTION
Following the modular approach for each of our component, the snackbar should be following the Material Design Spec without requiring a global font being set.

At some point, I think that we should remove the `font-family` that we apply on the `html` node.

Fix #4701.