### PR TITLE
[TableFooter] Render the children independently of adjustForCheckbox

### DIFF
--- a/src/Table/TableFooter.js
+++ b/src/Table/TableFooter.js
@@ -73,11 +73,14 @@ class TableFooter extends Component {
       };
 
       let newDescendants;
+
       if (adjustForCheckbox) {
         newDescendants = [
           <TableRowColumn key={`fpcb${rowNumber}`} style={{width: 24}} />,
           ...React.Children.toArray(child.props.children),
         ];
+      } else {
+        newDescendants = child.props.children;
       }
 
       return React.cloneElement(child, newChildProps, newDescendants);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


I'm glad the Table component was rewrote on the `next` branch.
The `master` version has quite some API limitations :see_no_evil:.
> It's an opinionated shitshow

As would say @nathanmarks :joy:.

Nevertheless, this fix is quite simple.
Thanks @Serfenia and @florian-steffen for the original PRs.

Closes #4296.
Closes #4581.
Closes #4582.