### PR TITLE
[IE] Remove the unsupported initial property

### DIFF
--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -32,7 +32,6 @@ function getStyles(props, context) {
     },
     checkWhenDisabled: {
       fill: checkbox.disabledColor,
-      cursor: 'not-allowed',
     },
     box: {
       position: 'absolute',
@@ -47,7 +46,6 @@ function getStyles(props, context) {
     },
     boxWhenDisabled: {
       fill: props.checked ? 'transparent' : checkbox.disabledColor,
-      cursor: 'not-allowed',
     },
     label: {
       color: props.disabled ? checkbox.labelDisabledColor : checkbox.labelColor,

--- a/src/RadioButton/RadioButton.js
+++ b/src/RadioButton/RadioButton.js
@@ -37,11 +37,9 @@ function getStyles(props, context) {
     },
     targetWhenDisabled: {
       fill: radioButton.disabledColor,
-      cursor: 'not-allowed',
     },
     fillWhenDisabled: {
       fill: radioButton.disabledColor,
-      cursor: 'not-allowed',
     },
     label: {
       color: props.disabled ? radioButton.labelDisabledColor : radioButton.labelColor,

--- a/src/TextField/EnhancedTextarea.js
+++ b/src/TextField/EnhancedTextarea.js
@@ -14,7 +14,7 @@ function getStyles(props, context, state) {
       resize: 'none',
       font: 'inherit',
       padding: 0,
-      cursor: props.disabled ? 'not-allowed' : 'initial',
+      cursor: 'inherit',
     },
     shadow: {
       resize: 'none',

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -32,6 +32,7 @@ const getStyles = (props, context, state) => {
       backgroundColor: backgroundColor,
       fontFamily: baseTheme.fontFamily,
       transition: transitions.easeOut('200ms', 'height'),
+      cursor: props.disabled ? 'not-allowed' : 'auto',
     },
     error: {
       position: 'relative',
@@ -53,7 +54,7 @@ const getStyles = (props, context, state) => {
       outline: 'none',
       backgroundColor: 'rgba(0,0,0,0)',
       color: props.disabled ? disabledTextColor : textColor,
-      cursor: props.disabled ? 'not-allowed' : 'initial',
+      cursor: 'inherit',
       font: 'inherit',
       WebkitTapHighlightColor: 'rgba(0,0,0,0)', // Remove mobile color flashing (deprecated style).
     },

--- a/src/TextField/TextFieldLabel.js
+++ b/src/TextField/TextFieldLabel.js
@@ -8,7 +8,6 @@ function getStyles(props) {
     top: 38,
     transition: transitions.easeOut(),
     zIndex: 1, // Needed to display label above Chrome's autocomplete field background
-    cursor: props.disabled ? 'not-allowed' : 'text',
     transform: 'scale(1) translate(0, 0)',
     transformOrigin: 'left top',
     pointerEvents: 'auto',

--- a/src/TextField/TextFieldUnderline.js
+++ b/src/TextField/TextFieldUnderline.js
@@ -85,7 +85,6 @@ const TextFieldUnderline = (props) => {
     disabled: {
       borderBottom: 'dotted 2px',
       borderColor: disabledTextColor,
-      cursor: 'not-allowed',
     },
     focus: {
       borderBottom: 'solid 2px',

--- a/src/Toggle/Toggle.js
+++ b/src/Toggle/Toggle.js
@@ -63,16 +63,13 @@ function getStyles(props, context, state) {
     },
     trackWhenDisabled: {
       backgroundColor: toggle.trackDisabledColor,
-      cursor: 'not-allowed',
     },
     thumbWhenDisabled: {
       backgroundColor: toggle.thumbDisabledColor,
-      cursor: 'not-allowed',
     },
     label: {
       color: disabled ? toggle.labelDisabledColor : toggle.labelColor,
       width: `calc(100% - ${(toggleTrackWidth + 10)}px)`,
-      cursor: disabled ? 'not-allowed' : 'initial',
     },
   };
 

--- a/src/internal/EnhancedSwitch.js
+++ b/src/internal/EnhancedSwitch.js
@@ -12,8 +12,8 @@ function getStyles(props, context) {
 
   return {
     root: {
+      cursor: props.disabled ? 'not-allowed' : 'pointer',
       position: 'relative',
-      cursor: props.disabled ? 'default' : 'pointer',
       overflow: 'visible',
       display: 'table',
       height: 'auto',
@@ -21,7 +21,7 @@ function getStyles(props, context) {
     },
     input: {
       position: 'absolute',
-      cursor: props.disabled ? 'default' : 'pointer',
+      cursor: 'inherit',
       pointerEvents: 'all',
       opacity: 0,
       width: '100%',


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Following #4170. I'm fixing the unsupported `initial` value. I'm also fixing all the switches.
The `not-allowed` value wasn't taken into account.

cc @TildeWill.
