### PR TITLE
[TimePicker -> TimeDisplay]: Inherit text color from theme

### DIFF
--- a/src/TimePicker/TimeDisplay.js
+++ b/src/TimePicker/TimeDisplay.js
@@ -70,7 +70,7 @@ class TimeDisplay extends Component {
         borderTopLeftRadius: 2,
         borderTopRightRadius: 2,
         backgroundColor: timePicker.headerColor,
-        color: 'white',
+        color: timePicker.textColor,
       },
       text: {
         margin: '6px 0',

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -293,7 +293,7 @@ export default function getMuiTheme(muiTheme, ...more) {
     },
     timePicker: {
       color: palette.alternateTextColor,
-      textColor: palette.textColor,
+      textColor: palette.alternateTextColor,
       accentColor: palette.primary1Color,
       clockColor: palette.textColor,
       clockCircleColor: palette.clockCircleColor,

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -293,7 +293,7 @@ export default function getMuiTheme(muiTheme, ...more) {
     },
     timePicker: {
       color: palette.alternateTextColor,
-      textColor: palette.accent3Color,
+      textColor: palette.textColor,
       accentColor: palette.primary1Color,
       clockColor: palette.textColor,
       clockCircleColor: palette.clockCircleColor,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

TimeDisplay component has text color fixed to 'white' instead of inheriting it from the theme. I looked at DatePicker component to see how it works, I found out that, unlike TimePicker, it's using datePicket.textColor from theme to set text color. This pull request brings TimePicker on a par with DatePicker.