### PR TITLE
[Stepper] Fix children count method

### DIFF
--- a/src/Stepper/Stepper.js
+++ b/src/Stepper/Stepper.js
@@ -24,7 +24,7 @@ class Stepper extends Component {
     /**
      * Should be two or more `<Step />` components
      */
-    children: PropTypes.arrayOf(PropTypes.element),
+    children: PropTypes.arrayOf(PropTypes.node),
     /**
      * If set to `true`, the `Stepper` will assist in controlling steps for linear flow
      */
@@ -70,6 +70,7 @@ class Stepper extends Component {
      * and nth child selectors, etc
      * That's what some of this garbage is for :)
      */
+    const numChildren = React.Children.toArray(children).length;
     const steps = React.Children.map(children, (step, index) => {
       const controlProps = {index};
 
@@ -81,7 +82,7 @@ class Stepper extends Component {
         controlProps.disabled = true;
       }
 
-      if (index + 1 === children.length) {
+      if (index + 1 === numChildren) {
         controlProps.last = true;
       }
 

--- a/src/Stepper/Stepper.spec.js
+++ b/src/Stepper/Stepper.spec.js
@@ -88,5 +88,20 @@ describe('<Stepper />', () => {
       assert.notOk(wrapper.find('.child-1').prop('active'));
       assert.ok(wrapper.find('.child-2').prop('active'));
     });
+
+    it('passes last down correctly when rendering children containing arrays', () => {
+      const wrapper = shallowWithContext(
+        <Stepper linear={false}>
+          <div className="child-0" />
+          {[
+            <div key={1} className="child-1" />,
+            <div key={2} className="child-2" />,
+          ]}
+        </Stepper>
+      );
+      assert.notOk(wrapper.find('.child-0').prop('last'));
+      assert.notOk(wrapper.find('.child-1').prop('last'));
+      assert.ok(wrapper.find('.child-2').prop('last'));
+    });
   });
 });


### PR DESCRIPTION
Hi guys,

this issue occurs when children are passed down as an array, example in unit tests, which results in   the left border of the StepperContent being incorrectly rendered down the line.

let me know if you require any updates,
Cheers