### PR TITLE
[FlatButton, FloatingActionButton, IconButton] Added target html attribute.

### DIFF
--- a/docs/src/app/components/pages/components/FlatButton/ExampleIcon.js
+++ b/docs/src/app/components/pages/components/FlatButton/ExampleIcon.js
@@ -23,6 +23,7 @@ const FlatButtonExampleIcon = () => (
     <FlatButton
       href="https://github.com/callemall/material-ui"
       secondary={true}
+      target="_blank"
       icon={<FontIcon className="muidocs-icon-custom-github" />}
       style={style}
     />

--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -96,12 +96,7 @@ class FlatButton extends Component {
     /**
      * Target attribute applied to the button.
      */
-    target: PropTypes.oneOf([
-      '_blank',
-      '_self',
-      '_parent',
-      '_top',
-    ]),
+    target: PropTypes.string,
   };
 
   static defaultProps = {
@@ -169,7 +164,6 @@ class FlatButton extends Component {
       rippleColor,
       secondary,
       style,
-      target,
       ...other
     } = this.props;
 
@@ -269,7 +263,6 @@ class FlatButton extends Component {
     return (
       <EnhancedButton
         {...other}
-        target={target}
         disabled={disabled}
         focusRippleColor={buttonRippleColor}
         focusRippleOpacity={0.3}

--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -93,6 +93,15 @@ class FlatButton extends Component {
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
+    /**
+     * Target attribute applied to the button.
+     */
+    target: PropTypes.oneOf([
+      '_blank',
+      '_self',
+      '_parent',
+      '_top',
+    ]),
   };
 
   static defaultProps = {
@@ -160,6 +169,7 @@ class FlatButton extends Component {
       rippleColor,
       secondary,
       style,
+      target,
       ...other
     } = this.props;
 
@@ -259,6 +269,7 @@ class FlatButton extends Component {
     return (
       <EnhancedButton
         {...other}
+        target={target}
         disabled={disabled}
         focusRippleColor={buttonRippleColor}
         focusRippleOpacity={0.3}

--- a/src/FlatButton/FlatButton.spec.js
+++ b/src/FlatButton/FlatButton.spec.js
@@ -191,4 +191,11 @@ describe('<FlatButton />', () => {
       assert.strictEqual(wrapper.find(ActionAndroid).props().style.foo, 'bar');
     });
   });
+
+  describe('props: target', () => {
+    const wrapper = shallowWithContext(
+      <FlatButton target="_blank" label="Button" />
+    );
+    assert.strictEqual(wrapper.node.props.target, '_blank', 'should be _blank');
+  });
 });

--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -130,12 +130,7 @@ class FloatingActionButton extends Component {
      /**
      * Target attribute applied to the button.
      */
-    target: PropTypes.oneOf([
-      '_blank',
-      '_self',
-      '_parent',
-      '_top',
-    ]),
+    target: PropTypes.string,
     /**
      * The zDepth of the underlying `Paper` component.
      */
@@ -259,7 +254,6 @@ class FloatingActionButton extends Component {
       secondary, // eslint-disable-line no-unused-vars
       iconStyle,
       iconClassName,
-      target,
       zDepth, // eslint-disable-line no-unused-vars
       ...other
     } = this.props;
@@ -321,7 +315,6 @@ class FloatingActionButton extends Component {
           )}
           focusRippleColor={styles.icon.color}
           touchRippleColor={styles.icon.color}
-          target={target}
         >
           <div
             ref="overlay"

--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -127,6 +127,15 @@ class FloatingActionButton extends Component {
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
+     /**
+     * Target attribute applied to the button.
+     */
+    target: PropTypes.oneOf([
+      '_blank',
+      '_self',
+      '_parent',
+      '_top',
+    ]),
     /**
      * The zDepth of the underlying `Paper` component.
      */
@@ -250,6 +259,7 @@ class FloatingActionButton extends Component {
       secondary, // eslint-disable-line no-unused-vars
       iconStyle,
       iconClassName,
+      target,
       zDepth, // eslint-disable-line no-unused-vars
       ...other
     } = this.props;
@@ -311,6 +321,7 @@ class FloatingActionButton extends Component {
           )}
           focusRippleColor={styles.icon.color}
           touchRippleColor={styles.icon.color}
+          target={target}
         >
           <div
             ref="overlay"

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -91,6 +91,15 @@ class IconButton extends Component {
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
+     /**
+     * Target attribute applied to the button.
+     */
+    target: PropTypes.oneOf([
+      '_blank',
+      '_self',
+      '_parent',
+      '_top',
+    ]),
     /**
      * The text to supply to the element's tooltip.
      */
@@ -188,6 +197,7 @@ class IconButton extends Component {
       children,
       iconClassName,
       onKeyboardFocus, // eslint-disable-line no-unused-vars
+      target,
       tooltip,
       tooltipPosition: tooltipPositionProp,
       tooltipStyles,
@@ -243,6 +253,7 @@ class IconButton extends Component {
         centerRipple={true}
         disabled={disabled}
         style={Object.assign(styles.root, this.props.style)}
+        target={target}
         disableTouchRipple={disableTouchRipple}
         onBlur={this.handleBlur}
         onFocus={this.handleFocus}

--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -214,6 +214,10 @@ class RaisedButton extends Component {
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
+    /**
+     * Target attribute applied to the button.
+     */
+    target: PropTypes.string,
   };
 
   static defaultProps = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

Fixes #5459.
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Added target properties on aforementioned components and written a test for FlatButton that validates the rendering with the target property.

I've also updated the docs page of FlatButtonExampleIcon with the link to the github page with a target="_blank". Not sure if that's desirable, see [target _blank vulnerability](https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/). I'd like to hear your thoughts on this matter.

What I haven't done is implement the fifth feature of the target attribute: 

```
framename - Opens the linked document in a named frame
```

Then again I'm not sure if this is desirable to be implemented aswell as it can be defined as an enum now :smiley:.
