### PR TITLE
[Popover] Prevent creating multiple timeouts when popover is closing

### DIFF
--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -118,6 +118,8 @@ class Popover extends Component {
       open: props.open,
       closing: false,
     };
+
+    this.timeout = null;
   }
 
   componentWillReceiveProps(nextProps) {
@@ -130,10 +132,13 @@ class Popover extends Component {
         });
       } else {
         if (nextProps.animated) {
+          if (this.timeout !== null) return;
           this.setState({closing: true});
           this.timeout = setTimeout(() => {
             this.setState({
               open: false,
+            }, () => {
+              this.timeout = null;
             });
           }, 500);
         } else {
@@ -150,7 +155,10 @@ class Popover extends Component {
   }
 
   componentWillUnmount() {
-    clearTimeout(this.timeout);
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+      this.timeout = null;
+    }
   }
 
   renderLayer = () => {

--- a/src/Popover/Popover.spec.js
+++ b/src/Popover/Popover.spec.js
@@ -1,0 +1,26 @@
+/* eslint-env mocha */
+
+import React from 'react';
+import {assert} from 'chai';
+import {shallow} from 'enzyme';
+import Popover from './Popover';
+import getMuiTheme from '../styles/getMuiTheme';
+
+describe('<Popover />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
+  describe('state: closing', () => {
+    it('should not create new timeout when popover is already closing', () => {
+      const wrapper = shallowWithContext(<Popover open={true} />);
+
+      wrapper.setProps({open: false});
+      const timeout = wrapper.instance().timeout;
+
+      wrapper.setProps({open: false});
+      const nextTimeout = wrapper.instance().timeout;
+
+      assert.equal(timeout, nextTimeout);
+    });
+  });
+});


### PR DESCRIPTION
This fix closes https://github.com/callemall/material-ui/issues/4163. 

When user clicks on a `SelectField`, the `Popover` component is creating a new timeout to close itself after 500ms delay. This was a problem, because timeouts haven't been cleared when there is a new timeout being created (it's usually cleared when component will unmount). 

Possible fixes were either to clear old timeout every time `open` prop was changed or to simply prevent it from creating next one.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).