### PR TITLE
[Menu] use 'muiTheme.menuItem.selectedTextColor' for 'style.selectedM…

### DIFF
--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -35,7 +35,7 @@ function getStyles(props, context) {
       width: width,
     },
     selectedMenuItem: {
-      color: muiTheme.baseTheme.palette.accent1Color,
+      color: muiTheme.menuItem.selectedTextColor,
     },
   };
 


### PR DESCRIPTION
related issues: #5166, #3388

As the 'selectedTextColor' is already set in the compiled theme we should use it. That way the user is able to overwride it.

tbd:
going further **there should be a way to pass it by a styleObject**
**either per a new 'labelSelectedStyle' or by 'labelStyle.selected'**
i would use the approach oliviertassinari used at the border-radius... smth. like that:
`style={Object.assign(styles.selected, labelSelectedStyle)}`

i didn't got time for that yet, but i would provide an PR for that in correspondence with the callemall-feedback i get

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).