### PR TITLE
[Tabs] Let each tab set its own width

### DIFF
--- a/docs/src/app/components/pages/components/Tabs/ExampleLabelWidth.js
+++ b/docs/src/app/components/pages/components/Tabs/ExampleLabelWidth.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import {Tabs, Tab} from 'material-ui/Tabs';
+
+const TabsExampleLabelWidth = () => (
+  <Tabs >
+    <Tab labelWidth={100} label="100 width" />
+    <Tab labelWidth={250} label="250 width" />
+    <Tab labelWidth={400} label="400 width" />
+  </Tabs>
+);
+
+export default TabsExampleLabelWidth;

--- a/docs/src/app/components/pages/components/Tabs/Page.js
+++ b/docs/src/app/components/pages/components/Tabs/Page.js
@@ -16,6 +16,8 @@ import tabsExampleIconCode from '!raw!./ExampleIcon';
 import TabsExampleIcon from './ExampleIcon';
 import tabsExampleIconTextCode from '!raw!./ExampleIconText';
 import TabsExampleIconText from './ExampleIconText';
+import tabsExampleLabelWidthCode from '!raw!./ExampleLabelWidth';
+import TabsExampleLabelWidth from './ExampleLabelWidth';
 import tabsCode from '!raw!material-ui/Tabs/Tabs';
 import tabCode from '!raw!material-ui/Tabs/Tab';
 
@@ -28,6 +30,8 @@ const descriptions = {
   'and allowing tabs to be swiped on touch devices.',
   icon: 'An example of tabs with icon.',
   iconText: 'An example of tabs with icon and text.',
+  labelWidth: 'An example using the `labelWidth` property. Each tab label specifies its own fixed width regardless ' +
+  'of the container\'s width and is aligned to the left. This prop must be set on every tab to work properly.',
 };
 
 const TabsPage = () => (
@@ -54,6 +58,13 @@ const TabsPage = () => (
       code={tabsExampleSwipeableCode}
     >
       <TabsExampleSwipeable />
+    </CodeExample>
+    <CodeExample
+      title="Fixed label width example"
+      description={descriptions.labelWidth}
+      code={tabsExampleLabelWidthCode}
+    >
+      <TabsExampleLabelWidth />
     </CodeExample>
     <CodeExample
       title="Icon example"

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -44,6 +44,11 @@ class Tab extends Component {
      */
     label: PropTypes.node,
     /**
+     * Specify a fixed width for every tab-label and aligns to the left. If this
+     * prop is not set, each tab-label takes an equal share of the container's width.
+     */
+    labelWidth: PropTypes.number,
+    /**
      * Fired when the active tab changes by touch or tap.
      * Use this event to specify any functionality when an active tab changes.
      * For example - we are using this to route to home when the third tab becomes active.
@@ -95,6 +100,7 @@ class Tab extends Component {
       onTouchTap, // eslint-disable-line no-unused-vars
       selected, // eslint-disable-line no-unused-vars
       label,
+      labelWidth, // eslint-disable-line no-unused-vars
       style,
       value, // eslint-disable-line no-unused-vars
       width, // eslint-disable-line no-unused-vars


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


The Tab component has a new prop of type number: labelWidth. This number
is the width of the label in pixels. The user must either set this prop
to every tab or none. If this condition is not met, the ink bar is not
drawn, and a warning is displayed in the console.

The docs have also been updated with information and an example for this
prop.

This solves issue #4420. This approach was suggested in #5301.