### PR TITLE
[Snackbar] Large screen snackbar does not cover up 100% width of screen anymore

### DIFF
--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -20,15 +20,14 @@ function getStyles(props, context, state) {
   const styles = {
     root: {
       position: 'fixed',
-      left: 0,
+      left: '50%',
       display: 'flex',
-      right: 0,
       bottom: 0,
       zIndex: zIndex.snackbar,
       visibility: open ? 'visible' : 'hidden',
       transform: open ?
-        'translate(0, 0)' :
-        `translate(0, ${desktopSubheaderHeight}px)`,
+        'translate(-50%, 0)' :
+        `translate(-50%, ${desktopSubheaderHeight}px)`,
       transition: `${transitions.easeOut('400ms', 'transform')}, ${
         transitions.easeOut('400ms', 'visibility')}`,
     },

--- a/src/Snackbar/SnackbarBody.js
+++ b/src/Snackbar/SnackbarBody.js
@@ -39,7 +39,7 @@ function getStyles(props, context) {
       maxWidth: isSmall ? 'inherit' : 568,
       minWidth: isSmall ? 'inherit' : 288,
       width: isSmall ? 'calc(100vw - 48px)' : 'auto',
-      flexGrow: isSmall ? 1 : 0
+      flexGrow: isSmall ? 1 : 0,
     },
     content: {
       fontSize: 14,

--- a/src/Snackbar/SnackbarBody.js
+++ b/src/Snackbar/SnackbarBody.js
@@ -38,8 +38,8 @@ function getStyles(props, context) {
       borderRadius: isSmall ? 0 : 2,
       maxWidth: isSmall ? 'inherit' : 568,
       minWidth: isSmall ? 'inherit' : 288,
-      flexGrow: isSmall ? 1 : 0,
-      margin: 'auto',
+      width: isSmall ? 'calc(100vw - 48px)' : 'auto',
+      flexGrow: isSmall ? 1 : 0
     },
     content: {
       fontSize: 14,


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Closes https://github.com/callemall/material-ui/issues/4359.
