### PR TITLE
[Popover] Fix ghost clicks in onRequestClose

### DIFF
--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -222,7 +222,8 @@ class Popover extends Component {
     }
   }
 
-  componentClickAway = () => {
+  componentClickAway = (event) => {
+    event.preventDefault();
     this.requestClose('clickAway');
   };
 


### PR DESCRIPTION
Preventing event default in Popover's `componentClickAway` to prevent ghost clicks.

This solves https://github.com/callemall/material-ui/issues/5748


