### PR TITLE
[NestList]When the nested level is deep, and nestedLists are too many, the performace is bad

### DIFF
--- a/src/List/NestedList.js
+++ b/src/List/NestedList.js
@@ -23,15 +23,12 @@ class NestedList extends Component {
       nestedLevel,
       style,
     } = this.props;
-
-    const styles = {
-      root: {
-        display: open ? null : 'none',
-      },
-    };
+    
+    if (!open && !this._hasOpened) return null;
+    this._hasOpened = true;
 
     return (
-      <List style={Object.assign({}, styles.root, style)}>
+      <List style={Object.assign({}, style)}>
         {
           React.Children.map(children, (child) => {
             return React.isValidElement(child) ? (


### PR DESCRIPTION

When the nest level is deep and there are too many nested items(Maybe 1000 and more),  the component's performance is very bad, because it inits every nested items even the are not opened to show,  so I change the code!