### PR TITLE
[ListItemText] Prevent rendering plain object

### DIFF
--- a/src/List/ListItemText.js
+++ b/src/List/ListItemText.js
@@ -35,12 +35,12 @@ export default function ListItemText(props, context) {
       {primary && (
         typeof primary === 'string' ? (
           <Text type="subheading">{primary}</Text>
-        ) : { primary }
+        ) : primary
       )}
       {secondary && (
         typeof secondary === 'string' ? (
           <Text className={classes.secondary} type="body1">{secondary}</Text>
-        ) : { secondary }
+        ) : secondary
       )}
     </div>
   );


### PR DESCRIPTION
Passing jsx tags as `primary` or `secondary` props to `ListItemText` causes React to throw invariant violation error: `Uncaught Invariant Violation: Objects are not valid as a React child…`. According to `PropTypes` they can be of any renderable type, but inside the component there is a faulty wrapping in the plain object in case they are not strings