### PR TITLE
[EnhancedTextarea] Guard for if scrollHeight is not present

### DIFF
--- a/src/TextField/EnhancedTextarea.js
+++ b/src/TextField/EnhancedTextarea.js
@@ -97,6 +97,10 @@ class EnhancedTextarea extends Component {
 
     let newHeight = shadow.scrollHeight;
 
+    // Guarding for jsdom, where scrollHeight isn't present.
+    // See https://github.com/tmpvar/jsdom/issues/1013
+    if (newHeight === undefined) return;
+
     if (this.props.rowsMax >= this.props.rows) {
       newHeight = Math.min(this.props.rowsMax * rowsHeight, newHeight);
     }


### PR DESCRIPTION
Hello!  I'm using Material UI and testing the app in Mocha with jsdom (and using Enzyme).

When running tests using `TextField`, I see React warnings like this:
```
Warning: `NaN` is an invalid value for the `height` css style property. Check the render method of `EnhancedTextarea`.
```

This appears to be happening because `EnhancedTextarea` is using an element's `scrollHeight` and jsdom doesn't do layout and support this (https://github.com/tmpvar/jsdom/issues/1013).  That `undefined` value flows through until it leads to the `NaN` bug shown above.

This pull request guards for the existence of `scrollHeight`, which fixes this warning and would help other folks testing their Material UI apps in a jsdom environment.  Although supporting this test-only code in the Material UI codebase is a great direction, and I've made no effort to look at other components that might have similar gotchas.

If other folks have ideas about what would make sense here, that would be great.  Thanks!