### PR TITLE
[Stepper] Add iconContainerStyle to StepButton and StepLabel

### DIFF
--- a/src/Stepper/StepButton.js
+++ b/src/Stepper/StepButton.js
@@ -53,6 +53,10 @@ class StepButton extends Component {
       PropTypes.string,
       PropTypes.number,
     ]),
+    /**
+     * Override the inline-styles of the icon container element.
+     */
+    iconContainerStyle: PropTypes.object,
     /** @ignore */
     last: PropTypes.bool,
     /** @ignore */
@@ -113,6 +117,7 @@ class StepButton extends Component {
       completed,
       disabled,
       icon,
+      iconContainerStyle,
       last, // eslint-disable-line no-unused-vars
       onMouseEnter, // eslint-disable-line no-unused-vars
       onMouseLeave, // eslint-disable-line no-unused-vars
@@ -134,7 +139,7 @@ class StepButton extends Component {
         onTouchStart={this.handleTouchStart}
         {...other}
       >
-        {React.cloneElement(child, {active, completed, disabled, icon})}
+        {React.cloneElement(child, {active, completed, disabled, icon, iconContainerStyle})}
       </EnhancedButton>
     );
   }

--- a/src/Stepper/StepButton.spec.js
+++ b/src/Stepper/StepButton.spec.js
@@ -31,6 +31,22 @@ describe('<StepButton />', () => {
     assert.strictEqual(stepLabel.props().children, 'Step One');
   });
 
+  it('should pass iconContainerStyle to StepLabel', () => {
+    const wrapper = themedShallow(
+      <StepButton
+        iconContainerStyle={{width: 50, color: 'cyan', marginTop: 200, border: '1px solid violet'}}
+        icon={1}
+      >
+        StepOne
+      </StepButton>
+    );
+    const stepLabel = wrapper.find('StepLabel');
+    assert.strictEqual(stepLabel.props().iconContainerStyle.width, 50);
+    assert.strictEqual(stepLabel.props().iconContainerStyle.color, 'cyan');
+    assert.strictEqual(stepLabel.props().iconContainerStyle.marginTop, 200);
+    assert.strictEqual(stepLabel.props().iconContainerStyle.border, '1px solid violet');
+  });
+
   it('should pass props to StepLabel', () => {
     const wrapper = themedShallow(
       <StepButton

--- a/src/Stepper/StepLabel.js
+++ b/src/Stepper/StepLabel.js
@@ -82,6 +82,10 @@ class StepLabel extends Component {
       PropTypes.number,
     ]),
     /**
+     * Override the inline-styles of the icon container element.
+     */
+    iconContainerStyle: PropTypes.object,
+    /**
      * @ignore
      */
     last: PropTypes.bool,
@@ -134,6 +138,7 @@ class StepLabel extends Component {
       children,
       completed,
       icon: userIcon,
+      iconContainerStyle,
       last, // eslint-disable-line no-unused-vars
       style,
       ...other
@@ -146,7 +151,7 @@ class StepLabel extends Component {
     return (
       <span style={prepareStyles(Object.assign(styles.root, style))} {...other}>
         {icon && (
-          <span style={prepareStyles(styles.iconContainer)}>
+          <span style={prepareStyles(Object.assign(styles.iconContainer, iconContainerStyle))}>
             {icon}
           </span>
         )}

--- a/src/Stepper/StepLabel.spec.js
+++ b/src/Stepper/StepLabel.spec.js
@@ -117,6 +117,25 @@ describe('<StepLabel />', () => {
     });
   });
 
+  describe('prop: iconContainerStyle', () => {
+    it('merges values into the icon container node style prop', () => {
+      const wrapper = shallowWithContext(
+        <StepLabel
+          iconContainerStyle={{width: 64, color: 'lime', paddingBottom: 300, border: '3px solid teal'}}
+          icon={1}
+        >
+          Step One
+        </StepLabel>
+      );
+      const iconContainer = wrapper.find('span').at(1);
+      const props = iconContainer.props();
+      assert.strictEqual(props.style.width, 64);
+      assert.strictEqual(props.style.color, 'lime');
+      assert.strictEqual(props.style.paddingBottom, 300);
+      assert.strictEqual(props.style.border, '3px solid teal');
+    });
+  });
+
   describe('prop combinations', () => {
     it('renders with active styling when active', () => {
       const wrapper = shallowWithContext(


### PR DESCRIPTION
Currently, it is possible to customize the icon of a StepButton or StepLabel with the `icon` prop.  However, the `<span>` container for this icon has a fixed width of 24px. 

This change adds the ability to customize the style of this icon container element.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


