### PR TITLE
[MenuItem][ListItem] Allow overriding hoverColor

### DIFF
--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -28,7 +28,7 @@ function getStyles(props, context, state) {
   const {listItem} = muiTheme;
 
   const textColor = muiTheme.baseTheme.palette.textColor;
-  const hoverColor = fade(textColor, 0.1);
+  const hoverColor = props.hoverColor || fade(textColor, 0.1);
   const singleAvatar = !secondaryText && (leftAvatar || rightAvatar);
   const singleNoAvatar = !secondaryText && !(leftAvatar || rightAvatar);
   const twoLine = secondaryText && secondaryTextLines === 1;
@@ -164,6 +164,10 @@ class ListItem extends Component {
      * or `rightToggle` is set.
      */
     disabled: PropTypes.bool,
+    /**
+    * Override the hover background color.
+    */
+    hoverColor: PropTypes.string,
     /**
      * If true, the nested `ListItem`s are initially displayed.
      */

--- a/src/List/ListItem.spec.js
+++ b/src/List/ListItem.spec.js
@@ -146,4 +146,18 @@ describe('<ListItem />', () => {
       assert.strictEqual(wrapper.find(NestedList).props().open, true);
     });
   });
+
+  describe('props: hoverColor', () => {
+    it('should use a background color on hover if hoverColor is specified', () => {
+      const testColor = '#ededed';
+      const wrapper = shallowWithContext(
+        <ListItem
+          hoverColor={testColor}
+        />
+      );
+      wrapper.find('EnhancedButton').simulate('mouseEnter');
+      wrapper.update();
+      assert.strictEqual(wrapper.find('EnhancedButton').prop('style').backgroundColor, testColor);
+    });
+  });
 });

--- a/src/MenuItem/MenuItem.js
+++ b/src/MenuItem/MenuItem.js
@@ -292,6 +292,7 @@ class MenuItem extends Component {
       <ListItem
         {...other}
         disabled={disabled}
+        hoverColor={this.context.muiTheme.menuItem.hoverColor}
         innerDivStyle={mergedInnerDivStyles}
         insetChildren={insetChildren}
         leftIcon={leftIconElement}

--- a/src/MenuItem/MenuItem.spec.js
+++ b/src/MenuItem/MenuItem.spec.js
@@ -15,4 +15,13 @@ describe('<MenuItem />', () => {
     const wrapper = shallowWithContext(<MenuItem />);
     assert.strictEqual(wrapper.find(ListItem).props().style.minHeight, '48px');
   });
+
+  it('should pass hoverColor from the theme to the <ListItem />', () => {
+    const testColor = '#ededed';
+    const muiThemeWithHoverColor = getMuiTheme({menuItem: {hoverColor: testColor}});
+    const shallowWithHoverColor = (node) => shallow(node, {context: {muiTheme: muiThemeWithHoverColor}});
+
+    const wrapper = shallowWithHoverColor(<MenuItem />);
+    assert.strictEqual(wrapper.find(ListItem).prop('hoverColor'), testColor);
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

This combines the efforts of #4957 and #5000 and adds some tests. Closes #4227.

This solves my particular use case, but I'm not sure it's the greatest API. Does it make sense for the ListItem to take `hoverColor` as a prop, while MenuItem gets it from the theme? Should MenuItem also take a prop that can override the theme, or should ListItem also have a theme option, or both?

But since the style system is getting overhauled anyway, maybe it's not worth it to make those changes. I'd love to get your feedback!

Closes #5000.
Closes #4957.
Closes #4227.