### PR TITLE
[CardHeader] Do not pass CardHeader property titleColor to the DOM

### DIFF
--- a/src/Card/CardHeader.js
+++ b/src/Card/CardHeader.js
@@ -115,6 +115,7 @@ class CardHeader extends Component {
       textStyle,
       title,
       titleStyle,
+      titleColor,
       ...other,
     } = this.props;
 


### PR DESCRIPTION
Using the titleColor property on CardHeader, react gives a warning
> "Warning: Unknown prop `titleColor` on \<div\> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop"

Note that the titleColor works properly, the header text is displayed in the given color, the only problem is the warning.