### PR TITLE
[TextField] Better support for type=search

### DIFF
--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -50,7 +50,6 @@ const getStyles = (props, context, state) => {
       pointerEvents: 'none',
     },
     input: {
-      WebkitTapHighlightColor: 'rgba(0,0,0,0)', // Remove mobile color flashing (deprecated style)
       padding: 0,
       position: 'relative',
       width: '100%',
@@ -60,6 +59,8 @@ const getStyles = (props, context, state) => {
       color: props.disabled ? disabledTextColor : textColor,
       cursor: props.disabled ? 'not-allowed' : 'initial',
       font: 'inherit',
+      appearance: 'textfield', // Improve type search style.
+      WebkitTapHighlightColor: 'rgba(0,0,0,0)', // Remove mobile color flashing (deprecated style).
     },
     textarea: {
     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

The component looks better with this new property when `type="search"`:
![capture d ecran 2016-08-13 a 07 30 39](https://cloud.githubusercontent.com/assets/3165635/17641644/926d24c4-6128-11e6-8aaf-89e02dbacc9e.png)
![capture d ecran 2016-08-13 a 07 30 32](https://cloud.githubusercontent.com/assets/3165635/17641646/974cad84-6128-11e6-9d85-ca96d816450a.png)

We still have an additional padding, removing it requires the use of:
```css
.input_selector::-webkit-search-decoration {
    -webkit-appearance: none;
}
```
That I can only use on the `next` branch. I don't think that we should be using pattern like [`injectStyle()`](https://github.com/callemall/material-ui/blob/master/src/internal/EnhancedButton.js#L13) as it's breaking style isloation.

Closes #4906.

