### PR TITLE
[TableBody] Fix row selection re-render bug

### DIFF
--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -129,15 +129,16 @@ class TableBody extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.allRowsSelected && !nextProps.allRowsSelected) {
-      this.setState({
-        selectedRows: [],
-      });
-      // TODO: should else be conditional, not run any time props other than allRowsSelected change?
-    } else {
-      this.setState({
-        selectedRows: this.calculatePreselectedRows(nextProps),
-      });
+    if (this.props.allRowsSelected !== nextProps.allRowsSelected) {
+      if (!nextProps.allRowsSelected) {
+        this.setState({
+          selectedRows: [],
+        });
+      } else {
+        this.setState({
+          selectedRows: this.calculatePreselectedRows(nextProps),
+        });
+      }
     }
   }
 

--- a/test/integration/Table/SelectionObservingTable.js
+++ b/test/integration/Table/SelectionObservingTable.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import {
+  Table,
+  TableBody,
+  TableHeader,
+  TableHeaderColumn,
+  TableRow,
+  TableRowColumn,
+} from 'src/Table';
+
+const tableData = [
+  {name: 'John Smith'},
+  {name: 'Randal White'},
+  {name: 'Olivier'},
+];
+
+class SelectionObservingTable extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      selectionChangeCount: 0,
+    };
+  }
+
+  render() {
+    return (
+      <div>
+        Selection Change Count: {this.state.selectionChangeCount}
+        <Table
+          selectable={true}
+          onRowSelection={() => this.setState({selectionChangeCount: this.state.selectionChangeCount + 1})}
+        >
+          <TableHeader>
+            <TableRow>
+              <TableHeaderColumn>
+                Name
+              </TableHeaderColumn>
+            </TableRow>
+          </TableHeader>
+          <TableBody displayRowCheckbox={true}>
+            {tableData.map( (row, index) => (
+              <TableRow key={index}>
+                <TableRowColumn>
+                  {row.name}
+                </TableRowColumn>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    );
+  }
+}
+
+export default SelectionObservingTable;

--- a/test/integration/Table/SelectionObservingTable.spec.js
+++ b/test/integration/Table/SelectionObservingTable.spec.js
@@ -1,0 +1,62 @@
+/* eslint-env mocha */
+import React from 'react';
+import {mount} from 'enzyme';
+import {assert} from 'chai';
+import getMuiTheme from 'src/styles/getMuiTheme';
+import SelectionObservingTable from './SelectionObservingTable';
+
+describe('<SelectionObservingTable />', () => {
+  it('preserves selected change', () => {
+    const muiTheme = getMuiTheme();
+    const mountWithContext = (node) => mount(node, {
+      context: {muiTheme},
+      childContextTypes: {muiTheme: React.PropTypes.object},
+    });
+
+    const wrapper = mountWithContext(
+      <SelectionObservingTable />
+    );
+
+    assert.deepEqual(
+      wrapper.find('Checkbox').map((checkbox) => checkbox.props().checked),
+      [
+        false,
+        false,
+        false,
+        false,
+      ],
+      'should use the selected property for the initial value'
+    );
+
+    let input;
+    input = wrapper.find('Checkbox').at(1).find('input');
+    input.node.checked = !input.node.checked;
+    input.simulate('change');
+
+    assert.deepEqual(
+      wrapper.find('Checkbox').map((checkbox) => checkbox.props().checked),
+      [
+        false,
+        true,
+        false,
+        false,
+      ],
+      'should preserve initial selection'
+    );
+
+    input = wrapper.find('Checkbox').at(2).find('input');
+    input.node.checked = !input.node.checked;
+    input.simulate('change');
+
+    assert.deepEqual(
+      wrapper.find('Checkbox').map((checkbox) => checkbox.props().checked),
+      [
+        false,
+        false,
+        true,
+        false,
+      ],
+      'should preserve updated selection'
+    );
+  });
+});


### PR DESCRIPTION
Non-selection related table re-rendering previously caused the user's
selection to be lost because the state was being reset unnecessarily.

I took the opportunity to remove the prescient `TODO` comment that did
correctly predict that this might be a problem.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

