### PR TITLE
[Layout] rename xs prefixed props

### DIFF
--- a/docs/api/Layout/Layout.md
+++ b/docs/api/Layout/Layout.md
@@ -18,10 +18,10 @@ Props
 | md | gridPropType |  | Defines the number of grids the component is going to use. It's applied for the `md` breakpoint and wider screens if not overridden. |
 | lg | gridPropType |  | Defines the number of grids the component is going to use. It's applied for the `lg` breakpoint and wider screens if not overridden. |
 | xl | gridPropType |  | Defines the number of grids the component is going to use. It's applied for the `xl` breakpoint and wider screens. |
-| xsAlign | enum:&nbsp;'flex-start'<br>&nbsp;'center'<br>&nbsp;'flex-end'<br>&nbsp;'stretch'<br> | 'flex-start' | Defines the `align-items` style property. It's applied for all the screen sizes. |
-| xsDirection | enum:&nbsp;'column'<br>&nbsp;'row'<br> | 'row' | Defines the `flex-direction` style property. It's applied for all the screen sizes. |
-| xsGutter | union | 16 | Defines the space between the type `item` component. It can only be used on a type `container` component. |
-| xsJustify | enum:&nbsp;'flex-start'<br>&nbsp;'center'<br>&nbsp;'flex-end'<br>&nbsp;'space-between'<br>&nbsp;'space-around'<br> | 'flex-start' | Defines the `justify-content` style property. It's applied for all the screen sizes. |
-| xsWrap | enum:&nbsp;'nowrap'<br>&nbsp;'wrap'<br>&nbsp;'wrap-reverse'<br> | 'wrap' | Defines the `flex-wrap` style property. It's applied for all the screen sizes. |
+| align | enum:&nbsp;'flex-start'<br>&nbsp;'center'<br>&nbsp;'flex-end'<br>&nbsp;'stretch'<br> | 'flex-start' | Defines the `align-items` style property. It's applied for all the screen sizes. |
+| direction | enum:&nbsp;'column'<br>&nbsp;'row'<br> | 'row' | Defines the `flex-direction` style property. It's applied for all the screen sizes. |
+| gutter | union | 16 | Defines the space between the type `item` component. It can only be used on a type `container` component. |
+| justify | enum:&nbsp;'flex-start'<br>&nbsp;'center'<br>&nbsp;'flex-end'<br>&nbsp;'space-between'<br>&nbsp;'space-around'<br> | 'flex-start' | Defines the `justify-content` style property. It's applied for all the screen sizes. |
+| wrap | enum:&nbsp;'nowrap'<br>&nbsp;'wrap'<br>&nbsp;'wrap-reverse'<br> | 'wrap' | Defines the `flex-wrap` style property. It's applied for all the screen sizes. |
 
 Other properties (not documented) are applied to the root element.

