### PR TITLE
[next][utils] cloneChildrenWithClassName should allow optional jsx elements

### DIFF
--- a/src/Card/CardActions.spec.js
+++ b/src/Card/CardActions.spec.js
@@ -24,10 +24,12 @@ describe('<CardActions />', () => {
   });
 
   it('should pass the actionSpacing class to children', () => {
+    const child3 = false
     const wrapper = shallow(
       <CardActions>
         <div id="child1" />
         <div id="child2" />
+        {child3 && <div id="child3" />}
       </CardActions>,
     );
 

--- a/src/Card/CardActions.spec.js
+++ b/src/Card/CardActions.spec.js
@@ -24,7 +24,7 @@ describe('<CardActions />', () => {
   });
 
   it('should pass the actionSpacing class to children', () => {
-    const child3 = false
+    const child3 = false;
     const wrapper = shallow(
       <CardActions>
         <div id="child1" />

--- a/src/utils/reactHelpers.js
+++ b/src/utils/reactHelpers.js
@@ -4,7 +4,7 @@ import { cloneElement, Children } from 'react';
 
 export function cloneChildrenWithClassName(children, className) {
   return Children.map(children, (child) => {
-    return cloneElement(child, {
+    return child && cloneElement(child, {
       className: child.props.hasOwnProperty('className') ?
         `${child.props.className} ${className}` : className,
     });

--- a/src/utils/reactHelpers.js
+++ b/src/utils/reactHelpers.js
@@ -1,10 +1,10 @@
 // @flow weak
 
-import { cloneElement, Children } from 'react';
+import { cloneElement, Children, isValidElement } from 'react';
 
 export function cloneChildrenWithClassName(children, className) {
   return Children.map(children, (child) => {
-    return child && cloneElement(child, {
+    return isValidElement(child) && cloneElement(child, {
       className: child.props.hasOwnProperty('className') ?
         `${child.props.className} ${className}` : className,
     });


### PR DESCRIPTION
Optional jsx elements (such as in `CardActions`) should be allowed.  Currently they fail with:

```javascript
 TypeError: Cannot read property 'props' of null
      at src/utils/reactHelpers.js:8:18
      at mapSingleChildIntoContext (node_modules/react/lib/ReactChildren.js:107:26)
      at traverseAllChildrenImpl (node_modules/react/lib/traverseAllChildren.js:77:5)
      at traverseAllChildrenImpl (node_modules/react/lib/traverseAllChildren.js:93:23)
      at traverseAllChildren (node_modules/react/lib/traverseAllChildren.js:172:10)
      at mapIntoWithKeyPrefixInternal (node_modules/react/lib/ReactChildren.js:127:3)
      at Object.mapChildren [as map] (node_modules/react/lib/ReactChildren.js:149:3)
      at cloneChildrenWithClassName (src/utils/reactHelpers.js:6:19)
      at CardActions (src/Card/CardActions.js:33:24)
```

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

