### PR TITLE
[RaisedButton] Update file upload example

### DIFF
--- a/docs/src/app/components/pages/components/RaisedButton/ExampleComplex.js
+++ b/docs/src/app/components/pages/components/RaisedButton/ExampleComplex.js
@@ -25,6 +25,7 @@ const RaisedButtonExampleComplex = () => (
       label="Choose an Image"
       labelPosition="before"
       style={styles.button}
+      containerElement="label"
     >
       <input type="file" style={styles.exampleImageInput} />
     </RaisedButton>


### PR DESCRIPTION
This shows how to correctly embed a file input file into a RaisedButton ensuring that the file input remains clickable cross browser #3689 #4983 #1178