### PR TITLE
[next][IconButton] add optional accent styling

### DIFF
--- a/docs/site/src/demos/buttons/IconButtons.js
+++ b/docs/site/src/demos/buttons/IconButtons.js
@@ -15,7 +15,8 @@ export default function IconButtons(props, context) {
   return (
     <div>
       <IconButton className={classes.button}>delete</IconButton>
-      <IconButton className={classes.button}>add_shopping_cart</IconButton>
+      <IconButton accent className={classes.button}>alarm</IconButton>
+      <IconButton contrast className={classes.button}>add_shopping_cart</IconButton>
     </div>
   );
 }

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -74,6 +74,10 @@ styleSheet.registerLocalTheme((theme) => {
 export default class IconButton extends Component {
   static propTypes = {
     /**
+     * If true, will use the theme's accent color.
+     */
+    accent: PropTypes.bool,
+    /**
      * The icon element. If a string is passed,
      * it will be used as a material icon font ligature.
      */
@@ -82,6 +86,9 @@ export default class IconButton extends Component {
      * The CSS class name of the root element.
      */
     className: PropTypes.string,
+    /**
+     * If true, will use the theme's contrast color.
+     */
     contrast: PropTypes.bool,
     /**
      * If true, the button will be disabled.
@@ -98,6 +105,7 @@ export default class IconButton extends Component {
   };
 
   static defaultProps = {
+    accent: false,
     contrast: false,
     disabled: false,
     ripple: true,
@@ -108,11 +116,12 @@ export default class IconButton extends Component {
   };
 
   render() {
-    const { children, className, contrast, theme, ...other } = this.props;
+    const { accent, children, className, contrast, theme, ...other } = this.props;
     const classes = this.context.styleManager.render(styleSheet, theme);
     return (
       <ButtonBase
         className={classNames(classes.iconButton, {
+          [classes.accent]: accent,
           [classes.contrast]: contrast,
         }, className)}
         centerRipple


### PR DESCRIPTION
Add `accent` optional prop to `IconButton`

Fixes #5559

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


