### PR TITLE
[Popover] Add missing animated=false

### DIFF
--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -172,25 +172,32 @@ class Popover extends Component {
 
   renderLayer = () => {
     const {
-      animated, // eslint-disable-line no-unused-vars
+      animated,
       animation,
       children,
       style,
       ...other,
     } = this.props;
 
-    let Animation = animation || PopoverAnimationDefault;
     let styleRoot = style;
 
-    if (!Animation) {
-      Animation = Paper;
+    if (!animated) {
       styleRoot = {
         position: 'fixed',
       };
+
       if (!this.state.open) {
         return null;
       }
+
+      return (
+        <Paper style={Object.assign({}, styleRoot, style)} {...other}>
+          {children}
+        </Paper>
+      );
     }
+
+    const Animation = animation || PopoverAnimationDefault;
 
     return (
       <Animation {...other} style={styleRoot} open={this.state.open && !this.state.closing}>


### PR DESCRIPTION
This PR changes two things: `<Popover animated={false} />` was not respected, it is now displayed as `<Paper>` if open, and `null` if closed. It also removes the `if (!Animation)` case because Animation defaults to PopoverAnimationDefault if it is false.