### PR TITLE
[AutoComplete] Add popoverProps to pass to Popover

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -151,6 +151,10 @@ class AutoComplete extends Component {
      */
     openOnFocus: PropTypes.bool,
     /**
+     * Props to be passed to popover.
+     */
+    popoverProps: PropTypes.object,
+    /**
      * Text being input to auto complete.
      */
     searchText: PropTypes.string,
@@ -382,6 +386,7 @@ class AutoComplete extends Component {
       onNewRequest, // eslint-disable-line no-unused-vars
       onUpdateInput, // eslint-disable-line no-unused-vars
       openOnFocus, // eslint-disable-line no-unused-vars
+      popoverProps,
       searchText: searchTextProp, // eslint-disable-line no-unused-vars
       ...other,
     } = this.props;
@@ -491,6 +496,7 @@ class AutoComplete extends Component {
           style={textFieldStyle}
         />
         <Popover
+          {...popoverProps}
           style={styles.popover}
           canAutoPosition={false}
           anchorOrigin={anchorOrigin}

--- a/src/AutoComplete/AutoComplete.spec.js
+++ b/src/AutoComplete/AutoComplete.spec.js
@@ -6,6 +6,7 @@ import {shallow} from 'enzyme';
 import {spy} from 'sinon';
 import AutoComplete from './AutoComplete';
 import Menu from '../Menu/Menu';
+import Popover from '../Popover/Popover';
 import getMuiTheme from '../styles/getMuiTheme';
 
 describe('<AutoComplete />', () => {
@@ -84,6 +85,21 @@ describe('<AutoComplete />', () => {
         assert.strictEqual(wrapper.state().searchText, 'foo');
         done();
       }, 20);
+    });
+  });
+
+  describe('props: popoverProps', () => {
+    it('should pass popoverProps to Popover', () => {
+      const wrapper = shallowWithContext(
+        <AutoComplete
+          dataSource={['foo', 'bar']}
+          popoverProps={{
+            zDepth: 3,
+          }}
+        />
+      );
+
+      assert.strictEqual(wrapper.find(Popover).prop('zDepth'), 3, 'should pass popoverProps to Popover');
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Like the menuProps property, a passthrough for props for the Popover component. Does not close any issues that I could find.

