### PR TITLE
[BottomNavigation] Fix SVG icon positioning

### DIFF
--- a/src/BottomNavigation/BottomNavigationItem.js
+++ b/src/BottomNavigation/BottomNavigationItem.js
@@ -29,10 +29,13 @@ function getStyles(props, context) {
         bottomNavigation.unselectedFontSize,
       transition: 'color 0.3s, font-size 0.3s',
       color: color,
-      margin: 'auto',
     },
     icon: {
       display: 'block',
+      /**
+       * Used to ensure SVG icons are centered
+       */
+      width: '100%',
     },
     iconColor: color,
   };


### PR DESCRIPTION
Fixes https://github.com/callemall/material-ui/issues/4981 by setting the icon to 100% width so centering applies in the case of SVGs.

FYI I considered wrapping the icons in a div instead and implementing different centering, but I'd rather avoid adding DOM nodes unless necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/callemall/material-ui/4982)
<!-- Reviewable:end -->
