### PR TITLE
[withWidth] Compute the width as soon as possible

### DIFF
--- a/src/utils/withWidth.js
+++ b/src/utils/withWidth.js
@@ -9,7 +9,7 @@ export default function withWidth(options = {}) {
   const {
     largeWidth = 992,
     mediumWidth = 768,
-    resizeInterval = 166,
+    resizeInterval = 166, // Corresponds to 10 frames at 60 Hz.
   } = options;
 
   return (MyComponent) => {
@@ -22,8 +22,11 @@ export default function withWidth(options = {}) {
         width: SMALL,
       };
 
-      componentDidMount() {
-        this.updateWidth();
+      componentWillMount() {
+        // We make sure that we are in a browser environment.
+        if (typeof window !== 'undefined') {
+          this.updateWidth();
+        }
       }
 
       componentWillUnmount() {
@@ -60,8 +63,8 @@ export default function withWidth(options = {}) {
         return (
           <EventListener target="window" onResize={this.handleResize}>
             <MyComponent
-              {...this.props}
               width={this.state.width}
+              {...this.props}
             />
           </EventListener>
         );

--- a/src/utils/withWidth.spec.js
+++ b/src/utils/withWidth.spec.js
@@ -1,0 +1,27 @@
+/* eslint-env mocha */
+
+import React from 'react';
+import {shallow} from 'enzyme';
+import {assert} from 'chai';
+import withWidth, {MEDIUM, LARGE} from './withWidth';
+
+describe('utils/withWidth', () => {
+  const Dumb = () => <div />;
+  const DumbWithWidth = withWidth()(Dumb);
+
+  describe('prop: width', () => {
+    it('should be able to override it', () => {
+      const wrapper = shallow(<DumbWithWidth width={MEDIUM} />);
+
+      assert.strictEqual(wrapper.find(Dumb).props().width, MEDIUM);
+    });
+  });
+
+  describe('browser', () => {
+    it('should provide the right width to the child element', () => {
+      const wrapper = shallow(<DumbWithWidth />);
+
+      assert.strictEqual(wrapper.find(Dumb).props().width, LARGE);
+    });
+  });
+});

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function(config) {
   config.set({
     autoWatch: false,
     basePath: '../',
-    browsers: ['PhantomJS'],
+    browsers: ['PhantomJS_Sized'],
     client: {
       mocha: {
         grep: opts.grep,
@@ -90,6 +90,17 @@ module.exports = function(config) {
     },
     webpackServer: {
       noInfo: true,
+    },
+    customLaunchers: {
+      'PhantomJS_Sized': {
+        base: 'PhantomJS',
+        options: {
+          viewportSize: { // Matches JSDom size.
+            width: 1024,
+            height: 768,
+          },
+        },
+      },
     },
   });
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


Thanks @PolGuixe for raising this point.
The documentation seems to render 3% more quickly as we are saving one render of the `Drawer` component.

Closes #5140.