### PR TITLE
[GitHub] Improve ISSUE_TEMPLATE to ask for a running snippet

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,22 +1,24 @@
-### Problem description
-
-### Steps to reproduce
-
-### Versions
-
-- Material-UI: 
-- React: 
-- Browser: 
-
 <!-- Have a QUESTION? Please ask in [StackOverflow or gitter](http://tr.im/77pVj before opening an issue.
 
 If you are having an issue with click events, please re-read the [README](http://tr.im/410Fg) (you did read the README, right? :-) ).
 
-If you think you have found a _new_ issue that hasn't already been reported or fixed in HEAD, please complete the template above.
+If you think you have found a _new_ issue that hasn't already been reported or fixed in HEAD, please complete the template below.
 
-For feature requests, please delete the template above and use this one instead:
+For feature requests, please delete the template below and use this one instead:
 
 ### Description
 ### Images & references
 
 -->
+
+### Problem description
+
+### Link to minimally-working code that reproduces the issue
+
+<!-- You may provide a repository or use our template-ready webpackbin http://www.webpackbin.com/4kSRu0OCb-->
+
+### Versions
+
+- Material-UI:
+- React:
+- Browser:


### PR DESCRIPTION
Many issues are being opened without user even knowing how to reproduce
it, a bin would help a lot and also **speed up collaborators work**.

Moving the comments about StackOverflow and regular issues up may help
to decrease the number of users asking non-related Material UI
questions.