### PR TITLE
[next][RadioGroup] add `onFocus` as optional property.  

### DIFF
--- a/src/Radio/RadioGroup.js
+++ b/src/Radio/RadioGroup.js
@@ -56,6 +56,7 @@ export default class RadioGroup extends Component {
     name: PropTypes.string,
     onBlur: PropTypes.func,
     onChange: PropTypes.func,
+    onFocus: PropTypes.func,
     onKeyDown: PropTypes.func,
     selectedValue: PropTypes.string,
   };
@@ -158,6 +159,10 @@ export default class RadioGroup extends Component {
           this.setTabIndex(i);
           break;
         }
+      }
+
+      if (this.props.onFocus) {
+        this.props.onFocus(event);
       }
     }
   };


### PR DESCRIPTION
Fixes #5583

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


### Description
With the current `next` `RadioGroup`, it has all the intelligence to navigate radios (yay!).  With the desire to add material helper text around the group, I need to know if any of those radios have focus, which the `RadioGroup` is keenly aware but it is not yet exposed.

### Images & references
[Material Design required field specification with helper texts](https://material.google.com/components/text-fields.html#text-fields-required-fields)

### Problem description
**Given** a `RadioGroup` with `Radio`s
**And** the `RadioGroup` is initialized with a prop `onFocus`
**When** any of the `Radio`s receive focus
**Then** `RadioGroup` should emit a focus event to the optional `onFocus` listener provided