### PR TITLE
[EnhancedSwitch] Add onTouchTap prop

### DIFF
--- a/src/internal/EnhancedSwitch.js
+++ b/src/internal/EnhancedSwitch.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, {Component, PropTypes} from 'react';
 import EventListener from 'react-event-listener';
 import keycode from 'keycode';
 import transitions from '../styles/transitions';
@@ -90,9 +90,9 @@ class EnhancedSwitch extends Component {
     onMouseUp: PropTypes.func,
     onParentShouldUpdate: PropTypes.func,
     onSwitch: PropTypes.func,
-    onTouchTap: PropTypes.func,
     onTouchEnd: PropTypes.func,
     onTouchStart: PropTypes.func,
+    onTouchTap: PropTypes.func,
     rippleColor: PropTypes.string,
     rippleStyle: PropTypes.object,
     style: PropTypes.object,
@@ -290,109 +290,109 @@ class EnhancedSwitch extends Component {
       ...other
   } = this.props;
 
-const {prepareStyles} = this.context.muiTheme;
-const styles = getStyles(this.props, this.context);
-const wrapStyles = Object.assign(styles.wrap, iconStyle);
-const mergedRippleStyle = Object.assign(styles.ripple, rippleStyle);
+    const {prepareStyles} = this.context.muiTheme;
+    const styles = getStyles(this.props, this.context);
+    const wrapStyles = Object.assign(styles.wrap, iconStyle);
+    const mergedRippleStyle = Object.assign(styles.ripple, rippleStyle);
 
-if (thumbStyle) {
-  wrapStyles.marginLeft /= 2;
-  wrapStyles.marginRight /= 2;
-}
+    if (thumbStyle) {
+      wrapStyles.marginLeft /= 2;
+      wrapStyles.marginRight /= 2;
+    }
 
-const labelElement = label && (
-  <label style={prepareStyles(Object.assign(styles.label, labelStyle))}>
-    {label}
-  </label>
+    const labelElement = label && (
+    <label style={prepareStyles(Object.assign(styles.label, labelStyle))}>
+      {label}
+    </label>
 );
 
-const showTouchRipple = !disabled && !disableTouchRipple;
-const showFocusRipple = !disabled && !disableFocusRipple;
+    const showTouchRipple = !disabled && !disableTouchRipple;
+    const showFocusRipple = !disabled && !disableFocusRipple;
 
-const touchRipple = (
-  <TouchRipple
-    ref="touchRipple"
-    key="touchRipple"
-    style={mergedRippleStyle}
-    color={mergedRippleStyle.color}
-    muiTheme={this.context.muiTheme}
-    centerRipple={true}
-    />
+    const touchRipple = (
+      <TouchRipple
+        ref="touchRipple"
+        key="touchRipple"
+        style={mergedRippleStyle}
+        color={mergedRippleStyle.color}
+        muiTheme={this.context.muiTheme}
+        centerRipple={true}
+      />
 );
 
-const focusRipple = (
-  <FocusRipple
-    key="focusRipple"
-    innerStyle={mergedRippleStyle}
-    color={mergedRippleStyle.color}
-    muiTheme={this.context.muiTheme}
-    show={this.state.isKeyboardFocused}
-    />
+    const focusRipple = (
+      <FocusRipple
+        key="focusRipple"
+        innerStyle={mergedRippleStyle}
+        color={mergedRippleStyle.color}
+        muiTheme={this.context.muiTheme}
+        show={this.state.isKeyboardFocused}
+      />
 );
 
-const ripples = [
-  showTouchRipple ? touchRipple : null,
-  showFocusRipple ? focusRipple : null,
-];
+    const ripples = [
+      showTouchRipple ? touchRipple : null,
+      showFocusRipple ? focusRipple : null,
+    ];
 
-const inputElement = (
-  <input
-    {...other}
-    ref="checkbox"
-    type={inputType}
-    style={prepareStyles(Object.assign(styles.input, inputStyle))}
-    name={name}
-    value={value}
-    disabled={disabled}
-    onBlur={this.handleBlur}
-    onFocus={this.handleFocus}
-    onChange={this.handleChange}
-    onMouseUp={showTouchRipple && this.handleMouseUp}
-    onMouseDown={showTouchRipple && this.handleMouseDown}
-    onMouseLeave={showTouchRipple && this.handleMouseLeave}
-    onTouchTap={this.handleTouchTap}
-    onTouchStart={showTouchRipple && this.handleTouchStart}
-    onTouchEnd={showTouchRipple && this.handleTouchEnd}
-    />
+    const inputElement = (
+      <input
+        {...other}
+        ref="checkbox"
+        type={inputType}
+        style={prepareStyles(Object.assign(styles.input, inputStyle))}
+        name={name}
+        value={value}
+        disabled={disabled}
+        onBlur={this.handleBlur}
+        onFocus={this.handleFocus}
+        onChange={this.handleChange}
+        onMouseUp={showTouchRipple && this.handleMouseUp}
+        onMouseDown={showTouchRipple && this.handleMouseDown}
+        onMouseLeave={showTouchRipple && this.handleMouseLeave}
+        onTouchTap={this.handleTouchTap}
+        onTouchStart={showTouchRipple && this.handleTouchStart}
+        onTouchEnd={showTouchRipple && this.handleTouchEnd}
+      />
 );
 
 // If toggle component (indicated by whether the style includes thumb) manually lay out
 // elements in order to nest ripple elements
-const switchOrThumbElement = !thumbStyle ? (
+    const switchOrThumbElement = !thumbStyle ? (
+      <div style={prepareStyles(wrapStyles)}>
+        {switchElement}
+        {ripples}
+      </div>
+) : (
   <div style={prepareStyles(wrapStyles)}>
-    {switchElement}
-    {ripples}
+    <div style={prepareStyles(Object.assign({}, trackStyle))} />
+    <Paper style={thumbStyle} zDepth={1} circle={true}> {ripples} </Paper>
   </div>
-) : (
-    <div style={prepareStyles(wrapStyles)}>
-      <div style={prepareStyles(Object.assign({}, trackStyle))} />
-      <Paper style={thumbStyle} zDepth={1} circle={true}> {ripples} </Paper>
-    </div>
   );
 
-const elementsInOrder = labelPosition === 'right' ? (
+    const elementsInOrder = labelPosition === 'right' ? (
+      <div style={styles.controls}>
+        {switchOrThumbElement}
+        {labelElement}
+      </div>
+) : (
   <div style={styles.controls}>
-    {switchOrThumbElement}
     {labelElement}
+    {switchOrThumbElement}
   </div>
-) : (
-    <div style={styles.controls}>
-      {labelElement}
-      {switchOrThumbElement}
-    </div>
   );
 
-return (
-  <div ref="root" className={className} style={prepareStyles(Object.assign(styles.root, style))}>
-    <EventListener
-      target="window"
-      onKeyDown={this.handleKeyDown}
-      onKeyUp={this.handleKeyUp}
-      />
-    {inputElement}
-    {elementsInOrder}
-  </div>
-);
+    return (
+      <div ref="root" className={className} style={prepareStyles(Object.assign(styles.root, style))}>
+        <EventListener
+          target="window"
+          onKeyDown={this.handleKeyDown}
+          onKeyUp={this.handleKeyUp}
+        />
+        {inputElement}
+        {elementsInOrder}
+      </div>
+    );
   }
 }
 


### PR DESCRIPTION
See #5104

In other components, it's possible to stop propagation on the touch tap event to prevent parent elements from firing their normal behaviors. EnhancedSwitch (and, by extension, Checkbox and other switches) did not have an onTouchTap prop to hook into.

This PR adds onTouchTap to EnhancedSwitch to correct this problem.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [X] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

