### PR TITLE
[TextField] Breaks character composition #3394 bug fixed

### DIFF
--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -345,9 +345,10 @@ class TextField extends Component {
   };
 
   handleInputChange = (event) => {
-    this.setState({hasValue: isValid(event.target.value)});
     if (this.props.onChange) {
       this.props.onChange(event, event.target.value);
+    } else {
+      this.setState({hasValue: isValid(event.target.value)});
     }
   };
 


### PR DESCRIPTION
Fix https://github.com/callemall/material-ui/issues/3394

demo.js:
```jsx
<div>
    <Dialog
        title="Dialog With Date Picker"
        modal={true}
        open={true}
    >
        Open a Date Picker dialog from within a dialog.
        <TextField
            value={this.state.value}
            onChange={(e, v)=> {
                this.setState({
                    value: v,
                });
            }}
        />

    </Dialog>
</div>
...

```
description:

Step1，user input several chars into TextField.
Step2，user delete all chars what he input just now.
Step3，user input press a key by Chinese IME

TextField.js

```
...
handleInputChange = (event) => {
        this.setState({hasValue: isValid(event.target.value), isClean: false});
        if (this.props.onChange) this.props.onChange(event, event.target.value);
  };
...
```

the state value {hasValue: isValid(event.target.value)} will change.
so it will trigger TextField component update , render function will be called.
But in the same time, onChange handler will be called too，it will trigger TextField component update again.

Two Times component update actions will recurrence the bug.


