### PR TITLE
[TextField] Add ability to style label color when a value is present

### DIFF
--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -1,7 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import ReactDOM from 'react-dom';
 import shallowEqual from 'recompose/shallowEqual';
-import {fade} from '../utils/colorManipulator';
 import transitions from '../styles/transitions';
 import EnhancedTextarea from './EnhancedTextarea';
 import TextFieldHint from './TextFieldHint';
@@ -18,7 +17,6 @@ const getStyles = (props, context, state) => {
       textColor,
       disabledTextColor,
       backgroundColor,
-      hintColor,
       errorColor,
     },
   } = context.muiTheme;
@@ -44,7 +42,7 @@ const getStyles = (props, context, state) => {
       transition: transitions.easeOut(),
     },
     floatingLabel: {
-      color: hintColor,
+      color: props.disabled ? disabledTextColor : floatingLabelColor,
       pointerEvents: 'none',
     },
     input: {
@@ -75,10 +73,6 @@ const getStyles = (props, context, state) => {
 
   // Do not assign a height to the textarea as he handles it on his own.
   styles.input.height = '100%';
-
-  if (state.hasValue) {
-    styles.floatingLabel.color = fade(props.disabled ? disabledTextColor : floatingLabelColor, 0.5);
-  }
 
   if (state.isFocused) {
     styles.floatingLabel.color = focusColor;

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -284,7 +284,7 @@ export default function getMuiTheme(muiTheme, ...more) {
     textField: {
       textColor: palette.textColor,
       hintColor: palette.disabledColor,
-      floatingLabelColor: palette.textColor,
+      floatingLabelColor: palette.disabledColor,
       disabledTextColor: palette.disabledColor,
       errorColor: red500,
       focusColor: palette.primary1Color,


### PR DESCRIPTION
Hi, first, thank you for this great library.

Recently I've been attempting to theme our site, and ran into an issue while trying to style `TextField` components.

## Description of problem
Given the following code:
```jsx
<TextField
  floatingLabelFixed={true}
  floatingLabelText="TextField w/o value"
/>
<TextField
  floatingLabelFixed={true}
  floatingLabelText="TextField w/ value"
  defaultValue="Some Value"
/>
```

I get the following output:
![screen shot 2016-10-31 at 10 45 27 am](https://cloud.githubusercontent.com/assets/207950/19864875/501c691e-9f57-11e6-83f0-075454b5eafa.png)


Where you can see that the label for the input without a value is `rgba(0, 0, 0, 0.298039)` while the label for the input WITH a value is `rgba(0, 0, 0, 0.498039)`

## Root cause

The source of this issue is [src/TextField/TextField.js:80](https://github.com/callemall/material-ui/blob/master/src/TextField/TextField.js#L80): 
```
const getStyles = (props, context, state) => {
  /* ... */
  if (state.hasValue) {
    styles.floatingLabel.color = fade(props.disabled ? disabledTextColor : floatingLabelColor, 0.5);
  }
  /* ... */
}
```

## Possible solutions
1. Remove the `fade( /*...*/, 0.5)` wrapper around the `props.disable` ternary.
    * This would be my preferred approach, but would change the way labels look for current users which _could_ be something that people desire or are depending on (?).
2. Add a  `floatingLabelHasValueColor` option to the `textField` theme config that is used when present, otherwise, fall back to the current behavior.
    * This would allow for use to specify the color to use for a label when the input has a value (In, my case I would like this to be the same as when there is _not_ a value).

I'm more than happy to update this MR to use the first approach (or any other suggestions/approaches you may have), but figured it was best to start with a solution that would not change existing behavior unless you confirmed a desire to do so.

Thanks again, and please let me know anything I can do to help support this PR.