### PR TITLE
[core] Add babel-runtime to the release

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -18,6 +18,7 @@
     },
     "release": {
       "plugins": [
+        "transform-runtime",
         ["transform-react-remove-prop-types", {"mode": "wrap"}]
       ],
     }

--- a/package.json
+++ b/package.json
@@ -43,12 +43,13 @@
     "react-tap-event-plugin": "^1.0.0"
   },
   "dependencies": {
+    "babel-runtime": "^6.11.6",
     "inline-style-prefixer": "^2.0.1",
     "keycode": "^2.1.1",
     "lodash": "^4.13.1",
     "react-addons-create-fragment": "^15.0.0",
     "react-addons-transition-group": "^15.0.0",
-    "react-event-listener": "^0.2.1",
+    "react-event-listener": "^0.3.0",
     "recompose": "^0.20.2",
     "simple-assign": "^0.1.0",
     "warning": "^3.0.0"
@@ -64,6 +65,7 @@
     "babel-plugin-transform-react-inline-elements": "^6.6.5",
     "babel-plugin-transform-react-remove-prop-types": "^0.2.6",
     "babel-plugin-transform-replace-object-assign": "^0.2.1",
+    "babel-plugin-transform-runtime": "^6.15.0",
     "babel-polyfill": "^6.7.4",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.11.1",


### PR DESCRIPTION
From my own test, the build folder is 4% smaller.
The main advantage is probably at the runtime where the same modules
are shared in memory by the browser.

*react-boostrap* is following the same approach:
https://github.com/react-bootstrap/react-bootstrap/blob/master/.babelrc#L9

@nathanmarks Would be great to have your feedback on this.