### PR TITLE
[DatePicker] Fix focus for datepicker by closing on blur and opening …

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "react-tap-event-plugin": "^2.0.0",
     "recursive-readdir-sync": "^1.0.6",
     "rimraf": "^2.5.3",
-    "sinon": "^1.17.3",
+    "sinon": "^2.0.0-pre",
     "webpack": "^1.13.3"
   }
 }

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -1,5 +1,4 @@
 import React, {Component, PropTypes} from 'react';
-import ReactDOM from 'react-dom';
 import EventListener from 'react-event-listener';
 import keycode from 'keycode';
 import {dateTimeFormat, formatIso, isEqualDate} from './dateUtils';

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -174,27 +174,21 @@ class DatePicker extends Component {
   }
 
   getDate() {
-    return this.state.date;
+    /**
+     * if the date is not selected then set it to new date
+     * (get the current system date while doing so)
+     * else set it to the currently selected date
+     */
+    return this.state.date ? this.state.date : new Date();
   }
 
   /**
    * Open the date-picker dialog programmatically from a parent.
    */
   openDialog() {
-    /**
-     * if the date is not selected then set it to new date
-     * (get the current system date while doing so)
-     * else set it to the currently selected date
-     */
-    if (this.state.date !== undefined) {
-      this.setState({
-        dialogDate: this.getDate(),
-      }, this.refs.dialogWindow.show);
-    } else {
-      this.setState({
-        dialogDate: new Date(),
-      }, this.refs.dialogWindow.show);
-    }
+    this.setState({
+      dialogDate: this.getDate(),
+    }, this.refs.dialogWindow.show);
   }
 
   /**

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -316,6 +316,7 @@ class DatePicker extends Component {
       minDate,
       mode,
       okLabel,
+      onDismiss, // eslint-disable-line no-unused-vars
       onFocus, // eslint-disable-line no-unused-vars
       onShow,
       onTouchTap, // eslint-disable-line no-unused-vars

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -247,7 +247,7 @@ class DatePicker extends Component {
     }
 
     if (this.props.onDismiss) {
-      this.props.onDismiss(event);
+      this.props.onDismiss();
     }
   };
 

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -177,6 +177,8 @@ class DatePicker extends Component {
     }
   }
 
+  element = null;
+
   getDate() {
     /**
      * if the date is not selected then set it to new date

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -202,13 +202,6 @@ class DatePicker extends Component {
     this.handleFocus();
   }
 
-  createEvent = () => {
-    const inputComponent = ReactDOM.findDOMNode(this.refs.input);
-    const input = inputComponent.getElementsByTagName('input')[0];
-
-    input.focus();
-  };
-
   handleAccept = (date) => {
     if (!this.isControlled()) {
       this.setState({
@@ -230,7 +223,7 @@ class DatePicker extends Component {
 
   handleBlur = (event, shouldSetFocus) => {
     if (shouldSetFocus) {
-      this.createEvent();
+      this.refs.input.focus();
     }
 
     if (this.state.isFocused) {

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -89,6 +89,10 @@ class DatePicker extends Component {
      */
     okLabel: PropTypes.node,
     /**
+     * Callback function that is fired when the Date Picker's `TextField` blurs.
+     */
+    onBlur: PropTypes.func,
+    /**
      * Callback function that is fired when the date value changes.
      *
      * @param {null} null Since there is no particular event associated with the change,
@@ -211,8 +215,21 @@ class DatePicker extends Component {
     }
   };
 
+  handleBlur = (event) => {
+    this.refs.dialogWindow.dismiss();
+
+    if (this.props.onBlur) {
+      this.props.onBlur(event);
+    }
+  };
+
   handleFocus = (event) => {
-    event.target.blur();
+    if (!this.props.disabled) {
+      setTimeout(() => {
+        this.openDialog();
+      }, 0);
+    }
+
     if (this.props.onFocus) {
       this.props.onFocus(event);
     }
@@ -288,6 +305,7 @@ class DatePicker extends Component {
         <TextField
           {...other}
           onFocus={this.handleFocus}
+          onBlur={this.handleBlur}
           onTouchTap={this.handleTouchTap}
           ref="input"
           style={textFieldStyle}

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -156,7 +156,6 @@ class DatePicker extends Component {
 
   state = {
     date: undefined,
-    isFocused: false,
   };
 
   componentWillMount() {
@@ -175,6 +174,8 @@ class DatePicker extends Component {
       }
     }
   }
+
+  isFocused = false;
 
   element = null;
 
@@ -210,11 +211,7 @@ class DatePicker extends Component {
       });
     }
 
-    setTimeout(() => {
-      this.setState({
-        isFocused: false,
-      });
-    }, 0);
+    this.isFocused = false;
     this.refs.input.focus();
 
     if (this.props.onChange) {
@@ -227,10 +224,9 @@ class DatePicker extends Component {
       this.refs.input.focus();
     }
 
-    if (this.state.isFocused) {
-      this.setState({
-        isFocused: false,
-      }, this.refs.dialogWindow.dismiss);
+    if (this.isFocused) {
+      this.isFocused = false;
+      this.refs.dialogWindow.dismiss();
     }
 
     if (this.props.onBlur) {
@@ -239,11 +235,9 @@ class DatePicker extends Component {
   };
 
   handleDismiss = () => {
-    if (this.state.isFocused) {
+    if (this.isFocused) {
       this.refs.input.focus();
-      this.setState({
-        isFocused: false,
-      });
+      this.isFocused = false;
     }
 
     if (this.props.onDismiss) {
@@ -252,10 +246,9 @@ class DatePicker extends Component {
   };
 
   handleFocus = (event) => {
-    if (!this.props.disabled && !this.state.isFocused) {
-      this.setState({
-        isFocused: true,
-      }, this.openDialog);
+    if (!this.isFocused) {
+      this.isFocused = true;
+      this.openDialog();
     }
 
     if (this.props.onFocus) {

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -264,7 +264,7 @@ class DatePicker extends Component {
     this.handleFocus(event);
   };
 
-  handleWindowKeyUp = (event) => {
+  handleWindowKeyDown = (event) => {
     if (!this.refs.dialogWindow.state.open) {
       return;
     }
@@ -331,17 +331,16 @@ class DatePicker extends Component {
     return (
       <div ref={(node) => this.element = node} className={className} style={prepareStyles(Object.assign({}, style))}>
         <TextField
+          readOnly={true}
           {...other}
           onFocus={this.handleFocus}
-          onTouchTap={this.handleTouchTap}
-          readOnly={true}
           ref="input"
           style={textFieldStyle}
           value={this.state.date ? formatDate(this.state.date) : ''}
         />
         <EventListener
           target="window"
-          onKeyDown={this.handleWindowKeyUp}
+          onKeyDown={this.handleWindowKeyDown}
         />
         <DatePickerDialog
           DateTimeFormat={DateTimeFormat}

--- a/src/DatePicker/DatePicker.spec.js
+++ b/src/DatePicker/DatePicker.spec.js
@@ -1,6 +1,7 @@
 /* eslint-env mocha */
