### PR TITLE
[IconMenu] Makes the warning message more explicit

### DIFF
--- a/docs/src/app/components/pages/components/IconMenu/ExampleControlled.js
+++ b/docs/src/app/components/pages/components/IconMenu/ExampleControlled.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Component} from 'react';
 import IconMenu from 'material-ui/IconMenu';
 import MenuItem from 'material-ui/MenuItem';
 import IconButton from 'material-ui/IconButton';
@@ -7,15 +7,15 @@ import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 import ContentFilter from 'material-ui/svg-icons/content/filter-list';
 import FileFileDownload from 'material-ui/svg-icons/file/file-download';
 
-export default class IconMenuExampleControlled extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      valueSingle: '3',
-      valueMultiple: ['3', '5'],
-    };
-  }
+/**
+ * Three controlled examples, the first allowing a single selection, the second multiple selections,
+ * the third using internal state.
+ */
+export default class IconMenuExampleControlled extends Component {
+  state = {
+    valueSingle: '3',
+    valueMultiple: ['3', '5'],
+  };
 
   handleChangeSingle = (event, value) => {
     this.setState({

--- a/docs/src/app/components/pages/components/IconMenu/ExampleNested.js
+++ b/docs/src/app/components/pages/components/IconMenu/ExampleNested.js
@@ -7,41 +7,42 @@ import Download from 'material-ui/svg-icons/file/file-download';
 import ArrowDropRight from 'material-ui/svg-icons/navigation-arrow-drop-right';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 
+/**
+ * Example of nested menus within an IconMenu.
+ */
 const IconMenuExampleNested = () => (
-  <div>
-    <IconMenu
-      iconButtonElement={<IconButton><MoreVertIcon /></IconButton>}
-      anchorOrigin={{horizontal: 'left', vertical: 'top'}}
-      targetOrigin={{horizontal: 'left', vertical: 'top'}}
-    >
-      <MenuItem
-        primaryText="Copy & Paste"
-        rightIcon={<ArrowDropRight />}
-        menuItems={[
-          <MenuItem primaryText="Cut" />,
-          <MenuItem primaryText="Copy" />,
-          <Divider />,
-          <MenuItem primaryText="Paste" />,
-        ]}
-      />
+  <IconMenu
+    iconButtonElement={<IconButton><MoreVertIcon /></IconButton>}
+    anchorOrigin={{horizontal: 'left', vertical: 'top'}}
+    targetOrigin={{horizontal: 'left', vertical: 'top'}}
+  >
+    <MenuItem
+      primaryText="Copy & Paste"
+      rightIcon={<ArrowDropRight />}
+      menuItems={[
+        <MenuItem primaryText="Cut" />,
+        <MenuItem primaryText="Copy" />,
+        <Divider />,
+        <MenuItem primaryText="Paste" />,
+      ]}
+    />
 
-      <MenuItem
-        primaryText="Case Tools"
-        rightIcon={<ArrowDropRight />}
-        menuItems={[
-          <MenuItem primaryText="UPPERCASE" />,
-          <MenuItem primaryText="lowercase" />,
-          <MenuItem primaryText="CamelCase" />,
-          <MenuItem primaryText="Propercase" />,
-        ]}
-      />
-      <Divider />
-      <MenuItem primaryText="Download" leftIcon={<Download />} />
-      <Divider />
-      <MenuItem value="Del" primaryText="Delete" />
+    <MenuItem
+      primaryText="Case Tools"
+      rightIcon={<ArrowDropRight />}
+      menuItems={[
+        <MenuItem primaryText="UPPERCASE" />,
+        <MenuItem primaryText="lowercase" />,
+        <MenuItem primaryText="CamelCase" />,
+        <MenuItem primaryText="Propercase" />,
+      ]}
+    />
+    <Divider />
+    <MenuItem primaryText="Download" leftIcon={<Download />} />
+    <Divider />
+    <MenuItem value="Del" primaryText="Delete" />
 
-    </IconMenu>
-  </div>
+  </IconMenu>
 );
 
 export default IconMenuExampleNested;

--- a/docs/src/app/components/pages/components/IconMenu/ExampleScrollable.js
+++ b/docs/src/app/components/pages/components/IconMenu/ExampleScrollable.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import IconMenu from 'material-ui/IconMenu';
 import MenuItem from 'material-ui/MenuItem';
-import IconButton from 'material-ui/IconButton/IconButton';
+import IconButton from 'material-ui/IconButton';
 import MapsPlace from 'material-ui/svg-icons/maps/place';
 
+/**
+ * The `maxHeight` property limits the height of the menu, above which it will be scrollable.
+ */
 const IconMenuExampleScrollable = () => (
   <IconMenu
     iconButtonElement={<IconButton><MapsPlace /></IconButton>}

--- a/docs/src/app/components/pages/components/IconMenu/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/IconMenu/ExampleSimple.js
@@ -1,9 +1,13 @@
 import React from 'react';
 import IconMenu from 'material-ui/IconMenu';
 import MenuItem from 'material-ui/MenuItem';
-import IconButton from 'material-ui/IconButton/IconButton';
+import IconButton from 'material-ui/IconButton';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 
+/**
+ * Simple Icon Menus demonstrating some of the layouts possible using the `anchorOrigin` and
+ * `targetOrigin` properties.
+ */
 const IconMenuExampleSimple = () => (
   <div>
     <IconMenu

--- a/docs/src/app/components/pages/components/IconMenu/Page.js
+++ b/docs/src/app/components/pages/components/IconMenu/Page.js
@@ -16,43 +16,30 @@ import IconMenuExampleNested from './ExampleNested';
 import iconMenuExampleNestedCode from '!raw!./ExampleNested';
 import iconMenuCode from '!raw!material-ui/IconMenu/IconMenu';
 
-const descriptions = {
-  simple: 'Simple Icon Menus demonstrating some of the layouts possible using the `anchorOrigin` and `' +
-  'targetOrigin` properties.',
-  controlled: 'Three controlled examples, the first allowing a single selection, the second multiple selections,' +
-    ' the third using internal state.',
-  scrollable: 'The `maxHeight` property limits the height of the menu, above which it will be scrollable.',
-  nested: 'Example of nested menus within an IconMenu.',
-};
-
 const IconMenusPage = () => (
   <div>
     <Title render={(previousTitle) => `Icon Menu - ${previousTitle}`} />
     <MarkdownElement text={iconMenuReadmeText} />
     <CodeExample
       title="Icon Menu positioning"
-      description={descriptions.simple}
       code={iconMenuExampleSimpleCode}
     >
       <IconMenuExampleSimple />
     </CodeExample>
     <CodeExample
       title="Controlled Icon Menus"
-      description={descriptions.controlled}
       code={iconMenuExampleControlledCode}
     >
       <IconMenuExampleControlled />
     </CodeExample>
     <CodeExample
       title="Scrollable Icon Menu"
-      description={descriptions.scrollable}
       code={iconMenuExampleScrollableCode}
     >
       <IconMenuExampleScrollable />
     </CodeExample>
     <CodeExample
       title="Nested Icon Menus"
-      description={descriptions.nested}
       code={iconMenuExampleNestedCode}
     >
       <IconMenuExampleNested />

--- a/src/IconMenu/IconMenu.js
+++ b/src/IconMenu/IconMenu.js
@@ -265,8 +265,9 @@ class IconMenu extends Component {
     const mergedRootStyles = Object.assign(styles.root, style);
     const mergedMenuStyles = Object.assign(styles.menu, menuStyle);
 
-    warning(iconButtonElement.type.muiName === 'IconButton',
-      '<IconMenu /> expects an <IconButton /> to be passed as the `iconButtonElement` property.');
+    warning(iconButtonElement.type.muiName !== 'SvgIcon',
+      `Material-UI: You shoud not provide an <SvgIcon /> to the 'iconButtonElement' property of <IconMenu />.
+You should wrapped it with an <IconButton />.`);
 
     const iconButton = React.cloneElement(iconButtonElement, {
       onKeyboardFocus: onKeyboardFocus,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


This change makes the warning less restrictive to fix [those comments](https://github.com/callemall/material-ui/commit/0ad7f2a2fa8badfb285bc88de8698273e9e0b04a#commitcomment-19315108).
(cc @bartvde @Philipp91)

We focus on addressing the core issue. i.e having a better error message than
> Warning: Unknown props `onKeyboardFocus`,

when not using the API correctly.

> Warning: Material-UI: You shoud not provide an <SvgIcon /> to
the 'iconButtonElement' property of <IconMenu />.
You should wrap it with an <IconButton />.