### PR TITLE
[colorManipulator.js] add warning to decomposeColor

### DIFF
--- a/src/utils/colorManipulator.js
+++ b/src/utils/colorManipulator.js
@@ -80,7 +80,7 @@ export function convertHexToRGB(color) {
 /**
  * Returns an object with the type and values of a color.
  *
- * Note: Does not support rgb % values.
+ * Note: Does not support rgb % values and color names.
  *
  * @param {string} color - CSS color, i.e. one of: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla()
  * @returns {{type: string, values: number[]}} A MUI color object
@@ -92,8 +92,8 @@ export function decomposeColor(color) {
 
   const marker = color.indexOf('(');
 
-  warning(marker !== -1, `Material-UI: The ${color} color was not parsed correctly. 
-  This may cause issues in component rendering. Use an RGB color representation instead.`);
+  warning(marker !== -1, `Material-UI: The ${color} color was not parsed correctly,
+  because it has an unsupported format (color name or RGB %). This may cause issues in component rendering.`);
 
   const type = color.substring(0, marker);
   let values = color.substring(marker + 1, color.length - 1).split(',');

--- a/src/utils/colorManipulator.js
+++ b/src/utils/colorManipulator.js
@@ -92,8 +92,8 @@ export function decomposeColor(color) {
 
   const marker = color.indexOf('(');
 
-  warning(marker !== -1, `Material-UI: The ${color} color was not parsed correctly. This may cause issues in component rendering.
-  Use an RGB color representation instead.`);
+  warning(marker !== -1, `Material-UI: The ${color} color was not parsed correctly. 
+  This may cause issues in component rendering. Use an RGB color representation instead.`);
 
   const type = color.substring(0, marker);
   let values = color.substring(marker + 1, color.length - 1).split(',');

--- a/src/utils/colorManipulator.js
+++ b/src/utils/colorManipulator.js
@@ -1,3 +1,5 @@
+import warning from 'warning';
+
 /**
  * Returns a number whose value is limited to the given range.
  *
@@ -89,6 +91,10 @@ export function decomposeColor(color) {
   }
 
   const marker = color.indexOf('(');
+
+  warning(marker !== -1, `Material-UI: The ${color} color was not parsed correctly. This may cause issues in component rendering.
+  Use an RGB color representation instead.`);
+
   const type = color.substring(0, marker);
   let values = color.substring(marker + 1, color.length - 1).split(',');
   values = values.map((value) => parseFloat(value));


### PR DESCRIPTION
A warning that fires when the color string format is not in one of the expected formats. It doesn't try to stop the code, but at least warns the user that something is off instead of failing silently. 

Motivated by #4841.

- [ ] PR has tests / ~docs demo~, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

