### PR TITLE
[TextField] Add isRequired property

### DIFF
--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -47,6 +47,9 @@ const getStyles = (props, context, state) => {
       color: hintColor,
       pointerEvents: 'none',
     },
+    floatingLabelAsterisk: {
+      color: hintColor,
+    },
     input: {
       padding: 0,
       position: 'relative',
@@ -78,10 +81,12 @@ const getStyles = (props, context, state) => {
 
   if (state.hasValue) {
     styles.floatingLabel.color = fade(props.disabled ? disabledTextColor : floatingLabelColor, 0.5);
+    styles.floatingLabelAsterisk.color = fade(props.disabled ? disabledTextColor : floatingLabelColor, 0.5);
   }
 
   if (state.isFocused) {
     styles.floatingLabel.color = focusColor;
+    styles.floatingLabelAsterisk.color = styles.error.color;
   }
 
   if (props.floatingLabelText) {
@@ -177,6 +182,10 @@ class TextField extends Component {
      */
     inputStyle: PropTypes.object,
     /**
+     * Whether the input value is required.
+     */
+    isRequired: PropTypes.bool,
+    /**
      * If true, a textarea element will be rendered.
      * The textarea also grows and shrinks according to the number of lines.
      */
@@ -246,6 +255,7 @@ class TextField extends Component {
     floatingLabelFixed: false,
     multiLine: false,
     fullWidth: false,
+    isRequired: false,
     type: 'text',
     underlineShow: true,
     rows: 1,
@@ -386,6 +396,7 @@ class TextField extends Component {
       hintStyle,
       id,
       inputStyle,
+      isRequired,
       multiLine,
       onBlur, // eslint-disable-line no-unused-vars
       onChange, // eslint-disable-line no-unused-vars
@@ -414,10 +425,12 @@ class TextField extends Component {
       <TextFieldLabel
         muiTheme={this.context.muiTheme}
         style={Object.assign(styles.floatingLabel, this.props.floatingLabelStyle)}
+        asteriskStyle={Object.assign(styles.floatingLabelAsterisk)}
         shrinkStyle={this.props.floatingLabelFocusStyle}
         htmlFor={inputId}
         shrink={this.state.hasValue || this.state.isFocused || floatingLabelFixed}
         disabled={disabled}
+        isRequired={isRequired}
       >
         {floatingLabelText}
       </TextFieldLabel>

--- a/src/TextField/TextFieldLabel.js
+++ b/src/TextField/TextFieldLabel.js
@@ -31,7 +31,9 @@ const TextFieldLabel = (props) => {
     className,
     children,
     htmlFor,
+    isRequired,
     onTouchTap,
+    asteriskStyle,
   } = props;
 
   const {prepareStyles} = muiTheme;
@@ -45,11 +47,16 @@ const TextFieldLabel = (props) => {
       onTouchTap={onTouchTap}
     >
       {children}
+      {isRequired ? <span style={asteriskStyle}>{'\u2009'}*</span> : null}
     </label>
   );
 };
 
 TextFieldLabel.propTypes = {
+  /**
+   * Override the inline-styles of the asterisk element.
+   */
+  asteriskStyle: PropTypes.object,
   /**
    * The label contents.
    */
@@ -66,6 +73,10 @@ TextFieldLabel.propTypes = {
    * The id of the target element that this label should refer to.
    */
   htmlFor: PropTypes.string,
+  /**
+   * Whether the input value of this label's field is required.
+   */
+  isRequired: PropTypes.bool,
   /**
    * @ignore
    * The material-ui theme applied to this component.
@@ -91,6 +102,7 @@ TextFieldLabel.propTypes = {
 
 TextFieldLabel.defaultProps = {
   disabled: false,
+  isRequired: false,
   shrink: false,
 };
 

--- a/src/TextField/TextFieldLabel.spec.js
+++ b/src/TextField/TextFieldLabel.spec.js
@@ -22,4 +22,21 @@ describe('<TextFieldLabel>', () => {
     wrapper.setProps({shrink: true});
     expect(wrapper.prop('style').color).to.equal('focuscolor');
   });
+
+  it('displays an asterisk if isRequired is true', () => {
+    const wrapper = shallow(
+      <TextFieldLabel
+        muiTheme={getMuiTheme()}
+        isRequired={true}
+        shrink={false}
+        style={{color: 'regularcolor'}}
+        shrinkStyle={{color: 'focuscolor'}}
+        asteriskStyle={{color: 'asteriskcolor'}}
+      />
+    );
+
+    expect(wrapper.type()).to.equal('label');
+    expect(wrapper.text()).to.contain('*');
+    expect(wrapper.find('span').first().prop('style').color).to.equal('asteriskcolor');
+  });
 });


### PR DESCRIPTION
This PR adds required inputs as shown in the [Material Specs](https://material.google.com/components/text-fields.html#text-fields-required-fields). This is really useful to show that input is required before the user starts typing or submits a form.
![ezgif-929265930](https://cloud.githubusercontent.com/assets/5544859/18894648/63744c3c-8514-11e6-8c0d-97dcfa19561f.gif)

I'm not sure if using `styles.error.color` is a good idea for the asterisk, but at least it's better than hard-coding red.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


