### PR TITLE
[Dialog] Add workaround for Chrome flexbox bug

### DIFF
--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -230,8 +230,9 @@ class DialogInline extends Component {
       if (React.Children.count(actions)) {
         maxDialogContentHeight -= dialogContent.nextSibling.offsetHeight;
       }
-
-      dialogContent.style.maxHeight = `${maxDialogContentHeight}px`;
+      const maxHeight = `${maxDialogContentHeight}px`;
+      dialogContent.style.height = maxHeight; // important when the child is a flexbox
+      dialogContent.style.maxHeight = maxHeight;
     }
   }
 


### PR DESCRIPTION
Hi,
It's for Dialogs.
There's a bug in Chrome with the flexbox layout when a parent node has a max-height, but no height.
The workaround is to also set the height;

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

