### PR TITLE
[core] add displayName and unit tests to components

### DIFF
--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -62,6 +62,8 @@ export function getStyles(props, context) {
 }
 
 class AppBar extends Component {
+  static displayName = 'AppBar';
+
   static muiName = 'AppBar';
 
   static propTypes = {

--- a/src/AppBar/AppBar.spec.js
+++ b/src/AppBar/AppBar.spec.js
@@ -11,6 +11,10 @@ describe('<AppBar />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(AppBar.displayName, 'AppBar');
+  });
+
   it('renders children by default', () => {
     const testChildren = <div />;
     const wrapper = shallowWithContext(

--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -42,6 +42,8 @@ function getStyles(props, context, state) {
 }
 
 class AutoComplete extends Component {
+  static displayName = 'AutoComplete';
+
   static propTypes = {
     /**
      * Location of the anchor for the auto complete.

--- a/src/AutoComplete/AutoComplete.spec.js
+++ b/src/AutoComplete/AutoComplete.spec.js
@@ -12,6 +12,10 @@ describe('<AutoComplete />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(AutoComplete.displayName, 'AutoComplete');
+  });
+
   describe('filter', () => {
     it('search using fuzzy filter', () => {
       assert.strictEqual(AutoComplete.fuzzyFilter('ea', 'Peach'), true, 'should match Peach with ea');

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -35,6 +35,8 @@ function getStyles(props, context) {
 }
 
 class Avatar extends Component {
+  static displayName = 'Avatar';
+
   static muiName = 'Avatar';
 
   static propTypes = {

--- a/src/Avatar/Avatar.spec.js
+++ b/src/Avatar/Avatar.spec.js
@@ -11,6 +11,10 @@ describe('<Avatar />', () => {
 
   const testChildren = <div className="unique">Hello World</div>;
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Avatar.displayName, 'Avatar');
+  });
+
   it('renders children by default', () => {
     const wrapper = shallowWithContext(
       <Avatar>{testChildren}</Avatar>

--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -49,6 +49,8 @@ function getStyles(props, context) {
 }
 
 class Badge extends Component {
+  static displayName = 'Badge';
+
   static propTypes = {
     /**
      * This is the content rendered within the badge.

--- a/src/Badge/Badge.spec.js
+++ b/src/Badge/Badge.spec.js
@@ -11,6 +11,10 @@ describe('<Badge />', () => {
   const badgeTheme = muiTheme.badge;
   const testChildren = <div className="unique">Hello World</div>;
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Badge.displayName, 'Badge');
+  });
+
   it('renders children and badgeContent', () => {
     const wrapper = shallowWithContext(
       <Badge badgeContent={10}>{testChildren}</Badge>

--- a/src/BottomNavigation/BottomNavigation.js
+++ b/src/BottomNavigation/BottomNavigation.js
@@ -47,6 +47,8 @@ const BottomNavigation = (props, context) => {
   );
 };
 
+BottomNavigation.displayName = 'BottomNavigation';
+
 BottomNavigation.propTypes = {
   /**
    * The `BottomNavigationItem`s to populate the element with.

--- a/src/BottomNavigation/BottomNavigation.spec.js
+++ b/src/BottomNavigation/BottomNavigation.spec.js
@@ -10,6 +10,10 @@ describe('<BottomNavigation />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(BottomNavigation.displayName, 'BottomNavigation');
+  });
+
   describe('prop: selectedIndex', () => {
     it('determines which BottomNavigationItem is selected', () => {
       const wrapper = shallowWithContext(

--- a/src/BottomNavigation/BottomNavigationItem.js
+++ b/src/BottomNavigation/BottomNavigationItem.js
@@ -66,6 +66,8 @@ const BottomNavigationItem = (props, context) => {
   );
 };
 
+BottomNavigationItem.displayName = 'BottomNavigationItem';
+
 BottomNavigationItem.propTypes = {
   /**
    * Set the icon representing the view for this item.

--- a/src/BottomNavigation/BottomNavigationItem.spec.js
+++ b/src/BottomNavigation/BottomNavigationItem.spec.js
@@ -10,6 +10,10 @@ describe('<BottomNavigationItem />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(BottomNavigationItem.displayName, 'BottomNavigationItem');
+  });
+
   describe('prop: icon', () => {
     it('should be able to customize the icon', () => {
       const wrapper = shallowWithContext(

--- a/src/Card/Card.js
+++ b/src/Card/Card.js
@@ -3,6 +3,8 @@ import Paper from '../Paper';
 import CardExpandable from './CardExpandable';
 
 class Card extends Component {
+  static displayName = 'Card';
+
   static propTypes = {
     /**
      * Can be used to render elements inside the Card.

--- a/src/Card/Card.spec.js
+++ b/src/Card/Card.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import Card from './Card';
+
+describe('<Card />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Card.displayName, 'Card');
+  });
+});

--- a/src/Card/CardActions.js
+++ b/src/Card/CardActions.js
@@ -13,6 +13,8 @@ function getStyles() {
 }
 
 class CardActions extends Component {
+  static displayName = 'CardActions';
+
   static propTypes = {
     /**
      * If true, a click on this card component expands the card.

--- a/src/Card/CardActions.spec.js
+++ b/src/Card/CardActions.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import CardActions from './CardActions';
+
+describe('<CardActions />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(CardActions.displayName, 'CardActions');
+  });
+});

--- a/src/Card/CardExpandable.js
+++ b/src/Card/CardExpandable.js
@@ -16,6 +16,8 @@ function getStyles() {
 }
 
 class CardExpandable extends Component {
+  static displayName = 'CardExpandable';
+
   static propTypes = {
     expanded: PropTypes.bool,
     onExpanding: PropTypes.func.isRequired,

--- a/src/Card/CardExpandable.spec.js
+++ b/src/Card/CardExpandable.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import CardExpandable from './CardExpandable';
+
+describe('<CardExpandable />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(CardExpandable.displayName, 'CardExpandable');
+  });
+});

--- a/src/Card/CardHeader.js
+++ b/src/Card/CardHeader.js
@@ -35,6 +35,8 @@ function getStyles(props, context) {
 }
 
 class CardHeader extends Component {
+  static displayName = 'CardHeader';
+
   static muiName = 'CardHeader';
 
   static propTypes = {

--- a/src/Card/CardHeader.spec.js
+++ b/src/Card/CardHeader.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import CardHeader from './CardHeader';
+
+describe('<CardHeader />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(CardHeader.displayName, 'CardHeader');
+  });
+});

--- a/src/Card/CardMedia.js
+++ b/src/Card/CardMedia.js
@@ -37,6 +37,8 @@ function getStyles(props, context) {
 }
 
 class CardMedia extends Component {
+  static displayName = 'CardMedia';
+
   static propTypes = {
     /**
      * If true, a click on this card component expands the card.

--- a/src/Card/CardMedia.spec.js
+++ b/src/Card/CardMedia.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import CardMedia from './CardMedia';
+
+describe('<CardMedia />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(CardMedia.displayName, 'CardMedia');
+  });
+});

--- a/src/Card/CardText.js
+++ b/src/Card/CardText.js
@@ -13,6 +13,8 @@ function getStyles(props, context) {
 }
 
 class CardText extends Component {
+  static displayName = 'CardText';
+
   static muiName = 'CardText';
 
   static propTypes = {

--- a/src/Card/CardText.spec.js
+++ b/src/Card/CardText.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import CardText from './CardText';
+
+describe('<CardText />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(CardText.displayName, 'CardText');
+  });
+});

--- a/src/Card/CardTitle.js
+++ b/src/Card/CardTitle.js
@@ -23,6 +23,8 @@ function getStyles(props, context) {
 }
 
 class CardTitle extends Component {
+  static displayName = 'CardTitle';
+
   static muiName = 'CardTitle';
 
   static propTypes = {

--- a/src/Card/CardTitle.spec.js
+++ b/src/Card/CardTitle.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import CardTitle from './CardTitle';
+
+describe('<CardTitle />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(CardTitle.displayName, 'CardTitle');
+  });
+});

--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -56,6 +56,8 @@ function getStyles(props, context) {
 }
 
 class Checkbox extends Component {
+  static displayName = 'Checkbox';
+
   static propTypes = {
     /**
      * Checkbox is checked if true.

--- a/src/Checkbox/Checkbox.spec.js
+++ b/src/Checkbox/Checkbox.spec.js
@@ -13,6 +13,10 @@ describe('<Checkbox />', () => {
     childContextTypes: {muiTheme: PropTypes.object},
   });
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Checkbox.displayName, 'Checkbox');
+  });
+
   describe('props: defaultChecked', () => {
     it('should display checkmark when checked by default', () => {
       const wrapper = shallowWithContext(
@@ -97,4 +101,3 @@ describe('<Checkbox />', () => {
     });
   });
 });
-

--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -43,6 +43,7 @@ function getStyles(props, context, state) {
 }
 
 class Chip extends Component {
+  static displayName = 'Chip';
 
   static propTypes = {
     /**

--- a/src/Chip/Chip.spec.js
+++ b/src/Chip/Chip.spec.js
@@ -16,6 +16,10 @@ describe('<Chip />', () => {
     return shallow(node, {context});
   };
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Chip.displayName, 'Chip');
+  });
+
   describe('state', () => {
     const wrapper = themedShallow(
       <Chip onTouchTap={() => {}}>Label</Chip>

--- a/src/CircularProgress/CircularProgress.js
+++ b/src/CircularProgress/CircularProgress.js
@@ -57,6 +57,8 @@ function getStyles(props, context) {
 }
 
 class CircularProgress extends Component {
+  static displayName = 'CircularProgress';
+
   static propTypes = {
     /**
      * Override the progress's color.

--- a/src/CircularProgress/CircularProgress.spec.js
+++ b/src/CircularProgress/CircularProgress.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import CircularProgress from './CircularProgress';
+
+describe('<CircularProgress />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(CircularProgress.displayName, 'CircularProgress');
+  });
+});

--- a/src/DatePicker/Calendar.js
+++ b/src/DatePicker/Calendar.js
@@ -26,6 +26,8 @@ import {
 const daysArray = [...Array(7)];
 
 class Calendar extends Component {
+  static displayName = 'Calendar';
+
   static propTypes = {
     DateTimeFormat: PropTypes.func.isRequired,
     autoOk: PropTypes.bool,

--- a/src/DatePicker/Calendar.spec.js
+++ b/src/DatePicker/Calendar.spec.js
@@ -10,6 +10,10 @@ describe('<Calendar />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Calendar.displayName, 'Calendar');
+  });
+
   describe('Next Month Button', () => {
     it('should initially be disabled if the current month is the same as the month in the maxDate prop', () => {
       const initialDate = new Date(1448967059892); // Tue, 01 Dec 2015 10:50:59 GMT

--- a/src/DatePicker/CalendarActionButtons.js
+++ b/src/DatePicker/CalendarActionButtons.js
@@ -2,6 +2,8 @@ import React, {Component, PropTypes} from 'react';
 import FlatButton from '../FlatButton';
 
 class CalendarActionButton extends Component {
+  static displayName = 'CalendarActionButtons';
+
   static propTypes = {
     autoOk: PropTypes.bool,
     cancelLabel: PropTypes.node,

--- a/src/DatePicker/CalendarActionButtons.spec.js
+++ b/src/DatePicker/CalendarActionButtons.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import CalendarActionButtons from './CalendarActionButtons';
+
+describe('<CalendarActionButtons />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(CalendarActionButtons.displayName, 'CalendarActionButtons');
+  });
+});

--- a/src/DatePicker/CalendarMonth.js
+++ b/src/DatePicker/CalendarMonth.js
@@ -3,6 +3,8 @@ import {isBetweenDates, isEqualDate, getWeekArray} from './dateUtils';
 import DayButton from './DayButton';
 
 class CalendarMonth extends Component {
+  static displayName = 'CalendarMonth';
+
   static propTypes = {
     autoOk: PropTypes.bool,
     displayDate: PropTypes.object.isRequired,

--- a/src/DatePicker/CalendarMonth.spec.js
+++ b/src/DatePicker/CalendarMonth.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import CalendarMonth from './CalendarMonth';
+
+describe('<CalendarMonth />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(CalendarMonth.displayName, 'CalendarMonth');
+  });
+});

--- a/src/DatePicker/CalendarToolbar.js
+++ b/src/DatePicker/CalendarToolbar.js
@@ -24,6 +24,8 @@ const styles = {
 };
 
 class CalendarToolbar extends Component {
+  static displayName = 'CalendarToolbar';
+
   static propTypes = {
     DateTimeFormat: PropTypes.func.isRequired,
     displayDate: PropTypes.object.isRequired,

--- a/src/DatePicker/CalendarToolbar.spec.js
+++ b/src/DatePicker/CalendarToolbar.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import CalendarToolbar from './CalendarToolbar';
+
+describe('<CalendarToolbar />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(CalendarToolbar.displayName, 'CalendarToolbar');
+  });
+});

--- a/src/DatePicker/CalendarYear.js
+++ b/src/DatePicker/CalendarYear.js
@@ -4,6 +4,8 @@ import YearButton from './YearButton';
 import {cloneDate} from './dateUtils';
 
 class CalendarYear extends Component {
+  static displayName = 'CalendarYear';
+
   static propTypes = {
     displayDate: PropTypes.object.isRequired,
     maxDate: PropTypes.object,

--- a/src/DatePicker/CalendarYear.spec.js
+++ b/src/DatePicker/CalendarYear.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import CalendarYear from './CalendarYear';
+
+describe('<CalendarYear />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(CalendarYear.displayName, 'CalendarYear');
+  });
+});

--- a/src/DatePicker/DateDisplay.js
+++ b/src/DatePicker/DateDisplay.js
@@ -56,6 +56,8 @@ function getStyles(props, context, state) {
 }
 
 class DateDisplay extends Component {
+  static displayName = 'DateDisplay';
+
   static propTypes = {
     DateTimeFormat: PropTypes.func.isRequired,
     disableYearSelection: PropTypes.bool,

--- a/src/DatePicker/DateDisplay.spec.js
+++ b/src/DatePicker/DateDisplay.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import DateDisplay from './DateDisplay';
+
+describe('<DateDisplay />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(DateDisplay.displayName, 'DateDisplay');
+  });
+});

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -5,6 +5,8 @@ import TextField from '../TextField';
 import deprecated from '../utils/deprecatedPropType';
 
 class DatePicker extends Component {
+  static displayName = 'DatePicker';
+
   static propTypes = {
     /**
      * Constructor for date formatting for the specified `locale`.

--- a/src/DatePicker/DatePicker.spec.js
+++ b/src/DatePicker/DatePicker.spec.js
@@ -11,6 +11,10 @@ describe('<DatePicker />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(DatePicker.displayName, 'DatePicker');
+  });
+
   describe('formatDate', () => {
     it('should use the default format', () => {
       const initialDate = new Date(1448967059892); // Tue, 01 Dec 2015 10:50:59 GMT

--- a/src/DatePicker/DatePickerDialog.js
+++ b/src/DatePicker/DatePickerDialog.js
@@ -8,6 +8,8 @@ import PopoverAnimationVertical from '../Popover/PopoverAnimationVertical';
 import {dateTimeFormat} from './dateUtils';
 
 class DatePickerDialog extends Component {
+  static displayName = 'DatePickerDialog';
+
   static propTypes = {
     DateTimeFormat: PropTypes.func,
     animation: PropTypes.func,

--- a/src/DatePicker/DatePickerDialog.spec.js
+++ b/src/DatePicker/DatePickerDialog.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import DatePickerDialog from './DatePickerDialog';
+
+describe('<DatePickerDialog />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(DatePickerDialog.displayName, 'DatePickerDialog');
+  });
+});

--- a/src/DatePicker/DayButton.js
+++ b/src/DatePicker/DayButton.js
@@ -51,6 +51,8 @@ function getStyles(props, context, state) {
 }
 
 class DayButton extends Component {
+  static displayName = 'DayButton';
+
   static propTypes = {
     date: PropTypes.object,
     disabled: PropTypes.bool,

--- a/src/DatePicker/DayButton.spec.js
+++ b/src/DatePicker/DayButton.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import DayButton from './DayButton';
+
+describe('<DayButton />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(DayButton.displayName, 'DayButton');
+  });
+});

--- a/src/DatePicker/YearButton.js
+++ b/src/DatePicker/YearButton.js
@@ -30,6 +30,8 @@ function getStyles(props, context, state) {
 }
 
 class YearButton extends Component {
+  static displayName = 'YearButton';
+
   static propTypes = {
     /**
      * The css class name of the root element.

--- a/src/DatePicker/YearButton.spec.js
+++ b/src/DatePicker/YearButton.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import YearButton from './YearButton';
+
+describe('<YearButton />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(YearButton.displayName, 'YearButton');
+  });
+});

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -10,6 +10,8 @@ import Paper from '../Paper';
 import ReactTransitionGroup from 'react-addons-transition-group';
 
 class TransitionItem extends Component {
+  static displayName = 'TransitionItem';
+
   static propTypes = {
     children: PropTypes.node,
     style: PropTypes.object,
@@ -148,6 +150,8 @@ function getStyles(props, context) {
 }
 
 class DialogInline extends Component {
+  static displayName = 'DialogInline';
+
   static propTypes = {
     actions: PropTypes.node,
     actionsContainerClassName: PropTypes.string,
@@ -357,6 +361,8 @@ class DialogInline extends Component {
 }
 
 class Dialog extends Component {
+  static displayName = 'Dialog';
+
   static propTypes = {
     /**
      * Action buttons to display below the Dialog content (`children`).

--- a/src/Dialog/Dialog.spec.js
+++ b/src/Dialog/Dialog.spec.js
@@ -11,6 +11,10 @@ describe('<Dialog />', () => {
   const muiTheme = getMuiTheme();
   const mountWithContext = (node) => mount(node, {context: {muiTheme}});
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Dialog.displayName, 'Dialog');
+  });
+
   it('appends a dialog to the document body', () => {
     const testClass = 'test-dialog-class';
     mountWithContext(

--- a/src/Divider/Divider.js
+++ b/src/Divider/Divider.js
@@ -49,6 +49,7 @@ const Divider = (props, context) => {
   );
 };
 
+Divider.displayName = 'Divider';
 Divider.muiName = 'Divider';
 Divider.propTypes = propTypes;
 Divider.defaultProps = defaultProps;

--- a/src/Divider/Divider.spec.js
+++ b/src/Divider/Divider.spec.js
@@ -9,6 +9,10 @@ describe('<Divider />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Divider.displayName, 'Divider');
+  });
+
   it('renders className', () => {
     const wrapper = shallowWithContext(
       <Divider

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -11,6 +11,8 @@ import propTypes from '../utils/propTypes';
 let openNavEventHandler = null;
 
 class Drawer extends Component {
+  static displayName = 'Drawer';
+
   static propTypes = {
     /**
      * The contents of the `Drawer`

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import Drawer from './Drawer';
+
+describe('<Drawer />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Drawer.displayName, 'Drawer');
+  });
+});

--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -68,6 +68,8 @@ function getStyles(props, context) {
 }
 
 class DropDownMenu extends Component {
+  static displayName = 'DropDownMenu';
+
   static muiName = 'DropDownMenu';
 
   // The nested styles for drop-down-menu are modified by toolbar and possibly

--- a/src/DropDownMenu/DropDownMenu.spec.js
+++ b/src/DropDownMenu/DropDownMenu.spec.js
@@ -9,6 +9,10 @@ describe('<DropDownMenu />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(DropDownMenu.displayName, 'DropDownMenu');
+  });
+
   it('displays the text field of menuItems prop at index x when value prop is x', () => {
     const wrapper = shallowWithContext(
       <DropDownMenu value={1}>

--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -14,6 +14,8 @@ function validateLabel(props, propName, componentName) {
 }
 
 class FlatButton extends Component {
+  static displayName = 'FlatButton';
+
   static muiName = 'FlatButton';
 
   static propTypes = {

--- a/src/FlatButton/FlatButton.spec.js
+++ b/src/FlatButton/FlatButton.spec.js
@@ -13,6 +13,10 @@ describe('<FlatButton />', () => {
   const flatButtonTheme = muiTheme.flatButton;
   const testChildren = <div className="unique">Hello World</div>;
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(FlatButton.displayName, 'FlatButton');
+  });
+
   it('renders an enhanced button', () => {
     const wrapper = shallowWithContext(
       <FlatButton>Button</FlatButton>

--- a/src/FlatButton/FlatButtonLabel.js
+++ b/src/FlatButton/FlatButtonLabel.js
@@ -14,6 +14,8 @@ function getStyles(props, context) {
 }
 
 class FlatButtonLabel extends Component {
+  static displayName = 'FlatButtonLabel';
+
   static propTypes = {
     label: PropTypes.node,
     style: PropTypes.object,

--- a/src/FlatButton/FlatButtonLabel.spec.js
+++ b/src/FlatButton/FlatButtonLabel.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import FlatButtonLabel from './FlatButtonLabel';
+
+describe('<FlatButtonLabel />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(FlatButtonLabel.displayName, 'FlatButtonLabel');
+  });
+});

--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -64,6 +64,8 @@ function getStyles(props, context) {
 }
 
 class FloatingActionButton extends Component {
+  static displayName = 'FloatingActionButton';
+
   static propTypes = {
     /**
      * This value will override the default background color for the button.

--- a/src/FloatingActionButton/FloatingActionButton.spec.js
+++ b/src/FloatingActionButton/FloatingActionButton.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import FloatingActionButton from './FloatingActionButton';
+
+describe('<FloatingActionButton />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(FloatingActionButton.displayName, 'FloatingActionButton');
+  });
+});

--- a/src/FontIcon/FontIcon.js
+++ b/src/FontIcon/FontIcon.js
@@ -24,6 +24,8 @@ function getStyles(props, context, state) {
 }
 
 class FontIcon extends Component {
+  static displayName = 'FontIcon';
+
   static muiName = 'FontIcon';
 
   static propTypes = {

--- a/src/FontIcon/FontIcon.spec.js
+++ b/src/FontIcon/FontIcon.spec.js
@@ -10,6 +10,10 @@ describe('<FontIcon />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(FontIcon.displayName, 'FontIcon');
+  });
+
   it('renders className', () => {
     const wrapper = shallowWithContext(
       <FontIcon

--- a/src/GridList/GridList.js
+++ b/src/GridList/GridList.js
@@ -15,6 +15,8 @@ function getStyles(props) {
 }
 
 class GridList extends Component {
+  static displayName = 'GridList';
+
   static propTypes = {
     /**
      * Number of px for one cell height.

--- a/src/GridList/GridList.spec.js
+++ b/src/GridList/GridList.spec.js
@@ -22,6 +22,10 @@ describe('<GridList />', () => {
     },
   ];
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(GridList.displayName, 'GridList');
+  });
+
   it('renders children and change cellHeight', () => {
     const cellHeight = 250;
     const wrapper = shallowWithContext(

--- a/src/GridList/GridTile.js
+++ b/src/GridList/GridTile.js
@@ -58,6 +58,8 @@ function getStyles(props, context) {
 }
 
 class GridTile extends Component {
+  static displayName = 'GridTile';
+
   static propTypes = {
     /**
      * An IconButton element to be used as secondary action target

--- a/src/GridList/GridTile.spec.js
+++ b/src/GridList/GridTile.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import GridTile from './GridTile';
+
+describe('<GridTile />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(GridTile.displayName, 'GridTile');
+  });
+});

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -39,6 +39,8 @@ function getStyles(props, context) {
 }
 
 class IconButton extends Component {
+  static displayName = 'IconButton';
+
   static muiName = 'IconButton';
 
   static propTypes = {

--- a/src/IconButton/IconButton.spec.js
+++ b/src/IconButton/IconButton.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import IconButton from './IconButton';
+
+describe('<IconButton />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(IconButton.displayName, 'IconButton');
+  });
+});

--- a/src/IconMenu/IconMenu.js
+++ b/src/IconMenu/IconMenu.js
@@ -6,6 +6,8 @@ import Menu from '../Menu/Menu';
 import Popover from '../Popover/Popover';
 
 class IconMenu extends Component {
+  static displayName = 'IconMenu';
+
   static muiName = 'IconMenu';
 
   static propTypes = {

--- a/src/IconMenu/IconMenu.spec.js
+++ b/src/IconMenu/IconMenu.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import IconMenu from './IconMenu';
+
+describe('<IconMenu />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(IconMenu.displayName, 'IconMenu');
+  });
+});

--- a/src/LinearProgress/LinearProgress.js
+++ b/src/LinearProgress/LinearProgress.js
@@ -63,6 +63,8 @@ function getStyles(props, context) {
 }
 
 class LinearProgress extends Component {
+  static displayName = 'LinearProgress';
+
   static propTypes = {
     /**
      * The mode of show your progress, indeterminate for

--- a/src/LinearProgress/LinearProgress.spec.js
+++ b/src/LinearProgress/LinearProgress.spec.js
@@ -9,6 +9,10 @@ describe('<LinearProgress />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(LinearProgress.displayName, 'LinearProgress');
+  });
+
   describe('props: min', () => {
     it('should work when min equal zero', () => {
       const wrapper = shallowWithContext(

--- a/src/List/List.js
+++ b/src/List/List.js
@@ -5,6 +5,8 @@ import deprecated from '../utils/deprecatedPropType';
 import warning from 'warning';
 
 class List extends Component {
+  static displayName = 'List';
+
   static propTypes = {
     /**
      * These are usually `ListItem`s that are passed to

--- a/src/List/List.spec.js
+++ b/src/List/List.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import List from './List';
+
+describe('<List />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(List.displayName, 'List');
+  });
+});

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -139,6 +139,8 @@ function getStyles(props, context, state) {
 }
 
 class ListItem extends Component {
+  static displayName = 'ListItem';
+
   static muiName = 'ListItem';
 
   static propTypes = {

--- a/src/List/ListItem.spec.js
+++ b/src/List/ListItem.spec.js
@@ -10,6 +10,10 @@ describe('<ListItem />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(ListItem.displayName, 'ListItem');
+  });
+
   it('should render an EnhancedButton', () => {
     const wrapper = shallowWithContext(
       <ListItem />

--- a/src/List/NestedList.js
+++ b/src/List/NestedList.js
@@ -2,6 +2,8 @@ import React, {Component, PropTypes} from 'react';
 import List from './List';
 
 class NestedList extends Component {
+  static displayName = 'NestedList';
+
   static propTypes = {
     children: PropTypes.node,
     nestedLevel: PropTypes.number.isRequired,

--- a/src/List/NestedList.spec.js
+++ b/src/List/NestedList.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import NestedList from './NestedList';
+
+describe('<NestedList />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(NestedList.displayName, 'NestedList');
+  });
+});

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -64,6 +64,8 @@ function getStyles(props, context) {
 }
 
 class Menu extends Component {
+  static displayName = 'Menu';
+
   static propTypes = {
     /**
      * If true, the menu will apply transitions when it

--- a/src/Menu/Menu.spec.js
+++ b/src/Menu/Menu.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import Menu from './Menu';
+
+describe('<Menu />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Menu.displayName, 'Menu');
+  });
+});

--- a/src/MenuItem/MenuItem.js
+++ b/src/MenuItem/MenuItem.js
@@ -54,6 +54,8 @@ function getStyles(props, context) {
 }
 
 class MenuItem extends Component {
+  static displayName = 'MenuItem';
+
   static muiName = 'MenuItem';
 
   static propTypes = {

--- a/src/MenuItem/MenuItem.spec.js
+++ b/src/MenuItem/MenuItem.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import MenuItem from './MenuItem';
+
+describe('<MenuItem />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(MenuItem.displayName, 'MenuItem');
+  });
+});

--- a/src/Paper/Paper.js
+++ b/src/Paper/Paper.js
@@ -30,6 +30,8 @@ function getStyles(props, context) {
 }
 
 class Paper extends Component {
+  static displayName = 'Paper';
+
   static propTypes = {
     /**
      * Children passed into the paper element.

--- a/src/Paper/Paper.spec.js
+++ b/src/Paper/Paper.spec.js
@@ -10,6 +10,10 @@ describe('<Paper />', () => {
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
   const testChildren = <div className="unique">Hello World</div>;
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Paper.displayName, 'Paper');
+  });
+
   it('renders children by default', () => {
     const wrapper = shallowWithContext(
       <Paper>{testChildren}</Paper>

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -8,6 +8,8 @@ import throttle from 'lodash/throttle';
 import PopoverAnimationDefault from './PopoverAnimationDefault';
 
 class Popover extends Component {
+  static displayName = 'Popover';
+
   static propTypes = {
     /**
      * This is the DOM element that will be used to set the position of the

--- a/src/Popover/Popover.spec.js
+++ b/src/Popover/Popover.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import Popover from './Popover';
+
+describe('<Popover />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Popover.displayName, 'Popover');
+  });
+});

--- a/src/Popover/PopoverAnimationDefault.js
+++ b/src/Popover/PopoverAnimationDefault.js
@@ -36,7 +36,9 @@ function getStyles(props, context, state) {
   };
 }
 
-class PopoverDefaultAnimation extends Component {
+class PopoverAnimationDefault extends Component {
+  static displayName = 'PopoverAnimationDefault';
+
   static propTypes = {
     children: PropTypes.node,
     /**
@@ -101,4 +103,4 @@ class PopoverDefaultAnimation extends Component {
   }
 }
 
-export default PopoverDefaultAnimation;
+export default PopoverAnimationDefault;

--- a/src/Popover/PopoverAnimationDefault.js
+++ b/src/Popover/PopoverAnimationDefault.js
@@ -36,7 +36,7 @@ function getStyles(props, context, state) {
   };
 }
 
-class PopoverAnimationDefault extends Component {
+class PopoverDefaultAnimation extends Component {
   static displayName = 'PopoverAnimationDefault';
 
   static propTypes = {
@@ -103,4 +103,4 @@ class PopoverAnimationDefault extends Component {
   }
 }
 
-export default PopoverAnimationDefault;
+export default PopoverDefaultAnimation;

--- a/src/Popover/PopoverAnimationDefault.spec.js
+++ b/src/Popover/PopoverAnimationDefault.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import PopoverAnimationDefault from './PopoverAnimationDefault';
+
+describe('<PopoverAnimationDefault />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(PopoverAnimationDefault.displayName, 'PopoverAnimationDefault');
+  });
+});

--- a/src/Popover/PopoverAnimationVertical.js
+++ b/src/Popover/PopoverAnimationVertical.js
@@ -23,6 +23,8 @@ function getStyles(props, context, state) {
 }
 
 class PopoverAnimationVertical extends Component {
+  static displayName = 'PopoverAnimationVertical';
+
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,

--- a/src/Popover/PopoverAnimationVertical.spec.js
+++ b/src/Popover/PopoverAnimationVertical.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import PopoverAnimationVertical from './PopoverAnimationVertical';
+
+describe('<PopoverAnimationVertical />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(PopoverAnimationVertical.displayName, 'PopoverAnimationVertical');
+  });
+});

--- a/src/RadioButton/RadioButton.js
+++ b/src/RadioButton/RadioButton.js
@@ -53,6 +53,8 @@ function getStyles(props, context) {
 }
 
 class RadioButton extends Component {
+  static displayName = 'RadioButton';
+
   static propTypes = {
     /**
      * @ignore

--- a/src/RadioButton/RadioButton.spec.js
+++ b/src/RadioButton/RadioButton.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import RadioButton from './RadioButton';
+
+describe('<RadioButton />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(RadioButton.displayName, 'RadioButton');
+  });
+});

--- a/src/RadioButton/RadioButtonGroup.js
+++ b/src/RadioButton/RadioButtonGroup.js
@@ -3,6 +3,8 @@ import RadioButton from '../RadioButton';
 import warning from 'warning';
 
 class RadioButtonGroup extends Component {
+  static displayName = 'RadioButtonGroup';
+
   static propTypes = {
     /**
      * Should be used to pass `RadioButton` components.

--- a/src/RadioButton/RadioButtonGroup.spec.js
+++ b/src/RadioButton/RadioButtonGroup.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import RadioButtonGroup from './RadioButtonGroup';
+
+describe('<RadioButtonGroup />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(RadioButtonGroup.displayName, 'RadioButtonGroup');
+  });
+});

--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -111,6 +111,8 @@ function getStyles(props, context, state) {
 }
 
 class RaisedButton extends Component {
+  static displayName = 'RaisedButton';
+
   static muiName = 'RaisedButton';
 
   static propTypes = {

--- a/src/RaisedButton/RaisedButton.spec.js
+++ b/src/RaisedButton/RaisedButton.spec.js
@@ -15,6 +15,10 @@ describe('<RaisedButton />', () => {
   const mountWithContext = (node) => mount(node, {context: {muiTheme}});
   const testChildren = <span className="unique">Hello World</span>;
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(RaisedButton.displayName, 'RaisedButton');
+  });
+
   it('renders an enhanced button inside paper', () => {
     const wrapper = shallowWithContext(
       <RaisedButton>Button</RaisedButton>

--- a/src/RefreshIndicator/RefreshIndicator.js
+++ b/src/RefreshIndicator/RefreshIndicator.js
@@ -24,6 +24,8 @@ function getStyles(props) {
 }
 
 class RefreshIndicator extends Component {
+  static displayName = 'RefreshIndicator';
+
   static propTypes = {
     /**
      * Override the theme's color of the indicator while it's status is

--- a/src/RefreshIndicator/RefreshIndicator.spec.js
+++ b/src/RefreshIndicator/RefreshIndicator.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import RefreshIndicator from './RefreshIndicator';
+
+describe('<RefreshIndicator />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(RefreshIndicator.displayName, 'RefreshIndicator');
+  });
+});

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -23,6 +23,8 @@ function getStyles(props) {
 }
 
 class SelectField extends Component {
+  static displayName = 'SelectField';
+
   static propTypes = {
     /**
      * If true, the width will automatically be set according to the

--- a/src/SelectField/SelectField.spec.js
+++ b/src/SelectField/SelectField.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import SelectField from './SelectField';
+
+describe('<SelectField />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(SelectField.displayName, 'SelectField');
+  });
+});

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -229,6 +229,8 @@ const getStyles = (props, context, state) => {
 };
 
 class Slider extends Component {
+  static displayName = 'Slider';
+
   static propTypes = {
     /**
      * The axis on which the slider will slide.

--- a/src/Slider/Slider.spec.js
+++ b/src/Slider/Slider.spec.js
@@ -21,6 +21,10 @@ describe('<Slider />', () => {
     return shallowWrapper.children().at(2);
   };
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Slider.displayName, 'Slider');
+  });
+
   it('renders slider and the hidden input', () => {
     const wrapper = shallowWithContext(
       <Slider name="slider" />

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -38,6 +38,8 @@ function getStyles(props, context, state) {
 }
 
 class Snackbar extends Component {
+  static displayName = 'Snackbar';
+
   static propTypes = {
     /**
      * The label for the action on the snackbar.

--- a/src/Snackbar/Snackbar.spec.js
+++ b/src/Snackbar/Snackbar.spec.js
@@ -9,6 +9,10 @@ describe('<Snackbar />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Snackbar.displayName, 'Snackbar');
+  });
+
   describe('props: open', () => {
     it('should be hidden when open is false', () => {
       const wrapper = shallowWithContext(

--- a/src/Snackbar/SnackbarBody.js
+++ b/src/Snackbar/SnackbarBody.js
@@ -93,6 +93,8 @@ export const SnackbarBody = (props, context) => {
   );
 };
 
+SnackbarBody.displayName = 'SnackbarBody';
+
 SnackbarBody.propTypes = {
   /**
    * The label for the action on the snackbar.

--- a/src/Snackbar/SnackbarBody.spec.js
+++ b/src/Snackbar/SnackbarBody.spec.js
@@ -10,6 +10,10 @@ describe('<SnackbarBody />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(SnackbarBody.displayName, 'SnackbarBody');
+  });
+
   describe('props: open', () => {
     it('should be hidden when open is false', () => {
       const wrapper = shallowWithContext(

--- a/src/Stepper/Step.js
+++ b/src/Stepper/Step.js
@@ -20,6 +20,7 @@ const getStyles = ({index}, {stepper}) => {
 };
 
 export default class Step extends Component {
+  static displayName = 'Step';
 
   static propTypes = {
     /**

--- a/src/Stepper/Step.spec.js
+++ b/src/Stepper/Step.spec.js
@@ -17,6 +17,10 @@ describe('<Step />', () => {
     });
   };
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Step.displayName, 'Step');
+  });
+
   it('merges styles and other props into the root node', () => {
     const wrapper = shallowWithContext(
       <Step

--- a/src/Stepper/StepButton.js
+++ b/src/Stepper/StepButton.js
@@ -27,6 +27,7 @@ const getStyles = (props, context, state) => {
 };
 
 class StepButton extends Component {
+  static displayName = 'StepButton';
 
   static propTypes = {
     /**

--- a/src/Stepper/StepButton.spec.js
+++ b/src/Stepper/StepButton.spec.js
@@ -13,6 +13,10 @@ describe('<StepButton />', () => {
     return shallow(node, {context});
   };
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(StepButton.displayName, 'StepButton');
+  });
+
   it('should merge user styles in', () => {
     const wrapper = themedShallow(
       <StepButton style={{backgroundColor: 'purple'}}>Step One</StepButton>

--- a/src/Stepper/StepConnector.js
+++ b/src/Stepper/StepConnector.js
@@ -49,6 +49,7 @@ const StepConnector = (props, context) => {
   );
 };
 
+StepConnector.displayName = 'StepConnector';
 StepConnector.propTypes = propTypes;
 StepConnector.contextTypes = contextTypes;
 

--- a/src/Stepper/StepConnector.spec.js
+++ b/src/Stepper/StepConnector.spec.js
@@ -12,6 +12,10 @@ describe('<StepConnector />', () => {
     return shallow(node, {context});
   };
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(StepConnector.displayName, 'StepConnector');
+  });
+
   describe('rendering', () => {
     const wrapper = themedShallow(
       <StepConnector />

--- a/src/Stepper/StepContent.js
+++ b/src/Stepper/StepContent.js
@@ -25,6 +25,8 @@ const getStyles = (props, context) => {
 };
 
 class StepContent extends Component {
+  static displayName = 'StepContent';
+
   static propTypes = {
     /**
      * Expands the content

--- a/src/Stepper/StepContent.spec.js
+++ b/src/Stepper/StepContent.spec.js
@@ -17,6 +17,10 @@ describe('<StepContent />', () => {
     });
   };
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(StepContent.displayName, 'StepContent');
+  });
+
   it('renders a div', () => {
     const wrapper = shallowWithContext(
       <StepContent />

--- a/src/Stepper/StepLabel.js
+++ b/src/Stepper/StepLabel.js
@@ -54,6 +54,8 @@ const getStyles = ({active, completed, disabled}, {muiTheme, stepper}) => {
 };
 
 class StepLabel extends Component {
+  static displayName = 'StepLabel';
+
   static muiName = 'StepLabel';
 
   static propTypes = {

--- a/src/Stepper/StepLabel.spec.js
+++ b/src/Stepper/StepLabel.spec.js
@@ -19,6 +19,10 @@ describe('<StepLabel />', () => {
     });
   };
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(StepLabel.displayName, 'StepLabel');
+  });
+
   it('merges styles and other props into the root node', () => {
     const wrapper = shallowWithContext(
       <StepLabel

--- a/src/Stepper/Stepper.js
+++ b/src/Stepper/Stepper.js
@@ -15,6 +15,7 @@ const getStyles = (props) => {
 };
 
 class Stepper extends Component {
+  static displayName = 'Stepper';
 
   static propTypes = {
     /**

--- a/src/Stepper/Stepper.spec.js
+++ b/src/Stepper/Stepper.spec.js
@@ -16,6 +16,10 @@ describe('<Stepper />', () => {
     });
   };
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Stepper.displayName, 'Stepper');
+  });
+
   it('merges user styles into the root node', () => {
     const wrapper = shallowWithContext(
       <Stepper

--- a/src/Subheader/Subheader.js
+++ b/src/Subheader/Subheader.js
@@ -52,6 +52,7 @@ const Subheader = (props, context) => {
   );
 };
 
+Subheader.displayName = 'Subheader';
 Subheader.muiName = 'Subheader';
 Subheader.propTypes = propTypes;
 Subheader.defaultProps = defaultProps;

--- a/src/Subheader/Subheader.spec.js
+++ b/src/Subheader/Subheader.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import Subheader from './Subheader';
+
+describe('<Subheader />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Subheader.displayName, 'Subheader');
+  });
+});

--- a/src/SvgIcon/SvgIcon.js
+++ b/src/SvgIcon/SvgIcon.js
@@ -2,6 +2,8 @@ import React, {Component, PropTypes} from 'react';
 import transitions from '../styles/transitions';
 
 class SvgIcon extends Component {
+  static displayName = 'SvgIcon';
+
   static muiName = 'SvgIcon';
 
   static propTypes = {

--- a/src/SvgIcon/SvgIcon.spec.js
+++ b/src/SvgIcon/SvgIcon.spec.js
@@ -11,6 +11,10 @@ describe('<SvgIcon />', () => {
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
   const path = <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />;
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(SvgIcon.displayName, 'SvgIcon');
+  });
+
   it('renders children by default', () => {
     const wrapper = shallowWithContext(
       <SvgIcon>{path}</SvgIcon>

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -29,6 +29,8 @@ function getStyles(props, context) {
 }
 
 class Table extends Component {
+  static displayName = 'Table';
+
   static propTypes = {
     /**
      * Set to true to indicate that all rows should be selected.

--- a/src/Table/Table.spec.js
+++ b/src/Table/Table.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import Table from './Table';
+
+describe('<Table />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Table.displayName, 'Table');
+  });
+});

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -4,6 +4,8 @@ import TableRowColumn from './TableRowColumn';
 import ClickAwayListener from '../internal/ClickAwayListener';
 
 class TableBody extends Component {
+  static displayName = 'TableBody';
+
   static muiName = 'TableBody';
 
   static propTypes = {

--- a/src/Table/TableBody.spec.js
+++ b/src/Table/TableBody.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import TableBody from './TableBody';
+
+describe('<TableBody />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(TableBody.displayName, 'TableBody');
+  });
+});

--- a/src/Table/TableFooter.js
+++ b/src/Table/TableFooter.js
@@ -16,6 +16,8 @@ function getStyles(props, context) {
 }
 
 class TableFooter extends Component {
+  static displayName = 'TableFooter';
+
   static muiName = 'TableFooter';
 
   static propTypes = {

--- a/src/Table/TableFooter.spec.js
+++ b/src/Table/TableFooter.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import TableFooter from './TableFooter';
+
+describe('<TableFooter />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(TableFooter.displayName, 'TableFooter');
+  });
+});

--- a/src/Table/TableHeader.js
+++ b/src/Table/TableHeader.js
@@ -13,6 +13,8 @@ function getStyles(props, context) {
 }
 
 class TableHeader extends Component {
+  static displayName = 'TableHeader';
+
   static muiName = 'TableHeader';
 
   static propTypes = {

--- a/src/Table/TableHeader.spec.js
+++ b/src/Table/TableHeader.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import TableHeader from './TableHeader';
+
+describe('<TableHeader />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(TableHeader.displayName, 'TableHeader');
+  });
+});

--- a/src/Table/TableHeaderColumn.js
+++ b/src/Table/TableHeaderColumn.js
@@ -25,6 +25,8 @@ function getStyles(props, context) {
 }
 
 class TableHeaderColumn extends Component {
+  static displayName = 'TableHeaderColumn';
+
   static propTypes = {
     children: PropTypes.node,
     /**

--- a/src/Table/TableHeaderColumn.spec.js
+++ b/src/Table/TableHeaderColumn.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import TableHeaderColumn from './TableHeaderColumn';
+
+describe('<TableHeaderColumn />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(TableHeaderColumn.displayName, 'TableHeaderColumn');
+  });
+});

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -25,6 +25,8 @@ function getStyles(props, context, state) {
 }
 
 class TableRow extends Component {
+  static displayName = 'TableRow';
+
   static propTypes = {
     /**
      * Children passed to table row.

--- a/src/Table/TableRow.spec.js
+++ b/src/Table/TableRow.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import TableRow from './TableRow';
+
+describe('<TableRow />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(TableRow.displayName, 'TableRow');
+  });
+});

--- a/src/Table/TableRowColumn.js
+++ b/src/Table/TableRowColumn.js
@@ -24,6 +24,8 @@ function getStyles(props, context) {
 }
 
 class TableRowColumn extends Component {
+  static displayName = 'TableRowColumn';
+
   static propTypes = {
     children: PropTypes.node,
     /**

--- a/src/Table/TableRowColumn.spec.js
+++ b/src/Table/TableRowColumn.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import TableRowColumn from './TableRowColumn';
+
+describe('<TableRowColumn />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(TableRowColumn.displayName, 'TableRowColumn');
+  });
+});

--- a/src/Tabs/InkBar.js
+++ b/src/Tabs/InkBar.js
@@ -20,6 +20,8 @@ function getStyles(props, context) {
 }
 
 class InkBar extends Component {
+  static displayName = 'InkBar';
+
   static propTypes = {
     color: PropTypes.string,
     left: PropTypes.string.isRequired,

--- a/src/Tabs/InkBar.spec.js
+++ b/src/Tabs/InkBar.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import InkBar from './InkBar';
+
+describe('<InkBar />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(InkBar.displayName, 'InkBar');
+  });
+});

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -24,6 +24,8 @@ function getStyles(props, context) {
 }
 
 class Tab extends Component {
+  static displayName = 'Tab';
+
   static muiName = 'Tab';
 
   static propTypes = {

--- a/src/Tabs/Tab.spec.js
+++ b/src/Tabs/Tab.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import Tab from './Tab';
+
+describe('<Tab />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Tab.displayName, 'Tab');
+  });
+});

--- a/src/Tabs/TabTemplate.js
+++ b/src/Tabs/TabTemplate.js
@@ -1,6 +1,8 @@
 import React, {Component, PropTypes} from 'react';
 
 class TabTemplate extends Component {
+  static displayName = 'TabTemplate';
+
   static propTypes = {
     children: PropTypes.node,
     selected: PropTypes.bool,

--- a/src/Tabs/TabTemplate.spec.js
+++ b/src/Tabs/TabTemplate.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import TabTemplate from './TabTemplate';
+
+describe('<TabTemplate />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(TabTemplate.displayName, 'TabTemplate');
+  });
+});

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -17,6 +17,8 @@ function getStyles(props, context) {
 }
 
 class Tabs extends Component {
+  static displayName = 'Tabs';
+
   static propTypes = {
     /**
      * Should be used to pass `Tab` components.

--- a/src/Tabs/Tabs.spec.js
+++ b/src/Tabs/Tabs.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import Tabs from './Tabs';
+
+describe('<Tabs />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Tabs.displayName, 'Tabs');
+  });
+});

--- a/src/TextField/EnhancedTextarea.js
+++ b/src/TextField/EnhancedTextarea.js
@@ -30,6 +30,8 @@ function getStyles(props, context, state) {
 }
 
 class EnhancedTextarea extends Component {
+  static displayName = 'EnhancedTextarea';
+
   static propTypes = {
     defaultValue: PropTypes.any,
     disabled: PropTypes.bool,

--- a/src/TextField/EnhancedTextarea.spec.js
+++ b/src/TextField/EnhancedTextarea.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import EnhancedTextarea from './EnhancedTextarea';
+
+describe('<EnhancedTextarea />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(EnhancedTextarea.displayName, 'EnhancedTextarea');
+  });
+});

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -117,6 +117,8 @@ function isValid(value) {
 }
 
 class TextField extends Component {
+  static displayName = 'TextField';
+
   static propTypes = {
     children: PropTypes.node,
     /**

--- a/src/TextField/TextField.spec.js
+++ b/src/TextField/TextField.spec.js
@@ -10,6 +10,10 @@ describe('<TextField />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(TextField.displayName, 'TextField');
+  });
+
   it('passes event and value to the onChange callback', (done) => {
     const wrapper = shallowWithContext(
       <TextField

--- a/src/TextField/TextFieldHint.js
+++ b/src/TextField/TextFieldHint.js
@@ -40,6 +40,8 @@ const TextFieldHint = (props) => {
   );
 };
 
+TextFieldHint.displayName = 'TextFieldHint';
+
 TextFieldHint.propTypes = {
   /**
    * @ignore

--- a/src/TextField/TextFieldHint.spec.js
+++ b/src/TextField/TextFieldHint.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import TextFieldHint from './TextFieldHint';
+
+describe('<TextFieldHint />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(TextFieldHint.displayName, 'TextFieldHint');
+  });
+});

--- a/src/TextField/TextFieldLabel.js
+++ b/src/TextField/TextFieldLabel.js
@@ -49,6 +49,8 @@ const TextFieldLabel = (props) => {
   );
 };
 
+TextFieldLabel.displayName = 'TextFieldLabel';
+
 TextFieldLabel.propTypes = {
   /**
    * The label contents.

--- a/src/TextField/TextFieldLabel.spec.js
+++ b/src/TextField/TextFieldLabel.spec.js
@@ -1,11 +1,15 @@
 /* eslint-env mocha */
 import React from 'react';
 import {shallow} from 'enzyme';
-import {expect} from 'chai';
+import {assert, expect} from 'chai';
 import TextFieldLabel from './TextFieldLabel';
 import getMuiTheme from '../styles/getMuiTheme';
 
 describe('<TextFieldLabel>', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(TextFieldLabel.displayName, 'TextFieldLabel');
+  });
+
   it('uses focus styles', () => {
     const wrapper = shallow(
       <TextFieldLabel

--- a/src/TextField/TextFieldUnderline.js
+++ b/src/TextField/TextFieldUnderline.js
@@ -114,6 +114,7 @@ const TextFieldUnderline = (props) => {
   );
 };
 
+TextFieldUnderline.displayName = 'TextFieldUnderline';
 TextFieldUnderline.propTypes = propTypes;
 TextFieldUnderline.defaultProps = defaultProps;
 

--- a/src/TextField/TextFieldUnderline.spec.js
+++ b/src/TextField/TextFieldUnderline.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import TextFieldUnderline from './TextFieldUnderline';
+
+describe('<TextFieldUnderline />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(TextFieldUnderline.displayName, 'TextFieldUnderline');
+  });
+});

--- a/src/TimePicker/Clock.js
+++ b/src/TimePicker/Clock.js
@@ -4,6 +4,8 @@ import ClockHours from './ClockHours';
 import ClockMinutes from './ClockMinutes';
 
 class Clock extends Component {
+  static displayName = 'Clock';
+
   static propTypes = {
     format: PropTypes.oneOf(['ampm', '24hr']),
     initialTime: PropTypes.object,

--- a/src/TimePicker/Clock.spec.js
+++ b/src/TimePicker/Clock.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import Clock from './Clock';
+
+describe('<Clock />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Clock.displayName, 'Clock');
+  });
+});

--- a/src/TimePicker/ClockHours.js
+++ b/src/TimePicker/ClockHours.js
@@ -5,6 +5,8 @@ import ClockPointer from './ClockPointer';
 import {getTouchEventOffsetValues, rad2deg} from './timeUtils';
 
 class ClockHours extends Component {
+  static displayName = 'ClockHours';
+
   static propTypes = {
     format: PropTypes.oneOf(['ampm', '24hr']),
     initialHours: PropTypes.number,

--- a/src/TimePicker/ClockHours.spec.js
+++ b/src/TimePicker/ClockHours.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import ClockHours from './ClockHours';
+
+describe('<ClockHours />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(ClockHours.displayName, 'ClockHours');
+  });
+});

--- a/src/TimePicker/ClockMinutes.js
+++ b/src/TimePicker/ClockMinutes.js
@@ -4,6 +4,8 @@ import ClockPointer from './ClockPointer';
 import {getTouchEventOffsetValues, rad2deg} from './timeUtils';
 
 class ClockMinutes extends Component {
+  static displayName = 'ClockMinutes';
+
   static propTypes = {
     initialMinutes: PropTypes.number,
     onChange: PropTypes.func,

--- a/src/TimePicker/ClockMinutes.spec.js
+++ b/src/TimePicker/ClockMinutes.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import ClockMinutes from './ClockMinutes';
+
+describe('<ClockMinutes />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(ClockMinutes.displayName, 'ClockMinutes');
+  });
+});

--- a/src/TimePicker/ClockNumber.js
+++ b/src/TimePicker/ClockNumber.js
@@ -82,6 +82,8 @@ function getStyles(props, context) {
 }
 
 class ClockNumber extends Component {
+  static displayName = 'ClockNumber';
+
   static propTypes = {
     isSelected: PropTypes.bool,
     onSelected: PropTypes.func,

--- a/src/TimePicker/ClockNumber.spec.js
+++ b/src/TimePicker/ClockNumber.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import ClockNumber from './ClockNumber';
+
+describe('<ClockNumber />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(ClockNumber.displayName, 'ClockNumber');
+  });
+});

