### PR TITLE
[AutoComplete] if condition removed from componentWillReceiveProps function

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -223,9 +223,9 @@ class AutoComplete extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-      this.setState({
-        searchText: nextProps.searchText,
-      });
+    this.setState({
+      searchText: nextProps.searchText,
+    });
   }
 
   componentWillUnmount() {

--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -223,11 +223,9 @@ class AutoComplete extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.searchText !== nextProps.searchText) {
       this.setState({
         searchText: nextProps.searchText,
       });
-    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
 I was facing a problem while using react material AutoComplete . i was tried to make searchText props to empty on callback function of onNewRequest using react set state .so on a callback function of onNewRequest i was updating a state variable to a empty string.this should make the text field of autoComplete empty but it was not happening so. so when i try giving a look on AutoComplete.js file i get to know that there is a check on the code and it was like 
if (this.props.searchText !== nextProps.searchText) {
        this.setState({
          searchText: nextProps.searchText
        });
}
but the problem with this check is value of both **this.props.searchText**  and **nextProps.searchText** are same only so it never able to update searchText to empty string.due to which text field area is getting updated with selected value in place of making it empty. 
      
- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


…Props in AutoComplete.js