-import React from 'react';
-import {shallow} from 'enzyme';
+import React, {PropTypes} from 'react';
+import {shallow, mount} from 'enzyme';
+import {spy} from 'sinon';
 import {assert} from 'chai';
 
 import DatePicker from './DatePicker';
@@ -10,6 +11,10 @@ import TextField from '../TextField';
 describe('<DatePicker />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+  const mountWithContext = (node) => mount(node, {
+    context: {muiTheme},
+    childContextTypes: {muiTheme: PropTypes.object},
+  });
 
   describe('formatDate', () => {
     it('should use the default format', () => {
@@ -21,5 +26,29 @@ describe('<DatePicker />', () => {
       assert.strictEqual(wrapper.find(TextField).props().value, '2015-12-01',
         'should format the date to ISO 8601 (YYYY-MM-DD)');
     });
+  });
+
+  it('should call the onFocus method when TextField receives focus', () => {
+    const onFocus = spy();
+    const wrapper = mountWithContext(
+      <DatePicker id="mock-id" onFocus={onFocus} />
+    );
+
+    wrapper.find('input').simulate('focus');
+    assert.strictEqual(
+      onFocus.called,
+      true, 'should call DatePicker\'s onFocus method');
+  });
+
+  it('should call the onBlur method when TextField blurs', () => {
+    const onBlur = spy();
+    const wrapper = mountWithContext(
+      <DatePicker id="mock-id" onBlur={onBlur} />
+    );
+
+    wrapper.find('input').simulate('blur');
+    assert.strictEqual(
+      onBlur.called,
+      true, 'should call DatePicker\'s onBlur method');
   });
 });

