### PR TITLE
[MenuItem] Add openOnHover prop.

### DIFF
--- a/src/MenuItem/MenuItem.js
+++ b/src/MenuItem/MenuItem.js
@@ -113,6 +113,10 @@ class MenuItem extends Component {
      */
     onTouchTap: PropTypes.func,
     /**
+     * If true, the children popover will open on hover as well.
+     */
+    openOnHover: PropTypes.bool,
+    /**
      * Can be used to render primary text within the menu item.
      */
     primaryText: PropTypes.node,
@@ -140,6 +144,7 @@ class MenuItem extends Component {
     disabled: false,
     focusState: 'none',
     insetChildren: false,
+    openOnHover: false
   };
 
   static contextTypes = {
@@ -229,6 +234,7 @@ class MenuItem extends Component {
       insetChildren,
       leftIcon,
       menuItems,
+      openOnHover,
       rightIcon,
       secondaryText,
       style,
@@ -286,6 +292,9 @@ class MenuItem extends Component {
         </Popover>
       );
       other.onTouchTap = this.handleTouchTap;
+      if(openOnHover && menuItems) {
+        other.onMouseOver = this.handleTouchTap;
+      }
     }
 
     return (


### PR DESCRIPTION
- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s).

As the last comment in (#475) and as this issue (#5157) says, there is no openOnHover prop for nested menus. I tried implementing it and it seems to be working fine. All it does is bind the `onTouchTap` function to `onMouseOver` if the `openOnHover` prop is true.

Closes #5157.