--- a/src/TimePicker/ClockPointer.js
+++ b/src/TimePicker/ClockPointer.js
@@ -42,6 +42,8 @@ function getStyles(props, context, state) {
 }
 
 class ClockPointer extends Component {
+  static displayName = 'ClockPointer';
+
   static propTypes = {
     hasSelected: PropTypes.bool,
     type: PropTypes.oneOf(['hour', 'minute']),

--- a/src/TimePicker/ClockPointer.spec.js
+++ b/src/TimePicker/ClockPointer.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import ClockPointer from './ClockPointer';
+
+describe('<ClockPointer />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(ClockPointer.displayName, 'ClockPointer');
+  });
+});

--- a/src/TimePicker/TimeDisplay.js
+++ b/src/TimePicker/TimeDisplay.js
@@ -1,6 +1,8 @@
 import React, {Component, PropTypes} from 'react';
 
 class TimeDisplay extends Component {
+  static displayName = 'TimeDisplay';
+
   static propTypes = {
     affix: PropTypes.oneOf(['', 'pm', 'am']),
     format: PropTypes.oneOf(['ampm', '24hr']),

--- a/src/TimePicker/TimeDisplay.spec.js
+++ b/src/TimePicker/TimeDisplay.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import TimeDisplay from './TimeDisplay';
+
+describe('<TimeDisplay />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(TimeDisplay.displayName, 'TimeDisplay');
+  });
+});

