### PR TITLE
TableHeaderColumn ellipsis not working

### DIFF
--- a/src/Table/TableHeaderColumn.js
+++ b/src/Table/TableHeaderColumn.js
@@ -16,6 +16,7 @@ function getStyles(props, context) {
       textOverflow: 'ellipsis',
       color: tableHeaderColumn.textColor,
       position: 'relative',
+      overflow: 'hidden',
     },
     tooltip: {
       boxSizing: 'border-box',


### PR DESCRIPTION
The ellipsis doesn't work because overflow isn't set to `hidden`