### PR TITLE
[Table] Make onSelectAll functional - has to be called from Table component - Fixes #1565

### DIFF
--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -110,6 +110,10 @@ class Table extends Component {
      */
     onRowSelection: PropTypes.func,
     /**
+     * Callback when select all has been checked.
+     */
+    onSelectAll: PropTypes.func,
+    /**
      * If true, table rows can be selected.
      * If multiple row selection is desired, enable multiSelectable.
      * The default value is true.
@@ -214,6 +218,9 @@ class Table extends Component {
   };
 
   onSelectAll = () => {
+    // add custom behavior when select all button is pressed
+    if (this.props.onSelectAll) this.props.onSelectAll();
+    // default behavior
     if (this.props.onRowSelection) {
       if (!this.state.allRowsSelected) {
         this.props.onRowSelection('all');


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

- Now a callback function can be set as prop `onSelectAll` in the `<Table />` to add functionality in case the "Select All" checkbox is checked.
- This functionality is added in addition to the default behavior of checking all other checkboxes in the table.
- Fixes #1565