### PR TITLE
[IconMenu] Fix controlled IconMenus to honor onRequestChange

### DIFF
--- a/src/IconMenu/IconMenu.js
+++ b/src/IconMenu/IconMenu.js
@@ -179,16 +179,16 @@ class IconMenu extends Component {
 
     if (this.props.open !== null) {
       this.props.onRequestChange(false, reason);
+    } else {
+      this.setState({open: false}, () => {
+        // Set focus on the icon button when the menu close
+        if (isKeyboard) {
+          const iconButton = this.refs.iconButton;
+          ReactDOM.findDOMNode(iconButton).focus();
+          iconButton.setKeyboardFocus();
+        }
+      });
     }
-
-    this.setState({open: false}, () => {
-      // Set focus on the icon button when the menu close
-      if (isKeyboard) {
-        const iconButton = this.refs.iconButton;
-        ReactDOM.findDOMNode(iconButton).focus();
-        iconButton.setKeyboardFocus();
-      }
-    });
   }
 
   open(reason, event) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

This PR fixes a problem that allows controlled icon menus to close on its own. Now, if the icon menu is controlled, it will just call `onRequestChange` and not automatically close the menu.
