### PR TITLE
[Input] Add aria-required attribute

### DIFF
--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -253,6 +253,8 @@ export default class Input extends Component {
       [classes.disabled]: disabled,
     }, inputClassNameProp);
 
+    const required = muiFormControl && muiFormControl.required === true;
+
     return (
       <div className={wrapperClassName}>
         <ComponentProp
@@ -262,6 +264,7 @@ export default class Input extends Component {
           onFocus={this.handleFocus}
           onChange={this.handleChange}
           disabled={disabled}
+          aria-required={required ? true : undefined}
           {...other}
         />
       </div>

--- a/src/Input/Input.spec.js
+++ b/src/Input/Input.spec.js
@@ -28,6 +28,7 @@ describe('<Input />', () => {
     assert.strictEqual(input.is('input'), true, 'should be a <input>');
     assert.strictEqual(input.prop('type'), 'text', 'should pass the text type prop');
     assert.strictEqual(input.hasClass(classes.input), true, 'should have the input class');
+    assert.strictEqual(input.prop('aria-required'), undefined, 'should not have the area-required prop');
   });
 
   it('should render a disabled <input />', () => {
@@ -205,6 +206,14 @@ describe('<Input />', () => {
         assert.strictEqual(wrapper.hasClass(classes.error), false);
         wrapper.setProps({ error: true });
         assert.strictEqual(wrapper.hasClass(classes.error), true);
+      });
+    });
+
+    describe('required', () => {
+      it('should have the aria-required prop with value true', () => {
+        setFormControlContext({ required: true });
+        const input = wrapper.find('input');
+        assert.strictEqual(input.prop('aria-required'), true);
       });
     });
   });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has ~tests~ / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Adds the `aria-required` attribute to the input element of `Input`s as a hint for for screen readers. 

While HTML5 now supports the `required` attribute, which screen readers should also support, adding that instead of `aria-required` would cause some browsers to change behaviour, and to display visible hints that may clash with Material-UI error text, so using the legacy but supported `aria-required` seems preferable.