### PR TITLE
[Docs] Flat button example Firefox behavior fix (containerElement=label)

### DIFF
--- a/docs/src/app/components/pages/components/FlatButton/ExampleComplex.js
+++ b/docs/src/app/components/pages/components/FlatButton/ExampleComplex.js
@@ -4,7 +4,7 @@ import FontIcon from 'material-ui/FontIcon';
 import ActionAndroid from 'material-ui/svg-icons/action/android';
 
 const styles = {
-  button : {
+  button: {
     verticalAlign: 'top',
   },
   imageInput: {

--- a/docs/src/app/components/pages/components/FlatButton/ExampleComplex.js
+++ b/docs/src/app/components/pages/components/FlatButton/ExampleComplex.js
@@ -4,10 +4,10 @@ import FontIcon from 'material-ui/FontIcon';
 import ActionAndroid from 'material-ui/svg-icons/action/android';
 
 const styles = {
-  button: {
-    verticalAlign: 'top',
+  uploadButton: {
+    verticalAlign: 'middle',
   },
-  imageInput: {
+  uploadInput: {
     cursor: 'pointer',
     position: 'absolute',
     top: 0,
@@ -24,23 +24,21 @@ const FlatButtonExampleComplex = () => (
     <FlatButton
       label="Choose an Image"
       labelPosition="before"
-      style={styles.button}
+      style={styles.uploadButton}
       containerElement="label"
     >
-      <input type="file" style={styles.imageInput} />
+      <input type="file" style={styles.uploadInput} />
     </FlatButton>
     <FlatButton
       label="Label before"
       labelPosition="before"
       primary={true}
-      style={styles.button}
       icon={<ActionAndroid />}
     />
     <FlatButton
       href="https://github.com/callemall/material-ui"
       target="_blank"
       label="GitHub Link"
-      style={styles.button}
       secondary={true}
       icon={<FontIcon className="muidocs-icon-custom-github" />}
     />

--- a/docs/src/app/components/pages/components/FlatButton/ExampleComplex.js
+++ b/docs/src/app/components/pages/components/FlatButton/ExampleComplex.js
@@ -4,6 +4,10 @@ import FontIcon from 'material-ui/FontIcon';
 import ActionAndroid from 'material-ui/svg-icons/action/android';
 
 const styles = {
+  button : {
+    verticalAlign: 'top',
+  },
+
   imageInput: {
     cursor: 'pointer',
     position: 'absolute',
@@ -18,7 +22,12 @@ const styles = {
 
 const FlatButtonExampleComplex = () => (
   <div>
-    <FlatButton label="Choose an Image" labelPosition="before">
+    <FlatButton
+      label="Choose an Image"
+      labelPosition="before"
+      style={styles.button}
+      containerElement="label"
+    >
       <input type="file" style={styles.imageInput} />
     </FlatButton>
     <FlatButton
@@ -32,6 +41,7 @@ const FlatButtonExampleComplex = () => (
       href="https://github.com/callemall/material-ui"
       target="_blank"
       label="GitHub Link"
+      style={styles.button}
       secondary={true}
       icon={<FontIcon className="muidocs-icon-custom-github" />}
     />

--- a/docs/src/app/components/pages/components/FlatButton/ExampleComplex.js
+++ b/docs/src/app/components/pages/components/FlatButton/ExampleComplex.js
@@ -7,7 +7,6 @@ const styles = {
   button : {
     verticalAlign: 'top',
   },
-
   imageInput: {
     cursor: 'pointer',
     position: 'absolute',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
Simple fix of Flat button example in Firefox
[Issue link](https://github.com/callemall/material-ui/issues/5916)
Vertical-align added to keep them aligned properly

Closes #5916