### PR TITLE
[ListItem] Clear hover state if componet get's disabled

### DIFF
--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -318,6 +318,8 @@ class ListItem extends Component {
     // update the state when the component is controlled.
     if (nextProps.open !== null)
       this.setState({open: nextProps.open});
+    if (nextProps.disabled && this.state.hovered)
+      this.setState({hovered: false});
   }
 
   shouldComponentUpdate(nextProps, nextState, nextContext) {

--- a/src/List/ListItem.spec.js
+++ b/src/List/ListItem.spec.js
@@ -190,7 +190,7 @@ describe('<ListItem />', () => {
   describe('hover state', () => {
     it('should reset the hover state when disabled', () => {
       const wrapper = shallowWithContext(
-        <ListItem primaryText="foo"/>
+        <ListItem primaryText="foo" />
       );
 
       wrapper.find(EnhancedButton).simulate('mouseEnter');

--- a/src/List/ListItem.spec.js
+++ b/src/List/ListItem.spec.js
@@ -186,4 +186,19 @@ describe('<ListItem />', () => {
       assert.strictEqual(wrapper.find(EnhancedButton).props().style.backgroundColor, testColor);
     });
   });
+
+  describe('hover state', () => {
+    it('should reset the hover state when disabled', () => {
+      const wrapper = shallowWithContext(
+        <ListItem primaryText="foo"/>
+      );
+
+      wrapper.find(EnhancedButton).simulate('mouseEnter');
+      assert.strictEqual(wrapper.state().hovered, true, 'should respond to the event');
+      wrapper.setProps({
+        disabled: true,
+      });
+      assert.strictEqual(wrapper.state().hovered, false, 'should reset the state');
+    });
+  });
 });


### PR DESCRIPTION
Issue is anlog to https://github.com/callemall/material-ui/pull/4531
I had the same problem with ListItems instead of FlatButtons
https://github.com/callemall/material-ui/pull/4531#issuecomment-259443648


<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


