### PR TITLE
[Drawer] fix bug causing overlay 'clickaway' event to not close drawer

### DIFF
--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -175,7 +175,7 @@ class Drawer extends Component {
   }
 
   close(reason) {
-    if (this.props.open === null) this.setState({open: false});
+    if (this.props.open === null || reason === 'clickaway') this.setState({open: false});
     if (this.props.onRequestChange) this.props.onRequestChange(false, reason);
     return this;
   }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
Currently clicking the overlay on the drawer component does not close the drawer.

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


