### PR TITLE
[TimePicker] `autoOk` closing the dialog too early, fix #5499

### DIFF
--- a/docs/src/app/components/pages/components/TimePicker/ExampleComplex.js
+++ b/docs/src/app/components/pages/components/TimePicker/ExampleComplex.js
@@ -5,7 +5,7 @@ export default class TimePickerExampleComplex extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = {value24: null, value12: null, value24AutoOk: null};
+    this.state = {value24: null, value12: null};
   }
 
   handleChangeTimePicker24 = (event, date) => {
@@ -14,10 +14,6 @@ export default class TimePickerExampleComplex extends React.Component {
 
   handleChangeTimePicker12 = (event, date) => {
     this.setState({value12: date});
-  };
-
-  handleChangeTimePicker24AutoOK = (event, date) => {
-    this.setState({value24AutoOk: date});
   };
 
   render() {
@@ -34,13 +30,6 @@ export default class TimePickerExampleComplex extends React.Component {
           hintText="24hr Format"
           value={this.state.value24}
           onChange={this.handleChangeTimePicker24}
-        />
-        <TimePicker
-          format="24hr"
-          hintText="24hr Format with auto ok"
-          autoOk={true}
-          value={this.state.value24AutoOk}
-          onChange={this.handleChangeTimePicker24AutoOK}
         />
       </div>
     );

--- a/docs/src/app/components/pages/components/TimePicker/ExampleComplex.js
+++ b/docs/src/app/components/pages/components/TimePicker/ExampleComplex.js
@@ -5,7 +5,7 @@ export default class TimePickerExampleComplex extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = {value24: null, value12: null};
+    this.state = {value24: null, value12: null, value24AutoOk: null};
   }
 
   handleChangeTimePicker24 = (event, date) => {
@@ -14,6 +14,10 @@ export default class TimePickerExampleComplex extends React.Component {
 
   handleChangeTimePicker12 = (event, date) => {
     this.setState({value12: date});
+  };
+
+  handleChangeTimePicker24AutoOK = (event, date) => {
+    this.setState({value24AutoOk: date});
   };
 
   render() {
@@ -30,6 +34,13 @@ export default class TimePickerExampleComplex extends React.Component {
           hintText="24hr Format"
           value={this.state.value24}
           onChange={this.handleChangeTimePicker24}
+        />
+        <TimePicker
+          format="24hr"
+          hintText="24hr Format with auto ok"
+          autoOk={true}
+          value={this.state.value24AutoOk}
+          onChange={this.handleChangeTimePicker24AutoOK}
         />
       </div>
     );

--- a/docs/src/app/components/pages/components/TimePicker/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/TimePicker/ExampleSimple.js
@@ -7,6 +7,10 @@ const TimePickerExampleSimple = () => (
       hintText="12hr Format"
     />
     <TimePicker
+      hintText="12hr Format with auto ok"
+      autoOk={true}
+    />
+    <TimePicker
       format="24hr"
       hintText="24hr Format"
     />

--- a/src/TimePicker/Clock.js
+++ b/src/TimePicker/Clock.js
@@ -96,7 +96,7 @@ class Clock extends Component {
     }
   };
 
-  handleChangeMinutes = (minutes) => {
+  handleChangeMinutes = (minutes, finished) => {
     const time = new Date(this.state.selectedTime);
     time.setMinutes(minutes);
     this.setState({
@@ -104,7 +104,7 @@ class Clock extends Component {
     });
 
     const {onChangeMinutes} = this.props;
-    if (onChangeMinutes) {
+    if (onChangeMinutes && finished) {
       setTimeout(() => {
         onChangeMinutes(time);
       }, 0);

--- a/src/TimePicker/ClockMinutes.js
+++ b/src/TimePicker/ClockMinutes.js
@@ -54,7 +54,7 @@ class ClockMinutes extends Component {
 
   handleTouch = (event) => {
     event.preventDefault();
-    this.setClock(event.changedTouches[0], false);
+    this.setClock(event.changedTouches[0], event.type === 'touchend');
   };
 
   setClock(event, finish) {

--- a/src/TimePicker/ClockMinutes.spec.js
+++ b/src/TimePicker/ClockMinutes.spec.js
@@ -1,0 +1,33 @@
+/* eslint-env mocha */
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from 'chai';
+import sinon from 'sinon';
+
+import getMuiTheme from '../styles/getMuiTheme';
+import ClockMinutes from './ClockMinutes';
+
+describe('<ClockMinutes />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
+  it('at touchEnd as to call onChange once and return the second arg as true', () => {
+    const onChange = sinon.spy();
+    const wrapper = shallowWithContext(
+      <ClockMinutes onChange={onChange} />
+    );
+
+    wrapper.instance().center = {x: 100, y: 100};
+    wrapper.instance().basePoint = {x: 100, y: 0};
+    const simComp = wrapper.find('div').at(1);
+
+    simComp.simulate('touchEnd', {preventDefault() {}, type: 'touchend', changedTouches: [{offsetX: 50, offsetY: 70}]});
+    expect(onChange.calledOnce).to.equal(true);
+    expect(onChange.calledTwice).to.equal(false);
+    expect(onChange.args[0][1]).to.equal(true);
+    simComp.simulate('mouseUp', {preventDefault() {}, type: 'mouseUp', nativeEvent: {offsetX: 50, offsetY: 70}});
+    expect(onChange.calledOnce).to.equal(false);
+    expect(onChange.calledTwice).to.equal(true);
+    expect(onChange.args[0][1]).to.equal(true);
+  });
+});


### PR DESCRIPTION
Setting the autoOk to true the TimePicker modal window closed when clicked the first time on the timechooser I simply added a control to the event with a param that was ignored.

Closes #5499

<!-- Thanks so much for your PR, your contribution is appreciated! -->
- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


