### PR TITLE
[docs] Add a note regarding other properties

### DIFF
--- a/docs/src/app/components/PropTypeDescription.js
+++ b/docs/src/app/components/PropTypeDescription.js
@@ -100,6 +100,13 @@ function generateDescription(required, description, type) {
   return `${deprecated} ${jsDocText}${signature}`;
 }
 
+const styles = {
+  footnote: {
+    fontSize: '90%',
+    paddingLeft: '15px',
+  },
+};
+
 class PropTypeDescription extends Component {
 
   static propTypes = {
@@ -152,6 +159,8 @@ class PropTypeDescription extends Component {
       text += `| ${key} | ${generatePropType(prop.type)} | ${defaultValue} | ${description} |\n`;
     }
 
+    text += 'Other properties (no documented) are applied to the root element.';
+
     const requiredPropFootnote = (requiredProps === 1) ? '* required property' :
       (requiredProps > 1) ? '* required properties' :
         '';
@@ -159,7 +168,9 @@ class PropTypeDescription extends Component {
     return (
       <div className="propTypeDescription">
         <MarkdownElement text={text} />
-        <div style={{fontSize: '90%', paddingLeft: '15px'}}>{requiredPropFootnote}</div>
+        <div style={styles.footnote}>
+          {requiredPropFootnote}
+        </div>
       </div>
     );
   }

--- a/docs/src/app/components/pages/components/FlatButton/ExampleComplex.js
+++ b/docs/src/app/components/pages/components/FlatButton/ExampleComplex.js
@@ -4,7 +4,7 @@ import FontIcon from 'material-ui/FontIcon';
 import ActionAndroid from 'material-ui/svg-icons/action/android';
 
 const styles = {
-  exampleImageInput: {
+  imageInput: {
     cursor: 'pointer',
     position: 'absolute',
     top: 0,
@@ -19,9 +19,8 @@ const styles = {
 const FlatButtonExampleComplex = () => (
   <div>
     <FlatButton label="Choose an Image" labelPosition="before">
-      <input type="file" style={styles.exampleImageInput} />
+      <input type="file" style={styles.imageInput} />
     </FlatButton>
-
     <FlatButton
       label="Label before"
       labelPosition="before"
@@ -29,14 +28,13 @@ const FlatButtonExampleComplex = () => (
       style={styles.button}
       icon={<ActionAndroid />}
     />
-
     <FlatButton
-      label="GitHub Link"
       href="https://github.com/callemall/material-ui"
+      target="_blank"
+      label="GitHub Link"
       secondary={true}
       icon={<FontIcon className="muidocs-icon-custom-github" />}
     />
-
   </div>
 );
 

--- a/docs/src/app/components/pages/components/FlatButton/ExampleIcon.js
+++ b/docs/src/app/components/pages/components/FlatButton/ExampleIcon.js
@@ -22,6 +22,7 @@ const FlatButtonExampleIcon = () => (
     />
     <FlatButton
       href="https://github.com/callemall/material-ui"
+      target="_blank"
       secondary={true}
       icon={<FontIcon className="muidocs-icon-custom-github" />}
       style={style}

--- a/docs/src/app/components/pages/components/RaisedButton/ExampleComplex.js
+++ b/docs/src/app/components/pages/components/RaisedButton/ExampleComplex.js
@@ -37,8 +37,9 @@ const RaisedButtonExampleComplex = () => (
       style={styles.button}
     />
     <RaisedButton
-      label="Github Link"
       href="https://github.com/callemall/material-ui"
+      target="_blank"
+      label="Github Link"
       secondary={true}
       style={styles.button}
       icon={<FontIcon className="muidocs-icon-custom-github" />}

--- a/docs/src/app/components/pages/components/RaisedButton/ExampleIcon.js
+++ b/docs/src/app/components/pages/components/RaisedButton/ExampleIcon.js
@@ -21,6 +21,7 @@ const RaisedButtonExampleIcon = () => (
     />
     <RaisedButton
       href="https://github.com/callemall/material-ui"
+      target="_blank"
       secondary={true}
       icon={<FontIcon className="muidocs-icon-custom-github" />}
       style={style}

--- a/src/FlatButton/FlatButton.spec.js
+++ b/src/FlatButton/FlatButton.spec.js
@@ -191,4 +191,14 @@ describe('<FlatButton />', () => {
       assert.strictEqual(wrapper.find(ActionAndroid).props().style.foo, 'bar');
     });
   });
+
+  describe('props: other', () => {
+    it('should spread other properties to the root element', () => {
+      const wrapper = shallowWithContext(
+        <FlatButton target="_blank" label="Button" />
+      );
+
+      assert.strictEqual(wrapper.props().target, '_blank', 'should be _blank');
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

This is a continuation of #5479.
Thanks @jvhoven for raising it.
The behavior for other properties has never been documented.
It's quite important for users and us to be consistent.
I have also added a `target="_blank"` properties to our examples to make the example interaction less disruptive.

Closes #5479.