### PR TITLE
[Toggle] Fix label propTypes from `string` to `node`

### DIFF
--- a/src/Toggle/Toggle.js
+++ b/src/Toggle/Toggle.js
@@ -133,7 +133,7 @@ class Toggle extends Component {
     /**
      * Label for toggle.
      */
-    label: PropTypes.string,
+    label: PropTypes.node,
     /**
      * Where the label will be placed next to the toggle.
      */


### PR DESCRIPTION
Fixes Toggle component's label propTypes to accept React nodes instead of strings.
This closes #5461.