### PR TITLE
[IconButton] make hoveredStyle prop override style prop

### DIFF
--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -253,8 +253,8 @@ class IconButton extends Component {
 
     const mergedRootStyles = Object.assign(
       styles.root,
-      hovered ? hoveredStyle : {},
-      style
+      style,
+      hovered ? hoveredStyle : {}
     );
 
     const tooltipElement = tooltip ? (

--- a/src/IconButton/IconButton.spec.js
+++ b/src/IconButton/IconButton.spec.js
@@ -55,5 +55,21 @@ describe('<IconButton />', () => {
 
       assert.include(wrapper.props().style, hoveredStyle);
     });
+
+    it('should override the style prop', () => {
+      const buttonStyle = {
+        backgroundColor: 'blue',
+      };
+      const hoveredStyle = {
+        backgroundColor: 'green',
+      };
+      const wrapper = shallowWithContext(
+        <IconButton style={buttonStyle} hoveredStyle={hoveredStyle} />
+      );
+
+      wrapper.simulate('mouseEnter');
+
+      assert.include(wrapper.props().style, hoveredStyle);
+    });
   });
 });


### PR DESCRIPTION
Resolves #5857 

Puts the hoveredStyle prop at the end of the styling merge so that it overrides the style prop.

Added a test for it too.

Let me know if anything needs changed.

Thanks!