### PR TITLE
[TouchRipple] Fix issue #5626

### DIFF
--- a/src/internal/TouchRipple.js
+++ b/src/internal/TouchRipple.js
@@ -203,6 +203,7 @@ class TouchRipple extends Component {
         top: 0,
         left: 0,
         overflow: 'hidden',
+        pointerEvents: 'none',
       }, style);
 
       rippleGroup = (


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

In some browsers (Firefox and Safari), the addition of the ripple element during mousedown event was preventing the parent element from receiving click events. This patch fixes the problem by disabling pointer events for the ripple element.

You can test this by clicking at the GitHub button at the documentation page. Note that
you need to click outside the label text. In addition to the browser, the used operating system may also affect results. I have tested this patch on OS X. See the related issue for a more detailed discussion.

Closes #5626