### PR TITLE
[RaisedButton] Add a buttonStyle property

### DIFF
--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -121,6 +121,10 @@ class RaisedButton extends Component {
      */
     backgroundColor: PropTypes.string,
     /**
+     * Override the inline-styles of the button element.
+     */
+    buttonStyle: PropTypes.object,
+    /**
      * The content of the button.
      * If a label is provided via the `label` prop, the text within the label
      * will be displayed in addition to the content provided here.
@@ -327,6 +331,7 @@ class RaisedButton extends Component {
   render() {
     const {
       backgroundColor, // eslint-disable-line no-unused-vars
+      buttonStyle,
       children,
       className,
       disabled,
@@ -341,6 +346,7 @@ class RaisedButton extends Component {
       primary, // eslint-disable-line no-unused-vars
       rippleStyle,
       secondary, // eslint-disable-line no-unused-vars
+      style,
       ...other,
     } = this.props;
 
@@ -386,7 +392,7 @@ class RaisedButton extends Component {
     return (
       <Paper
         className={className}
-        style={Object.assign(styles.root, this.props.style)}
+        style={Object.assign(styles.root, style)}
         zDepth={this.state.zDepth}
       >
         <EnhancedButton
@@ -394,7 +400,7 @@ class RaisedButton extends Component {
           {...buttonEventHandlers}
           ref="container"
           disabled={disabled}
-          style={styles.button}
+          style={Object.assign(styles.button, buttonStyle)}
           focusRippleColor={mergedRippleStyles.color}
           touchRippleColor={mergedRippleStyles.color}
           focusRippleOpacity={mergedRippleStyles.opacity}

--- a/src/RaisedButton/RaisedButton.spec.js
+++ b/src/RaisedButton/RaisedButton.spec.js
@@ -147,7 +147,7 @@ describe('<RaisedButton />', () => {
     });
   });
 
-  describe('props: icon', () => {
+  describe('prop: icon', () => {
     it('should keep the style set on the icon', () => {
       const wrapper = shallowWithContext(
         <RaisedButton icon={<ActionAndroid style={{foo: 'bar'}} />} />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

I think that we should aim for having a customizability point for every inner element.
People won't stop messing around with the inner style. It could be used either for:
 - enforcing non-standard material specification
 - implementing a workaround on user side until it's fixed on the MaterialUI side.

Closes #5182.
Closes #3409.