### PR TITLE
[Tooltip] improve tooltip positioning, closes #5057

### DIFF
--- a/docs/src/app/components/pages/components/IconButton/ExampleSize.js
+++ b/docs/src/app/components/pages/components/IconButton/ExampleSize.js
@@ -34,11 +34,12 @@ const styles = {
 
 const IconButtonExampleSize = () => (
   <div>
-    <IconButton>
+    <IconButton tooltip="Default">
       <ActionHome />
     </IconButton>
 
     <IconButton
+      tooltip="Small Icon"
       iconStyle={styles.smallIcon}
       style={styles.small}
     >
@@ -46,6 +47,8 @@ const IconButtonExampleSize = () => (
     </IconButton>
 
     <IconButton
+      tooltip="Medium Icon"
+      tooltipPosition="top-right"
       iconStyle={styles.mediumIcon}
       style={styles.medium}
     >
@@ -53,6 +56,8 @@ const IconButtonExampleSize = () => (
     </IconButton>
 
     <IconButton
+      tooltip="Large Icon"
+      tooltipPosition="top-center"
       iconStyle={styles.largeIcon}
       style={styles.large}
     >

--- a/src/internal/Tooltip.js
+++ b/src/internal/Tooltip.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import transitions from '../styles/transitions';
 
-function getStyles(props, context, state) {
+function getStyles(props, context) {
   const verticalPosition = props.verticalPosition;
   const horizontalPosition = props.horizontalPosition;
   const touchMarginOffset = props.touch ? 10 : 0;
@@ -30,8 +30,8 @@ function getStyles(props, context, state) {
       userSelect: 'none',
       opacity: 0,
       right: horizontalPosition === 'left' ? 12 : null,
-      left: horizontalPosition === 'center' ?
-        (state.offsetWidth - 48) / 2 * -1 : null,
+      left: horizontalPosition === 'center' ? '50%' : null,
+      transform: horizontalPosition === 'center' ? 'translate(-50%, 0px)' : null,
       transition: `${transitions.easeOut('0ms', 'top', '450ms')}, ${
         transitions.easeOut('450ms', 'transform', '0ms')}, ${
         transitions.easeOut('450ms', 'opacity', '0ms')}`,
@@ -56,7 +56,8 @@ function getStyles(props, context, state) {
       top: verticalPosition === 'top' ?
         touchOffsetTop : 36,
       opacity: 0.9,
-      transform: `translate(0px, ${offset}px)`,
+      transform: horizontalPosition === 'center' ?
+        `translate(-50%, ${offset}px)` : `translate(0px, ${offset}px)`,
       transition: `${transitions.easeOut('0ms', 'top', '0ms')}, ${
         transitions.easeOut('450ms', 'transform', '0ms')}, ${
         transitions.easeOut('450ms', 'opacity', '0ms')}`,
@@ -98,17 +99,8 @@ class Tooltip extends Component {
     muiTheme: PropTypes.object.isRequired,
   };
 
-  state = {
-    offsetWidth: null,
-  };
-
   componentDidMount() {
     this.setRippleSize();
-    this.setTooltipPosition();
-  }
-
-  componentWillReceiveProps() {
-    this.setTooltipPosition();
   }
 
   componentDidUpdate() {
@@ -133,10 +125,6 @@ class Tooltip extends Component {
     }
   }
 
-  setTooltipPosition() {
-    this.setState({offsetWidth: this.refs.tooltip.offsetWidth});
-  }
-
   render() {
     const {
       horizontalPosition, // eslint-disable-line no-unused-vars
@@ -148,7 +136,7 @@ class Tooltip extends Component {
     } = this.props;
 
     const {prepareStyles} = this.context.muiTheme;
-    const styles = getStyles(this.props, this.context, this.state);
+    const styles = getStyles(this.props, this.context);
 
     return (
       <div

--- a/src/internal/Tooltip.js
+++ b/src/internal/Tooltip.js
@@ -53,8 +53,8 @@ function getStyles(props, context) {
         transitions.easeOut('450ms', 'backgroundColor', '0ms')}`,
     },
     rootWhenShown: {
-      top: verticalPosition === 'top' ?
-        touchOffsetTop : 36,
+      top: verticalPosition === 'top' ? touchOffsetTop : 'auto',
+      bottom: verticalPosition === 'bottom' ? 0 : 'auto',
       opacity: 0.9,
       transform: horizontalPosition === 'center' ?
         `translate(-50%, ${offset}px)` : `translate(0px, ${offset}px)`,


### PR DESCRIPTION
Hi! Thanks a lot for y'all's work on material-ui, it's been really great to use
:) :tada: 

<!-- Thanks so much for your PR, your contribution is appreciated! -->
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative
    form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the
    related issue(s) (http://tr.im/vFqem).

This patch changes the Tooltip centering to use a CSS transform. Before,
centering Tooltips relied on the elements they attached to to be exactly 48
pixels wide. By adding a 50% left offset to the tooltip itself, and then
applying a -50% horizontal translation, tooltips will be centered regardless of
their containers' widths.

This is related to #5057 but doesn't quite fix it yet. For example, even with
this patch, a tooltip position `top-right` on a large IconButton looks like this:

![Screenshot](http://i.imgur.com/yUo4ypF.png)

which…is not what i would expect from a right-aligned tooltip.

It'd probably be a good idea to fix tooltip positioning on custom size elements
entirely in one go, so I'll continue to work on this, just submitting for possible
feedback and such :)
