### PR TITLE
[FloatingActionButton] Reset hover state when disabled prop is changed

### DIFF
--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -118,7 +118,7 @@ class FlatButton extends Component {
   };
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.disabled && this.state.hovered) {
+    if (nextProps.disabled) {
       this.setState({
         hovered: false,
       });

--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -164,16 +164,16 @@ class FloatingActionButton extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
+    const nextState = {};
+
     if (nextProps.disabled !== this.props.disabled) {
-      this.setState({
-        zDepth: nextProps.disabled ? 0 : this.props.zDepth,
-      });
+      nextState.zDepth = nextProps.disabled ? 0 : this.props.zDepth;
     }
-    if (nextProps.disabled && this.state.hovered) {
-      this.setState({
-        hovered: false,
-      });
+    if (nextProps.disabled) {
+      nextState.hovered = false;
     }
+
+    this.setState(nextState);
   }
 
   handleMouseDown = (event) => {

--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -166,8 +166,12 @@ class FloatingActionButton extends Component {
   componentWillReceiveProps(nextProps) {
     if (nextProps.disabled !== this.props.disabled) {
       this.setState({
-        hovered: nextProps.disabled ? false : this.state.hovered,
         zDepth: nextProps.disabled ? 0 : this.props.zDepth,
+      });
+    }
+    if (nextProps.disabled && this.state.hovered) {
+      this.setState({
+        hovered: false,
       });
     }
   }

--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -166,6 +166,7 @@ class FloatingActionButton extends Component {
   componentWillReceiveProps(nextProps) {
     if (nextProps.disabled !== this.props.disabled) {
       this.setState({
+        hovered: nextProps.disabled ? false : this.state.hovered,
         zDepth: nextProps.disabled ? 0 : this.props.zDepth,
       });
     }

--- a/src/FloatingActionButton/FloatingActionButton.spec.js
+++ b/src/FloatingActionButton/FloatingActionButton.spec.js
@@ -1,0 +1,31 @@
+/* eslint-env mocha */
+import React from 'react';
+import {shallow} from 'enzyme';
+import {assert} from 'chai';
+
+import FloatingActionButton from './FloatingActionButton';
+import getMuiTheme from '../styles/getMuiTheme';
+import ContentAdd from '../svg-icons/content/add';
+
+describe('<FloatingActionButton />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
+  describe('hover state', () => {
+    it('should reset the hover state when disabled', () => {
+      const wrapper = shallowWithContext(
+        <FloatingActionButton>
+          <ContentAdd />
+        </FloatingActionButton>
+      );
+      wrapper.setState({
+        hovered: true,
+      });
+      assert.strictEqual(wrapper.state().hovered, true, 'should be hovered');
+      wrapper.setProps({
+        disabled: true,
+      });
+      assert.strictEqual(wrapper.state().hovered, false, 'should reset the state');
+    });
+  });
+});

--- a/src/FloatingActionButton/FloatingActionButton.spec.js
+++ b/src/FloatingActionButton/FloatingActionButton.spec.js
@@ -21,7 +21,6 @@ describe('<FloatingActionButton />', () => {
       wrapper.setState({
         hovered: true,
       });
-      assert.strictEqual(wrapper.state().hovered, true, 'should be hovered');
       wrapper.setProps({
         disabled: true,
       });

--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -243,7 +243,7 @@ class RaisedButton extends Component {
       initialZDepth: zDepth,
     };
 
-    if (nextProps.disabled && this.state.hovered) {
+    if (nextProps.disabled) {
       nextState.hovered = false;
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

FloatingActionButton hasn't handle the case when hovered state didn't reset if disabled prop would be received (the way FlatButton did).

I have added the test as well, but couldn't use `wrapper.children().at(0).simulate('mouseEnter');` because FloatingActionButton uses refs, so I set hover state using `setState` method on wrapper.

