### PR TITLE
[FloatingActionButton] Fix overriding the style property on the children

### DIFF
--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -270,7 +270,8 @@ class FloatingActionButton extends Component {
       style: Object.assign({},
         styles.icon,
         mini && styles.iconWhenMini,
-        iconStyle),
+        iconStyle,
+        this.props.children.props.style),
     });
 
     const buttonEventHandlers = disabled ? null : {

--- a/src/FloatingActionButton/FloatingActionButton.spec.js
+++ b/src/FloatingActionButton/FloatingActionButton.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import React from 'react';
-import {mount, shallow} from 'enzyme';
+import {shallow} from 'enzyme';
 import {assert} from 'chai';
 
 import FloatingActionButton from './FloatingActionButton';
@@ -11,7 +11,6 @@ import ContentAdd from '../svg-icons/content/add';
 describe('<FloatingActionButton />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
-  const mountWithContext = (node) => mount(node, {context: {muiTheme}});
 
   describe('hover state', () => {
     it('should reset the hover state when disabled', () => {
@@ -32,7 +31,7 @@ describe('<FloatingActionButton />', () => {
 
   describe('style', () => {
     it('should apply children style', () => {
-      const wrapper = mountWithContext(
+      const wrapper = shallowWithContext(
         <FloatingActionButton>
           <FontIcon
             className="material-icons"

--- a/src/FloatingActionButton/FloatingActionButton.spec.js
+++ b/src/FloatingActionButton/FloatingActionButton.spec.js
@@ -1,15 +1,17 @@
 /* eslint-env mocha */
 import React from 'react';
-import {shallow} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 import {assert} from 'chai';
 
 import FloatingActionButton from './FloatingActionButton';
+import FontIcon from '../FontIcon/FontIcon';
 import getMuiTheme from '../styles/getMuiTheme';
 import ContentAdd from '../svg-icons/content/add';
 
 describe('<FloatingActionButton />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+  const mountWithContext = (node) => mount(node, {context: {muiTheme}});
 
   describe('hover state', () => {
     it('should reset the hover state when disabled', () => {
@@ -25,6 +27,28 @@ describe('<FloatingActionButton />', () => {
         disabled: true,
       });
       assert.strictEqual(wrapper.state().hovered, false, 'should reset the state');
+    });
+  });
+
+  describe('style', () => {
+    it('should apply children style', () => {
+      const wrapper = mountWithContext(
+        <FloatingActionButton>
+          <FontIcon
+            className="material-icons"
+            style={{
+              transform: 'scale(1.5)',
+            }}
+          >
+            add
+          </FontIcon>
+        </FloatingActionButton>
+      );
+      assert.strictEqual(
+        wrapper.find(FontIcon).props().style.transform,
+        'scale(1.5)',
+        'should apply inline style'
+      );
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

FAB doesn't apply explicitly provided inline style of the children. FAB has ignored it.
This PR required to tweak FAB for work in #5241

