### PR TITLE
[TextField] Add a required property

### DIFF
--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -72,6 +72,10 @@ export default class TextField extends Component {
      * The CSS class name of the root element.
      */
     className: PropTypes.string,
+    /**
+     * Whether this text field is required.
+     */
+    required: PropTypes.bool,
   };
 
   static contextTypes = {
@@ -124,8 +128,10 @@ export default class TextField extends Component {
   renderLabel = (label) =>
     cloneElement(label, {
       className: classNames(this.classes.label, label.props.className),
+      dirty: this.state.dirty,
       shrink: label.props.hasOwnProperty('shrink') ? // Shrink the label if dirty or focused
         label.props.shrink : (this.state.dirty || this.state.focused),
+      required: this.props.required,
     });
 
   render() {

--- a/src/TextField/TextField.spec.js
+++ b/src/TextField/TextField.spec.js
@@ -242,5 +242,19 @@ describe('<TextField>', () => {
         'should be true when the TextField is not dirty or focused'
       );
     });
+
+    it('should forward the required prop to the label', () => {
+      const wrapper = shallow(
+        <TextField required>
+          <TextFieldLabel>Label</TextFieldLabel>
+        </TextField>
+      );
+
+      assert.strictEqual(
+        wrapper.find('TextFieldLabel').prop('required'),
+        true,
+        'should set the required prop of the label when the TextField is required'
+      );
+    });
   });
 });

--- a/src/TextField/TextFieldLabel.js
+++ b/src/TextField/TextFieldLabel.js
@@ -22,11 +22,22 @@ export const styleSheet = createStyleSheet('TextFieldLabel', (theme) => {
     animated: {
       transition: theme.transitions.create('transform', '200ms', null, easing.easeOut),
     },
+    asterisk: {
+      color: theme.palette.error[500],
+    },
   };
 }, { index: -10 });
 
 export default function TextFieldLabel(props, context) {
-  const { animated, className: classNameProp, shrink, ...other } = props;
+  const {
+    animated,
+    children,
+    className: classNameProp,
+    dirty,
+    required,
+    shrink,
+    ...other,
+  } = props;
   const classes = context.styleManager.render(styleSheet);
 
   const className = classNames(classes.root, {
@@ -35,13 +46,37 @@ export default function TextFieldLabel(props, context) {
   }, classNameProp);
 
   return (
-    <label className={className} {...other} />
+    <label className={className} {...other}>
+      {children}
+      {required && (
+        <span
+          className={classNames({
+            [classes.asterisk]: !dirty,
+          })}
+        >
+          {'\u2009'}*
+        </span>
+      )}
+    </label>
   );
 }
 
 TextFieldLabel.propTypes = {
   animated: PropTypes.bool,
+  /**
+   * Whether the input of this label contains input.
+   */
+  dirty: PropTypes.bool,
+  /**
+   * The contents of the `TextFieldLabel`
+   */
+  children: PropTypes.node,
   className: PropTypes.string,
+  /**
+   * Whether this label should indicate that the input
+   * is required.
+   */
+  required: PropTypes.bool,
   shrink: PropTypes.bool,
 };
 

--- a/src/TextField/TextFieldLabel.spec.js
+++ b/src/TextField/TextFieldLabel.spec.js
@@ -41,4 +41,15 @@ describe('<TextFieldLabel>', () => {
     const wrapper = shallow(<TextFieldLabel shrink />);
     assert.strictEqual(wrapper.hasClass(classes.shrink), true, 'should have the shrink class');
   });
+
+  it('should show an asterisk if required is set', () => {
+    const wrapper = shallow(<TextFieldLabel required />);
+    const text = wrapper.text();
+    assert.strictEqual(text.indexOf('*'), text.length - 1, 'should show an asterisk at the end');
+  });
+
+  it('should not show an asterisk by default', () => {
+    const wrapper = shallow(<TextFieldLabel />);
+    assert.strictEqual(wrapper.text().includes('*'), false, 'should not show an asterisk');
+  });
 });

--- a/test/regressions/site/src/tests/TextField/TextFieldRequired.js
+++ b/test/regressions/site/src/tests/TextField/TextFieldRequired.js
@@ -1,0 +1,19 @@
+// @flow weak
+
+import React from 'react';
+import TextField, { TextFieldInput, TextFieldLabel } from 'material-ui/TextField';
+
+export default function TextFieldRequired() {
+  return (
+    <div>
+      <TextField required>
+         <TextFieldLabel>Test</TextFieldLabel>
+         <TextFieldInput />
+       </TextField>
+      <TextField required>
+         <TextFieldLabel>Test</TextFieldLabel>
+         <TextFieldInput defaultValue="Hello world" />
+       </TextField>
+    </div>
+  );
+}


### PR DESCRIPTION
This is the `next` version of #5269. It doesn't include any tests yet, because I don't get them to run (`npm test` doesn't seem to actually run my unit tests). Any help is highly appreciated.

> This PR adds required inputs as shown in the [Material Specs](https://material.google.com/components/text-fields.html#text-fields-required-fields). This is really useful to show that input is required before the user starts typing or submits a form.
![ezgif-929265930](https://cloud.githubusercontent.com/assets/5544859/18894648/63744c3c-8514-11e6-8c0d-97dcfa19561f.gif)

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

