### PR TITLE
[Eslint] Fix array-bracket-spacing warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,7 @@ module.exports = {
     'material-ui',
   ],
   rules: {
-    'array-bracket-spacing': 'off', // use babel plugin rule
+    'array-bracket-spacing': ['error', 'never'],
     'arrow-body-style': 'off',
     'arrow-parens': ['error', 'always'], // airbnb use as-needed
     'consistent-this': ['error', 'self'],
@@ -31,7 +31,6 @@ module.exports = {
     'object-curly-spacing': 'off', // use babel plugin rule
     'operator-linebreak': ['error', 'after'], // aibnb is disabling this rule
     'babel/object-curly-spacing': ['error', 'always'],
-    'babel/array-bracket-spacing': ['error', 'never'],
     'import/no-unresolved': 'off',
     'import/no-named-as-default': 'off',
     'import/extensions': 'off',


### PR DESCRIPTION
Remove the eslint array-bracket-spacing warning.

![capture d ecran 2016-12-12 a 18 05 56](https://cloud.githubusercontent.com/assets/5749437/21108574/ea5ad844-c095-11e6-877b-92f9795ddf74.png)

There is no warning anymore 😃 