### PR TITLE
[DatePicker] Changes opacity of disabled day-buttons

### DIFF
--- a/src/DatePicker/DayButton.js
+++ b/src/DatePicker/DayButton.js
@@ -24,7 +24,7 @@ function getStyles(props, context, state) {
     root: {
       boxSizing: 'border-box',
       fontWeight: '400',
-      opacity: disabled && '0.6',
+      opacity: disabled && '0.3',
       padding: '4px 0px',
       position: 'relative',
       WebkitTapHighlightColor: 'rgba(0,0,0,0)', // Remove mobile color flashing (deprecated)

--- a/src/DatePicker/DayButton.js
+++ b/src/DatePicker/DayButton.js
@@ -24,7 +24,7 @@ function getStyles(props, context, state) {
     root: {
       boxSizing: 'border-box',
       fontWeight: '400',
-      opacity: disabled && '0.3',
+      opacity: disabled && '0.4',
       padding: '4px 0px',
       position: 'relative',
       WebkitTapHighlightColor: 'rgba(0,0,0,0)', // Remove mobile color flashing (deprecated)


### PR DESCRIPTION
- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

When `shouldDisableDate(date)` returns true, disabled dates in DatePicker are barely distinguishable from available dates. Unfortunately, the opacity for disabled day-buttons is not customizable. After playing around `opacity=0.3` did look pretty good. 
