### PR TITLE
[Tabs] Fix Firefox height issue

### DIFF
--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -11,7 +11,7 @@ function getStyles(props, context) {
     tabItemContainer: {
       width: '100%',
       backgroundColor: tabs.backgroundColor,
-      whiteSpace: 'nowrap',
+      display: 'flex',
     },
   };
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


This is situation now (you can check it on [documentation](http://www.material-ui.com/#/components/tabs)).
- Height of simple tabs in Chrome is 48px and 55px in Firefox.
- Height of tabs with icons in Chrome is 50px and 55px in Firefox.
- Height of tabs with icon and text in Chrome is 72px and 79 in Firefox.

If we align button using flex and not inline result would be:
- Height of simple tabs in Chrome and Firefox 48px.
- Height of tabs with icons in Chrome and Firefox 48px.
- Height of tabs with icon and text in Chrome and Firefox 72px.