### PR TITLE
[AutoComplete] Add onClose method

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -123,6 +123,8 @@ class AutoComplete extends Component {
     /** @ignore */
     onBlur: PropTypes.func,
     /** @ignore */
+    onClose: PropTypes.func,
+    /** @ignore */
     onFocus: PropTypes.func,
     /** @ignore */
     onKeyDown: PropTypes.func,
@@ -234,6 +236,8 @@ class AutoComplete extends Component {
       open: false,
       anchorEl: null,
     });
+    
+    this.props.onClose && this.props.onClose();
   }
 
   handleRequestClose = () => {


### PR DESCRIPTION
This is necessary for real-time validations. Normally you would use `onBlur` for this, but if the user is selecting from the drop down, then onBlur gets triggered before a value is selected.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] PR has tests / docs demo, and is linted.
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).
