### PR TITLE
[AutoComplete] Revert - Fire onUpdateInput when an item from the dropdown is selected

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -263,8 +263,6 @@ class AutoComplete extends Component {
         searchText: searchText,
       });
       this.close();
-
-      this.props.onUpdateInput(searchText, dataSource);
       this.props.onNewRequest(chosenRequest, index);
     }, this.props.menuCloseDelay);
   };

--- a/src/AutoComplete/AutoComplete.spec.js
+++ b/src/AutoComplete/AutoComplete.spec.js
@@ -88,34 +88,6 @@ describe('<AutoComplete />', () => {
     });
   });
 
-  describe('prop: onUpdateInput', () => {
-    it('should fire after selection from menu', (done) => {
-      const handleUpdateInput = spy();
-      const wrapper = shallowWithContext(
-        <AutoComplete
-          dataSource={['foo', 'bar']}
-          searchText="f"
-          onUpdateInput={handleUpdateInput}
-          menuCloseDelay={10}
-        />
-      );
-
-      wrapper.setState({open: true});
-      wrapper.find(Menu).props().onItemTouchTap({}, {
-        key: 0,
-      });
-      assert.strictEqual(handleUpdateInput.callCount, 0);
-      assert.strictEqual(wrapper.state().searchText, 'f');
-
-      setTimeout(() => {
-        assert.strictEqual(handleUpdateInput.callCount, 1);
-        assert.strictEqual(handleUpdateInput.getCall(0).args[0], 'foo');
-        assert.strictEqual(wrapper.state().searchText, 'foo');
-        done();
-      }, 20);
-    });
-  });
-
   describe('prop: popoverProps', () => {
     it('should pass popoverProps to Popover', () => {
       const wrapper = shallowWithContext(


### PR DESCRIPTION
@oliviertassinari As discussed in gitter and #3359, I am bringing the PR

Just for the record I am posting here what this PR should fix. Possible situation:

Geo Autocomplete, google geo data is used, new autocomplete data is fetched every time user changes input. If user choses some of the autocomplete's we want to save it somewhere is state(...then render in some place in application ) and clear searchText.
1) user changes input, onUpdateInput fires and fetches new dataSource.
2) user selects one of the fetched autocomplete results. But onUpdateInput fires again and inappropriate request happens that also updates dataSource property, searchText value is also updated.
3) onNewRequest fires and all seems here to be good, but what if would like to have here searchText's originally value to for example differently save chosenRequest(In order to implement something like exclusion autocomplete. The API can be - user starts input with minus. So we need to have originally searchText to see if this minus exists). With current behaviour we don't have such possibility.