### PR TITLE
updated peer dependency for react tap event plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "peerDependencies": {
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
-    "react-tap-event-plugin": "^1.0.0"
+    "react-tap-event-plugin": "^2.0.0"
   },
   "dependencies": {
     "babel-runtime": "^6.11.6",
@@ -98,11 +98,11 @@
     "mocha": "^3.1.2",
     "nodemon": "^1.11.0",
     "phantomjs-prebuilt": "^2.1.13",
-    "react": "^15.2.1",
-    "react-addons-test-utils": "^15.2.1",
-    "react-dom": "^15.2.1",
+    "react": "^15.4.0",
+    "react-addons-test-utils": "^15.4.0",
+    "react-dom": "^15.4.0",
     "react-hot-loader": "^1.3.0",
-    "react-tap-event-plugin": "^1.0.0",
+    "react-tap-event-plugin": "^2.0.0",
     "recursive-readdir-sync": "^1.0.6",
     "rimraf": "^2.5.3",
     "sinon": "^1.17.3",


### PR DESCRIPTION
Version 2.0.0 was recently released to support react 15.4.0

https://github.com/zilverline/react-tap-event-plugin/commit/f052c65bd7152a59a0fe075cbb8506a00dc4ad63


