### PR TITLE
[Docs] Fix origin documentation

### DIFF
--- a/src/IconMenu/IconMenu.js
+++ b/src/IconMenu/IconMenu.js
@@ -14,8 +14,8 @@ class IconMenu extends Component {
      * This is the point on the icon where the menu
      * `targetOrigin` will attach.
      * Options:
-     * vertical: [top, middle, bottom]
-     * horizontal: [left, center, right].
+     * vertical: [top, center, bottom]
+     * horizontal: [left, middle, right].
      */
     anchorOrigin: propTypes.origin,
     /**
@@ -104,8 +104,8 @@ class IconMenu extends Component {
      * This is the point on the menu which will stick to the menu
      * origin.
      * Options:
-     * vertical: [top, middle, bottom]
-     * horizontal: [left, center, right].
+     * vertical: [top, center, bottom]
+     * horizontal: [left, middle, right].
      */
     targetOrigin: propTypes.origin,
     /**

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -18,8 +18,8 @@ class Popover extends Component {
      * This is the point on the anchor where the popover's
      * `targetOrigin` will attach to.
      * Options:
-     * vertical: [top, middle, bottom];
-     * horizontal: [left, center, right].
+     * vertical: [top, center, bottom]
+     * horizontal: [left, middle, right].
      */
     anchorOrigin: propTypes.origin,
     /**
@@ -68,8 +68,8 @@ class Popover extends Component {
      * This is the point on the popover which will attach to
      * the anchor's origin.
      * Options:
-     * vertical: [top, middle, bottom];
-     * horizontal: [left, center, right].
+     * vertical: [top, center, bottom]
+     * horizontal: [left, middle, right].
      */
     targetOrigin: propTypes.origin,
     /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

`middle` and `center` values for origin are mixed up. Change in code would be more intuitive (same as vertical-align in CSS), but it will introduce a breaking change. 

So I've changed documentation accordingly to the current version of the code.
Fixes #2550