### PR TITLE
[TableFooter] Add children to footerRows when adjustForCheckbox === f…

### DIFF
--- a/src/Table/TableFooter.js
+++ b/src/Table/TableFooter.js
@@ -72,13 +72,16 @@ class TableFooter extends Component {
         style: Object.assign({}, styles.cell, child.props.style),
       };
 
-      let newDescendants;
+      let newDescendants = [];
       if (adjustForCheckbox) {
-        newDescendants = [
-          <TableRowColumn key={`fpcb${rowNumber}`} style={{width: 24}} />,
-          ...React.Children.toArray(child.props.children),
-        ];
-      }
+        newDescendants.push(
+          <TableRowColumn key={`fpcb${rowNumber}`} style={{width: 24}} />
+        );
+      } 
+
+      React.Children.forEach(child.props.children, (child) => {
+        newDescendants.push(child);
+      });
 
       return React.cloneElement(child, newChildProps, newDescendants);
     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

Children (columns) weren't being added to `const footerRows` (found on line 67 of TableFooter.js) when `adjustForCheckbox` was set to false. Thus, they weren't rendering.

I didn't see any tests for this component in the repo, so I didn't add any. I did, however, put together some code in the WebpackBin playground the renders two tables. The first using the code with the bug and the second using the fix from my PR. It can be found here: http://www.webpackbin.com/41NXLqQTZ