### PR TITLE
[EnhancedButton] Only apply type when needed

### DIFF
--- a/src/internal/EnhancedButton.js
+++ b/src/internal/EnhancedButton.js
@@ -339,12 +339,16 @@ class EnhancedButton extends Component {
       onKeyDown: this.handleKeyDown,
       onTouchTap: this.handleTouchTap,
       tabIndex: disabled || disableKeyboardFocus ? -1 : tabIndex,
-      type: type,
     };
+
     const buttonChildren = this.createButtonChildren();
 
     if (React.isValidElement(containerElement)) {
       return React.cloneElement(containerElement, buttonProps, buttonChildren);
+    }
+
+    if (!href && containerElement === 'button') {
+      buttonProps.type = type;
     }
 
     return React.createElement(href ? 'a' : containerElement, buttonProps, buttonChildren);

--- a/src/internal/EnhancedButton.spec.js
+++ b/src/internal/EnhancedButton.spec.js
@@ -119,14 +119,33 @@ describe('<EnhancedButton />', () => {
     assert.strictEqual(wrapper.node.props.style.background, 'none', 'should be none');
   });
 
-  it('should set the button type', () => {
-    const wrapper = shallowWithContext(
-      <EnhancedButton type="submit">Button</EnhancedButton>
-    );
-    assert.ok(wrapper.text(), 'Button', 'should say Button');
-    assert.ok(wrapper.is('button[type="submit"]'), 'should have the type attribute');
-    wrapper.setProps({type: 'reset'});
-    assert.ok(wrapper.is('button[type="reset"]'), 'should have the type attribute');
+  describe('prop: type', () => {
+    it('should set a button type by default', () => {
+      const wrapper = shallowWithContext(
+        <EnhancedButton>Button</EnhancedButton>
+      );
+
+      assert.strictEqual(wrapper.is('button[type="button"]'), true);
+    });
+
+    it('should not set a button type on span', () => {
+      const wrapper = shallowWithContext(
+        <EnhancedButton containerElement="span">Button</EnhancedButton>
+      );
+
+      assert.strictEqual(wrapper.props().type, undefined);
+    });
+
+    it('should set the button type', () => {
+      const wrapper = shallowWithContext(
+        <EnhancedButton type="submit">Button</EnhancedButton>
+      );
+
+      assert.strictEqual(wrapper.type(), 'button', 'should say Button');
+      assert.strictEqual(wrapper.is('button[type="submit"]'), true, 'should have the type attribute');
+      wrapper.setProps({type: 'reset'});
+      assert.strictEqual(wrapper.is('button[type="reset"]'), true, 'should have the type attribute');
+    });
   });
 
   it('should pass through other html attributes', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

The type property should only be applied on the `button` nodes.

Closes #5722.
