### PR TITLE
[AppBar] Fix onLeftIconButtonTouchTap event

### DIFF
--- a/docs/src/app/components/pages/components/AppBar/ExampleIconButton.js
+++ b/docs/src/app/components/pages/components/AppBar/ExampleIconButton.js
@@ -8,6 +8,10 @@ function handleTouchTap() {
   alert('onTouchTap triggered on the title component');
 }
 
+function handleTouchTapLeftIconButton() {
+  alert('onClick triggered on the left icon component');
+}
+
 const styles = {
   title: {
     cursor: 'pointer',
@@ -19,6 +23,7 @@ const AppBarExampleIconButton = () => (
     title={<span style={styles.title}>Title</span>}
     onTitleTouchTap={handleTouchTap}
     iconElementLeft={<IconButton><NavigationClose /></IconButton>}
+    onLeftIconButtonTouchTap={handleTouchTapLeftIconButton}
     iconElementRight={<FlatButton label="Save" />}
   />
 );

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -201,7 +201,7 @@ class AppBar extends Component {
 
     const {prepareStyles} = this.context.muiTheme;
     const styles = getStyles(this.props, this.context);
-
+    const self = this;
     let menuElementLeft;
     let menuElementRight;
 
@@ -230,6 +230,7 @@ class AppBar extends Component {
 
           iconElementLeftNode = React.cloneElement(iconElementLeft, {
             iconStyle: Object.assign({}, iconButtonIconStyle, iconElementLeft.props.iconStyle),
+            onClick: self.handleTouchTapLeftIconButton.bind(self),
           });
         }
 
@@ -279,6 +280,7 @@ class AppBar extends Component {
         case 'FlatButton':
           iconElementRightNode = React.cloneElement(iconElementRight, {
             style: Object.assign({}, styles.flatButton, iconElementRight.props.style),
+            onClick: self.handleTouchTapRightIconButton.bind(self),
           });
           break;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Bound the onClick event of the leftIconButton in AppBar to the onLeftIconButtonTouchTap event.
Fixes issue [#2482](https://github.com/callemall/material-ui/issues/2482)