--- a/src/TimePicker/TimePicker.js
+++ b/src/TimePicker/TimePicker.js
@@ -11,6 +11,8 @@ emptyTime.setSeconds(0);
 emptyTime.setMilliseconds(0);
 
 class TimePicker extends Component {
+  static displayName = 'TimePicker';
+
   static propTypes = {
     /**
      * If true, automatically accept and close the picker on set minutes.

--- a/src/TimePicker/TimePicker.spec.js
+++ b/src/TimePicker/TimePicker.spec.js
@@ -12,6 +12,10 @@ describe('<TimePicker />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(TimePicker.displayName, 'TimePicker');
+  });
+
   it('has to give value prop precedence over defaultTime', () => {
     const initialTime = new Date(1448967059892); // Tue, 01 Dec 2015 10:50:59 GMT
     const valueTime = addHours(initialTime, 2);

--- a/src/TimePicker/TimePickerDialog.js
+++ b/src/TimePicker/TimePickerDialog.js
@@ -6,6 +6,8 @@ import Dialog from '../Dialog';
 import FlatButton from '../FlatButton';
 
 class TimePickerDialog extends Component {
+  static displayName = 'TimePickerDialog';
+
   static propTypes = {
     autoOk: PropTypes.bool,
     bodyStyle: PropTypes.object,

--- a/src/TimePicker/TimePickerDialog.spec.js
+++ b/src/TimePicker/TimePickerDialog.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import TimePickerDialog from './TimePickerDialog';
+
+describe('<TimePickerDialog />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(TimePickerDialog.displayName, 'TimePickerDialog');
+  });
+});

--- a/src/Toggle/Toggle.js
+++ b/src/Toggle/Toggle.js
@@ -70,6 +70,8 @@ function getStyles(props, context, state) {
 }
 
 class Toggle extends Component {
+  static displayName = 'Toggle';
+
   static propTypes = {
     /**
      * Determines whether the Toggle is initially turned on.

--- a/src/Toggle/Toggle.spec.js
+++ b/src/Toggle/Toggle.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import Toggle from './Toggle';
+
+describe('<Toggle />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Toggle.displayName, 'Toggle');
+  });
+});

--- a/src/Toolbar/Toolbar.js
+++ b/src/Toolbar/Toolbar.js
@@ -22,6 +22,8 @@ function getStyles(props, context) {
 }
 
 class Toolbar extends Component {
+  static displayName = 'Toolbar';
+
   static propTypes = {
     /**
      * Can be a `ToolbarGroup` to render a group of related items.

--- a/src/Toolbar/Toolbar.spec.js
+++ b/src/Toolbar/Toolbar.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import Toolbar from './Toolbar';
+
+describe('<Toolbar />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Toolbar.displayName, 'Toolbar');
+  });
+});

--- a/src/Toolbar/ToolbarGroup.js
+++ b/src/Toolbar/ToolbarGroup.js
@@ -59,6 +59,8 @@ function getStyles(props, context) {
 }
 
 class ToolbarGroup extends Component {
+  static displayName = 'ToolbarGroup';
+
   static propTypes = {
     /**
      * Can be any node or number of nodes.

--- a/src/Toolbar/ToolbarGroup.spec.js
+++ b/src/Toolbar/ToolbarGroup.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import ToolbarGroup from './ToolbarGroup';
+
+describe('<ToolbarGroup />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(ToolbarGroup.displayName, 'ToolbarGroup');
+  });
+});

--- a/src/Toolbar/ToolbarSeparator.js
+++ b/src/Toolbar/ToolbarSeparator.js
@@ -20,6 +20,8 @@ function getStyles(props, context) {
 }
 
 class ToolbarSeparator extends Component {
+  static displayName = 'ToolbarSeparator';
+
   static muiName = 'ToolbarSeparator';
 
   static propTypes = {

--- a/src/Toolbar/ToolbarSeparator.spec.js
+++ b/src/Toolbar/ToolbarSeparator.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import ToolbarSeparator from './ToolbarSeparator';
+
+describe('<ToolbarSeparator />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(ToolbarSeparator.displayName, 'ToolbarSeparator');
+  });
+});

--- a/src/Toolbar/ToolbarTitle.js
+++ b/src/Toolbar/ToolbarTitle.js
@@ -20,6 +20,8 @@ function getStyles(props, context) {
 }
 
 class ToolbarTitle extends Component {
+  static displayName = 'ToolbarTitle';
+
   static muiName = 'ToolbarTitle';
 
   static propTypes = {

--- a/src/Toolbar/ToolbarTitle.spec.js
+++ b/src/Toolbar/ToolbarTitle.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import ToolbarTitle from './ToolbarTitle';
+
+describe('<ToolbarTitle />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(ToolbarTitle.displayName, 'ToolbarTitle');
+  });
+});

--- a/src/internal/AppCanvas.js
+++ b/src/internal/AppCanvas.js
@@ -1,6 +1,8 @@
 import React, {Component, PropTypes} from 'react';
 
 class AppCanvas extends Component {
+  static displayName = 'AppCanvas';
+
   static propTypes = {
     children: PropTypes.node,
   };

--- a/src/internal/AppCanvas.spec.js
+++ b/src/internal/AppCanvas.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import AppCanvas from './AppCanvas';
+
+describe('<AppCanvas />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(AppCanvas.displayName, 'AppCanvas');
+  });
+});

--- a/src/internal/AutoLockScrolling.js
+++ b/src/internal/AutoLockScrolling.js
@@ -4,6 +4,7 @@ let originalBodyOverflow = null;
 let lockingCounter = 0;
 
 export default class AutoLockScrolling extends Component {
+  static displayName = 'AutoLockScrolling';
 
   static propTypes = {
     lock: PropTypes.bool.isRequired,

--- a/src/internal/AutoLockScrolling.spec.js
+++ b/src/internal/AutoLockScrolling.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import AutoLockScrolling from './AutoLockScrolling';
+
+describe('<AutoLockScrolling />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(AutoLockScrolling.displayName, 'AutoLockScrolling');
+  });
+});

--- a/src/internal/BeforeAfterWrapper.js
+++ b/src/internal/BeforeAfterWrapper.js
@@ -41,6 +41,8 @@ const styles = {
 };
 
 class BeforeAfterWrapper extends Component {
+  static displayName = 'BeforeAfterWrapper';
+
   static propTypes = {
     afterElementType: PropTypes.string,
     afterStyle: PropTypes.object,

--- a/src/internal/BeforeAfterWrapper.spec.js
+++ b/src/internal/BeforeAfterWrapper.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import BeforeAfterWrapper from './BeforeAfterWrapper';
+
+describe('<BeforeAfterWrapper />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(BeforeAfterWrapper.displayName, 'BeforeAfterWrapper');
+  });
+});

--- a/src/internal/CircleRipple.js
+++ b/src/internal/CircleRipple.js
@@ -5,6 +5,8 @@ import autoPrefix from '../utils/autoPrefix';
 import transitions from '../styles/transitions';
 
 class CircleRipple extends Component {
+  static displayName = 'CircleRipple';
+
   static propTypes = {
     aborted: PropTypes.bool,
     color: PropTypes.string,

--- a/src/internal/CircleRipple.spec.js
+++ b/src/internal/CircleRipple.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import CircleRipple from './CircleRipple';
+
+describe('<CircleRipple />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(CircleRipple.displayName, 'CircleRipple');
+  });
+});

--- a/src/internal/ClearFix.js
+++ b/src/internal/ClearFix.js
@@ -24,6 +24,8 @@ const ClearFix = ({style, children, ...other}) => (
   </BeforeAfterWrapper>
 );
 
+ClearFix.displayName = 'ClearFix';
+
 ClearFix.muiName = 'ClearFix';
 
 ClearFix.propTypes = {

--- a/src/internal/ClearFix.spec.js
+++ b/src/internal/ClearFix.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import ClearFix from './ClearFix';
+
+describe('<ClearFix />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(ClearFix.displayName, 'ClearFix');
+  });
+});

--- a/src/internal/ClickAwayListener.js
+++ b/src/internal/ClickAwayListener.js
@@ -14,6 +14,7 @@ const bind = (callback) => clickAwayEvents.forEach((event) => events.on(document
 const unbind = (callback) => clickAwayEvents.forEach((event) => events.off(document, event, callback));
 
 export default class ClickAwayListener extends Component {
+  static displayName = 'ClickAwayListener';
 
   static propTypes = {
     children: PropTypes.node,

--- a/src/internal/ClickAwayListener.spec.js
+++ b/src/internal/ClickAwayListener.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import ClickAwayListener from './ClickAwayListener';
+
+describe('<ClickAwayListener />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(ClickAwayListener.displayName, 'ClickAwayListener');
+  });
+});

--- a/src/internal/EnhancedButton.js
+++ b/src/internal/EnhancedButton.js
@@ -37,6 +37,8 @@ function listenForTabPresses() {
 }
 
 class EnhancedButton extends Component {
+  static displayName = 'EnhancedButton';
+
   static propTypes = {
     centerRipple: PropTypes.bool,
     children: PropTypes.node,

--- a/src/internal/EnhancedButton.spec.js
+++ b/src/internal/EnhancedButton.spec.js
@@ -10,6 +10,10 @@ describe('<EnhancedButton />', () => {
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
   const testChildren = <div className="unique">Hello World</div>;
 
+  it('should have the correct displayName', () => {
+    assert.strictEqual(EnhancedButton.displayName, 'EnhancedButton');
+  });
+
   it('renders a button', () => {
     const wrapper = shallowWithContext(
       <EnhancedButton>Button</EnhancedButton>

--- a/src/internal/EnhancedSwitch.js
+++ b/src/internal/EnhancedSwitch.js
@@ -69,6 +69,8 @@ function getStyles(props, context) {
 }
 
 class EnhancedSwitch extends Component {
+  static displayName = 'EnhancedSwitch';
+
   static propTypes = {
     checked: PropTypes.bool,
     className: PropTypes.string,

--- a/src/internal/EnhancedSwitch.spec.js
+++ b/src/internal/EnhancedSwitch.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import EnhancedSwitch from './EnhancedSwitch';
+
+describe('<EnhancedSwitch />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(EnhancedSwitch.displayName, 'EnhancedSwitch');
+  });
+});

--- a/src/internal/ExpandTransition.js
+++ b/src/internal/ExpandTransition.js
@@ -3,6 +3,8 @@ import ReactTransitionGroup from 'react-addons-transition-group';
 import ExpandTransitionChild from './ExpandTransitionChild';
 
 class ExpandTransition extends Component {
+  static displayName = 'ExpandTransition';
+
   static propTypes = {
     children: PropTypes.node,
     enterDelay: PropTypes.number,

--- a/src/internal/ExpandTransition.spec.js
+++ b/src/internal/ExpandTransition.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import ExpandTransition from './ExpandTransition';
+
+describe('<ExpandTransition />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(ExpandTransition.displayName, 'ExpandTransition');
+  });
+});

--- a/src/internal/ExpandTransitionChild.js
+++ b/src/internal/ExpandTransitionChild.js
@@ -5,6 +5,8 @@ import transitions from '../styles/transitions';
 const reflow = (elem) => elem.offsetHeight;
 
 class ExpandTransitionChild extends Component {
+  static displayName = 'ExpandTransitionChild';
+
   static propTypes = {
     children: PropTypes.node,
     enterDelay: PropTypes.number,

--- a/src/internal/ExpandTransitionChild.spec.js
+++ b/src/internal/ExpandTransitionChild.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import ExpandTransitionChild from './ExpandTransitionChild';
+
+describe('<ExpandTransitionChild />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(ExpandTransitionChild.displayName, 'ExpandTransitionChild');
+  });
+});

--- a/src/internal/FocusRipple.js
+++ b/src/internal/FocusRipple.js
@@ -8,6 +8,8 @@ import ScaleInTransitionGroup from './ScaleIn';
 const pulsateDuration = 750;
 
 class FocusRipple extends Component {
+  static displayName = 'FocusRipple';
+
   static propTypes = {
     color: PropTypes.string,
     innerStyle: PropTypes.object,

--- a/src/internal/FocusRipple.spec.js
+++ b/src/internal/FocusRipple.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import FocusRipple from './FocusRipple';
+
+describe('<FocusRipple />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(FocusRipple.displayName, 'FocusRipple');
+  });
+});

--- a/src/internal/Overlay.js
+++ b/src/internal/Overlay.js
@@ -39,6 +39,8 @@ function getStyles(props, context) {
 }
 
 class Overlay extends Component {
+  static displayName = 'Overlay';
+
   static propTypes = {
     autoLockScrolling: PropTypes.bool,
     show: PropTypes.bool.isRequired,

--- a/src/internal/Overlay.spec.js
+++ b/src/internal/Overlay.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import Overlay from './Overlay';
+
+describe('<Overlay />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Overlay.displayName, 'Overlay');
+  });
+});

--- a/src/internal/RenderToLayer.js
+++ b/src/internal/RenderToLayer.js
@@ -5,6 +5,8 @@ import Dom from '../utils/dom';
 
 // heavily inspired by https://github.com/Khan/react-components/blob/master/js/layered-component-mixin.jsx
 class RenderToLayer extends Component {
+  static displayName = 'RenderToLayer';
+
   static propTypes = {
     componentClickAway: PropTypes.func,
     open: PropTypes.bool.isRequired,

--- a/src/internal/RenderToLayer.spec.js
+++ b/src/internal/RenderToLayer.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import RenderToLayer from './RenderToLayer';
+
+describe('<RenderToLayer />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(RenderToLayer.displayName, 'RenderToLayer');
+  });
+});

--- a/src/internal/ScaleIn.js
+++ b/src/internal/ScaleIn.js
@@ -3,6 +3,8 @@ import ReactTransitionGroup from 'react-addons-transition-group';
 import ScaleInChild from './ScaleInChild';
 
 class ScaleIn extends Component {
+  static displayName = 'ScaleIn';
+
   static propTypes = {
     childStyle: PropTypes.object,
     children: PropTypes.node,

--- a/src/internal/ScaleIn.spec.js
+++ b/src/internal/ScaleIn.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import ScaleIn from './ScaleIn';
+
+describe('<ScaleIn />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(ScaleIn.displayName, 'ScaleIn');
+  });
+});

--- a/src/internal/ScaleInChild.js
+++ b/src/internal/ScaleInChild.js
@@ -4,6 +4,8 @@ import autoPrefix from '../utils/autoPrefix';
 import transitions from '../styles/transitions';
 
 class ScaleInChild extends Component {
+  static displayName = 'ScaleInChild';
+
   static propTypes = {
     children: PropTypes.node,
     enterDelay: PropTypes.number,

--- a/src/internal/ScaleInChild.spec.js
+++ b/src/internal/ScaleInChild.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import ScaleInChild from './ScaleInChild';
+
+describe('<ScaleInChild />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(ScaleInChild.displayName, 'ScaleInChild');
+  });
+});

--- a/src/internal/SlideIn.js
+++ b/src/internal/SlideIn.js
@@ -3,6 +3,8 @@ import ReactTransitionGroup from 'react-addons-transition-group';
 import SlideInChild from './SlideInChild';
 
 class SlideIn extends Component {
+  static displayName = 'SlideIn';
+
   static propTypes = {
     childStyle: PropTypes.object,
     children: PropTypes.node,

--- a/src/internal/SlideIn.spec.js
+++ b/src/internal/SlideIn.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import SlideIn from './SlideIn';
+
+describe('<SlideIn />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(SlideIn.displayName, 'SlideIn');
+  });
+});

--- a/src/internal/SlideInChild.js
+++ b/src/internal/SlideInChild.js
@@ -4,6 +4,8 @@ import autoPrefix from '../utils/autoPrefix';
 import transitions from '../styles/transitions';
 
 class SlideInChild extends Component {
+  static displayName = 'SlideInChild';
+
   static propTypes = {
     children: PropTypes.node,
     direction: PropTypes.string,

--- a/src/internal/SlideInChild.spec.js
+++ b/src/internal/SlideInChild.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import SlideInChild from './SlideInChild';
+
+describe('<SlideInChild />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(SlideInChild.displayName, 'SlideInChild');
+  });
+});

--- a/src/internal/Tooltip.js
+++ b/src/internal/Tooltip.js
@@ -78,6 +78,8 @@ function getStyles(props, context, state) {
 }
 
 class Tooltip extends Component {
+  static displayName = 'Tooltip';
+
   static propTypes = {
     /**
      * The css class name of the root element.

--- a/src/internal/Tooltip.spec.js
+++ b/src/internal/Tooltip.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import Tooltip from './Tooltip';
+
+describe('<Tooltip />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(Tooltip.displayName, 'Tooltip');
+  });
+});

--- a/src/internal/TouchRipple.js
+++ b/src/internal/TouchRipple.js
@@ -8,6 +8,8 @@ import CircleRipple from './CircleRipple';
 const shift = ([, ...newArray]) => newArray;
 
 class TouchRipple extends Component {
+  static displayName = 'TouchRipple';
+
   static propTypes = {
     abortOnScroll: PropTypes.bool,
     centerRipple: PropTypes.bool,

--- a/src/internal/TouchRipple.spec.js
+++ b/src/internal/TouchRipple.spec.js
@@ -1,0 +1,9 @@
+/* eslint-env mocha */
+import {assert} from 'chai';
+import TouchRipple from './TouchRipple';
+
+describe('<TouchRipple />', () => {
+  it('should have the correct displayName', () => {
+    assert.strictEqual(TouchRipple.displayName, 'TouchRipple');
+  });
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

This PR adds a displayName property to most material-ui components. Having a displayName will help developers learn the ins and outs of the library by using the React devtools to inspect the component structure on production sites, even when that code is uglified.

- [X] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


