### PR TITLE
[Docs] Fix spelling mistake in `docs/src/app/components/PropTypeDescription.js`

### DIFF
--- a/docs/src/app/components/PropTypeDescription.js
+++ b/docs/src/app/components/PropTypeDescription.js
@@ -159,7 +159,7 @@ class PropTypeDescription extends Component {
       text += `| ${key} | ${generatePropType(prop.type)} | ${defaultValue} | ${description} |\n`;
     }
 
-    text += 'Other properties (no documented) are applied to the root element.';
+    text += 'Other properties (not documented) are applied to the root element.';
 
     const requiredPropFootnote = (requiredProps === 1) ? '* required property' :
       (requiredProps > 1) ? '* required properties' :


### PR DESCRIPTION
Fixes https://github.com/callemall/material-ui/issues/5882
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has ~tests~ / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


