### PR TITLE
[utils] Add a withWidth HoC

### DIFF
--- a/docs/site/src/components/AppFrame.js
+++ b/docs/site/src/components/AppFrame.js
@@ -2,13 +2,13 @@
 
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import compose from 'recompose/compose';
 import { createStyleSheet } from 'jss-theme-reactor';
 import Text from 'material-ui/Text';
 import AppBar from 'material-ui/AppBar';
 import Toolbar from 'material-ui/Toolbar';
 import IconButton from 'material-ui/IconButton';
-import { throttle } from 'material-ui/utils/helpers';
-import addEventListener from 'material-ui/utils/addEventListener';
+import withWidth, { isWidthUp } from 'material-ui/utils/withWidth';
 import AppDrawer from './AppDrawer';
 
 const globalStyleSheet = createStyleSheet('global', (theme) => ({
@@ -93,54 +93,20 @@ class AppFrame extends Component {
     children: PropTypes.node,
     dispatch: PropTypes.func.isRequired,
     routes: PropTypes.array,
+    width: PropTypes.string.isRequired,
   };
 
   static contextTypes = {
-    theme: PropTypes.object.isRequired,
     styleManager: PropTypes.object.isRequired,
   };
 
   state = {
-    drawerDocked: false,
     drawerOpen: false,
   };
 
   componentWillMount() {
     this.context.styleManager.render(globalStyleSheet);
-    this.resizeListener = addEventListener(window, 'resize', this.handleResize);
   }
-
-  componentDidMount() {
-    this.mounted = true;
-    this.checkWindowSize();
-  }
-
-  componentWillUnmount() {
-    this.mounted = false;
-
-    if (this.resizeListener) {
-      this.resizeListener.remove();
-    }
-  }
-
-  mounted = false;
-  resizeListener = undefined;
-
-  checkWindowSize = () => {
-    if (!this.mounted) {
-      return;
-    }
-
-    const breakpoint = this.context.theme.breakpoints.getWidth('lg');
-
-    if (this.state.drawerDocked && window.innerWidth < breakpoint) {
-      this.setState({ drawerDocked: false });
-    } else if (!this.state.drawerDocked && window.innerWidth >= breakpoint) {
-      this.setState({ drawerDocked: true });
-    }
-  };
-
-  handleResize = throttle(this.checkWindowSize, 100);
 
   handleDrawerOpen = () => {
     this.setState({ drawerOpen: true });
@@ -182,7 +148,7 @@ class AppFrame extends Component {
     const classes = this.context.styleManager.render(styleSheet);
     const title = this.getTitle();
 
-    let drawerDocked = this.state.drawerDocked;
+    let drawerDocked = isWidthUp('lg', this.props.width);
     let navIconClassName = classes.navIcon;
     let appBarClassName = classes.appBar;
 
@@ -223,4 +189,7 @@ class AppFrame extends Component {
   }
 }
 
-export default connect()(AppFrame);
+export default compose(
+  withWidth(),
+  connect(),
+)(AppFrame);

--- a/src/styles/breakpoints.js
+++ b/src/styles/breakpoints.js
@@ -1,5 +1,14 @@
 // @flow weak
 
+// Sorted ASC by size. That's important.
+export const keys = [
+  'xs',
+  'sm',
+  'md',
+  'lg',
+  'xl',
+];
+
 export default function createBreakpoints(
   breakpoints = {
     xs: 360,
@@ -11,7 +20,6 @@ export default function createBreakpoints(
   unit = 'px',
   step = 1,
 ) {
-  const keys = Object.keys(breakpoints);
   const values = keys.map((n) => breakpoints[n]);
 
   function up(name) {
@@ -33,7 +41,7 @@ export default function createBreakpoints(
 
   function only(name) {
     const keyIndex = keys.indexOf(name);
-    if (keyIndex === values.length - 1) {
+    if (keyIndex === keys.length - 1) {
       return up(name);
     }
     return between(name, name);

--- a/src/styles/withStyles.js
+++ b/src/styles/withStyles.js
@@ -9,8 +9,8 @@ const withStyles = (styleSheet) => (BaseComponent) => {
 
   const WithStyle = (ownerProps, context) => (
     factory({
-      ...ownerProps,
       classes: context.styleManager.render(styleSheet),
+      ...ownerProps,
     })
   );
 

--- a/src/utils/withWidth.js
+++ b/src/utils/withWidth.js
@@ -1,0 +1,113 @@
+// @flow weak
+
+import React, { Component, PropTypes } from 'react';
+import EventListener from 'react-event-listener';
+import createHelper from 'recompose/createHelper';
+import createEagerFactory from 'recompose/createEagerFactory';
+import { keys } from '../styles/breakpoints';
+
+export const isWidthUp = (baseWidth, width) => (
+  keys.indexOf(baseWidth) <= keys.indexOf(width)
+);
+
+export const isWidthDown = (baseWidth, width) => (
+  keys.indexOf(baseWidth) > keys.indexOf(width)
+);
+
+function withWidth(options = {}) {
+  const {
+    resizeInterval = 166, // Corresponds to 10 frames at 60 Hz.
+  } = options;
+
+  return (BaseComponent) => {
+    const factory = createEagerFactory(BaseComponent);
+
+    return class WithWidth extends Component {
+      static contextTypes = {
+        theme: PropTypes.object.isRequired,
+      };
+
+      state = {
+        width: null,
+      };
+
+      componentDidMount() {
+        this.updateWidth(window.innerWidth);
+      }
+
+      componentWillUnmount() {
+        clearTimeout(this.deferTimer);
+      }
+
+      deferTimer = null;
+
+      handleResize = () => {
+        clearTimeout(this.deferTimer);
+        this.deferTimer = setTimeout(() => {
+          this.updateWidth(window.innerWidth);
+        }, resizeInterval);
+      };
+
+      updateWidth(innerWidth) {
+        const breakpoints = this.context.theme.breakpoints;
+        let width = null;
+
+        /**
+         * Start with the slowest value as low end devices often have a small screen.
+         *
+         * innerWidth |0      xs      sm      md      lg      xl
+         *            |-------|-------|-------|-------|-------|------>
+         * width      |  xs   |  xs   |  sm   |  md   |  lg   |  xl
+         */
+        let index = 1;
+        while (width === null && index < breakpoints.keys.length) {
+          const currentWidth = breakpoints.keys[index];
+
+          if (innerWidth < breakpoints.getWidth(currentWidth)) {
+            width = breakpoints.keys[index - 1];
+            break;
+          }
+
+          index += 1;
+        }
+
+        width = width || 'xl';
+
+        if (width !== this.state.width) {
+          this.setState({
+            width,
+          });
+        }
+      }
+
+      render() {
+        const width = this.state.width;
+
+        /**
+         * When rendering the component on the server,
+         * we have no idea about the screen width.
+         * In order to prevent blinks and help the reconciliation
+         * we are not rendering the component.
+         *
+         * A better alternative would be to send client hints.
+         * But the browser support of this API is low:
+         * http://caniuse.com/#search=client%20hint
+         */
+        if (width === null) {
+          return null;
+        }
+
+        return (
+          <EventListener target="window" onResize={this.handleResize}>
+            {factory({
+              width,
+              ...this.props,
+            })}
+          </EventListener>
+        );
+      }
+    };
+  };
+}
+
+export default createHelper(withWidth, 'withWidth');

--- a/src/utils/withWidth.spec.js
+++ b/src/utils/withWidth.spec.js
@@ -1,0 +1,74 @@
+// @flow weak
+/* eslint-env mocha */
+
+import React from 'react';
+import { assert } from 'chai';
+import { createShallowWithContext, createMountWithContext } from 'test/utils';
+import withWidth, { isWidthUp, isWidthDown } from './withWidth';
+
+const Empty = () => <div />;
+Empty.propTypes = {}; // Breaks the referencial transparency for testing purposes.
+const EmptyWithWidth = withWidth()(Empty);
+
+describe('withWidth', () => {
+  let shallow;
+  let mount;
+
+  before(() => {
+    shallow = createShallowWithContext();
+    mount = createMountWithContext();
+  });
+
+  describe('server side rendering', () => {
+    it('should not render the children as the width is unkown', () => {
+      const wrapper = shallow(<EmptyWithWidth />);
+      assert.strictEqual(wrapper.type(), null, 'should render nothing');
+    });
+  });
+
+  describe('prop: width', () => {
+    it('should be able to override it', () => {
+      const wrapper = mount(<EmptyWithWidth width="foo" />);
+
+      assert.strictEqual(wrapper.find(Empty).props().width, 'foo');
+    });
+  });
+
+  describe('browser', () => {
+    it('should provide the right width to the child element', () => {
+      const wrapper = mount(<EmptyWithWidth />);
+
+      assert.strictEqual(wrapper.find(Empty).props().width, 'md');
+    });
+  });
+
+  describe('isWidthUp', () => {
+    it('should work as expected', () => {
+      assert.strictEqual(isWidthUp('md', 'lg'), true, 'should accept larger size');
+      assert.strictEqual(isWidthUp('md', 'md'), true, 'should be inclusive');
+      assert.strictEqual(isWidthUp('md', 'sm'), false, 'should reject smaller size');
+    });
+  });
+
+  describe('isWidthDown', () => {
+    it('should work as expected', () => {
+      assert.strictEqual(isWidthDown('md', 'lg'), false, 'should reject larger size');
+      assert.strictEqual(isWidthDown('md', 'md'), false, 'should be exclusive');
+      assert.strictEqual(isWidthDown('md', 'sm'), true, 'should accept smaller size');
+    });
+  });
+
+  describe('width computation', () => {
+    it('should work as expected', () => {
+      const wrapper = shallow(<EmptyWithWidth />);
+      const instance = wrapper.instance();
+      const updateWidth = instance.updateWidth.bind(instance);
+      const breakpoints = wrapper.context().theme.breakpoints;
+
+      breakpoints.keys.forEach((key) => {
+        updateWidth(breakpoints.getWidth(key));
+        assert.strictEqual(wrapper.state().width, key, 'should return the matching width');
+      });
+    });
+  });
+});

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -5,7 +5,7 @@ const path = require('path');
 module.exports = function setKarmaConfig(config) {
   config.set({
     basePath: '../',
-    browsers: ['PhantomJS'],
+    browsers: ['PhantomJS_Sized'],
     // to avoid DISCONNECTED messages on travis
     browserDisconnectTimeout: 10000, // default 2000
     browserDisconnectTolerance: 1, // default 0
@@ -85,6 +85,17 @@ module.exports = function setKarmaConfig(config) {
     },
     webpackServer: {
       noInfo: true,
+    },
+    customLaunchers: {
+      PhantomJS_Sized: {
+        base: 'PhantomJS',
+        options: {
+          viewportSize: { // Matches JSDom size.
+            width: 1024,
+            height: 768,
+          },
+        },
+      },
     },
   });
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

In some case, media queries aren't enough and computation is needed at the React level.
E.g.
```jsx
// ...

export default compose(
  pure,
  withStyles(styleSheet),
  withWidth(),
  connect((state, ownProps) => {
    return {
      moveUp: isWidthDown('md', ownProps.width) ?
        state.getIn(['snackbar', 'open']) :
        false,
    };
  }),
)(MainActionButton);
```



