### PR TITLE
[TextField] Better support for type=search

### DIFF
--- a/src/Progress/CircularProgress.spec.js
+++ b/src/Progress/CircularProgress.spec.js
@@ -26,15 +26,9 @@ describe('<CircularProgress>', () => {
     assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
   });
 
-  it('should contain a div with the wrapper class', () => {
-    const wrapper = shallow(<CircularProgress />);
-    assert.strictEqual(wrapper.childAt(0).is('div'), true, 'should be a div');
-    assert.strictEqual(wrapper.childAt(0).hasClass(classes.wrapper), true, 'should have the wrapper class');
-  });
-
   it('should contain an SVG with the svg class, and a circle with the circle class', () => {
     const wrapper = shallow(<CircularProgress />);
-    const svg = wrapper.childAt(0).childAt(0);
+    const svg = wrapper.childAt(0);
     assert.strictEqual(svg.is('svg'), true, 'should be a svg');
     assert.strictEqual(svg.hasClass(classes.svg), true, 'should have the svg class');
     assert.strictEqual(svg.childAt(0).is('circle'), true, 'should be a circle');

--- a/src/TextField/TextFieldInput.js
+++ b/src/TextField/TextFieldInput.js
@@ -17,6 +17,7 @@ export const styleSheet = createStyleSheet('TextFieldInput', (theme) => {
       whiteSpace: 'normal',
       background: 'none',
       lineHeight: 1,
+      appearance: 'textfield', // Improve type search style.
       '&:focus': {
         outline: 0,
       },


### PR DESCRIPTION
Port #4973 to the `next` branch.

@nathanmarks Pseudo-elements (`::`) doesn't seem to be supported by `stylishly`.
Should I work on this new plugin?