### PR TITLE
[DropDownMenu] Accept selectedMenuItemStyle prop

### DIFF
--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -135,6 +135,10 @@ class DropDownMenu extends Component {
      */
     openImmediately: PropTypes.bool,
     /**
+     * Override the inline-styles of selected menu items.
+     */
+    selectedMenuItemStyle: PropTypes.object,
+    /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
@@ -253,6 +257,7 @@ class DropDownMenu extends Component {
       maxHeight,
       menuStyle: menuStyleProp,
       openImmediately, // eslint-disable-line no-unused-vars
+      selectedMenuItemStyle,
       style,
       underlineStyle,
       value,
@@ -309,12 +314,13 @@ class DropDownMenu extends Component {
           onRequestClose={this.handleRequestCloseMenu}
         >
           <Menu
-            maxHeight={maxHeight}
             desktop={true}
-            value={value}
-            style={menuStyle}
             listStyle={listStyle}
+            maxHeight={maxHeight}
             onItemTouchTap={this.handleItemTouchTap}
+            selectedMenuItemStyle={selectedMenuItemStyle}
+            style={menuStyle}
+            value={value}
           >
             {children}
           </Menu>

--- a/src/DropDownMenu/DropDownMenu.spec.js
+++ b/src/DropDownMenu/DropDownMenu.spec.js
@@ -20,4 +20,34 @@ describe('<DropDownMenu />', () => {
 
     assert.strictEqual(wrapper.childAt(0).childAt(0).childAt(0).node, 'Never');
   });
+
+  it('passes expected props through to the underlying Menu', () => {
+    const props = {
+      listStyle: {color: 'black'},
+      maxHeight: 10,
+      menuStyle: {color: 'white'},
+      selectedMenuItemStyle: {color: 'blue'},
+      value: 1,
+    };
+
+    const wrapper = shallowWithContext(
+      <DropDownMenu
+        {...props}
+      >
+        <div value={1} primaryText="Never" />
+        <div value={2} primaryText="Every Night" />
+        <div value={3} primaryText="Weeknights" />
+      </DropDownMenu>
+    );
+
+    const menu = wrapper.childAt(1).childAt(0);
+    assert.include(menu.props(), {
+      desktop: true,
+      listStyle: props.listStyle,
+      maxHeight: props.maxHeight,
+      selectedMenuItemStyle: props.selectedMenuItemStyle,
+      style: props.menuStyle,
+      value: props.value,
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
- [X] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

This prop allows the selected menu item to be styled.  We are achieving
this by passing it through to the underlying `Menu` component.
