### PR TITLE
[Menu] Support any type of children

### DIFF
--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -525,20 +525,28 @@ class Menu extends Component {
 
     let menuItemIndex = 0;
     const newChildren = React.Children.map(filteredChildren, (child, index) => {
-      const childIsADivider = child.type && child.type.muiName === 'Divider';
       const childIsDisabled = child.props.disabled;
+      const childName = child.type ? child.type.muiName : '';
+      let newChild = child;
 
-      const clonedChild = childIsADivider ? React.cloneElement(child, {
-        style: Object.assign({}, styles.divider, child.props.style),
-      }) :
-        childIsDisabled ? React.cloneElement(child, {desktop: desktop}) :
-        this.cloneMenuItem(child, menuItemIndex, styles, index);
+      switch (childName) {
+        case 'MenuItem':
+          newChild = childIsDisabled ? React.cloneElement(child, {desktop: desktop}) :
+            this.cloneMenuItem(child, menuItemIndex, styles, index);
+          break;
 
-      if (!childIsADivider && !childIsDisabled) {
+        case 'Divider':
+          newChild = React.cloneElement(child, {
+            style: Object.assign({}, styles.divider, child.props.style),
+          });
+          break;
+      }
+
+      if (childName === 'MenuItem' && !childIsDisabled) {
         menuItemIndex++;
       }
 
-      return clonedChild;
+      return newChild;
     });
 
     return (

--- a/src/Menu/Menu.spec.js
+++ b/src/Menu/Menu.spec.js
@@ -161,26 +161,38 @@ describe('<Menu />', () => {
     );
   });
 
-  it("should merge the Divider's styles over the Menu's default divider styles", () => {
-    const style = {
-      color: 'red',
-      marginTop: '999px',
-    };
-    const wrapper = shallowWithContext(
-      <Menu>
-        <Divider style={style} />
-      </Menu>
-    );
+  describe('prop: children', () => {
+    it("should merge the Divider's styles over the Menu's default divider styles", () => {
+      const style = {
+        color: 'red',
+        marginTop: '999px',
+      };
+      const wrapper = shallowWithContext(
+        <Menu>
+          <Divider style={style} />
+        </Menu>
+      );
 
-    const divider = wrapper.find(Divider);
-    assert.strictEqual(divider.length, 1, 'there should be one divider child');
+      const divider = wrapper.find(Divider);
+      assert.strictEqual(divider.length, 1, 'there should be one divider child');
 
-    assert.deepEqual(
-      divider.props().style,
-      Object.assign({}, style, {
-        marginBottom: 8,
-      }),
-      "existing styles should be merged over Menu's styles"
-    );
+      assert.deepEqual(
+        divider.props().style,
+        Object.assign({}, style, {
+          marginBottom: 8,
+        }),
+        "existing styles should be merged over Menu's styles"
+      );
+    });
+
+    it('should be able to accept any children', () => {
+      const child = <div foo="bar" />;
+      const wrapper = shallowWithContext(
+        <Menu>
+          {child}
+        </Menu>
+      );
+      assert.strictEqual(wrapper.contains(child), true);
+    });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

This is a continuation of #5893.
Thanks @billyvg for submitting the original PR.

Closes #5893.
Closes #5830.