### PR TITLE
[DatePicker] Auto switch the view when a year is selected

### DIFF
--- a/src/DatePicker/Calendar.js
+++ b/src/DatePicker/Calendar.js
@@ -153,6 +153,7 @@ class Calendar extends Component {
     const date = cloneDate(this.state.selectedDate);
     date.setFullYear(year);
     this.setSelectedDate(date, event);
+    this.handleTouchTapDateDisplayMonthDay();
   };
 
   getToolbarInteractions() {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [X] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

This is in relation to issue https://github.com/callemall/material-ui/issues/4949#issuecomment-240452118 where it is not intuitive to the user to click the date after selecting the year. I added a new attribute autoSwitch; where if set true changes the view back to the monthDay view where the user can now complete the date selection. 

```jsx
<MaterialDatePicker hintText={this.props.hintText || 'Click to select a date'}
                            hintStyle={this.props.hintStyle || styles.hint}
                            autoSwitch={true}
                            autoOk={true}/>

```
