### PR TITLE
[FloatingActionButton] Get Rid of Thin White Border 

### DIFF
--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -26,6 +26,7 @@ function getStyles(props, context) {
     root: {
       transition: transitions.easeOut(),
       display: 'inline-block',
+      backgroundColor: 'transparent'
     },
     container: {
       backgroundColor,

--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -26,7 +26,7 @@ function getStyles(props, context) {
     root: {
       transition: transitions.easeOut(),
       display: 'inline-block',
-      backgroundColor: 'transparent'
+      backgroundColor: 'transparent',
     },
     container: {
       backgroundColor,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Hello there.

I've noticed that there is a thin white border around `FloatingActionButton`'s. It's particularly visible when the `FloatingActionButton` and the underlying element use dark colors, and it really looks bad:

![screen shot 2017-01-06 at 1 29 51 am](https://cloud.githubusercontent.com/assets/19643597/21710640/b313a366-d3af-11e6-814b-db7039087ad6.png)

The expected look and feel is:

![screen shot 2017-01-06 at 1 29 57 am](https://cloud.githubusercontent.com/assets/19643597/21710793/8dbda6a6-d3b0-11e6-9618-53604c80a624.png)

Upon taking a look at the source code, I realized this happens because `FloatingActionButton`'s contain a `Paper` element, whose default color is white. I suggest setting the `background-color` of that `Paper` element to `transparent` to solve this issue.

Here's the [WebpackBin](http://www.webpackbin.com/VyL4T7_rM) for this issue.