### PR TITLE
[SelectField] Add min-height to MenuItem

### DIFF
--- a/docs/src/app/components/pages/components/SelectField/ExampleNullable.js
+++ b/docs/src/app/components/pages/components/SelectField/ExampleNullable.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import SelectField from 'material-ui/SelectField';
+import MenuItem from 'material-ui/MenuItem';
+
+const styles = {
+  customWidth: {
+    width: 150,
+  },
+};
+
+/**
+ * `SelectField` can also be nullable. In this case, just specify a `MenuItem`
+ * with no text and with a `null` value. For instance, for a boolean:
+ */
+export default class SelectFieldExampleNullable extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {value: null};
+  }
+
+  handleChange = (event, index, value) => this.setState({value});
+
+  render() {
+    return (
+      <div>
+        <SelectField floatingLabelText="Ready?" value={this.state.value} onChange={this.handleChange}>
+          <MenuItem value={null} primaryText="" />
+          <MenuItem value={false} primaryText="No" />
+          <MenuItem value={true} primaryText="Yes" />
+        </SelectField>
+      </div>
+    );
+  }
+}

--- a/docs/src/app/components/pages/components/SelectField/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/SelectField/ExampleSimple.js
@@ -25,7 +25,6 @@ export default class SelectFieldExampleSimple extends React.Component {
     return (
       <div>
         <SelectField floatingLabelText="Frequency" value={this.state.value} onChange={this.handleChange}>
-          <MenuItem value={null} primaryText="" />
           <MenuItem value={1} primaryText="Never" />
           <MenuItem value={2} primaryText="Every Night" />
           <MenuItem value={3} primaryText="Weeknights" />
@@ -44,7 +43,6 @@ export default class SelectFieldExampleSimple extends React.Component {
           onChange={this.handleChange}
           style={styles.customWidth}
         >
-          <MenuItem value={null} primaryText="" />
           <MenuItem value={1} primaryText="Custom width" />
           <MenuItem value={2} primaryText="Every Night" />
           <MenuItem value={3} primaryText="Weeknights" />
@@ -58,7 +56,6 @@ export default class SelectFieldExampleSimple extends React.Component {
           onChange={this.handleChange}
           autoWidth={true}
         >
-          <MenuItem value={null} primaryText="" />
           <MenuItem value={1} primaryText="Auto width" />
           <MenuItem value={2} primaryText="Every Night" />
           <MenuItem value={3} primaryText="Weeknights" />

--- a/docs/src/app/components/pages/components/SelectField/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/SelectField/ExampleSimple.js
@@ -24,7 +24,8 @@ export default class SelectFieldExampleSimple extends React.Component {
   render() {
     return (
       <div>
-        <SelectField value={this.state.value} onChange={this.handleChange}>
+        <SelectField floatingLabelText="Frequency" value={this.state.value} onChange={this.handleChange}>
+          <MenuItem value={null} primaryText="" />
           <MenuItem value={1} primaryText="Never" />
           <MenuItem value={2} primaryText="Every Night" />
           <MenuItem value={3} primaryText="Weeknights" />
@@ -32,16 +33,18 @@ export default class SelectFieldExampleSimple extends React.Component {
           <MenuItem value={5} primaryText="Weekly" />
         </SelectField>
         <br />
-        <SelectField value={1} disabled={true}>
+        <SelectField floatingLabelText="Frequency" value={1} disabled={true}>
           <MenuItem value={1} primaryText="Disabled" />
           <MenuItem value={2} primaryText="Every Night" />
         </SelectField>
         <br />
         <SelectField
+          floatingLabelText="Frequency"
           value={this.state.value}
           onChange={this.handleChange}
           style={styles.customWidth}
         >
+          <MenuItem value={null} primaryText="" />
           <MenuItem value={1} primaryText="Custom width" />
           <MenuItem value={2} primaryText="Every Night" />
           <MenuItem value={3} primaryText="Weeknights" />
@@ -50,10 +53,12 @@ export default class SelectFieldExampleSimple extends React.Component {
         </SelectField>
         <br />
         <SelectField
+          floatingLabelText="Frequency"
           value={this.state.value}
           onChange={this.handleChange}
           autoWidth={true}
         >
+          <MenuItem value={null} primaryText="" />
           <MenuItem value={1} primaryText="Auto width" />
           <MenuItem value={2} primaryText="Every Night" />
           <MenuItem value={3} primaryText="Weeknights" />

--- a/docs/src/app/components/pages/components/SelectField/Page.js
+++ b/docs/src/app/components/pages/components/SelectField/Page.js
@@ -16,6 +16,8 @@ import SelectFieldExampleFloatingLabel from './ExampleFloatingLabel';
 import selectFieldExampleFloatingLabelCode from '!raw!./ExampleFloatingLabel';
 import SelectFieldExampleError from './ExampleError';
 import selectFieldExampleErrorCode from '!raw!./ExampleError';
+import SelectFieldExampleNullable from './ExampleNullable';
+import SelectFieldExampleNullableCode from '!raw!./ExampleNullable';
 import selectFieldCode from '!raw!material-ui/SelectField/SelectField';
 
 const SelectFieldPage = () => (
@@ -27,6 +29,12 @@ const SelectFieldPage = () => (
       code={selectFieldExampleSimpleCode}
     >
       <SelectFieldExampleSimple />
+    </CodeExample>
+    <CodeExample
+      title="Nullable select"
+      code={SelectFieldExampleNullableCode}
+    >
+        <SelectFieldExampleNullable />
     </CodeExample>
     <CodeExample
       title="Long example"

--- a/src/MenuItem/MenuItem.js
+++ b/src/MenuItem/MenuItem.js
@@ -20,6 +20,7 @@ function getStyles(props, context) {
     root: {
       color: props.disabled ? disabledColor : textColor,
       cursor: props.disabled ? 'not-allowed' : 'pointer',
+      minHeight: props.desktop ? '32px' : '48px',
       lineHeight: props.desktop ? '32px' : '48px',
       fontSize: props.desktop ? 15 : 16,
       whiteSpace: 'nowrap',

--- a/test/integration/MenuItem/MenuItem.spec.js
+++ b/test/integration/MenuItem/MenuItem.spec.js
@@ -1,0 +1,15 @@
+import {assert} from 'chai';
+import React from 'react';
+import {shallow} from 'enzyme';
+import getMuiTheme from 'src/styles/getMuiTheme';
+import MenuItem from 'src/MenuItem/MenuItem';
+
+describe('<MenuItem />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
+  it('should have a min-height to allow display even within null <SelectItem /> option', () => {
+    const wrapper = shallowWithContext(<MenuItem />);
+    assert.equal(wrapper.find('ListItem').prop('style').minHeight, '48px');
+  });
+});


### PR DESCRIPTION
This PR adds a `min-height` to `<MenuItem />` component. It especially allows to add an empty `<MenuItem />` in `<SelectField />` for nullable value. For instance:

``` jsx
<SelectField floatingLabelText="Frequency" value={this.state.value} onChange={this.handleChange}>
          <MenuItem value={null} primaryText="" />
          <MenuItem value={1} primaryText="Never" />
          <MenuItem value={1} primaryText="Always" />
</SelectField>
```
It is still not a perfect solution, as if we put some `primaryText` prop, text would still overlap with floating label (as explained in #4275).

![image](https://cloud.githubusercontent.com/assets/688373/18986214/363885b4-86fc-11e6-89f3-361666eff494.png)

Yet, I can't see any easy solution here. We should discuss about it in the issue directly. Meanwhile, this PR allows to bypass the problem.

Here is the updated sample preview:

![image](https://cloud.githubusercontent.com/assets/688373/18986902/6a58e7fa-86ff-11e6-8957-6901bee0df54.png)

Note: some tests are failing on both this branch and master on my dev machine. Hence, I suppose this is fine.