### PR TITLE
[Table] Fix deselect all logic

### DIFF
--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -131,8 +131,7 @@ class TableBody extends Component {
   componentWillReceiveProps(nextProps) {
     if (this.props.allRowsSelected && !nextProps.allRowsSelected) {
       this.setState({
-        selectedRows: this.state.selectedRows.length > 0 ?
-          [this.state.selectedRows[this.state.selectedRows.length - 1]] : [],
+        selectedRows: []
       });
       // TODO: should else be conditional, not run any time props other than allRowsSelected change?
     } else {

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -130,9 +130,10 @@ class TableBody extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.props.allRowsSelected && !nextProps.allRowsSelected) {
-      this.setState({
-        selectedRows: []
-      });
+      if (this.state.selectedRows.length === React.Children.count(nextProps.children)) {
+        // `selectedRows` has already been updated through `processRowSelection`
+        this.setState({selectedRows: []});
+      }
       // TODO: should else be conditional, not run any time props other than allRowsSelected change?
     } else {
       this.setState({


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Aware of #3980 and #4588. Since #2251 talks about implementing a completely new `Table` component set, and no clear ETA of a fix for `Table` in 0.16.0, this could fix major woes with the existing `Table` component and hopefully solve many users' issues.
- Removes logic that selects last row when deselecting all rows (Was this intentional?)
- Fixes logic where clicking on any row (when all rows are selected) selects the last row (related to first issue)
- Fixes #5192. Also fixes #5234.

> Side Note: `selectedRows` should be maintained by `Table`, and should be passed as prop to `TableBody`. Benefits of doing this:
> - `allItemsSelected` checkbox in `TableHeader` can be updated even if all rows are selected without using the selectAll checkbox
> - the dirty `length` check in bd8f70d won't be required since `TableBody` won't be able to mutate `selectedRows` internally.
