### PR TITLE
[autoprefixer] fix invalid style value when UA is all with inline-flex

### DIFF
--- a/src/styles/getMuiTheme.spec.js
+++ b/src/styles/getMuiTheme.spec.js
@@ -81,6 +81,22 @@ describe('./styles/getMuiTheme', () => {
         });
       });
 
+      it('should spread properties for display:flex when userAgent is all', () => {
+        const muiTheme = getMuiTheme({}, {
+          userAgent: 'all',
+        });
+
+        const display = 'inline-flex';
+        const stylePrepared = muiTheme.prepareStyles({
+          display,
+        });
+
+        expect(stylePrepared).to.deep.equal({
+          muiPrepared: true,
+          display: `-webkit-box; display: -moz-box; display: -ms-${display}box; display: -webkit-${display}; display: inline-flex`, // eslint-disable-line max-len
+        });
+      });
+
       it('should prefix for the userAgent when we provid a valid one', () => {
         const muiTheme = getMuiTheme({}, {
           userAgent: MSIE9_USER_AGENT,

--- a/src/utils/autoprefixer.js
+++ b/src/utils/autoprefixer.js
@@ -20,7 +20,14 @@ export default function(muiTheme) {
   if (userAgent === false) { // Disabled autoprefixer
     return null;
   } else if (userAgent === 'all' || userAgent === undefined) { // Prefix for all user agent
-    return (style) => InlineStylePrefixer.prefixAll(style);
+    return (style) => {
+      const isFlex = ['flex', 'inline-flex'].includes(style.display);
+      const o = InlineStylePrefixer.prefixAll(style);
+      if (isFlex) {
+        o.display = o.display.join('; display: ');
+      }
+      return o;
+    };
   } else {
     const prefixer = new InlineStylePrefixer({
       userAgent: userAgent,


### PR DESCRIPTION
## problem to be solved

autoprefixer made `display: inline-flex` into invalid value(`display: "-webkit-box, -moz-box, -ms-inline-flexbox, -webkit-inline-flex, inline-flex"`) when userAgent is all.
This problem affects Avatar component.

## solution

autoprefixer make `display: inline-flex` or `display: flex` into browser recognized value(`display: "-webkit-box; display: -moz-box; display: -ms-inline-flexbox: display: -webkit-inline-flex; display: inline-flex"`) when userAgent is all.

### ref

inline-style-prefixer/flex.js at master · rofrischmann/inline-style-prefixer https://github.com/rofrischmann/inline-style-prefixer/blob/master/modules/static/plugins/flex.js

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / ~~docs demo~~, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).
