### PR TITLE
[ToolbarGroup] Fix vertical alignment of nested IconButton

### DIFF
--- a/src/Toolbar/ToolbarGroup.js
+++ b/src/Toolbar/ToolbarGroup.js
@@ -22,6 +22,7 @@ function getStyles(props, context) {
       marginRight: lastChild ? -marginHorizontal : undefined,
       display: 'flex',
       justifyContent: 'space-between',
+      alignItems: 'center',
     },
     dropDownMenu: {
       root: {


### PR DESCRIPTION
### Problem description

From your [Toolbar docs](http://www.material-ui.com/#/components/toolbar):

Current behavior:
![image](https://cloud.githubusercontent.com/assets/185923/19570919/31086ace-96b9-11e6-8dc5-fd1ec2fc2bbd.png)

After adding `align-items: center;` to the ToolbarGroup's `<div>` element:
![image](https://cloud.githubusercontent.com/assets/185923/19570904/21ce1c8e-96b9-11e6-81bc-abfe97b12d10.png)

Note the improved vertical alignment of the IconButton.  What do you think?  Do you have a Toolbar "kitchen sink" where I can test broader effects?
