### PR TITLE
[Popover] Fix a callback leak

### DIFF
--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -159,6 +159,9 @@ class Popover extends Component {
   }
 
   componentWillUnmount() {
+    this.handleResize.cancel();
+    this.handleScroll.cancel();
+
     if (this.timeout) {
       clearTimeout(this.timeout);
       this.timeout = null;
@@ -206,10 +209,6 @@ class Popover extends Component {
     this.requestClose('clickAway');
   };
 
-  _resizeAutoPosition() {
-    this.setPlacement();
-  }
-
   getAnchorPosition(el) {
     if (!el) {
       el = ReactDOM.findDOMNode(this);
@@ -247,8 +246,6 @@ class Popover extends Component {
       return;
     }
 
-    const anchorEl = this.props.anchorEl || this.anchorEl;
-
     if (!this.refs.layer.getLayer()) {
       return;
     }
@@ -259,6 +256,7 @@ class Popover extends Component {
     }
 
     const {targetOrigin, anchorOrigin} = this.props;
+    const anchorEl = this.props.anchorEl || this.anchorEl;
 
     const anchor = this.getAnchorPosition(anchorEl);
     let target = this.getTargetPosition(targetEl);

--- a/src/Popover/Popover.spec.js
+++ b/src/Popover/Popover.spec.js
@@ -2,13 +2,14 @@
 
 import React from 'react';
 import {assert} from 'chai';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
 import Popover from './Popover';
 import getMuiTheme from '../styles/getMuiTheme';
 
 describe('<Popover />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+  const mountWithContext = (node) => mount(node, {context: {muiTheme}});
 
   describe('state: closing', () => {
     it('should not create new timeout when popover is already closing', () => {
@@ -21,6 +22,21 @@ describe('<Popover />', () => {
       const nextTimeout = wrapper.instance().timeout;
 
       assert.strictEqual(timeout, nextTimeout);
+    });
+  });
+
+  describe('unmounting', () => {
+    it('should stop listening correctly', (done) => {
+      const wrapper = mountWithContext(<Popover open={true} />);
+
+      wrapper.instance().handleScroll();
+      wrapper.instance().handleScroll();
+      wrapper.unmount();
+
+      setTimeout(() => {
+         // Wait for the end of the throttle. Makes sure we don't crash.
+        done();
+      }, 100);
     });
   });
 });


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

I have noticed errors like `undefined is not an object (evaluating 'n.refs.layer.getLayer')` in production using this lib. That should fix the timing leak.
This is a side effect of using `throttle`:
![capture d ecran 2016-09-11 a 16 26 08](https://cloud.githubusercontent.com/assets/3165635/18417883/8cf48fca-783c-11e6-87c0-2c9ee839e08e.png)
