### PR TITLE
[Tabs][TabTemplate] Add tabTemplateStyle prop to Tabs

### DIFF
--- a/src/Tabs/TabTemplate.js
+++ b/src/Tabs/TabTemplate.js
@@ -1,29 +1,29 @@
-import React, {Component, PropTypes} from 'react';
+import React, {PropTypes} from 'react';
 
-class TabTemplate extends Component {
-  static propTypes = {
-    children: PropTypes.node,
-    selected: PropTypes.bool,
-  };
+const styles = {
+  width: '100%',
+  position: 'relative',
+  textAlign: 'initial',
+};
 
-  render() {
-    const styles = {
-      width: '100%',
-      position: 'relative',
-      textAlign: 'initial',
-    };
-
-    if (!this.props.selected) {
-      styles.height = 0;
-      styles.overflow = 'hidden';
-    }
-
-    return (
-      <div style={styles}>
-        {this.props.children}
-      </div>
-    );
+const TabTemplate = ({children, selected, style}) => {
+  const templateStyle = Object.assign({}, styles, style);
+  if (!selected) {
+    templateStyle.height = 0;
+    templateStyle.overflow = 'hidden';
   }
-}
+
+  return (
+    <div style={templateStyle}>
+      {children}
+    </div>
+  );
+};
+
+TabTemplate.propTypes = {
+  children: PropTypes.node,
+  selected: PropTypes.bool,
+  style: PropTypes.object,
+};
 
 export default TabTemplate;

--- a/src/Tabs/TabTemplate.spec.js
+++ b/src/Tabs/TabTemplate.spec.js
@@ -1,0 +1,23 @@
+/* eslint-env mocha */
+import React from 'react';
+import {shallow} from 'enzyme';
+import {assert} from 'chai';
+import TabTemplate from './TabTemplate';
+import getMuiTheme from '../styles/getMuiTheme';
+
+describe('<TabTemplate />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
+  it('should have different tab template style', () => {
+    const wrapper = shallowWithContext(
+      <TabTemplate
+        style={{backgroundColor: 'red'}}
+        selected={true}
+      />
+    );
+
+    assert.strictEqual(wrapper.props().style.backgroundColor, 'red',
+      'should have backgroundColor equal to red');
+  });
+});

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -67,6 +67,10 @@ class Tabs extends Component {
      */
     tabTemplate: PropTypes.func,
     /**
+     * Override the inline-styles of the tab template.
+     */
+    tabTemplateStyle: PropTypes.object,
+    /**
      * Makes Tabs controllable and selects the tab whose value prop matches this prop.
      */
     value: PropTypes.any,
@@ -178,6 +182,7 @@ class Tabs extends Component {
       style,
       tabItemContainerStyle,
       tabTemplate,
+      tabTemplateStyle,
       ...other,
     } = this.props;
 
@@ -202,6 +207,7 @@ class Tabs extends Component {
         createElement(tabTemplate || TabTemplate, {
           key: index,
           selected: this.getSelected(tab, index),
+          style: tabTemplateStyle,
         }, tab.props.children) : undefined);
 
       return cloneElement(tab, {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

This PR introduces a way to extend the style of `<TabTemplate />` by `tabTemplateStyle` prop on `<Tabs />` and also changes `<TabTemplate />` to a stateless component.

Fixes #5281.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).