### PR TITLE
[IconButton] Add a hoveredStyle property

### DIFF
--- a/src/IconButton/IconButton.spec.js
+++ b/src/IconButton/IconButton.spec.js
@@ -1,0 +1,42 @@
+/* eslint-env mocha */
+import React from 'react';
+import {shallow} from 'enzyme';
+import {assert} from 'chai';
+import IconButton from './IconButton';
+import getMuiTheme from '../styles/getMuiTheme';
+
+const dummy = <div />;
+
+describe('<IconButton />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
+  it('renders an enhanced button', () => {
+    const wrapper = shallowWithContext(
+      <IconButton>Button</IconButton>
+    );
+    assert.strictEqual(wrapper.is('EnhancedButton'), true);
+  });
+
+  it('renders children', () => {
+    const wrapper = shallowWithContext(
+      <IconButton>{dummy}</IconButton>
+    );
+    assert.strictEqual(wrapper.containsMatchingElement(dummy), true, 'should contain the children');
+  });
+
+  describe('prop: hoveredStyle', () => {
+    it('should apply the style when hovered', () => {
+      const hoveredStyle = {
+        backgroundColor: 'blue',
+      };
+      const wrapper = shallowWithContext(
+        <IconButton hoveredStyle={hoveredStyle} />
+      );
+
+      wrapper.simulate('mouseEnter');
+
+      assert.include(wrapper.props().style, hoveredStyle);
+    });
+  });
+});

--- a/src/internal/EnhancedButton.js
+++ b/src/internal/EnhancedButton.js
@@ -94,7 +94,9 @@ class EnhancedButton extends Component {
     muiTheme: PropTypes.object.isRequired,
   };
 
-  state = {isKeyboardFocused: false};
+  state = {
+    isKeyboardFocused: false,
+  };
 
   componentWillMount() {
     const {disabled, disableKeyboardFocus, keyboardFocused} = this.props;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

This is a continuation of #5469.
Thanks @Sharlaan for the original PR.
In the `next` branch, users should be able to use CSS power to overrides the components. We will most likely not exposed a `hoverColor` or a `hoveredStyle` property as `:hover` will be available. 
The proposed `hoverColor` sounds too specific, I would rather reduce the API gap with `next`.

Closes #5469.
Closes #5449.