### PR TITLE
[EnhancedSwitch] Removing weird label invocation.

### DIFF
--- a/src/internal/EnhancedSwitch.js
+++ b/src/internal/EnhancedSwitch.js
@@ -293,9 +293,7 @@ class EnhancedSwitch extends Component {
     }
 
     const labelElement = label && (
-      <label style={prepareStyles(Object.assign(styles.label, labelStyle))}>
-        {label}
-      </label>
+      <label style={prepareStyles(Object.assign(styles.label, labelStyle))} />
     );
 
     const showTouchRipple = !disabled && !disableTouchRipple;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


Not sure if this is intentional, but this pattern seems very weird. I encounter a lot of strange behavior with labels and would guess that this is a bad invocation, which is trying to use the label as both a constructor and an instance.
If it is correct, could someone help me by explaining to me what this is doing? 
I'm confused somewhat by what this is doing...