### PR TITLE
[style] Add a withStyles HoC

### DIFF
--- a/src/styles/withStyles.js
+++ b/src/styles/withStyles.js
@@ -1,0 +1,24 @@
+// @flow weak
+
+import { PropTypes } from 'react';
+import createHelper from 'recompose/createHelper';
+import createEagerFactory from 'recompose/createEagerFactory';
+
+const withStyles = (styleSheet) => (BaseComponent) => {
+  const factory = createEagerFactory(BaseComponent);
+
+  const WithStyle = (ownerProps, context) => (
+    factory({
+      ...ownerProps,
+      classes: context.styleManager.render(styleSheet),
+    })
+  );
+
+  WithStyle.contextTypes = {
+    styleManager: PropTypes.object.isRequired,
+  };
+
+  return WithStyle;
+};
+
+export default createHelper(withStyles, 'withStyles');

--- a/src/styles/withStyles.spec.js
+++ b/src/styles/withStyles.spec.js
@@ -1,0 +1,34 @@
+// @flow weak
+/* eslint-env mocha */
+
+import React from 'react';
+import { assert } from 'chai';
+import { createShallowWithContext } from 'test/utils';
+import { createStyleSheet } from 'jss-theme-reactor';
+import withStyles from './withStyles';
+
+const Empty = () => <div />;
+Empty.propTypes = {}; // Breaks the referencial transparency for testing purposes.
+
+describe('withStyles', () => {
+  let shallow;
+
+  before(() => {
+    shallow = createShallowWithContext();
+  });
+
+  it('should provide a classes property', () => {
+    const styleSheet = createStyleSheet('TextField', () => ({
+      root: {
+        display: 'flex',
+      },
+    }));
+    const classes = shallow.context.styleManager.render(styleSheet);
+
+    const StyledComponent = withStyles(styleSheet)(Empty);
+    const wrapper = shallow(<StyledComponent />);
+
+    assert.strictEqual(wrapper.props().classes, classes,
+      'Should provide the classes property');
+  });
+});


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

I think that this HoC can be used for one main purpose:
It's for users looking for synergy in their styling solution.

It's a **tradeoff** between hiding implementation detail and performances.
Creating one additional React Component isn't free but always worth it.
The API is pretty close to https://github.com/airbnb/react-with-styles.

E.g. of use case:
```jsx
//...

export default compose(
  pure,
  withStyles(styleSheet),
  withWidth(),
  connect((state, ownProps) => {
    return {
      moveUp: ownProps.width === SMALL ?
        state.getIn(['snackbar', 'open']) :
        false,
    };
  }),
)(MainActionButton);
```