### PR TITLE
[AutoComplete] Fix Popover's style overriding popoverProps

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -388,12 +388,12 @@ class AutoComplete extends Component {
       openOnFocus, // eslint-disable-line no-unused-vars
       popoverProps,
       searchText: searchTextProp, // eslint-disable-line no-unused-vars
-      ...other,
+      ...other
     } = this.props;
 
     const {
       style: popoverStyle,
-      ...popoverOther,
+      ...popoverOther
     } = popoverProps || {};
 
     const {

--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -392,6 +392,11 @@ class AutoComplete extends Component {
     } = this.props;
 
     const {
+      style: popoverStyle,
+      ...popoverOther
+    } = popoverProps || {}
+
+    const {
       open,
       anchorEl,
       searchText,
@@ -496,8 +501,7 @@ class AutoComplete extends Component {
           style={textFieldStyle}
         />
         <Popover
-          {...popoverProps}
-          style={styles.popover}
+          style={Object.assign({}, styles.popover, popoverStyle)}
           canAutoPosition={false}
           anchorOrigin={anchorOrigin}
           targetOrigin={targetOrigin}
@@ -507,6 +511,7 @@ class AutoComplete extends Component {
           onRequestClose={this.handleRequestClose}
           animated={animated}
           animation={animation}
+          {...popoverOther}
         >
           {menu}
         </Popover>

--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -388,13 +388,13 @@ class AutoComplete extends Component {
       openOnFocus, // eslint-disable-line no-unused-vars
       popoverProps,
       searchText: searchTextProp, // eslint-disable-line no-unused-vars
-      ...other
+      ...other,
     } = this.props;
 
     const {
       style: popoverStyle,
-      ...popoverOther
-    } = popoverProps || {}
+      ...popoverOther,
+    } = popoverProps || {};
 
     const {
       open,


### PR DESCRIPTION
Fixes `Autocomplete`'s `Popover`'s `style`  overriding potential `style` passed via `popoverProps`


