### PR TITLE
[docs] Fix non-compiling example code on Themes page

### DIFF
--- a/docs/src/app/components/pages/customization/themes.md
+++ b/docs/src/app/components/pages/customization/themes.md
@@ -115,7 +115,7 @@ class Main extends React.Component {
 }
 
 Main.childContextTypes = {
-  muiTheme: PropTypes.object.isRequired,
+  muiTheme: React.PropTypes.object.isRequired,
 };
 
 export default Main;
@@ -137,7 +137,7 @@ class DeepDownTheTree extends React.Component {
 }
 
 DeepDownTheTree.contextTypes = {
-  muiTheme: PropTypes.object.isRequired,
+  muiTheme: React.PropTypes.object.isRequired,
 };
 
 export default DeepDownTheTree;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

This example code from the Themes docs page doesn't compile as written.  This caused 15 minutes of frustration I'd like to spare the next reader.

Thanks for the awesome library though, liking it so far!


