### PR TITLE
[Table] fix TableBody selectedRows state

### DIFF
--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -131,8 +131,7 @@ class TableBody extends Component {
   componentWillReceiveProps(nextProps) {
     if (this.props.allRowsSelected && !nextProps.allRowsSelected) {
       this.setState({
-        selectedRows: this.state.selectedRows.length > 0 ?
-          [this.state.selectedRows[this.state.selectedRows.length - 1]] : [],
+        selectedRows: []
       });
       // TODO: should else be conditional, not run any time props other than allRowsSelected change?
     } else {

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -131,7 +131,7 @@ class TableBody extends Component {
   componentWillReceiveProps(nextProps) {
     if (this.props.allRowsSelected && !nextProps.allRowsSelected) {
       this.setState({
-        selectedRows: []
+        selectedRows: [],
       });
       // TODO: should else be conditional, not run any time props other than allRowsSelected change?
     } else {


### PR DESCRIPTION
I have a bug when I "Unselect All" rows. (1. click select all to select all rows 2. click select all again to unselect all rows).

[Here is the TableBody.js source code](https://github.com/callemall/material-ui/blob/5f6adfb58a7c859bdd55dd8decd50f1c16bbe35b/src/Table/TableBody.js#L149): 
```
      this.setState({
        selectedRows: this.state.selectedRows.length > 0 ?
          [this.state.selectedRows[this.state.selectedRows.length - 1]] : [],
      });
```

Basically, this line of code evaluates to "If I have any selected rows, let my new selected row be the last selected rows)"

eg.

1. If I have 3 items in a grid and all of them are unselected:

> □ 1 Dog
> □ 2 Cat
> □ 3 Rat

2. When I click on the Select All button to select all selections:

> √ 1 Dog
> √ 2 Cat
> √ 3 Rat

3. When I click on the Select All button to remove all selections, I will end up with the following result:

> □ 1 Dog
> □ 2 Cat
> √ 3 Rat

The last row still selected, in this case, I just want to unselect all rows.

Closes #5249.
Closes #5192.
Closes #5234.