### PR TITLE
[RaisedButton] Use props.style.borderRadius if available

### DIFF
--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -57,7 +57,7 @@ function getStyles(props, context, state) {
   }
 
   const buttonHeight = style && style.height || button.height;
-  const borderRadius = style && style.borderRadius || 2;
+  const borderRadius = style && style.borderRadius || 2 + 'px';
 
   return {
     root: {

--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -57,7 +57,7 @@ function getStyles(props, context, state) {
   }
 
   const buttonHeight = style && style.height || button.height;
-  const borderRadius = 2;
+  const borderRadius = style && style.borderRadius || 2;
 
   return {
     root: {

--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -57,7 +57,7 @@ function getStyles(props, context, state) {
   }
 
   const buttonHeight = style && style.height || button.height;
-  const borderRadius = style && style.borderRadius || 2 + 'px';
+  const borderRadius = style && parseInt(style.borderRadius, 10) || 2;
 
   return {
     root: {
@@ -71,7 +71,7 @@ function getStyles(props, context, state) {
       lineHeight: `${buttonHeight}px`,
       width: '100%',
       padding: 0,
-      borderRadius: borderRadius,
+      borderRadius: `${borderRadius}px`,
       transition: transitions.easeOut(),
       backgroundColor: backgroundColor,
       // That's the default value for a button but not a link


### PR DESCRIPTION
use props.style.borderRadius if available instead of hardcoded integer

<RaisedButton ... style={{borderRadius: '5px'}} />

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Closes #3409.