### PR TITLE
[next][Button] accent/contrast prop consistency with IconButton. 

### DIFF
--- a/docs/site/src/demos/buttons/FlatButtons.js
+++ b/docs/site/src/demos/buttons/FlatButtons.js
@@ -17,6 +17,7 @@ export default function FlatButtons(props, context) {
       <Button className={classes.button}>Default</Button>
       <Button primary className={classes.button}>Primary</Button>
       <Button accent className={classes.button}>Accent</Button>
+      <Button contrast className={classes.button}>Contrast</Button>
       <Button disabled className={classes.button}>Disabled</Button>
     </div>
   );

--- a/docs/site/src/demos/buttons/RaisedButtons.js
+++ b/docs/site/src/demos/buttons/RaisedButtons.js
@@ -17,6 +17,7 @@ export default function RaisedButtons(props, context) {
       <Button raised className={classes.button}>Default</Button>
       <Button raised primary className={classes.button}>Primary</Button>
       <Button raised accent className={classes.button}>Accent</Button>
+      <Button raised contrast className={classes.button}>Contrast</Button>
       <Button
         raised
         disabled

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -50,7 +50,7 @@ export const styleSheet = createStyleSheet('Button', (theme) => {
       color: palette.accent.A200,
     },
     contrast: {
-      color: palette.type === 'light' ? palette.shades.dark.primary : palette.shades.light.secondary,
+      color: palette.getContrastText(palette.primary[500]),
     },
     raised: {
       color: getContrastText(palette.grey[300]),
@@ -83,6 +83,9 @@ export const styleSheet = createStyleSheet('Button', (theme) => {
       '&:hover': {
         backgroundColor: palette.accent.A400,
       },
+    },
+    raisedContrast: {
+      color: getContrastText(palette.primary[500]),
     },
     fab: {
       borderRadius: '50%',
@@ -128,6 +131,10 @@ export default class Button extends Component {
      * The element or component used for the root node.
      */
     component: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+    /**
+     * If true, will use the theme's contrast color.
+     */
+    contrast: PropTypes.bool,
     /**
      * If `true`, the button will be disabled.
      */
@@ -187,6 +194,7 @@ export default class Button extends Component {
       children,
       className: classNameProp,
       compact,
+      contrast,
       disabled,
       fab,
       primary,
@@ -202,8 +210,10 @@ export default class Button extends Component {
       [classes.fab]: fab,
       [classes.primary]: flat && primary,
       [classes.accent]: flat && accent,
+      [classes.contrast]: flat && contrast,
       [classes.raisedPrimary]: !flat && primary,
       [classes.raisedAccent]: !flat && accent,
+      [classes.raisedContrast]: !flat && contrast,
       [classes.compact]: compact,
       [classes.disabled]: disabled,
     }, classNameProp);

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -4,7 +4,6 @@ import React, { Component, PropTypes } from 'react';
 import { createStyleSheet } from 'jss-theme-reactor';
 import classNames from 'classnames';
 import ButtonBase from '../internal/ButtonBase';
-import { getContrastText } from '../styles/palette';
 
 export const styleSheet = createStyleSheet('Button', (theme) => {
   const { typography, palette, transitions, shadows } = theme;
@@ -53,7 +52,7 @@ export const styleSheet = createStyleSheet('Button', (theme) => {
       color: palette.getContrastText(palette.primary[500]),
     },
     raised: {
-      color: getContrastText(palette.grey[300]),
+      color: palette.getContrastText(palette.grey[300]),
       backgroundColor: palette.grey[300],
       boxShadow: shadows[2],
       '&$keyboardFocused': {
@@ -71,21 +70,21 @@ export const styleSheet = createStyleSheet('Button', (theme) => {
     },
     keyboardFocused: {},
     raisedPrimary: {
-      color: getContrastText(palette.primary[500]),
+      color: palette.getContrastText(palette.primary[500]),
       backgroundColor: palette.primary[500],
       '&:hover': {
         backgroundColor: palette.primary[700],
       },
     },
     raisedAccent: {
-      color: getContrastText(palette.accent.A200),
+      color: palette.getContrastText(palette.accent.A200),
       backgroundColor: palette.accent.A200,
       '&:hover': {
         backgroundColor: palette.accent.A400,
       },
     },
     raisedContrast: {
-      color: getContrastText(palette.primary[500]),
+      color: palette.getContrastText(palette.primary[500]),
     },
     fab: {
       borderRadius: '50%',
@@ -175,6 +174,7 @@ export default class Button extends Component {
     accent: false,
     component: 'button',
     compact: false,
+    contrast: false,
     disabled: false,
     fab: false,
     focusRipple: true,

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -25,9 +25,6 @@ export const styleSheet = createStyleSheet('IconButton', (theme) => {
       zIndex: 1,
       transition: transitions.create('background-color', '150ms'),
     },
-    primary: {
-      color: palette.primary[500],
-    },
     accent: {
       color: palette.accent.A200,
     },

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -25,9 +25,14 @@ export const styleSheet = createStyleSheet('IconButton', (theme) => {
       zIndex: 1,
       transition: transitions.create('background-color', '150ms'),
     },
+    primary: {
+      color: palette.primary[500],
+    },
+    accent: {
+      color: palette.accent.A200,
+    },
     contrast: {
-      color: palette.type === 'light' ?
-        palette.shades.dark.text.primary : palette.shades.light.text.secondary,
+      color: palette.getContrastText(palette.primary[500]),
     },
     label: {
       width: '100%',
@@ -41,12 +46,6 @@ export const styleSheet = createStyleSheet('IconButton', (theme) => {
     },
     keyboardFocused: {
       backgroundColor: palette.text.divider,
-    },
-    primary: {
-      color: palette.primary[500],
-    },
-    accent: {
-      color: palette.accent.A200,
     },
   };
 });


### PR DESCRIPTION
Fixes #5559.

Consistent availability of `accent` and `contrast` between `Button` and `Icon`.

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