--- a/docs/site/src/pages/layout/responsive-ui/AutoLayout.js
+++ b/docs/site/src/pages/layout/responsive-ui/AutoLayout.js
@@ -21,7 +21,7 @@ export default function AutoLayout(props, context) {
 
   return (
     <div className={classes.root}>
-      <Layout container xsGutter={24}>
+      <Layout container gutter={24}>
         <Layout item xs>
           <Paper className={classes.paper}>
             xs
@@ -38,7 +38,7 @@ export default function AutoLayout(props, context) {
           </Paper>
         </Layout>
       </Layout>
-      <Layout container xsGutter={24}>
+      <Layout container gutter={24}>
         <Layout item xs>
           <Paper className={classes.paper}>
             xs

--- a/docs/site/src/pages/layout/responsive-ui/CenteredLayout.js
+++ b/docs/site/src/pages/layout/responsive-ui/CenteredLayout.js
@@ -21,7 +21,7 @@ export default function CenteredLayout(props, context) {
 
   return (
     <div className={classes.root}>
-      <Layout container xsGutter={24}>
+      <Layout container gutter={24}>
         <Layout item xs={12}>
           <Paper className={classes.paper}>
             xs=12

--- a/docs/site/src/pages/layout/responsive-ui/FullWidthLayout.js
+++ b/docs/site/src/pages/layout/responsive-ui/FullWidthLayout.js
@@ -22,7 +22,7 @@ export default function FullWidthLayout(props, context) {
 
   return (
     <div className={classes.root}>
-      <Layout container xsGutter={24}>
+      <Layout container gutter={24}>
         <Layout item xs={12}>
           <Paper className={classes.paper}>
             xs=12

--- a/docs/site/src/pages/layout/responsive-ui/GuttersLayout.js
+++ b/docs/site/src/pages/layout/responsive-ui/GuttersLayout.js
@@ -34,7 +34,7 @@ export default class GuttersLayout extends Component {
   }
 
   state = {
-    xsGutter: '16',
+    gutter: '16',
   }
 
   handleChange = (key) => (event, value) => {
@@ -46,7 +46,7 @@ export default class GuttersLayout extends Component {
   render() {
     const classes = this.context.styleManager.render(styleSheet);
     const {
-      xsGutter,
+      gutter,
     } = this.state;
 
     return (
@@ -55,8 +55,8 @@ export default class GuttersLayout extends Component {
           <Layout
             container
             className={classes.demo}
-            xsJustify="center"
-            xsGutter={Number(xsGutter)}
+            justify="center"
+            gutter={Number(gutter)}
           >
             {CELLS.map((cell, i) => (
               <Layout key={i} item>
@@ -69,11 +69,11 @@ export default class GuttersLayout extends Component {
           <Paper className={classes.control}>
             <Layout container>
               <Layout item>
-                <FormLabel>xsGutter</FormLabel>
+                <FormLabel>gutter</FormLabel>
                 <RadioGroup
-                  aria-label="xsGutter"
-                  selectedValue={xsGutter}
-                  onChange={this.handleChange('xsGutter')}
+                  aria-label="gutter"
+                  selectedValue={gutter}
+                  onChange={this.handleChange('gutter')}
                   row
                 >
                   <LabelRadio label="0" value="0" />

--- a/docs/site/src/pages/layout/responsive-ui/InteractiveLayout.js
+++ b/docs/site/src/pages/layout/responsive-ui/InteractiveLayout.js
@@ -37,10 +37,10 @@ export default class InteractiveLayout extends Component {
   }
 
   state = {
-    xsDirection: 'row',
-    xsJustify: 'center',
-    xsAlign: 'center',
-    xsGutter: '16',
+    direction: 'row',
+    justify: 'center',
+    align: 'center',
+    gutter: '16',
   }
 
   handleChange = (key) => (event, value) => {
@@ -52,9 +52,9 @@ export default class InteractiveLayout extends Component {
   render() {
     const classes = this.context.styleManager.render(styleSheet);
     const {
-      xsAlign,
-      xsDirection,
-      xsJustify,
+      align,
+      direction,
+      justify,
     } = this.state;
 
     return (
@@ -63,9 +63,9 @@ export default class InteractiveLayout extends Component {
           <Layout
             container
             className={classes.demo}
-            xsAlign={xsAlign}
-            xsDirection={xsDirection}
-            xsJustify={xsJustify}
+            align={align}
+            direction={direction}
+            justify={justify}
           >
             {CELLS.map((cell, i) => (
               <Layout key={i} item>
@@ -80,11 +80,11 @@ export default class InteractiveLayout extends Component {
           <Paper className={classes.control}>
             <Layout container>
               <Layout item xs={6} sm={4}>
-                <FormLabel>xsDirection</FormLabel>
+                <FormLabel>direction</FormLabel>
                 <RadioGroup
-                  aria-label="xsDirection"
-                  selectedValue={xsDirection}
-                  onChange={this.handleChange('xsDirection')}
+                  aria-label="direction"
+                  selectedValue={direction}
+                  onChange={this.handleChange('direction')}
                 >
                   <LabelRadio label="row" value="row" />
                   <LabelRadio label="row-reverse" value="row-reverse" />
@@ -93,11 +93,11 @@ export default class InteractiveLayout extends Component {
                 </RadioGroup>
               </Layout>
               <Layout item xs={6} sm={4}>
-                <FormLabel>xsJustify</FormLabel>
+                <FormLabel>justify</FormLabel>
                 <RadioGroup
-                  aria-label="xsJustify"
-                  selectedValue={xsJustify}
-                  onChange={this.handleChange('xsJustify')}
+                  aria-label="justify"
+                  selectedValue={justify}
+                  onChange={this.handleChange('justify')}
                 >
                   <LabelRadio label="flex-start" value="flex-start" />
                   <LabelRadio label="center" value="center" />
@@ -107,11 +107,11 @@ export default class InteractiveLayout extends Component {
                 </RadioGroup>
               </Layout>
               <Layout item xs={6} sm={4}>
-                <FormLabel>xsAlign</FormLabel>
+                <FormLabel>align</FormLabel>
                 <RadioGroup
-                  aria-label="xsAlign"
-                  selectedValue={xsAlign}
-                  onChange={this.handleChange('xsAlign')}
+                  aria-label="align"
+                  selectedValue={align}
+                  onChange={this.handleChange('align')}
                 >
                   <LabelRadio label="flex-start" value="flex-start" />
                   <LabelRadio label="center" value="center" />

--- a/src/Layout/Layout.js
+++ b/src/Layout/Layout.js
@@ -140,16 +140,16 @@ function Layout(props, context) {
     component: ComponentProp,
     container,
     item,
-    xsAlign,
-    xsDirection,
+    align,
+    direction,
     xs,
     sm,
     md,
     lg,
     xl,
-    xsGutter,
-    xsJustify,
-    xsWrap,
+    gutter,
+    justify,
+    wrap,
     ...other
   } = props;
 
@@ -160,11 +160,11 @@ function Layout(props, context) {
       className={classNames({
         [classes.typeContainer]: container,
         [classes.typeItem]: item,
-        [classes[`gutter-xs-${xsGutter}`]]: container && xsGutter !== 0,
-        [classes[`direction-xs-${xsDirection}`]]: xsDirection !== Layout.defaultProps.xsDirection,
-        [classes[`wrap-xs-${xsWrap}`]]: xsWrap !== Layout.defaultProps.xsWrap,
-        [classes[`align-xs-${xsAlign}`]]: xsAlign !== Layout.defaultProps.xsAlign,
-        [classes[`justify-xs-${xsJustify}`]]: xsJustify !== Layout.defaultProps.xsJustify,
+        [classes[`gutter-xs-${gutter}`]]: container && gutter !== 0,
+        [classes[`direction-xs-${direction}`]]: direction !== Layout.defaultProps.direction,
+        [classes[`wrap-xs-${wrap}`]]: wrap !== Layout.defaultProps.wrap,
+        [classes[`align-xs-${align}`]]: align !== Layout.defaultProps.align,
+        [classes[`justify-xs-${justify}`]]: justify !== Layout.defaultProps.justify,
         [classes['grid-xs']]: xs === true,
         [classes[`grid-xs-${xs}`]]: xs && xs !== true,
         [classes['grid-sm']]: sm === true,
@@ -240,7 +240,7 @@ Layout.propTypes = {
    * Defines the `align-items` style property.
    * It's applied for all the screen sizes.
    */
-  xsAlign: PropTypes.oneOf([
+  align: PropTypes.oneOf([ // eslint-disable-line react/sort-prop-types
     'flex-start',
     'center',
     'flex-end',
@@ -250,7 +250,7 @@ Layout.propTypes = {
    * Defines the `flex-direction` style property.
    * It's applied for all the screen sizes.
    */
-  xsDirection: PropTypes.oneOf([
+  direction: PropTypes.oneOf([ // eslint-disable-line react/sort-prop-types
     'row',
     'row-reverse',
     'column',
@@ -260,12 +260,12 @@ Layout.propTypes = {
    * Defines the space between the type `item` component.
    * It can only be used on a type `container` component.
    */
-  xsGutter: PropTypes.oneOf(GUTTERS),
+  gutter: PropTypes.oneOf(GUTTERS), // eslint-disable-line react/sort-prop-types
   /**
    * Defines the `justify-content` style property.
    * It's applied for all the screen sizes.
    */
-  xsJustify: PropTypes.oneOf([
+  justify: PropTypes.oneOf([ // eslint-disable-line react/sort-prop-types
     'flex-start',
     'center',
     'flex-end',
@@ -276,7 +276,7 @@ Layout.propTypes = {
    * Defines the `flex-wrap` style property.
    * It's applied for all the screen sizes.
    */
-  xsWrap: PropTypes.oneOf([
+  wrap: PropTypes.oneOf([ // eslint-disable-line react/sort-prop-types
     'nowrap',
     'wrap',
     'wrap-reverse',
@@ -287,11 +287,11 @@ Layout.defaultProps = {
   component: 'div',
   container: false,
   item: false,
-  xsAlign: 'flex-start',
-  xsDirection: 'row',
-  xsGutter: 16,
-  xsJustify: 'flex-start',
-  xsWrap: 'wrap',
+  align: 'flex-start',
+  direction: 'row',
+  gutter: 16,
+  justify: 'flex-start',
+  wrap: 'wrap',
 };
 
 Layout.contextTypes = {

--- a/src/Layout/Layout.spec.js
+++ b/src/Layout/Layout.spec.js
@@ -54,7 +54,7 @@ describe('<Layout />', () => {
     });
   });
 
-  describe('prop: xsGutter', () => {
+  describe('prop: gutter', () => {
     it('should have a default gutter', () => {
       const wrapper = shallow(<Layout container />);
       assert.strictEqual(wrapper.hasClass(classes['gutter-xs-16']), true);

--- a/test/regressions/site/src/tests/Layout/AutoLayout.js
+++ b/test/regressions/site/src/tests/Layout/AutoLayout.js
@@ -20,7 +20,7 @@ export default function AutoLayout(props, context) {
 
   return (
     <div className={classes.root}>
-      <Layout container xsGutter={24}>
+      <Layout container gutter={24}>
         <Layout item xs>
           <Paper className={classes.paper}>
             xs
@@ -37,7 +37,7 @@ export default function AutoLayout(props, context) {
           </Paper>
         </Layout>
       </Layout>
-      <Layout container xsGutter={24}>
+      <Layout container gutter={24}>
         <Layout item xs>
           <Paper className={classes.paper}>
             xs

--- a/test/regressions/site/src/tests/Layout/SimpleLayout.js
+++ b/test/regressions/site/src/tests/Layout/SimpleLayout.js
@@ -20,7 +20,7 @@ export default function SimpleLayout(props, context) {
 
   return (
     <div className={classes.root}>
-      <Layout container xsGutter={24}>
+      <Layout container gutter={24}>
         <Layout item xs={12}>
           <Paper className={classes.paper}>
             xs=12

--- a/test/regressions/site/src/tests/Layout/StressLayout.js
+++ b/test/regressions/site/src/tests/Layout/StressLayout.js
@@ -21,8 +21,8 @@ export default function StressLayout(props, context) {
 
   return (
     <div className={classes.root}>
-      <Layout container xsGutter={24} xsDirection="column">
-        <Layout container item xsGutter={8}>
+      <Layout container gutter={24} direction="column">
+        <Layout container item gutter={8}>
           <Layout item xs={3}>
             <Paper className={classes.paper}>
               xs=3
@@ -37,8 +37,8 @@ export default function StressLayout(props, context) {
         <Layout
           container
           item
-          xsGutter={8}
-          xsDirection="row-reverse"
+          gutter={8}
+          direction="row-reverse"
         >
           <Layout item xs={3}>
             <Paper className={classes.paper}>
@@ -54,8 +54,8 @@ export default function StressLayout(props, context) {
         <Layout
           container
           item
-          xsGutter={8}
-          xsJustify="space-between"
+          gutter={8}
+          justify="space-between"
         >
           <Layout item xs={3}>
             <Paper className={classes.paper}>
@@ -71,9 +71,9 @@ export default function StressLayout(props, context) {
         <Layout
           container
           item
-          xsGutter={8}
-          xsAlign="stretch"
-          xsDirection="column-reverse"
+          gutter={8}
+          align="stretch"
+          direction="column-reverse"
         >
           <Layout item>
             <Paper className={classes.paper}>


### PR DESCRIPTION
Fixes #5925

See discussion in issue.

**If** material-ui is mobile first
**Then** the default prop name should apply to all ranges
**When** a responsive change is needed
**Then** you must prefix the prop with that responsive range

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

