### PR TITLE
[CheckBox] Fix incorrect hitbox size after clicking checkbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,6 @@
     "recursive-readdir-sync": "^1.0.6",
     "rimraf": "^2.5.3",
     "sinon": "^1.17.3",
-    "webpack": "^1.13.1",
+    "webpack": "^1.13.1"
   }
 }

--- a/src/internal/CircleRipple.js
+++ b/src/internal/CircleRipple.js
@@ -90,7 +90,7 @@ class CircleRipple extends Component {
       width: '100%',
       borderRadius: '50%',
       backgroundColor: color,
-      cursor:'auto',
+      cursor: 'auto',
     }, style);
 
     return (

--- a/src/internal/CircleRipple.js
+++ b/src/internal/CircleRipple.js
@@ -90,6 +90,7 @@ class CircleRipple extends Component {
       width: '100%',
       borderRadius: '50%',
       backgroundColor: color,
+      cursor:'auto',
     }, style);
 
     return (

--- a/src/internal/EnhancedSwitch.js
+++ b/src/internal/EnhancedSwitch.js
@@ -46,7 +46,7 @@ function getStyles(props, context) {
       lineHeight: '24px',
       color: baseTheme.palette.textColor,
       fontFamily: baseTheme.fontFamily,
-      whiteSpace:'nowrap',
+      whiteSpace: 'nowrap',
       paddingRight: '5',
     },
     wrap: {
@@ -299,7 +299,6 @@ class EnhancedSwitch extends Component {
       <label style={prepareStyles(Object.assign(styles.label, labelStyle))}>
         {inputElement}
         {label}
-      
       </label>
     );
 
@@ -387,7 +386,6 @@ class EnhancedSwitch extends Component {
         />
         {inputElement}
         {elementsInOrder}
-
       </div>
     );
   }

--- a/src/internal/EnhancedSwitch.js
+++ b/src/internal/EnhancedSwitch.js
@@ -17,7 +17,8 @@ function getStyles(props, context) {
       overflow: 'visible',
       display: 'table',
       height: 'auto',
-      width: '100%',
+      width: 'auto',
+
     },
     input: {
       position: 'absolute',
@@ -45,6 +46,8 @@ function getStyles(props, context) {
       lineHeight: '24px',
       color: baseTheme.palette.textColor,
       fontFamily: baseTheme.fontFamily,
+      whiteSpace:'nowrap',
+      paddingRight: '5',
     },
     wrap: {
       transition: transitions.easeOut(),
@@ -294,7 +297,9 @@ class EnhancedSwitch extends Component {
 
     const labelElement = label && (
       <label style={prepareStyles(Object.assign(styles.label, labelStyle))}>
+        {inputElement}
         {label}
+      
       </label>
     );
 
@@ -382,6 +387,7 @@ class EnhancedSwitch extends Component {
         />
         {inputElement}
         {elementsInOrder}
+
       </div>
     );
   }

--- a/src/internal/TouchRipple.js
+++ b/src/internal/TouchRipple.js
@@ -203,6 +203,7 @@ class TouchRipple extends Component {
         top: 0,
         left: 0,
         overflow: 'hidden',
+        cursor: 'auto',
       }, style);
 
       rippleGroup = (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

fixed issue #5150. Once a checkbox is clicked, the space occupied by the ripple animation turns into a new hitbox. The ripple is a child of the input checkbox and inherits the cursor:pointer property. Since the ripple is bigger than the checkbox it shows a pointer a little distance away from the checkbox but does not affect the checked value on clicking. Also made the width of the original hitbox to be only till the end of label text as it used to show a cursor pointer well beyond the label as well.
