### PR TITLE
[TextField] Remove the isClean logic

### DIFF
--- a/docs/src/app/components/pages/components/TextField/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/TextField/ExampleSimple.js
@@ -19,6 +19,10 @@ const TextFieldExampleSimple = () => (
       floatingLabelText="Floating Label Text"
     /><br />
     <TextField
+      defaultValue="Default Value"
+      floatingLabelText="Floating Label Text"
+    /><br />
+    <TextField
       hintText="Hint Text"
       floatingLabelText="Fixed Floating Label Text"
       floatingLabelFixed={true}

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -253,7 +253,6 @@ class TextField extends Component {
     isFocused: false,
     errorText: undefined,
     hasValue: false,
-    isClean: true,
   };
 
   componentWillMount() {
@@ -292,8 +291,7 @@ class TextField extends Component {
     }
 
     if (nextProps.hasOwnProperty('value')) {
-      const hasValue = isValid(nextProps.value) ||
-        (this.state.isClean && isValid(nextProps.defaultValue));
+      const hasValue = isValid(nextProps.value);
 
       this.setState({
         hasValue: hasValue,
@@ -336,7 +334,7 @@ class TextField extends Component {
   };
 
   handleInputChange = (event) => {
-    this.setState({hasValue: isValid(event.target.value), isClean: false});
+    this.setState({hasValue: isValid(event.target.value)});
     if (this.props.onChange) this.props.onChange(event, event.target.value);
   };
 

--- a/src/TextField/TextField.spec.js
+++ b/src/TextField/TextField.spec.js
@@ -30,43 +30,17 @@ describe('<TextField />', () => {
     wrapper.find('input').simulate('change', {target: {value: 'woof'}});
   });
 
-  it('shrinks TextFieldLabel when defaultValue is set and value is null', () => {
+  it('shrinks TextFieldLabel when defaultValue', () => {
     const wrapper = shallowWithContext(
       <TextField
         floatingLabelText="floating label text"
         defaultValue="default value"
-        value={null}
       />
     );
 
     assert.strictEqual(wrapper.find(TextFieldLabel).props().shrink, true, 'should shrink TextFieldLabel');
-
-    // set a new prop to trigger componentWillReceiveProps
-    wrapper.setProps({id: '1'});
+    wrapper.update();
     assert.strictEqual(wrapper.find(TextFieldLabel).props().shrink, true, 'should shrink TextFieldLabel');
-  });
-
-  it(`unshrinks TextFieldLabel when defaultValue is set, the component has had input change,
-        and value is re-set to null`, () => {
-    const wrapper = shallowWithContext(
-      <TextField
-        floatingLabelText="floating label text"
-        defaultValue="default value"
-        value={null}
-      />
-    );
-    assert.strictEqual(wrapper.find(TextFieldLabel).props().shrink, true, 'should shrink TextFieldLabel');
-
-    // make input change
-    const input = wrapper.find('input');
-    input.simulate('change', {target: {value: 'foo'}});
-    assert.strictEqual(wrapper.find(TextFieldLabel).props().shrink, true, 'should shrink TextFieldLabel');
-
-    // set value to null again, which should unshrink the TextFieldLabel, even though TextField's isClean
-    // state property is false.
-    wrapper.setProps({value: null});
-    assert.strictEqual(wrapper.state().isClean, false);
-    assert.strictEqual(wrapper.find(TextFieldLabel).props().shrink, false, 'should not shrink TextFieldLabel');
   });
 
   describe('prop: children', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Following #3450, I'm removing the isClean logic as React have now
deprecated switching for controlled / uncontrolled component.

As it turns out, for some reason, it's fixing #4430.

@joewalker Could you confirm? I was able to reproduce your issue.
Controlling the TextField inside a Dialog triggers a double render the first time
making the cursor jump.

Closes #4430.