### PR TITLE
[BottomSheet] Add new component

### DIFF
--- a/docs/src/app/AppRoutes.js
+++ b/docs/src/app/AppRoutes.js
@@ -24,6 +24,7 @@ import AutoCompletePage from './components/pages/components/AutoComplete/Page';
 import AvatarPage from './components/pages/components/Avatar/Page';
 import BadgePage from './components/pages/components/Badge/Page';
 import BottomNavigationPage from './components/pages/components/BottomNavigation/Page';
+import BottomSheetPage from './components/pages/components/BottomSheet/Page';
 import CardPage from './components/pages/components/Card/Page';
 import ChipPage from './components/pages/components/Chip/Page';
 import CircularProgressPage from './components/pages/components/CircularProgress/Page';
@@ -99,6 +100,7 @@ const AppRoutes = (
       <Route path="auto-complete" component={AutoCompletePage} />
       <Route path="avatar" component={AvatarPage} />
       <Route path="bottom-navigation" component={BottomNavigationPage} />
+      <Route path="bottom-sheet" component={BottomSheetPage} />
       <Route path="badge" component={BadgePage} />
       <Route path="card" component={CardPage} />
       <Route path="chip" component={ChipPage} />

--- a/docs/src/app/components/AppNavDrawer.js
+++ b/docs/src/app/components/AppNavDrawer.js
@@ -192,6 +192,11 @@ class AppNavDrawer extends Component {
                 href="#/components/bottom-navigation"
               />,
               <ListItem
+                primaryText="Bottom Sheet"
+                value="/components/bottom-sheet"
+                href="#/components/bottom-sheet"
+              />,
+              <ListItem
                 primaryText="Buttons"
                 primaryTogglesNestedList={true}
                 nestedItems={[

--- a/docs/src/app/components/pages/components/BottomSheet/ExampleAction.js
+++ b/docs/src/app/components/pages/components/BottomSheet/ExampleAction.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import BottomSheet from 'material-ui/BottomSheet';
+import TextField from 'material-ui/TextField';
+import RaisedButton from 'material-ui/RaisedButton';
+import {List, ListItem} from 'material-ui/List';
+import Divider from 'material-ui/Divider';
+import Phone from 'material-ui/svg-icons/communication/phone';
+import Email from 'material-ui/svg-icons/communication/email';
+
+export default class BottomSheetExampleSimple extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: false,
+      action: 'favorite',
+    };
+  }
+
+  handleTouchTap = () => {
+    this.setState({
+      open: true,
+    });
+  };
+
+  handleActionTouchTap = () => {
+    this.setState({
+      open: false,
+    });
+    alert('Added to favorites');
+  };
+
+  handleChangeAction = (event) => {
+    const value = event.target.value;
+    this.setState({
+      action: value,
+    });
+  };
+
+  handleRequestClose = () => {
+    this.setState({
+      open: false,
+    });
+  };
+
+  render() {
+    return (
+      <div>
+        <RaisedButton
+          onTouchTap={this.handleTouchTap}
+          label="Show contact"
+        />
+        <br />
+        <TextField
+          floatingLabelText="Set action name"
+          value={this.state.action}
+          onChange={this.handleChangeAction}
+        />
+        <BottomSheet
+          open={this.state.open}
+          action={this.state.action}
+          onActionTouchTap={this.handleActionTouchTap}
+          onRequestClose={this.handleRequestClose}
+        >
+          <List>
+            <ListItem
+              primaryText="(650) 555-1234"
+              secondaryText="Mobile"
+              leftIcon={<Phone />}
+            />
+            <ListItem
+              primaryText="(323) 555-6789"
+              secondaryText="Work"
+              insetChildren={true}
+            />
+            <Divider inset={true} />
+            <ListItem
+              primaryText="aliconnors@example.com"
+              secondaryText="Personal"
+              leftIcon={<Email />}
+            />
+          </List>
+        </BottomSheet>
+      </div>
+    );
+  }
+}

--- a/docs/src/app/components/pages/components/BottomSheet/ExampleAction.js
+++ b/docs/src/app/components/pages/components/BottomSheet/ExampleAction.js
@@ -13,7 +13,7 @@ export default class BottomSheetExampleSimple extends React.Component {
     super(props);
     this.state = {
       open: false,
-      action: 'favorite',
+      action: 'star',
     };
   }
 
@@ -59,6 +59,7 @@ export default class BottomSheetExampleSimple extends React.Component {
         <BottomSheet
           open={this.state.open}
           action={this.state.action}
+          persistent={true}
           onActionTouchTap={this.handleActionTouchTap}
           onRequestClose={this.handleRequestClose}
         >
@@ -78,6 +79,11 @@ export default class BottomSheetExampleSimple extends React.Component {
               primaryText="aliconnors@example.com"
               secondaryText="Personal"
               leftIcon={<Email />}
+            />
+            <ListItem
+              primaryText="ali_connors@example.com"
+              secondaryText="Work"
+              insetChildren={true}
             />
           </List>
         </BottomSheet>

--- a/docs/src/app/components/pages/components/BottomSheet/ExampleAction.js
+++ b/docs/src/app/components/pages/components/BottomSheet/ExampleAction.js
@@ -27,7 +27,7 @@ export default class BottomSheetExampleSimple extends React.Component {
     this.setState({
       open: false,
     });
-    alert('Added to favorites');
+    alert('Added to '+this.state.action);
   };
 
   handleChangeAction = (event) => {
@@ -48,7 +48,7 @@ export default class BottomSheetExampleSimple extends React.Component {
       <div>
         <RaisedButton
           onTouchTap={this.handleTouchTap}
-          label="Show contact"
+          label="contact with action"
         />
         <br />
         <TextField

--- a/docs/src/app/components/pages/components/BottomSheet/ExampleAction.js
+++ b/docs/src/app/components/pages/components/BottomSheet/ExampleAction.js
@@ -10,7 +10,7 @@ import Email from 'material-ui/svg-icons/communication/email';
 
 const listStyle = {
   paddingTop: 26
-}
+};
 
 export default class BottomSheetExampleSimple extends React.Component {
 
@@ -32,7 +32,7 @@ export default class BottomSheetExampleSimple extends React.Component {
     this.setState({
       open: false,
     });
-    alert('Added to '+this.state.action);
+    alert(`Added to ${this.state.action}`);
   };
 
   handleChangeAction = (event) => {

--- a/docs/src/app/components/pages/components/BottomSheet/ExampleAction.js
+++ b/docs/src/app/components/pages/components/BottomSheet/ExampleAction.js
@@ -7,6 +7,11 @@ import Divider from 'material-ui/Divider';
 import Phone from 'material-ui/svg-icons/communication/phone';
 import Email from 'material-ui/svg-icons/communication/email';
 
+
+const listStyle = {
+  paddingTop: 26
+}
+
 export default class BottomSheetExampleSimple extends React.Component {
 
   constructor(props) {
@@ -19,7 +24,7 @@ export default class BottomSheetExampleSimple extends React.Component {
 
   handleTouchTap = () => {
     this.setState({
-      open: true,
+      open: !this.state.open,
     });
   };
 
@@ -37,18 +42,12 @@ export default class BottomSheetExampleSimple extends React.Component {
     });
   };
 
-  handleRequestClose = () => {
-    this.setState({
-      open: false,
-    });
-  };
-
   render() {
     return (
       <div>
         <RaisedButton
           onTouchTap={this.handleTouchTap}
-          label="contact with action"
+          label="Toggle contact"
         />
         <br />
         <TextField
@@ -61,9 +60,8 @@ export default class BottomSheetExampleSimple extends React.Component {
           action={this.state.action}
           persistent={true}
           onActionTouchTap={this.handleActionTouchTap}
-          onRequestClose={this.handleRequestClose}
         >
-          <List>
+          <List style={listStyle}>
             <ListItem
               primaryText="(650) 555-1234"
               secondaryText="Mobile"

--- a/docs/src/app/components/pages/components/BottomSheet/ExampleInset.js
+++ b/docs/src/app/components/pages/components/BottomSheet/ExampleInset.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import BottomSheet from 'material-ui/BottomSheet';
+import RaisedButton from 'material-ui/RaisedButton';
+import IconButton from 'material-ui/IconButton';
+import FontIcon from 'material-ui/FontIcon';
+import { grey600 } from 'material-ui/styles/colors';
+
+const styles = {
+  leftBody: {
+    height: 64,
+    float: 'left',
+  },
+  rightBody: {
+    float: 'right'
+  },
+  icon: {
+    color: grey600,
+    padding: 16,
+    paddingLeft: 16,
+    fontSize: 36
+  },
+  iconButton: {
+    color: grey600,
+    paddingTop: 6,
+    fontSize: 36
+  }
+}
+
+export default class BottomSheetExampleSimple extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: false,
+    };
+  }
+
+  handleTouchTap = () => {
+    this.setState({
+      open: !this.state.open,
+    });
+  };
+
+  render() {
+    return (
+      <div>
+        <RaisedButton
+          onTouchTap={this.handleTouchTap}
+          label="Show Inset"
+        />
+        <BottomSheet
+          open={this.state.open}
+          persistent={true}
+          inset={true}
+        >
+          <div style={styles.leftBody}>
+            <IconButton tooltip="Close sheet" iconStyle={styles.iconButton} onTouchTap={this.handleTouchTap}>
+              <FontIcon className="material-icons">close</FontIcon>
+            </IconButton>
+          </div>
+          <div style={styles.rightBody}>
+            <FontIcon style={styles.icon} className="material-icons">fast_rewind</FontIcon>
+            <FontIcon style={styles.icon} className="material-icons">play_arrow</FontIcon>
+            <FontIcon style={styles.icon} className="material-icons">fast_forward</FontIcon>
+          </div>
+        </BottomSheet>
+      </div>
+    );
+  }
+}

--- a/docs/src/app/components/pages/components/BottomSheet/ExampleInset.js
+++ b/docs/src/app/components/pages/components/BottomSheet/ExampleInset.js
@@ -3,7 +3,7 @@ import BottomSheet from 'material-ui/BottomSheet';
 import RaisedButton from 'material-ui/RaisedButton';
 import IconButton from 'material-ui/IconButton';
 import FontIcon from 'material-ui/FontIcon';
-import { grey600 } from 'material-ui/styles/colors';
+import {grey600} from 'material-ui/styles/colors';
 
 const styles = {
   leftBody: {
@@ -11,20 +11,20 @@ const styles = {
     float: 'left',
   },
   rightBody: {
-    float: 'right'
+    float: 'right',
   },
   icon: {
     color: grey600,
     padding: 16,
     paddingLeft: 16,
-    fontSize: 36
+    fontSize: 36,
   },
   iconButton: {
     color: grey600,
     paddingTop: 6,
-    fontSize: 36
-  }
-}
+    fontSize: 36,
+  },
+};
 
 export default class BottomSheetExampleSimple extends React.Component {
 

--- a/docs/src/app/components/pages/components/BottomSheet/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/BottomSheet/ExampleSimple.js
@@ -33,7 +33,7 @@ export default class BottomSheetExampleSimple extends React.Component {
       <div>
         <RaisedButton
           onTouchTap={this.handleTouchTap}
-          label="Show More"
+          label="Show Options"
         />
         <BottomSheet
           open={this.state.open}

--- a/docs/src/app/components/pages/components/BottomSheet/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/BottomSheet/ExampleSimple.js
@@ -37,6 +37,7 @@ export default class BottomSheetExampleSimple extends React.Component {
         />
         <BottomSheet
           open={this.state.open}
+          modal={true}
           onRequestClose={this.handleRequestClose}
         >
           <List>

--- a/docs/src/app/components/pages/components/BottomSheet/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/BottomSheet/ExampleSimple.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import BottomSheet from 'material-ui/BottomSheet';
+import RaisedButton from 'material-ui/RaisedButton';
+import {List, ListItem} from 'material-ui/List';
+import Share from 'material-ui/svg-icons/social/share';
+import CloudUpload from 'material-ui/svg-icons/file/cloud-upload';
+import ContentCopy from 'material-ui/svg-icons/content/content-copy';
+import Print from 'material-ui/svg-icons/action/print';
+
+export default class BottomSheetExampleSimple extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: false,
+    };
+  }
+
+  handleTouchTap = () => {
+    this.setState({
+      open: true,
+    });
+  };
+
+  handleRequestClose = () => {
+    this.setState({
+      open: false,
+    });
+  };
+
+  render() {
+    return (
+      <div>
+        <RaisedButton
+          onTouchTap={this.handleTouchTap}
+          label="Show More"
+        />
+        <BottomSheet
+          open={this.state.open}
+          onRequestClose={this.handleRequestClose}
+        >
+          <List>
+            <ListItem
+              primaryText="Share"
+              leftIcon={<Share />}
+            />
+            <ListItem
+              primaryText="Upload"
+              leftIcon={<CloudUpload />}
+            />
+            <ListItem
+              primaryText="Copy"
+              leftIcon={<ContentCopy />}
+            />
+            <ListItem
+              primaryText="Print this page"
+              leftIcon={<Print />}
+            />
+          </List>
+        </BottomSheet>
+      </div>
+    );
+  }
+}

--- a/docs/src/app/components/pages/components/BottomSheet/Page.js
+++ b/docs/src/app/components/pages/components/BottomSheet/Page.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import Title from 'react-title-component';
+
+import CodeExample from '../../../CodeExample';
+import PropTypeDescription from '../../../PropTypeDescription';
+import MarkdownElement from '../../../MarkdownElement';
+
+import BottomSheetReadmeText from './README';
+import BottomSheetExampleSimple from './ExampleSimple';
+import BottomSheetExampleSimpleCode from '!raw!./ExampleSimple';
+import BottomSheetExampleAction from './ExampleAction';
+import BottomSheetExampleActionCode from '!raw!./ExampleAction';
+import BottomSheetCode from '!raw!material-ui/BottomSheet/BottomSheet';
+
+const descriptions = {
+  simple: '`BottomSheet` is a controlled component, and is displayed when `open` is `true`. Click away from the ' +
+  'BottomSheet to close it.',
+  action: 'A single `action` can be added to the BottomSheet, and triggers `onActionTouchTap`.'
+};
+
+const BottomSheetPage = () => {
+  return (
+    <div>
+      <Title render={(previousTitle) => `BottomSheet - ${previousTitle}`} />
+      <MarkdownElement text={BottomSheetReadmeText} />
+      <CodeExample
+        title="Simple example"
+        description={descriptions.simple}
+        code={BottomSheetExampleSimpleCode}
+      >
+        <BottomSheetExampleSimple />
+      </CodeExample>
+      <CodeExample
+        title="Example action"
+        description={descriptions.action}
+        code={BottomSheetExampleActionCode}
+      >
+        <BottomSheetExampleAction />
+      </CodeExample>
+      <PropTypeDescription code={BottomSheetCode} />
+    </div>
+  );
+};
+
+export default BottomSheetPage;

--- a/docs/src/app/components/pages/components/BottomSheet/Page.js
+++ b/docs/src/app/components/pages/components/BottomSheet/Page.js
@@ -13,9 +13,9 @@ import BottomSheetExampleActionCode from '!raw!./ExampleAction';
 import BottomSheetCode from '!raw!material-ui/BottomSheet/BottomSheet';
 
 const descriptions = {
-  simple: '`BottomSheet` is a controlled component, and is displayed when `open` is `true`. Click away from the ' +
+  simple: '`BottomSheet` is displayed when `open` is `true`. Click away from the ' +
   'BottomSheet to close it.',
-  action: 'A single `action` can be added to the BottomSheet, and triggers `onActionTouchTap`.'
+  action: 'Persistent bottom sheets have no `onRequestClose`, it has to be manually closed. A single `action` string can be added, and triggers `onActionTouchTap`.'
 };
 
 const BottomSheetPage = () => {

--- a/docs/src/app/components/pages/components/BottomSheet/Page.js
+++ b/docs/src/app/components/pages/components/BottomSheet/Page.js
@@ -24,14 +24,14 @@ const BottomSheetPage = () => {
       <Title render={(previousTitle) => `BottomSheet - ${previousTitle}`} />
       <MarkdownElement text={BottomSheetReadmeText} />
       <CodeExample
-        title="Simple example"
+        title="Modular example"
         description={descriptions.simple}
         code={BottomSheetExampleSimpleCode}
       >
         <BottomSheetExampleSimple />
       </CodeExample>
       <CodeExample
-        title="Example action"
+        title="Persistent with action"
         description={descriptions.action}
         code={BottomSheetExampleActionCode}
       >

--- a/docs/src/app/components/pages/components/BottomSheet/Page.js
+++ b/docs/src/app/components/pages/components/BottomSheet/Page.js
@@ -17,7 +17,8 @@ import BottomSheetCode from '!raw!material-ui/BottomSheet/BottomSheet';
 const descriptions = {
   simple: '`BottomSheet` is displayed when `open` is `true`. Click away from the ' +
   'BottomSheet to close it.',
-  action: 'Persistent bottom sheets have no `onRequestClose`, it has to be manually closed. A single `action` string can be added, and triggers `onActionTouchTap`.',
+  action: 'Persistent bottom sheets have no `onRequestClose`, it has to be manually ' +
+  'closed. A single `action` string can be added, and triggers `onActionTouchTap`.',
   inset: 'Inset persistent bottom sheets have no `action` prop.',
 };
 

--- a/docs/src/app/components/pages/components/BottomSheet/Page.js
+++ b/docs/src/app/components/pages/components/BottomSheet/Page.js
@@ -10,12 +10,15 @@ import BottomSheetExampleSimple from './ExampleSimple';
 import BottomSheetExampleSimpleCode from '!raw!./ExampleSimple';
 import BottomSheetExampleAction from './ExampleAction';
 import BottomSheetExampleActionCode from '!raw!./ExampleAction';
+import BottomSheetExampleInset from './ExampleInset';
+import BottomSheetExampleInsetCode from '!raw!./ExampleInset';
 import BottomSheetCode from '!raw!material-ui/BottomSheet/BottomSheet';
 
 const descriptions = {
   simple: '`BottomSheet` is displayed when `open` is `true`. Click away from the ' +
   'BottomSheet to close it.',
-  action: 'Persistent bottom sheets have no `onRequestClose`, it has to be manually closed. A single `action` string can be added, and triggers `onActionTouchTap`.'
+  action: 'Persistent bottom sheets have no `onRequestClose`, it has to be manually closed. A single `action` string can be added, and triggers `onActionTouchTap`.',
+  inset: 'Inset persistent bottom sheets have no `action` prop.',
 };
 
 const BottomSheetPage = () => {
@@ -36,6 +39,13 @@ const BottomSheetPage = () => {
         code={BottomSheetExampleActionCode}
       >
         <BottomSheetExampleAction />
+      </CodeExample>
+      <CodeExample
+        title="Inset persistent"
+        description={descriptions.inset}
+        code={BottomSheetExampleInsetCode}
+      >
+        <BottomSheetExampleInset />
       </CodeExample>
       <PropTypeDescription code={BottomSheetCode} />
     </div>

--- a/docs/src/app/components/pages/components/BottomSheet/README.md
+++ b/docs/src/app/components/pages/components/BottomSheet/README.md
@@ -1,0 +1,5 @@
+## Bottom Sheet
+
+The [bottom sheet](https://material.google.com/components/bottom-sheets.html#bottom-sheets-behavior) slides up from the bottom of the screen to reveal more content.
+
+### Examples

--- a/src/BottomSheet/BottomSheet.js
+++ b/src/BottomSheet/BottomSheet.js
@@ -1,0 +1,266 @@
+import React, {PropTypes, Component} from 'react';
+import ReactDOM from 'react-dom';
+import transitions from '../styles/transitions';
+import ClickAwayListener from '../internal/ClickAwayListener';
+import BottomSheetBody from './BottomSheetBody';
+import Paper from '../Paper';
+import FontIcon from 'material-ui/FontIcon';
+import FloatingActionButton from 'material-ui/FloatingActionButton';
+
+
+function getStyles(props, context, state) {
+  const {
+    muiTheme: {
+      baseTheme: {
+        spacing: {
+          desktopSubheaderHeight,
+        },
+      },
+      bottomSheet: {
+        actionColor,
+      },
+      zIndex,
+    },
+  } = context;
+
+  const {open} = state;
+
+  const styles = {
+    root: {
+      position: 'fixed',
+      left: '50%',
+      display: 'flex',
+      bottom: 0,
+      zIndex: zIndex.bottomSheet,
+      height: state.sheetHeight,
+      visibility: open ? 'visible' : 'hidden',
+      transform: open ?
+        'translate(-50%, 0)' :
+        `translate(-50%, ${state.sheetHeight}px)`,
+      transition: `${transitions.easeOut('400ms', 'transform')}, ${
+        transitions.easeOut('400ms', 'visibility')}`,
+    },
+    action: {
+      position: 'absolute',
+      color: actionColor,
+      right: 16,
+      top: -29,
+      transform: open ?
+        'scale(1)' :
+        `scale(0)`,
+      transition: `${transitions.easeOut('500ms', 'transform')}, ${
+        transitions.easeOut('500ms', 'visibility')}`,
+      transitionDelay: '200ms',
+    },
+  };
+
+  return styles;
+}
+
+class BottomSheet extends Component {
+  static propTypes = {
+     /**
+     * The contents of the `BottomSheet`
+     */
+    children: PropTypes.node,
+    /**
+     * The name for the floating action button on the bottom sheet. Can be any Material Design Icon: https://design.google.com/icons/ . Note: substitute spaces with `_`
+     */
+    action: PropTypes.string,
+    /**
+     * Override the inline-styles of the body element.
+     */
+    bodyStyle: PropTypes.object,
+    /**
+     * The css class name of the root element.
+     */
+    className: PropTypes.string,
+    /**
+     * Override the inline-styles of the content element.
+     */
+    contentStyle: PropTypes.object,
+    /**
+     * Fired when the action button is touchtapped.
+     *
+     * @param {object} event Action button event.
+     */
+    onActionTouchTap: PropTypes.func,
+    /**
+     * Fired when the `BottomSheet` is requested to be closed by a click outside the `BottomSheet`.
+     *
+     * Typically `onRequestClose` is used to set state in the parent component, which is used to control the `BottomSheet`
+     * `open` prop.
+     *
+     * The `reason` parameter can optionally be used to control the response to `onRequestClose`,
+     * for example ignoring `clickaway`.
+     *
+     * @param {string} reason Can be `"clickaway"`
+     */
+    onRequestClose: PropTypes.func,
+    /**
+     * Controls whether the `BottomSheet` is opened or not.
+     */
+    open: PropTypes.bool.isRequired,
+    /**
+     * Override the inline-styles of the root element.
+     */
+    style: PropTypes.object,
+  };
+
+  static contextTypes = {
+    muiTheme: PropTypes.object.isRequired,
+  };
+
+  componentWillMount() {
+    this.setState({
+      open: this.props.open,
+      sheetHeight: 'auto'
+    });
+  }
+
+  componentDidMount() {
+    if (this.state.open) {
+      this.setTransitionTimer();
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.open && nextProps.open) {
+      console.log("open prop changed")
+      this.setState({
+        open: false,
+      });
+      clearTimeout(this.timerOneAtTheTimeId);
+      this.timerOneAtTheTimeId = setTimeout(() => {
+        console.warn('timerOneAtTheTimeId')
+        this.setState({
+          open: true,
+        });
+      }, 400);
+    } else {
+      const open = nextProps.open;
+
+      if (open !== this.props.open){
+        console.log('open', open)
+        console.log('sheetHeight', ReactDOM.findDOMNode(this.refs.sheet).clientHeight)
+        this.setState({
+          open: open !== null ? open : this.state.open,
+          sheetHeight: open ? ReactDOM.findDOMNode(this.refs.sheet).clientHeight : 0,
+        });
+      }
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (prevState.open !== this.state.open) {
+      if (this.state.open) {
+        console.info("componentDidUpdate open: ", prevState.open, this.state.open)
+        console.info("componentDidUpdate sheetHeight: ", prevState.sheetHeight, this.state.sheetHeight)
+        this.setTransitionTimer();
+
+      } else {
+        console.info('componentDidUpdate NOT open', prevState.open, this.state.open);
+        console.info('componentDidUpdate sheetHeight', prevState.sheetHeight, this.state.sheetHeight);
+        if (prevState.sheetHeight === this.state.sheetHeight){
+          this.setState({
+            sheetHeight: ReactDOM.findDOMNode(this.refs.sheet).clientHeight
+          })
+        } else {
+           this.setAnimationTimer()
+        }
+      }
+    }
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.timerTransitionId);
+    clearTimeout(this.timerAnimationId);
+    clearTimeout(this.timerOneAtTheTimeId);
+  }
+
+  componentClickAway = () => {
+    if (this.timerTransitionId) {
+      // If transitioning, don't close the bottom sheet.
+      return;
+    }
+
+    if (this.props.open !== null && this.props.onRequestClose) {
+      this.props.onRequestClose('clickaway');
+    } else {
+      this.setState({
+        open: false
+      });
+    }
+  };
+
+
+  // Timer that controls delay before click-away events are captured (based on when animation completes)
+  setTransitionTimer() {
+    // console.warn('setTransitionTimer')
+    this.timerTransitionId = setTimeout(() => {
+      console.warn('setTransitionTimer setTimeout')
+      this.timerTransitionId = undefined;
+    }, 400);
+  }
+
+  // Timer that controls delay to let the sheet animate down, before setting `sheetHeight` back to `auto`
+  setAnimationTimer() {
+    console.warn('setAnimationTimer')
+    this.timerAnimationId = setTimeout(() => {
+      console.warn('setAnimationTimer setTimeout')
+      this.timerAnimationId = undefined;
+      this.setState({
+        sheetHeight: 'auto'
+      })
+    }, 500);
+  }
+
+  render() {
+    const {
+      action,
+      children,
+      contentStyle,
+      bodyStyle,
+      onRequestClose, // eslint-disable-line no-unused-vars
+      onActionTouchTap,
+      style,
+      ...other,
+    } = this.props;
+
+    const {
+      open,
+    } = this.state;
+
+    const styles = getStyles(this.props, this.context, this.state);
+
+    const actionButton = action && (
+      <FloatingActionButton
+        zDepth={2}
+        style={styles.action}
+        onTouchTap={onActionTouchTap}
+        disableTouchRipple={true}
+      >
+        <FontIcon className="material-icons">{action}</FontIcon>
+      </FloatingActionButton>
+    );
+
+
+    return (
+      <ClickAwayListener onClickAway={open ? this.componentClickAway : null}>
+        <Paper {...other} ref="sheet" rounded={false} style={Object.assign(styles.root, style)}>
+          {actionButton}
+          <BottomSheetBody
+            action={action}
+            contentStyle={contentStyle}
+            open={open}
+            style={bodyStyle}
+          >
+            {children}
+          </BottomSheetBody>
+        </Paper>
+      </ClickAwayListener>
+    );
+  }
+}
+
+export default BottomSheet;

--- a/src/BottomSheet/BottomSheet.js
+++ b/src/BottomSheet/BottomSheet.js
@@ -94,6 +94,10 @@ class BottomSheet extends Component {
      */
     persistent: PropTypes.bool,
     /**
+     * Controls whether the `BottomSheet` is inset
+     */
+    inset: PropTypes.bool,
+    /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
@@ -177,6 +181,7 @@ class BottomSheet extends Component {
       children,
       modal,
       persistent,
+      inset,
       contentStyle,
       bodyStyle,
       onRequestClose, // eslint-disable-line no-unused-vars
@@ -200,6 +205,7 @@ class BottomSheet extends Component {
             open={open}
             modal={modal}
             persistent={persistent}
+            inset={inset}
             onActionTouchTap={onActionTouchTap}
             style={bodyStyle}
           >

--- a/src/BottomSheet/BottomSheet.js
+++ b/src/BottomSheet/BottomSheet.js
@@ -4,9 +4,6 @@ import transitions from '../styles/transitions';
 import ClickAwayListener from '../internal/ClickAwayListener';
 import BottomSheetBody from './BottomSheetBody';
 import Paper from '../Paper';
-import FontIcon from 'material-ui/FontIcon';
-import FloatingActionButton from 'material-ui/FloatingActionButton';
-
 
 function getStyles(props, context, state) {
   const {
@@ -16,14 +13,12 @@ function getStyles(props, context, state) {
           desktopSubheaderHeight,
         },
       },
-      bottomSheet: {
-        actionColor,
-      },
       zIndex,
     },
   } = context;
 
   const {open} = state;
+  const {action} = props;
 
   const styles = {
     root: {
@@ -39,17 +34,7 @@ function getStyles(props, context, state) {
         `translate(-50%, ${desktopSubheaderHeight*6}px)`,
       transition: `${transitions.easeOut('400ms', 'transform')}, ${
         transitions.easeOut('400ms', 'visibility')}`,
-    },
-    action: {
-      position: 'absolute',
-      color: actionColor,
-      right: 16,
-      top: -29,
-      transform: open ?
-        'scale(1)' :
-        `scale(0)`,
-      transition: `${transitions.easeOut('500ms', 'transform')}`,
-      transitionDelay: '200ms',
+      transitionDelay: !open && action ? '200ms' : '0ms',
     },
   };
 
@@ -196,26 +181,14 @@ class BottomSheet extends Component {
 
     const styles = getStyles(this.props, this.context, this.state);
 
-    const actionButton = action && (
-      <FloatingActionButton
-        zDepth={2}
-        style={styles.action}
-        onTouchTap={onActionTouchTap}
-        disableTouchRipple={true}
-      >
-        <FontIcon className="material-icons">{action}</FontIcon>
-      </FloatingActionButton>
-    );
-
-
     return (
       <ClickAwayListener onClickAway={open ? this.componentClickAway : null}>
         <Paper {...other} ref="sheet" rounded={false} style={Object.assign(styles.root, style)}>
-          {actionButton}
           <BottomSheetBody
             action={action}
             contentStyle={contentStyle}
             open={open}
+            onActionTouchTap={onActionTouchTap}
             style={bodyStyle}
           >
             {children}

--- a/src/BottomSheet/BottomSheet.js
+++ b/src/BottomSheet/BottomSheet.js
@@ -192,7 +192,7 @@ class BottomSheet extends Component {
     const styles = getStyles(this.props, this.context, this.state);
 
     return (
-      <ClickAwayListener onClickAway={open ? this.componentClickAway : null}>
+      <ClickAwayListener onClickAway={open && modal ? this.componentClickAway : null}>
         <Paper {...other} ref="sheet" rounded={false} style={Object.assign(styles.root, style)}>
           <BottomSheetBody
             action={action}

--- a/src/BottomSheet/BottomSheet.js
+++ b/src/BottomSheet/BottomSheet.js
@@ -86,6 +86,14 @@ class BottomSheet extends Component {
      */
     open: PropTypes.bool.isRequired,
     /**
+     * Controls whether the `BottomSheet` is modular
+     */
+    modal: PropTypes.bool,
+    /**
+     * Controls whether the `BottomSheet` is persistent
+     */
+    persistent: PropTypes.bool,
+    /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
@@ -167,6 +175,8 @@ class BottomSheet extends Component {
     const {
       action,
       children,
+      modal,
+      persistent,
       contentStyle,
       bodyStyle,
       onRequestClose, // eslint-disable-line no-unused-vars
@@ -188,6 +198,8 @@ class BottomSheet extends Component {
             action={action}
             contentStyle={contentStyle}
             open={open}
+            modal={modal}
+            persistent={persistent}
             onActionTouchTap={onActionTouchTap}
             style={bodyStyle}
           >

--- a/src/BottomSheet/BottomSheet.js
+++ b/src/BottomSheet/BottomSheet.js
@@ -32,11 +32,11 @@ function getStyles(props, context, state) {
       display: 'flex',
       bottom: 0,
       zIndex: zIndex.bottomSheet,
-      height: state.sheetHeight,
+      maxHeight: '100%',
       visibility: open ? 'visible' : 'hidden',
       transform: open ?
         'translate(-50%, 0)' :
-        `translate(-50%, ${state.sheetHeight}px)`,
+        `translate(-50%, ${desktopSubheaderHeight*6}px)`,
       transition: `${transitions.easeOut('400ms', 'transform')}, ${
         transitions.easeOut('400ms', 'visibility')}`,
     },
@@ -48,8 +48,7 @@ function getStyles(props, context, state) {
       transform: open ?
         'scale(1)' :
         `scale(0)`,
-      transition: `${transitions.easeOut('500ms', 'transform')}, ${
-        transitions.easeOut('500ms', 'visibility')}`,
+      transition: `${transitions.easeOut('500ms', 'transform')}`,
       transitionDelay: '200ms',
     },
   };
@@ -113,8 +112,7 @@ class BottomSheet extends Component {
 
   componentWillMount() {
     this.setState({
-      open: this.props.open,
-      sheetHeight: 'auto'
+      open: this.props.open
     });
   }
 
@@ -126,26 +124,20 @@ class BottomSheet extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.props.open && nextProps.open) {
-      console.log("open prop changed")
       this.setState({
         open: false,
       });
       clearTimeout(this.timerOneAtTheTimeId);
       this.timerOneAtTheTimeId = setTimeout(() => {
-        console.warn('timerOneAtTheTimeId')
         this.setState({
           open: true,
         });
       }, 400);
     } else {
       const open = nextProps.open;
-
       if (open !== this.props.open){
-        console.log('open', open)
-        console.log('sheetHeight', ReactDOM.findDOMNode(this.refs.sheet).clientHeight)
         this.setState({
           open: open !== null ? open : this.state.open,
-          sheetHeight: open ? ReactDOM.findDOMNode(this.refs.sheet).clientHeight : 0,
         });
       }
     }
@@ -154,27 +146,13 @@ class BottomSheet extends Component {
   componentDidUpdate(prevProps, prevState) {
     if (prevState.open !== this.state.open) {
       if (this.state.open) {
-        console.info("componentDidUpdate open: ", prevState.open, this.state.open)
-        console.info("componentDidUpdate sheetHeight: ", prevState.sheetHeight, this.state.sheetHeight)
         this.setTransitionTimer();
-
-      } else {
-        console.info('componentDidUpdate NOT open', prevState.open, this.state.open);
-        console.info('componentDidUpdate sheetHeight', prevState.sheetHeight, this.state.sheetHeight);
-        if (prevState.sheetHeight === this.state.sheetHeight){
-          this.setState({
-            sheetHeight: ReactDOM.findDOMNode(this.refs.sheet).clientHeight
-          })
-        } else {
-           this.setAnimationTimer()
-        }
       }
     }
   }
 
   componentWillUnmount() {
     clearTimeout(this.timerTransitionId);
-    clearTimeout(this.timerAnimationId);
     clearTimeout(this.timerOneAtTheTimeId);
   }
 
@@ -193,26 +171,11 @@ class BottomSheet extends Component {
     }
   };
 
-
   // Timer that controls delay before click-away events are captured (based on when animation completes)
   setTransitionTimer() {
-    // console.warn('setTransitionTimer')
     this.timerTransitionId = setTimeout(() => {
-      console.warn('setTransitionTimer setTimeout')
       this.timerTransitionId = undefined;
     }, 400);
-  }
-
-  // Timer that controls delay to let the sheet animate down, before setting `sheetHeight` back to `auto`
-  setAnimationTimer() {
-    console.warn('setAnimationTimer')
-    this.timerAnimationId = setTimeout(() => {
-      console.warn('setAnimationTimer setTimeout')
-      this.timerAnimationId = undefined;
-      this.setState({
-        sheetHeight: 'auto'
-      })
-    }, 500);
   }
 
   render() {

--- a/src/BottomSheet/BottomSheet.spec.js
+++ b/src/BottomSheet/BottomSheet.spec.js
@@ -17,51 +17,11 @@ describe('<BottomSheet />', () => {
       );
 
       assert.strictEqual(
-        wrapper.find('div').at(0).node.props.style.visibility,
+        wrapper.find('Paper').at(0).node.props.style.visibility,
         'hidden',
         'The element should be hidden.'
       );
     });
-  });
-
-  it('should show the next action after an update', (done) => {
-    const wrapper = shallowWithContext(
-      <BottomSheet open={true} action="favorite"  />
-    );
-
-    wrapper.setProps({
-      action: 'done',
-    });
-    assert.strictEqual(wrapper.state('action'), 'favorite');
-
-    setTimeout(() => {
-      assert.strictEqual(wrapper.state('action'), 'done',
-        'Should take into account the next action');
-      done();
-    }, 500);
-  });
-
-  it('should show the latest action of consecutive updates', (done) => {
-    const wrapper = shallowWithContext(
-      <BottomSheet open={false} action="favorite" />
-    );
-
-    wrapper.setProps({
-      open: true,
-      action: 'done',
-    });
-    assert.strictEqual(wrapper.state('action'), 'done');
-    wrapper.setProps({
-      open: true,
-      action: 'star',
-    });
-    assert.strictEqual(wrapper.state('action'), 'done');
-
-    setTimeout(() => {
-      assert.strictEqual(wrapper.state('action'), 'star',
-        'Should take into account the latest action');
-      done();
-    }, 500);
   });
 
   describe('prop: contentStyle', () => {

--- a/src/BottomSheet/BottomSheet.spec.js
+++ b/src/BottomSheet/BottomSheet.spec.js
@@ -13,7 +13,7 @@ describe('<BottomSheet />', () => {
   describe('prop: open', () => {
     it('should be hidden when open is false', () => {
       const wrapper = shallowWithContext(
-        <BottomSheet open={false} message="Message" />
+        <BottomSheet open={false} action="done" />
       );
 
       assert.strictEqual(
@@ -22,56 +22,44 @@ describe('<BottomSheet />', () => {
         'The element should be hidden.'
       );
     });
-
-    it('should be hidden when open is true', () => {
-      const wrapper = shallowWithContext(
-        <BottomSheet open={true} message="Message" />
-      );
-
-      assert.strictEqual(
-        wrapper.find('div').at(0).node.props.style.visibility,
-        'visible',
-        'The element should be hidden.'
-      );
-    });
   });
 
-  it('should show the next message after an update', (done) => {
+  it('should show the next action after an update', (done) => {
     const wrapper = shallowWithContext(
-      <BottomSheet open={true} message="First message" />
+      <BottomSheet open={true} action="favorite"  />
     );
 
     wrapper.setProps({
-      message: 'Second message',
+      action: 'done',
     });
-    assert.strictEqual(wrapper.state('message'), 'First message');
+    assert.strictEqual(wrapper.state('action'), 'favorite');
 
     setTimeout(() => {
-      assert.strictEqual(wrapper.state('message'), 'Second message',
-        'Should take into account the next message');
+      assert.strictEqual(wrapper.state('action'), 'done',
+        'Should take into account the next action');
       done();
     }, 500);
   });
 
-  it('should show the latest message of consecutive updates', (done) => {
+  it('should show the latest action of consecutive updates', (done) => {
     const wrapper = shallowWithContext(
-      <BottomSheet open={false} message="First message" />
+      <BottomSheet open={false} action="favorite" />
     );
 
     wrapper.setProps({
       open: true,
-      message: 'Second message',
+      action: 'done',
     });
-    assert.strictEqual(wrapper.state('message'), 'Second message');
+    assert.strictEqual(wrapper.state('action'), 'done');
     wrapper.setProps({
       open: true,
-      message: 'Third message',
+      action: 'star',
     });
-    assert.strictEqual(wrapper.state('message'), 'Second message');
+    assert.strictEqual(wrapper.state('action'), 'done');
 
     setTimeout(() => {
-      assert.strictEqual(wrapper.state('message'), 'Third message',
-        'Should take into account the latest message');
+      assert.strictEqual(wrapper.state('action'), 'star',
+        'Should take into account the latest action');
       done();
     }, 500);
   });
@@ -80,7 +68,7 @@ describe('<BottomSheet />', () => {
     it('should apply the style on the right element', () => {
       const contentStyle = {};
       const wrapper = shallowWithContext(
-        <BottomSheet open={false} message="" contentStyle={contentStyle} />
+        <BottomSheet open={false} action="" contentStyle={contentStyle} />
       );
 
       assert.strictEqual(

--- a/src/BottomSheet/BottomSheet.spec.js
+++ b/src/BottomSheet/BottomSheet.spec.js
@@ -1,0 +1,92 @@
+/* eslint-env mocha */
+import React from 'react';
+import {shallow} from 'enzyme';
+import {assert} from 'chai';
+import BottomSheet from './BottomSheet';
+import BottomSheetBody from './BottomSheetBody';
+import getMuiTheme from '../styles/getMuiTheme';
+
+describe('<BottomSheet />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
+  describe('prop: open', () => {
+    it('should be hidden when open is false', () => {
+      const wrapper = shallowWithContext(
+        <BottomSheet open={false} message="Message" />
+      );
+
+      assert.strictEqual(
+        wrapper.find('div').at(0).node.props.style.visibility,
+        'hidden',
+        'The element should be hidden.'
+      );
+    });
+
+    it('should be hidden when open is true', () => {
+      const wrapper = shallowWithContext(
+        <BottomSheet open={true} message="Message" />
+      );
+
+      assert.strictEqual(
+        wrapper.find('div').at(0).node.props.style.visibility,
+        'visible',
+        'The element should be hidden.'
+      );
+    });
+  });
+
+  it('should show the next message after an update', (done) => {
+    const wrapper = shallowWithContext(
+      <BottomSheet open={true} message="First message" />
+    );
+
+    wrapper.setProps({
+      message: 'Second message',
+    });
+    assert.strictEqual(wrapper.state('message'), 'First message');
+
+    setTimeout(() => {
+      assert.strictEqual(wrapper.state('message'), 'Second message',
+        'Should take into account the next message');
+      done();
+    }, 500);
+  });
+
+  it('should show the latest message of consecutive updates', (done) => {
+    const wrapper = shallowWithContext(
+      <BottomSheet open={false} message="First message" />
+    );
+
+    wrapper.setProps({
+      open: true,
+      message: 'Second message',
+    });
+    assert.strictEqual(wrapper.state('message'), 'Second message');
+    wrapper.setProps({
+      open: true,
+      message: 'Third message',
+    });
+    assert.strictEqual(wrapper.state('message'), 'Second message');
+
+    setTimeout(() => {
+      assert.strictEqual(wrapper.state('message'), 'Third message',
+        'Should take into account the latest message');
+      done();
+    }, 500);
+  });
+
+  describe('prop: contentStyle', () => {
+    it('should apply the style on the right element', () => {
+      const contentStyle = {};
+      const wrapper = shallowWithContext(
+        <BottomSheet open={false} message="" contentStyle={contentStyle} />
+      );
+
+      assert.strictEqual(
+        wrapper.find(BottomSheetBody).props().contentStyle,
+        contentStyle
+      );
+    });
+  });
+});

--- a/src/BottomSheet/BottomSheetBody.js
+++ b/src/BottomSheet/BottomSheetBody.js
@@ -7,6 +7,8 @@ import FloatingActionButton from 'material-ui/FloatingActionButton';
 function getStyles(props, context) {
   const {
     open,
+    modal,
+    persistent,
     action,
     width,
   } = props;
@@ -36,20 +38,22 @@ function getStyles(props, context) {
     root: {
       fontFamily: fontFamily,
       backgroundColor: backgroundColor,
-      maxWidth: isSmall ? 'inherit' : 568,
-      minWidth: isSmall ? 'inherit' : 288,
-      width: isSmall ? `calc(100vw - ${desktopGutter * 2}px)` : 'auto',
-      flexGrow: isSmall ? 1 : 0,
+      maxWidth: isSmall && modal ? 'inherit' : '100%',
+      minWidth: isSmall && modal ? 'inherit' : 288,
+      width: isSmall && modal ? `100vw` : modal ? 'auto' : '100vw',
+      flexGrow: isSmall && modal ? 1 : 0,
     },
     content: {
       fontSize: 14,
       color: textColor,
       paddingTop: action ? 16 : 0,
+      paddingRight: isSmall && modal ? 16 : persistent ? 24 : 0,
+      paddingLeft: isSmall && modal ? 16 : persistent ? 24 : 0,
     },
     action: {
       position: 'absolute',
       color: actionColor,
-      right: 16,
+      right: 24,
       top: -29,
       transform: open ?
         'scale(1)' :
@@ -67,6 +71,8 @@ export const BottomSheetBody = (props, context) => {
   const {
     action,
     children,
+    modal,
+    persistent,
     contentStyle,
     open, // eslint-disable-line no-unused-vars
     onActionTouchTap,
@@ -121,6 +127,14 @@ BottomSheetBody.propTypes = {
    * Controls whether the `BottomSheet` is opened or not.
    */
   open: PropTypes.bool.isRequired,
+  /**
+   * Controls whether the `BottomSheet` is modular
+   */
+  modal: PropTypes.bool,
+  /**
+   * Controls whether the `BottomSheet` is persistent
+   */
+  persistent: PropTypes.bool,
   /**
    * Override the inline-styles of the root element.
    */

--- a/src/BottomSheet/BottomSheetBody.js
+++ b/src/BottomSheet/BottomSheetBody.js
@@ -9,6 +9,7 @@ function getStyles(props, context) {
     open,
     modal,
     persistent,
+    inset,
     action,
     width,
   } = props;
@@ -38,7 +39,7 @@ function getStyles(props, context) {
     root: {
       fontFamily: fontFamily,
       backgroundColor: backgroundColor,
-      maxWidth: isSmall && modal ? 'inherit' : '100%',
+      maxWidth: isSmall && modal ? 'inherit' : inset ? 960 : '100%',
       minWidth: isSmall && modal ? 'inherit' : 288,
       width: isSmall && modal ? `100vw` : modal ? 'auto' : '100vw',
       flexGrow: isSmall && modal ? 1 : 0,
@@ -77,6 +78,7 @@ export const BottomSheetBody = (props, context) => {
     children,
     modal,
     persistent,
+    inset,
     contentStyle,
     open, // eslint-disable-line no-unused-vars
     onActionTouchTap,
@@ -139,6 +141,10 @@ BottomSheetBody.propTypes = {
    * Controls whether the `BottomSheet` is persistent
    */
   persistent: PropTypes.bool,
+  /**
+   * Controls whether the `BottomSheet` is inset
+   */
+  inset: PropTypes.bool,
   /**
    * Override the inline-styles of the root element.
    */

--- a/src/BottomSheet/BottomSheetBody.js
+++ b/src/BottomSheet/BottomSheetBody.js
@@ -46,14 +46,18 @@ function getStyles(props, context) {
     content: {
       fontSize: 14,
       color: textColor,
-      paddingTop: action ? 16 : 0,
+      paddingTop: 0,
       paddingRight: isSmall && modal ? 16 : persistent ? 24 : 0,
       paddingLeft: isSmall && modal ? 16 : persistent ? 24 : 0,
+      opacity: open ? 1 : 0,
+      transition: open ?
+        transitions.easeOut('500ms', 'opacity', '100ms') :
+        transitions.easeOut('400ms', 'opacity'),
     },
     action: {
       position: 'absolute',
       color: actionColor,
-      right: 24,
+      right: 32,
       top: -29,
       transform: open ?
         'scale(1)' :

--- a/src/BottomSheet/BottomSheetBody.js
+++ b/src/BottomSheet/BottomSheetBody.js
@@ -1,8 +1,8 @@
 import React, {PropTypes} from 'react';
 import transitions from '../styles/transitions';
 import withWidth, {SMALL} from '../utils/withWidth';
-import FontIcon from 'material-ui/FontIcon';
-import FloatingActionButton from 'material-ui/FloatingActionButton';
+import FontIcon from '../FontIcon';
+import FloatingActionButton from '../FloatingActionButton';
 
 function getStyles(props, context) {
   const {

--- a/src/BottomSheet/BottomSheetBody.js
+++ b/src/BottomSheet/BottomSheetBody.js
@@ -1,0 +1,108 @@
+import React, {PropTypes} from 'react';
+import transitions from '../styles/transitions';
+import withWidth, {SMALL} from '../utils/withWidth';
+
+function getStyles(props, context) {
+  const {
+    open,
+    action,
+    width,
+  } = props;
+
+  const {
+    muiTheme: {
+      baseTheme: {
+        spacing: {
+          desktopGutter,
+        },
+        fontFamily,
+      },
+      bottomSheet: {
+        backgroundColor,
+        textColor,
+      },
+      floatingActionButton: {
+        buttonSize
+      }
+    },
+  } = context;
+
+  const isSmall = width === SMALL;
+
+  const styles = {
+    root: {
+      fontFamily: fontFamily,
+      backgroundColor: backgroundColor,
+      maxWidth: isSmall ? 'inherit' : 568,
+      minWidth: isSmall ? 'inherit' : 288,
+      width: isSmall ? `calc(100vw - ${desktopGutter * 2}px)` : 'auto',
+      flexGrow: isSmall ? 1 : 0,
+    },
+    content: {
+      fontSize: 14,
+      color: textColor,
+      paddingTop: action ? 16 : 0,
+    },
+
+  };
+
+  return styles;
+}
+
+export const BottomSheetBody = (props, context) => {
+  const {
+    children,
+    contentStyle,
+    open, // eslint-disable-line no-unused-vars
+    style,
+    ...other,
+  } = props;
+
+  const {prepareStyles} = context.muiTheme;
+  const styles = getStyles(props, context);
+
+
+
+  return (
+    <div {...other} style={prepareStyles(Object.assign(styles.root, style))}>
+
+      <div style={prepareStyles(Object.assign(styles.content, contentStyle))}>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+BottomSheetBody.propTypes = {
+   /**
+   * The contents of the `BottomSheet`
+   */
+  children: PropTypes.node,
+  /**
+   * The name for the floating action button on the bottom sheet. Can be any Material Design Icon: https://design.google.com/icons/ . Note: substitute spaces with `_`
+   */
+  action: PropTypes.string,
+  /**
+   * Override the inline-styles of the content element.
+   */
+  contentStyle: PropTypes.object,
+  /**
+   * Controls whether the `BottomSheet` is opened or not.
+   */
+  open: PropTypes.bool.isRequired,
+  /**
+   * Override the inline-styles of the root element.
+   */
+  style: PropTypes.object,
+  /**
+   * @ignore
+   * Width of the screen.
+   */
+  width: PropTypes.number.isRequired,
+};
+
+BottomSheetBody.contextTypes = {
+  muiTheme: PropTypes.object.isRequired,
+};
+
+export default withWidth()(BottomSheetBody);

--- a/src/BottomSheet/BottomSheetBody.js
+++ b/src/BottomSheet/BottomSheetBody.js
@@ -1,6 +1,8 @@
 import React, {PropTypes} from 'react';
 import transitions from '../styles/transitions';
 import withWidth, {SMALL} from '../utils/withWidth';
+import FontIcon from 'material-ui/FontIcon';
+import FloatingActionButton from 'material-ui/FloatingActionButton';
 
 function getStyles(props, context) {
   const {
@@ -18,6 +20,7 @@ function getStyles(props, context) {
         fontFamily,
       },
       bottomSheet: {
+        actionColor,
         backgroundColor,
         textColor,
       },
@@ -43,6 +46,17 @@ function getStyles(props, context) {
       color: textColor,
       paddingTop: action ? 16 : 0,
     },
+    action: {
+      position: 'absolute',
+      color: actionColor,
+      right: 16,
+      top: -29,
+      transform: open ?
+        'scale(1)' :
+        `scale(0)`,
+      transition: `${transitions.easeOut('500ms', 'transform')}`,
+      transitionDelay: open ? '200ms' : '0ms',
+    },
 
   };
 
@@ -51,9 +65,11 @@ function getStyles(props, context) {
 
 export const BottomSheetBody = (props, context) => {
   const {
+    action,
     children,
     contentStyle,
     open, // eslint-disable-line no-unused-vars
+    onActionTouchTap,
     style,
     ...other,
   } = props;
@@ -61,11 +77,20 @@ export const BottomSheetBody = (props, context) => {
   const {prepareStyles} = context.muiTheme;
   const styles = getStyles(props, context);
 
-
+  const actionButton = action && (
+      <FloatingActionButton
+        zDepth={2}
+        style={styles.action}
+        onTouchTap={onActionTouchTap}
+        disableTouchRipple={true}
+      >
+        <FontIcon className="material-icons">{action}</FontIcon>
+      </FloatingActionButton>
+    );
 
   return (
     <div {...other} style={prepareStyles(Object.assign(styles.root, style))}>
-
+      {actionButton}
       <div style={prepareStyles(Object.assign(styles.content, contentStyle))}>
         {children}
       </div>
@@ -86,6 +111,12 @@ BottomSheetBody.propTypes = {
    * Override the inline-styles of the content element.
    */
   contentStyle: PropTypes.object,
+  /**
+   * Fired when the action button is touchtapped.
+   *
+   * @param {object} event Action button event.
+   */
+  onActionTouchTap: PropTypes.func,
   /**
    * Controls whether the `BottomSheet` is opened or not.
    */

--- a/src/BottomSheet/BottomSheetBody.spec.js
+++ b/src/BottomSheet/BottomSheetBody.spec.js
@@ -13,7 +13,7 @@ describe('<BottomSheetBody />', () => {
   describe('props: open', () => {
     it('should be hidden when open is false', () => {
       const wrapper = shallowWithContext(
-        <BottomSheetBody open={false} message="Message" width={SMALL} />
+        <BottomSheetBody open={false} action="done" width={SMALL} />
       );
 
       assert.strictEqual(
@@ -25,7 +25,7 @@ describe('<BottomSheetBody />', () => {
 
     it('should be visible when open is true', () => {
       const wrapper = shallowWithContext(
-        <BottomSheetBody open={true} message="Message" width={SMALL} />
+        <BottomSheetBody open={true} action="done" width={SMALL} />
       );
 
       assert.strictEqual(

--- a/src/BottomSheet/BottomSheetBody.spec.js
+++ b/src/BottomSheet/BottomSheetBody.spec.js
@@ -1,0 +1,38 @@
+/* eslint-env mocha */
+import React from 'react';
+import {shallow} from 'enzyme';
+import {assert} from 'chai';
+import {BottomSheetBody} from './BottomSheetBody';
+import getMuiTheme from '../styles/getMuiTheme';
+import {SMALL} from '../utils/withWidth';
+
+describe('<BottomSheetBody />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
+  describe('props: open', () => {
+    it('should be hidden when open is false', () => {
+      const wrapper = shallowWithContext(
+        <BottomSheetBody open={false} message="Message" width={SMALL} />
+      );
+
+      assert.strictEqual(
+        wrapper.find('div').at(1).node.props.style.opacity,
+        0,
+        'The element should be hidden.'
+      );
+    });
+
+    it('should be visible when open is true', () => {
+      const wrapper = shallowWithContext(
+        <BottomSheetBody open={true} message="Message" width={SMALL} />
+      );
+
+      assert.strictEqual(
+        wrapper.find('div').at(1).node.props.style.opacity,
+        1,
+        'The element should be visible.'
+      );
+    });
+  });
+});

--- a/src/BottomSheet/index.js
+++ b/src/BottomSheet/index.js
@@ -1,0 +1,4 @@
+export BottomSheet from './BottomSheet';
+export BottomSheetBody from './BottomSheetBody';
+
+export default from './BottomSheet';

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ export Avatar from './Avatar';
 export Badge from './Badge';
 export BottomNavigation from './BottomNavigation';
 export BottomNavigationItem from './BottomNavigation/BottomNavigationItem';
+export BottomSheet from './BottomSheet';
+export BottomSheetBody from './BottomSheet/BottomSheetBody';
 export Card from './Card';
 export CardActions from './Card/CardActions';
 export CardHeader from './Card/CardHeader';

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -57,6 +57,10 @@ export default function getMuiTheme(muiTheme, ...more) {
       unselectedFontSize: 12,
       selectedFontSize: 14,
     },
+    bottomSheet: {
+      backgroundColor: palette.canvasColor,
+      actionColor: palette.accent1Color,
+    },
     button: {
       height: 36,
       minWidth: 88,

--- a/src/styles/zIndex.js
+++ b/src/styles/zIndex.js
@@ -1,9 +1,9 @@
 export default {
-  bottomSheet: 900,
   menu: 1000,
   appBar: 1100,
   drawerOverlay: 1200,
   drawer: 1300,
+  bottomSheet: 1250,
   dialogOverlay: 1400,
   dialog: 1500,
   layer: 2000,

--- a/src/styles/zIndex.js
+++ b/src/styles/zIndex.js
@@ -1,4 +1,5 @@
 export default {
+  bottomSheet: 900,
   menu: 1000,
   appBar: 1100,
   drawerOverlay: 1200,


### PR DESCRIPTION
I've made a `BottomSheet` component, it was based of `Snackbar`. 

It has `modal`, `persistent`, and `inset` props, to accomodate for most of the MD-specs. And an option to add a `FloatingActionButton` as prop `action` (string), which will render 1 FAB on the sheet with the string of the `action` as the icon.

Note: 
The tests pass, but I get an error: 

> Warning: Exception thrown by hook while handling onSetChildren: Invariant Violation: Expected onBeforeMountComponent() parent and onSetChildren() to be consistent (15 has parents 0 and 13).

I'm not sure how to fix that, as I'm not very experienced with working with Mocha or Karma.

I've asked in gitter if someone was working on it, but no reply yet, so see what you do with this.
- [x] PR has tests / docs demo, and is linted.

Fix #2126.