### PR TITLE
[docs] add react-tap-event-plugin in docs/package.json

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -46,6 +46,7 @@
     "react-native": "^0.17.0",
     "react-router": "^2.5.2",
     "react-swipeable-views": "^0.6.3",
+    "react-tap-event-plugin": "^1.0.0",
     "recast": "^0.11.10",
     "style-loader": "0.13.1",
     "webpack": "^1.13.1",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [X] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

I ran those step:

```javascript

git clone 

cd material-ui

npm i

cd docs

npm i

npm start

```

and when I open `localhost:3000`, I found the project lacked `react-tap-event-plugin`, so I `npm i react-tap-event-plugin --save-dev`.
 
so, the pr is about added `react-tap-event-plugin` in `docs/package.json`