### PR TITLE
[Collapse] overflow must be visible when in

### DIFF
--- a/src/transitions/Collapse.js
+++ b/src/transitions/Collapse.js
@@ -14,6 +14,9 @@ export const styleSheet = createStyleSheet('Collapse', (theme) => {
       overflow: 'hidden',
       transition: theme.transitions.create('height'),
     },
+    containerIn: {
+      overflow: 'visible',
+    },
     entered: {
       height: 'auto',
       transitionDuration: '0ms',
@@ -146,6 +149,7 @@ export default class Collapse extends Component {
     const {
       children,
       containerClassName,
+      in: inProp,
       onEnter, // eslint-disable-line no-unused-vars
       onEntering, // eslint-disable-line no-unused-vars
       onExit, // eslint-disable-line no-unused-vars
@@ -155,10 +159,15 @@ export default class Collapse extends Component {
     } = this.props;
 
     const classes = this.context.styleManager.render(styleSheet);
-    const containerClasses = classNames(classes.container, containerClassName);
+    const containerClasses = classNames(
+      classes.container,
+      { [classes.containerIn]: inProp },
+      containerClassName,
+    );
 
     return (
       <Transition
+        in={inProp}
         onEntering={this.handleEntering}
         onEnter={this.handleEnter}
         onEntered={this.handleEntered}

--- a/src/transitions/Collapse.spec.js
+++ b/src/transitions/Collapse.spec.js
@@ -21,12 +21,20 @@ describe('<Collapse />', () => {
     assert.strictEqual(wrapper.is('Transition'), true, 'is a Transition component');
   });
 
-  it('should render a container around the wrapper', () => {
-    const wrapper = shallow(<Collapse containerClassName="woof" />);
-    assert.strictEqual(wrapper.childAt(0).is('div'), true, 'should be a div');
-    assert.strictEqual(wrapper.childAt(0).hasClass(classes.container), true,
-      'should have the container class');
-    assert.strictEqual(wrapper.childAt(0).hasClass('woof'), true, 'should have the user class');
+  describe('container', () => {
+    it('should render around the wrapper', () => {
+      const wrapper = shallow(<Collapse containerClassName="woof" />);
+      assert.strictEqual(wrapper.childAt(0).is('div'), true, 'should be a div');
+      assert.strictEqual(wrapper.childAt(0).hasClass(classes.container), true,
+        'should have the container class');
+      assert.strictEqual(wrapper.childAt(0).hasClass('woof'), true, 'should have the user class');
+    });
+
+    it('should render containerIn class', () => {
+      const wrapper = shallow(<Collapse in />);
+      assert.strictEqual(wrapper.childAt(0).hasClass(classes.containerIn), true,
+        'should have the containerIn class');
+    });
   });
 
   it('should render a wrapper around the children', () => {


### PR DESCRIPTION
Collapse must counter default container class `overflow: hidden` when `in` so that an uncollapsed element will push into a confined vertical space.  Without `overflow: visible` on `in` it is possible that only some or none will show depending on the available space.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

