### PR TITLE
[Menu] Add a dividerStyle property

### DIFF
--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -495,7 +495,9 @@ class Menu extends Component {
       const childIsADivider = child.type && child.type.muiName === 'Divider';
       const childIsDisabled = child.props.disabled;
 
-      const clonedChild = childIsADivider ? React.cloneElement(child, {style: styles.divider}) :
+      const clonedChild = childIsADivider ? React.cloneElement(child, {
+        style: Object.assign({}, styles.divider, child.props.style),
+      }) :
         childIsDisabled ? React.cloneElement(child, {desktop: desktop}) :
         this.cloneMenuItem(child, menuItemIndex, styles, index);
 

--- a/test/integration/Menu/Menu.spec.js
+++ b/test/integration/Menu/Menu.spec.js
@@ -1,0 +1,51 @@
+/* eslint-env mocha */
+import React from 'react';
+import {shallow} from 'enzyme';
+import {assert} from 'chai';
+import Divider from 'src/Divider';
+import Menu from 'src/Menu';
+import MenuItem from 'src/MenuItem';
+import getMuiTheme from 'src/styles/getMuiTheme';
+
+describe('<Menu />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
+
+  it('should render MenuItem and Divider children', () => {
+    const wrapper = shallowWithContext(
+      <Menu>
+        <MenuItem primaryText="item 1" />
+        <Divider />
+        <MenuItem primaryText="item 2" />
+      </Menu>
+    );
+
+    const menuItemsAndDividers = wrapper.children().children().children();
+    assert.strictEqual(menuItemsAndDividers.length, 3, 'there should be three children');
+    assert.strictEqual(menuItemsAndDividers.get(0).type, MenuItem, 'first child should be a MenuItem');
+    assert.strictEqual(menuItemsAndDividers.get(1).type, Divider, 'second child should be a Divider');
+    assert.strictEqual(menuItemsAndDividers.get(2).type, MenuItem, 'third child should be a MenuItem');
+
+    assert.deepEqual(menuItemsAndDividers.get(1).props.style,
+                     {marginTop: 7, marginBottom: 8},
+                     'the Divider gets default styles');
+  });
+
+  it("should merge the Divider's styles over the Menu's default divider styles", () => {
+    const style = {color: 'red', marginTop: '999px'};
+    const wrapper = shallowWithContext(
+      <Menu>
+        <Divider style={style} />
+      </Menu>
+    );
+
+    const divider = wrapper.find('Divider');
+    assert.strictEqual(divider.length, 1, 'there should be one divider child');
+
+    const expectedMergedStyle = Object.assign({}, style, {marginBottom: 8});
+    assert.deepEqual(divider.props().style,
+                     expectedMergedStyle,
+                     "existing styles should be merged over Menu's styles");
+  });
+});


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
  * Linted -- **but no tests or docs**.  I can add this if you think it is justified.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


Add a dividerStyle property that allows users to customize the style on any Divider children of the Menu.