### PR TITLE
[next][MuiThemeProvider] Fix sheet order

### DIFF
--- a/src/styles/MuiThemeProvider.js
+++ b/src/styles/MuiThemeProvider.js
@@ -6,6 +6,10 @@ import jssPreset from 'jss-preset-default';
 import { createMuiTheme } from './theme';
 
 export const MUI_SHEET_ORDER = [
+  'Collapse',
+  'Fade',
+  'Slide',
+
   'Backdrop',
   'Modal',
 
@@ -24,7 +28,7 @@ export const MUI_SHEET_ORDER = [
 
   'Popover',
   'Dialog',
-  'DialogAction',
+  'DialogActions',
   'DialogContent',
   'DialogContentText',
   'DialogTitle',

--- a/src/styles/MuiThemeProvider.js
+++ b/src/styles/MuiThemeProvider.js
@@ -27,14 +27,15 @@ export const MUI_SHEET_ORDER = [
   'Divider',
 
   'Popover',
+
+  'Button',
+  'IconButton',
+
   'Dialog',
   'DialogActions',
   'DialogContent',
   'DialogContentText',
   'DialogTitle',
-
-  'Button',
-  'IconButton',
 
   'Switch',
   'Checkbox',


### PR DESCRIPTION
`DialogActions` was incorrectly listed as `DialogAction`. Noticed others interspersed with my styles - added `Fade`, `Slide`, `Collapse`



- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

