### PR TITLE
[Subheader] Remove `desktop` and `focusState` props from being passed to <div>

### DIFF
--- a/src/Menu/Menu.spec.js
+++ b/src/Menu/Menu.spec.js
@@ -1,0 +1,64 @@
+/* eslint-env mocha */
+import React from 'react';
+import {shallow} from 'enzyme';
+import {assert} from 'chai';
+import getMuiTheme from '../styles/getMuiTheme';
+import Menu from './Menu';
+import MenuItem from '../MenuItem';
+import Subheader from '../Subheader';
+import Divider from '../Divider';
+
+describe('<Menu />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+
+  describe('Child Items', () => {
+    let wrapper;
+
+    before(() => {
+      wrapper = shallowWithContext(
+        <Menu autoWidth={false}>
+          <Subheader>A Header</Subheader>
+          <MenuItem value={1} primaryText="Never" />
+          <Divider />
+          <MenuItem value={2} primaryText="Always" />
+          <MenuItem value={3} primaryText="Maybe" />
+          <MenuItem value={4} primaryText="No" />
+        </Menu>
+      );
+    });
+
+    it('renders the Subheader', () => {
+      assert.strictEqual(wrapper.childAt(0).childAt(0).childAt(0).name(), 'Subheader');
+      assert.strictEqual(wrapper.childAt(0).childAt(0).childAt(0).childAt(0).node, 'A Header');
+    });
+
+    it('renders the Divider', () => {
+      assert.strictEqual(wrapper.childAt(0).childAt(0).childAt(2).name(), 'Divider');
+    });
+
+    it('renders the MenuItem', () => {
+      assert.strictEqual(wrapper.childAt(0).childAt(0).childAt(1).name(), 'MenuItem');
+      assert.strictEqual(wrapper.childAt(0).childAt(0).childAt(3).name(), 'MenuItem');
+    });
+
+    it('has the right MenuItem count', () => {
+      const inst = wrapper.instance();
+      const filteredChildren = inst.getFilteredChildren(wrapper.childAt(0).childAt(0).prop('children'));
+      const menuItemCount = inst.getMenuItemCount(filteredChildren);
+      assert.strictEqual(menuItemCount, 4);
+    });
+
+    it('uses keyboard tab to cycle through MenuItem, but stops at `menuItemCount` - 1 (3)', () => {
+      assert.strictEqual(wrapper.state('focusIndex'), 0);
+      wrapper.childAt(0).simulate('keyDown', {which: 9, preventDefault: () => {}});
+      assert.strictEqual(wrapper.state('focusIndex'), 1);
+      wrapper.childAt(0).simulate('keyDown', {which: 9, preventDefault: () => {}});
+      assert.strictEqual(wrapper.state('focusIndex'), 2);
+      wrapper.childAt(0).simulate('keyDown', {which: 9, preventDefault: () => {}});
+      assert.strictEqual(wrapper.state('focusIndex'), 3);
+      wrapper.childAt(0).simulate('keyDown', {which: 9, preventDefault: () => {}});
+      assert.strictEqual(wrapper.state('focusIndex'), 3);
+    });
+  });
+});

--- a/src/Subheader/Subheader.js
+++ b/src/Subheader/Subheader.js
@@ -3,8 +3,6 @@ import React, {PropTypes} from 'react';
 const Subheader = (props, context) => {
   const {
     children,
-    desktop, // eslint-disable-line no-unused-vars
-    focusState, // eslint-disable-line no-unused-vars
     inset,
     style,
     ...other
@@ -41,22 +39,6 @@ Subheader.propTypes = {
    * Node that will be placed inside the `Subheader`.
    */
   children: PropTypes.node,
-  /**
-   * @ignore
-   * If true, the menu item will render with compact desktop
-   * styles.
-   */
-  desktop: PropTypes.bool,
-  /**
-   * @ignore
-   * The focus state of the menu item. This prop is used to set the focus
-   * state of the underlying `ListItem`.
-   */
-  focusState: PropTypes.oneOf([
-    'none',
-    'focused',
-    'keyboard-focused',
-  ]),
   /**
    * If true, the `Subheader` will be indented.
    */

--- a/src/Subheader/Subheader.js
+++ b/src/Subheader/Subheader.js
@@ -3,6 +3,8 @@ import React, {PropTypes} from 'react';
 const Subheader = (props, context) => {
   const {
     children,
+    desktop, // eslint-disable-line no-unused-vars
+    focusState, // eslint-disable-line no-unused-vars
     inset,
     style,
     ...other
@@ -39,6 +41,22 @@ Subheader.propTypes = {
    * Node that will be placed inside the `Subheader`.
    */
   children: PropTypes.node,
+  /**
+   * @ignore
+   * If true, the menu item will render with compact desktop
+   * styles.
+   */
+  desktop: PropTypes.bool,
+  /**
+   * @ignore
+   * The focus state of the menu item. This prop is used to set the focus
+   * state of the underlying `ListItem`.
+   */
+  focusState: PropTypes.oneOf([
+    'none',
+    'focused',
+    'keyboard-focused',
+  ]),
   /**
    * If true, the `Subheader` will be indented.
    */


### PR DESCRIPTION
If you use a `<Subheader>` inside of a `<Menu>`, it can be passed these two props which are then passed to a `<div>`

Fixes #5830

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [X] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

