### PR TITLE
The step content container's height was expanded without content for …

### DIFF
--- a/src/internal/ExpandTransition.js
+++ b/src/internal/ExpandTransition.js
@@ -58,7 +58,7 @@ class ExpandTransition extends Component {
     const mergedRootStyles = Object.assign({}, {
       position: 'relative',
       overflow: 'hidden',
-      height: '100%',
+      height: 'auto',
     }, style);
 
     const newChildren = loading ? [] : this.renderChildren(children);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


…nonactive steps. Setting height to auto instead of 100%, fixed issue.