--- a/src/DatePicker/DatePicker.spec.js
+++ b/src/DatePicker/DatePicker.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import React, {PropTypes} from 'react';
 import {shallow, mount} from 'enzyme';
-import {spy} from 'sinon';
+import {spy, useFakeTimers} from 'sinon';
 import {assert} from 'chai';
 
 import DatePicker from './DatePicker';
@@ -25,6 +25,33 @@ describe('<DatePicker />', () => {
 
       assert.strictEqual(wrapper.find(TextField).props().value, '2015-12-01',
         'should format the date to ISO 8601 (YYYY-MM-DD)');
+    });
+  });
+
+  describe('getDate method', () => {
+    it('should select current date if no defaultDate is passed', () => {
+      const now = new Date();
+      const clock = useFakeTimers(now.getTime());
+
+      const datePicker = shallowWithContext(
+        <DatePicker />
+      ).instance();
+
+      assert.strictEqual(datePicker.getDate().toString(), now.toString(),
+      'should set the date to the current time when defaultDate is missing');
+
+      clock.restore();
+    });
+
+    it('should select defaultDate date if it is passed', () => {
+      const defaultDate = new Date(358327500000); // Sun, 10 May 1981 09:25:00 GMT
+
+      const datePicker = shallowWithContext(
+        <DatePicker value={defaultDate} />
+      ).instance();
+
+      assert.strictEqual(datePicker.getDate().toString(), defaultDate.toString(),
+      'should set the date to the defaultDate that was set');
     });
   });
 

--- a/src/DatePicker/DatePicker.spec.js
+++ b/src/DatePicker/DatePicker.spec.js
@@ -58,7 +58,7 @@ describe('<DatePicker />', () => {
   it('should call the onFocus method when TextField receives focus', () => {
     const onFocus = spy();
     const wrapper = mountWithContext(
-      <DatePicker id="mock-id" onFocus={onFocus} />
+      <DatePicker onFocus={onFocus} />
     );
 
     wrapper.find('input').simulate('focus');
@@ -70,7 +70,7 @@ describe('<DatePicker />', () => {
   it('should call the onBlur method when TextField blurs', () => {
     const onBlur = spy();
     const wrapper = mountWithContext(
-      <DatePicker id="mock-id" onBlur={onBlur} />
+      <DatePicker onBlur={onBlur} />
     );
 
     wrapper.find('input').simulate('blur');

--- a/src/DatePicker/DatePickerDialog.js
+++ b/src/DatePicker/DatePickerDialog.js
@@ -148,7 +148,6 @@ class DatePickerDialog extends Component {
           ref="dialog"
           repositionOnUpdate={true}
           open={open}
-          modal={true}
           onRequestClose={this.handleRequestClose}
           style={Object.assign(styles.dialogBodyContent, containerStyle)}
         >

--- a/src/DatePicker/DatePickerDialog.js
+++ b/src/DatePicker/DatePickerDialog.js
@@ -148,6 +148,7 @@ class DatePickerDialog extends Component {
           ref="dialog"
           repositionOnUpdate={true}
           open={open}
+          modal={true}
           onRequestClose={this.handleRequestClose}
           style={Object.assign(styles.dialogBodyContent, containerStyle)}
         >

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -245,7 +245,7 @@ class DialogInline extends Component {
     }
   }
 
-  handleTouchTapOverlay = () => {
+  handleMouseDownOverlay = () => {
     this.requestClose(false);
   };
 
@@ -349,7 +349,7 @@ class DialogInline extends Component {
           show={open}
           className={overlayClassName}
           style={styles.overlay}
-          onTouchTap={this.handleTouchTapOverlay}
+          onMouseDown={this.handleMouseDownOverlay}
         />
       </div>
     );


### PR DESCRIPTION
When the `TextField` in the `DatePicker` received focus it was blurring the `TextField` so it didn't look as if it was selected. However you could still tab between fields and the `DatePicker` would stay in place, despite the fact that the `DatePicker` is no longer selected/in focus. With this PR when we `handleFocus` for the `TextField` and we will open the `DatePickerDialog`. 

I think the original reason why the `DatePicker` blurred when the `TextField` received focus was because there was no handling of `onBlur` (despite the documentation saying that it's there). This PR adds the `onBlur` and a `handleBlur` that is passed into the `TextField`. When the `TextField` blurs then the `DatePickerDialog` will be dismissed. When the `TextField` receives focus then the `DatePickerDialog` will be shown.

Closes #5612
Related #5030

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).