### PR TITLE
[TextField] Fix wrong style behing applied to div elements

### DIFF
--- a/src/TextField/EnhancedTextarea.js
+++ b/src/TextField/EnhancedTextarea.js
@@ -145,9 +145,7 @@ class EnhancedTextarea extends Component {
 
     const {prepareStyles} = this.context.muiTheme;
     const styles = getStyles(this.props, this.context, this.state);
-    const rootStyles = Object.assign(styles.root, style, {
-      appearance: 'none', // Fix leaking property.
-    });
+    const rootStyles = Object.assign(styles.root, style);
     const textareaStyles = Object.assign(styles.textarea, textareaStyle);
     const shadowStyles = Object.assign({}, textareaStyles, styles.shadow, shadowStyle);
 

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -57,8 +57,10 @@ const getStyles = (props, context, state) => {
       color: props.disabled ? disabledTextColor : textColor,
       cursor: props.disabled ? 'not-allowed' : 'initial',
       font: 'inherit',
-      appearance: 'textfield', // Improve type search style.
       WebkitTapHighlightColor: 'rgba(0,0,0,0)', // Remove mobile color flashing (deprecated style).
+    },
+    inputNative: {
+      appearance: 'textfield', // Improve type search style.
     },
   };
 
@@ -428,7 +430,7 @@ class TextField extends Component {
       onFocus: this.handleInputFocus,
     };
 
-    const inputStyleMerged = Object.assign(styles.input, inputStyle);
+    const childStyleMerged = Object.assign(styles.input, inputStyle);
 
     let inputElement;
     if (children) {
@@ -436,25 +438,25 @@ class TextField extends Component {
         {
           ...inputProps,
           ...children.props,
-          style: Object.assign(inputStyleMerged, children.props.style),
+          style: Object.assign(childStyleMerged, children.props.style),
         });
     } else {
       inputElement = multiLine ? (
         <EnhancedTextarea
-          {...other}
-          {...inputProps}
-          style={inputStyleMerged}
+          style={childStyleMerged}
+          textareaStyle={Object.assign(styles.textarea, styles.inputNative, textareaStyle)}
           rows={rows}
           rowsMax={rowsMax}
+          {...other}
+          {...inputProps}
           onHeightChange={this.handleHeightChange}
-          textareaStyle={Object.assign(styles.textarea, textareaStyle)}
         />
       ) : (
         <input
+          type={type}
+          style={prepareStyles(Object.assign(styles.inputNative, childStyleMerged))}
           {...other}
           {...inputProps}
-          style={prepareStyles(inputStyleMerged)}
-          type={type}
         />
       );
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

The `appearance` property should no longer be leaked an applied on a `div` element.
I was also able to remove the `TextField` specific fix I wasn't happy with 😄  (#5412).

Closes #5438.