### PR TITLE
[RadioButtonGroup] Modifying `selected` initial value check to account for falsy value

### DIFF
--- a/src/RadioButton/RadioButtonGroup.js
+++ b/src/RadioButton/RadioButtonGroup.js
@@ -62,6 +62,13 @@ class RadioButtonGroup extends Component {
 
   componentWillMount() {
     let cnt = 0;
+    let selected = '';
+    const {valueSelected, defaultSelected} = this.props;
+    if (valueSelected !== undefined) {
+      selected = valueSelected;
+    } else if (defaultSelected !== undefined) {
+      selected = defaultSelected;
+    }
 
     React.Children.forEach(this.props.children, (option) => {
       if (this.hasCheckAttribute(option)) cnt++;
@@ -69,7 +76,7 @@ class RadioButtonGroup extends Component {
 
     this.setState({
       numberCheckedRadioButtons: cnt,
-      selected: this.props.valueSelected || this.props.defaultSelected || '',
+      selected,
     });
   }
 

--- a/src/RadioButton/RadioButtonGroup.spec.js
+++ b/src/RadioButton/RadioButtonGroup.spec.js
@@ -1,0 +1,39 @@
+/* eslint-env mocha */
+
+import React from 'react';
+import {assert} from 'chai';
+import {shallow} from 'enzyme';
+import RadioButtonGroup from './RadioButtonGroup';
+import getMuiTheme from '../styles/getMuiTheme';
+
+describe('<RadioButtonGroup />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
+  describe('initial state', () => {
+    it('should accept string valueSelected prop and set to state', () => {
+      const wrapper = shallowWithContext(<RadioButtonGroup name="testGroup" valueSelected={'value'} />);
+      assert.strictEqual(wrapper.state('selected'), 'value');
+    });
+    it('should accept truthy valueSelected prop and set to state', () => {
+      const wrapper = shallowWithContext(<RadioButtonGroup name="testGroup" valueSelected={true} />);
+      assert.strictEqual(wrapper.state('selected'), true);
+    });
+    it('should accept falsy valueSelected prop and set to state', () => {
+      const wrapper = shallowWithContext(<RadioButtonGroup name="testGroup" valueSelected={false} />);
+      assert.strictEqual(wrapper.state('selected'), false);
+    });
+    it('should accept string defaultSelected prop and set to state', () => {
+      const wrapper = shallowWithContext(<RadioButtonGroup name="testGroup" defaultSelected={'value'} />);
+      assert.strictEqual(wrapper.state('selected'), 'value');
+    });
+    it('should accept truthy defaultSelected prop and set to state', () => {
+      const wrapper = shallowWithContext(<RadioButtonGroup name="testGroup" defaultSelected={true} />);
+      assert.strictEqual(wrapper.state('selected'), true);
+    });
+    it('should accept falsy defaultSelected prop and set to state', () => {
+      const wrapper = shallowWithContext(<RadioButtonGroup name="testGroup" defaultSelected={false} />);
+      assert.strictEqual(wrapper.state('selected'), false);
+    });
+  });
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

This closes #5087. The issue was related to passing falsy values for the `selectedValue` or `defaultValue` props into the component. This PR changes the behavior to check for _defined_ values instead.