### PR TITLE
[Card] closeIcon and openIcon customizable in Card, fix #5488

### DIFF
--- a/src/Card/Card.js
+++ b/src/Card/Card.js
@@ -110,7 +110,12 @@ class Card extends Component {
       }
       if (currentChild.props.showExpandableButton === true) {
         doClone = true;
-        newChild = <CardExpandable expanded={expanded} onExpanding={this.handleExpanding} />;
+        newChild = (<CardExpandable
+          closeIcon={currentChild.props.closeIcon}
+          expanded={expanded}
+          onExpanding={this.handleExpanding}
+          openIcon={currentChild.props.openIcon}
+                    />);
       }
       if (doClone) {
         element = React.cloneElement(currentChild, newProps, currentChild.props.children, newChild);

--- a/src/Card/Card.js
+++ b/src/Card/Card.js
@@ -110,12 +110,14 @@ class Card extends Component {
       }
       if (currentChild.props.showExpandableButton === true) {
         doClone = true;
-        newChild = (<CardExpandable
-          closeIcon={currentChild.props.closeIcon}
-          expanded={expanded}
-          onExpanding={this.handleExpanding}
-          openIcon={currentChild.props.openIcon}
-                    />);
+        newChild = (
+          <CardExpandable
+            closeIcon={currentChild.props.closeIcon}
+            expanded={expanded}
+            onExpanding={this.handleExpanding}
+            openIcon={currentChild.props.openIcon}
+          />
+        );
       }
       if (doClone) {
         element = React.cloneElement(currentChild, newProps, currentChild.props.children, newChild);

--- a/src/Card/CardExpandable.js
+++ b/src/Card/CardExpandable.js
@@ -17,14 +17,26 @@ function getStyles() {
 
 class CardExpandable extends Component {
   static propTypes = {
+    closeIcon: PropTypes.node,
     expanded: PropTypes.bool,
     onExpanding: PropTypes.func.isRequired,
+    openIcon: PropTypes.node,
     style: PropTypes.object,
   };
 
   static contextTypes = {
     muiTheme: PropTypes.object.isRequired,
   };
+
+  getCorrectIcon(isExpanded, propIconOpen, propIconClose) {
+    if (isExpanded) {
+      if (propIconOpen) return propIconOpen;
+      return <OpenIcon />;
+    } else {
+      if (propIconClose) return propIconClose;
+      return <CloseIcon />;
+    }
+  }
 
   render() {
     const styles = getStyles(this.props, this.context);
@@ -34,7 +46,7 @@ class CardExpandable extends Component {
         style={Object.assign(styles.root, this.props.style)}
         onTouchTap={this.props.onExpanding}
       >
-        {this.props.expanded ? <OpenIcon /> : <CloseIcon />}
+        {this.getCorrectIcon(this.props.expanded, this.props.openIcon, this.props.closeIcon)}
       </IconButton>
     );
   }

--- a/src/Card/CardExpandable.js
+++ b/src/Card/CardExpandable.js
@@ -28,15 +28,10 @@ class CardExpandable extends Component {
     muiTheme: PropTypes.object.isRequired,
   };
 
-  getCorrectIcon(isExpanded, propIconOpen, propIconClose) {
-    if (isExpanded) {
-      if (propIconOpen) return propIconOpen;
-      return <OpenIcon />;
-    } else {
-      if (propIconClose) return propIconClose;
-      return <CloseIcon />;
-    }
-  }
+  static defaultProps = {
+    closeIcon: <CloseIcon />,
+    openIcon: <OpenIcon />,
+  };
 
   render() {
     const styles = getStyles(this.props, this.context);
@@ -46,7 +41,7 @@ class CardExpandable extends Component {
         style={Object.assign(styles.root, this.props.style)}
         onTouchTap={this.props.onExpanding}
       >
-        {this.getCorrectIcon(this.props.expanded, this.props.openIcon, this.props.closeIcon)}
+        {this.props.expanded ? this.props.openIcon : this.props.closeIcon}
       </IconButton>
     );
   }

--- a/src/Card/CardHeader.js
+++ b/src/Card/CardHeader.js
@@ -53,7 +53,7 @@ class CardHeader extends Component {
      */
     children: PropTypes.node,
     /**
-     * Can be used to pass a closeIcon if you don't like the default expandable close Icon
+     * Can be used to pass a closeIcon if you don't like the default expandable close Icon.
      */
     closeIcon: PropTypes.node,
     /**
@@ -61,7 +61,7 @@ class CardHeader extends Component {
      */
     expandable: PropTypes.bool,
     /**
-     * Can be used to pass a openIcon if you don't like the default expandable open Icon
+     * Can be used to pass a openIcon if you don't like the default expandable open Icon.
      */
     openIcon: PropTypes.node,
     /**

--- a/src/Card/CardHeader.js
+++ b/src/Card/CardHeader.js
@@ -53,9 +53,17 @@ class CardHeader extends Component {
      */
     children: PropTypes.node,
     /**
+     * Can be used to pass a closeIcon if you don't like the default expandable close Icon
+     */
+    closeIcon: PropTypes.node,
+    /**
      * If true, this card component is expandable.
      */
     expandable: PropTypes.bool,
+    /**
+     * Can be used to pass a openIcon if you don't like the default expandable open Icon
+     */
+    openIcon: PropTypes.node,
     /**
      * If true, this card component will include a button to expand the card.
      */
@@ -107,7 +115,9 @@ class CardHeader extends Component {
       actAsExpander, // eslint-disable-line no-unused-vars
       avatar: avatarProp,
       children,
+      closeIcon, // eslint-disable-line no-unused-vars
       expandable, // eslint-disable-line no-unused-vars
+      openIcon, // eslint-disable-line no-unused-vars
       showExpandableButton, // eslint-disable-line no-unused-vars
       style,
       subtitle,

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -366,7 +366,7 @@ class ListItem extends Component {
       >
         {contentChildren}
       </div>
-     );
+    );
   }
 
   createLabelElement(styles, contentChildren, additionalProps) {
@@ -390,7 +390,7 @@ class ListItem extends Component {
       >
         {contentChildren}
       </label>
-     );
+    );
   }
 
   createTextElement(styles, data, key) {

--- a/test/integration/Card/Card.spec.js
+++ b/test/integration/Card/Card.spec.js
@@ -1,0 +1,43 @@
+/* eslint-env mocha */
+import React from 'react';
+import {mount} from 'enzyme';
+import {assert} from 'chai';
+import getMuiTheme from 'src/styles/getMuiTheme';
+import {Card, CardActions, CardHeader, CardText} from 'src/Card';
+import FlatButton from 'src/FlatButton';
+import OpenIcon from 'src/svg-icons/action/visibility';
+import CloseIcon from 'src/svg-icons/action/visibility-off';
+
+
+describe('<Card />', () => {
+  const muiTheme = getMuiTheme();
+  const mountWithContext = (node) => mount(node, {context: {muiTheme},
+    childContextTypes: {muiTheme: React.PropTypes.object}});
+  it('renders a openIcon inside the CardHeader with custom color', () => {
+    const wrapper = mountWithContext(
+      <Card>
+        <CardHeader
+          title="Without Avatar"
+          subtitle="Subtitle"
+          actAsExpander={true}
+          showExpandableButton={true}
+          closeIcon={<CloseIcon color="#ff0000" />}
+          openIcon={<OpenIcon color="#00ff00" />}
+        />
+        <CardActions>
+          <FlatButton label="Action1" />
+          <FlatButton label="Action2" />
+        </CardActions>
+        <CardText expandable={true}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            Donec mattis pretium massa. Aliquam erat volutpat. Nulla facilisi.
+            Donec vulputate interdum sollicitudin. Nunc lacinia auctor quam sed pellentesque.
+            Aliquam dui mauris, mattis quis lacus id, pellentesque lobortis odio.
+        </CardText>
+      </Card>
+    );
+    assert.strictEqual(wrapper.find(CloseIcon).node.props.color, '#ff0000', 'CloseIcon should have color #ff0000');
+    wrapper.find('IconButton').simulate('touchTap');
+    assert.strictEqual(wrapper.find(OpenIcon).node.props.color, '#00ff00', 'OpenIcon should have color #00ff00');
+  });
+});

--- a/test/integration/Card/Card.spec.js
+++ b/test/integration/Card/Card.spec.js
@@ -37,7 +37,7 @@ describe('<Card />', () => {
       </Card>
     );
     assert.strictEqual(wrapper.find(CloseIcon).node.props.color, '#ff0000', 'CloseIcon should have color #ff0000');
-    wrapper.find('IconButton').simulate('touchTap');
+    wrapper.setState({expanded: true});
     assert.strictEqual(wrapper.find(OpenIcon).node.props.color, '#00ff00', 'OpenIcon should have color #00ff00');
   });
 });


### PR DESCRIPTION
Added the possibility to change the expandable button Icon in the Card component, this gives more opportunity to customize the component and solves #5488.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


