### PR TITLE
[next] Update react docgen dependency

### DIFF
--- a/docs/api/Dialog/Dialog.md
+++ b/docs/api/Dialog/Dialog.md
@@ -20,6 +20,7 @@ Props
 | className | string |  |  The CSS class name of the root element. |
 | hideOnBackdropClick | bool | true |  If `true`, clicking the backdrop will fire the `onRequestClose` callback. |
 | hideOnEscapeKeyUp | bool | true |  If `true`, hitting escape will fire the `onRequestClose` callback. |
+| maxWidth | enum:&nbsp;'xs'<br>&nbsp;'sm'<br>&nbsp;'md'<br> | 'sm' |  Determine the max width of the dialog. The dialog width grows with the size of the screen, this property is useful on the desktop where you might need some coherent different width size across your application. |
 | onBackdropClick | function |  |  Callback fires when the backdrop is clicked on. |
 | onEnter | function |  |  Callback fired before the dialog is entering. |
 | onEntering | function |  |  Callback fired when the dialog is entering. |

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "warning": "^3.0.0"
   },
   "devDependencies": {
-    "@nmarks/react-docgen": "^2.9.1",
     "app-module-path": "^2.1.0",
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
@@ -124,6 +123,7 @@
     "react-a11y": "^0.3.3",
     "react-addons-perf": "^15.4.0",
     "react-addons-test-utils": "^15.4.0",
+    "react-docgen": "^2.12.1",
     "react-dom": "^15.4.0",
     "recast": "^0.11.17",
     "recursive-readdir-sync": "^1.0.6",

--- a/scripts/build-api-docs.js
+++ b/scripts/build-api-docs.js
@@ -3,7 +3,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import * as reactDocgen from '@nmarks/react-docgen';
+import * as reactDocgen from 'react-docgen';
 import generateMarkdown from './generate-docs-markdown';
 
 const componentRegex = /^([A-Z][a-z]+)+\.js/;


### PR DESCRIPTION
Was using a scoped version so that we could use imported variables as default props.

I had opened a PR on the repo which has since been merged + released.


