### PR TITLE
[RaisedButton] Fix hover on touch devices

### DIFF
--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -315,6 +315,7 @@ class RaisedButton extends Component {
 
   handleTouchEnd = (event) => {
     this.setState({
+      touched: true,
       zDepth: this.state.initialZDepth,
     });
 


### PR DESCRIPTION
Replies the #5077 fix on RaisedButton, that is affected with the same issue of FloatingActionButton described in #5076.
