### PR TITLE
[SelectField] Fix formatting in documentation

### DIFF
--- a/docs/src/app/components/pages/components/SelectField/ExampleFloatingLabel.js
+++ b/docs/src/app/components/pages/components/SelectField/ExampleFloatingLabel.js
@@ -12,7 +12,7 @@ const items = [
 
 /**
  * `SelectField` supports a floating label with the `floatingLabelText` property. This can be fixed in place with the
- * `floatingLabelFixed property, and can be customised with the `floatingLabelText` property.
+ * `floatingLabelFixed` property, and can be customised with the `floatingLabelText` property.
  */
 export default class SelectFieldExampleFloatingLabel extends React.Component {
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

This PR adds a missing closing backtick to the docstring of `SelectFieldExampleFloatingLabel`, which shows up at http://www.material-ui.com/#/components/select-field.

![image](https://cloud.githubusercontent.com/assets/130362/17467014/1e525aa4-5cce-11e6-9ef3-4e483cbe79a4.png)


- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


