### PR TITLE
[IconButton] Remove unused conditional

### DIFF
--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -171,7 +171,7 @@ class IconButton extends Component {
     if (keyboardFocused && !this.props.disabled) {
       this.showTooltip();
       if (this.props.onFocus) this.props.onFocus(event);
-    } else if (!this.state.hovered) {
+    } else {
       this.hideTooltip();
       if (this.props.onBlur) this.props.onBlur(event);
     }


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


It appears that this conditional was added in 77a3d71, but even at that time,
there does not seem to be any calls to set the state of `hovered`, and so it it
always `undefined` which means we always are entering this `if` block.