### PR TITLE
[ListItem] Fix primaryTogglesNestedList behavior when left checkbox is present

### DIFF
--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -430,9 +430,15 @@ class ListItem extends Component {
 
   handleNestedListToggle = (event) => {
     event.stopPropagation();
-    this.setState({open: !this.state.open}, () => {
-      this.props.onNestedListToggle(this);
-    });
+
+    if (event.target.type === 'checkbox')
+      this.setState({open: this.state.open}, () => {
+        this.props.onNestedListToggle(this);
+      });
+    else
+      this.setState({open: !this.state.open}, () => {
+        this.props.onNestedListToggle(this);
+      });
   };
 
   handleRightIconButtonKeyboardFocus = (event, isKeyboardFocused) => {
@@ -646,7 +652,7 @@ class ListItem extends Component {
     return (
       <div>
         {
-          hasCheckbox ? this.createLabelElement(styles, contentChildren, other) :
+          hasCheckbox && !primaryTogglesNestedList ? this.createLabelElement(styles, contentChildren, other) :
           disabled ? this.createDisabledElement(styles, contentChildren, other) : (
             <EnhancedButton
               containerElement={'span'}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

When set to true, `primaryTogglesNestedList` property toggles nested list even when checkbox is present.

The fix addresses #4753 