### PR TITLE
Revert "[TableRowColumn] Tooltip visible with TableRowColumn"

### DIFF
--- a/src/Table/TableRowColumn.js
+++ b/src/Table/TableRowColumn.js
@@ -10,6 +10,7 @@ function getStyles(props, context) {
       height: tableRowColumn.height,
       textAlign: 'left',
       fontSize: 13,
+      overflow: 'hidden',
       whiteSpace: 'nowrap',
       textOverflow: 'ellipsis',
     },


### PR DESCRIPTION
This reverts #5014 and fixes #5377.