### PR TITLE
[Tabs] Default to `width: auto`. Add `fillWidth` prop.

### DIFF
--- a/docs/src/app/components/pages/components/Tabs/ExampleFillWidth.js
+++ b/docs/src/app/components/pages/components/Tabs/ExampleFillWidth.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import {Tabs, Tab} from 'material-ui/Tabs';
+
+const styles = {
+  headline: {
+    fontSize: 24,
+    fontWeight: 400,
+    marginBottom: 12,
+    paddingTop: 16,
+  },
+};
+
+const TabsExampleFillWidth = () => (
+  <Tabs fillWidth>
+    <Tab label="Item One">
+      <div>
+        <h2 style={styles.headline}>Tab One</h2>
+        <p>
+          {'This is an example tab.'}
+        </p>
+        <p>
+          {'You can put any sort of HTML or React component in here. '}
+          {'It even keeps the component state!'}
+        </p>
+      </div>
+    </Tab>
+
+    <Tab label="Item Two">
+      <div>
+        <h2 style={styles.headline}>Tab Two</h2>
+        <p>
+          {'This is another example tab.'}
+        </p>
+      </div>
+    </Tab>
+  </Tabs>
+);
+
+export default TabsExampleFillWidth;

--- a/docs/src/app/components/pages/components/Tabs/ExampleFillWidth.js
+++ b/docs/src/app/components/pages/components/Tabs/ExampleFillWidth.js
@@ -11,7 +11,7 @@ const styles = {
 };
 
 const TabsExampleFillWidth = () => (
-  <Tabs fillWidth>
+  <Tabs fillWidth={true}>
     <Tab label="Item One">
       <div>
         <h2 style={styles.headline}>Tab One</h2>

--- a/docs/src/app/components/pages/components/Tabs/Page.js
+++ b/docs/src/app/components/pages/components/Tabs/Page.js
@@ -10,6 +10,8 @@ import tabsExampleSimpleCode from '!raw!./ExampleSimple';
 import TabsExampleSimple from './ExampleSimple';
 import tabsExampleControlledCode from '!raw!./ExampleControlled';
 import TabsExampleControlled from './ExampleControlled';
+import tabsExampleFillWidthCode from '!raw!./ExampleFillWidth';
+import TabsExampleFillWidth from './ExampleFillWidth';
 import tabsExampleSwipeableCode from '!raw!./ExampleSwipeable';
 import TabsExampleSwipeable from './ExampleSwipeable';
 import tabsExampleIconCode from '!raw!./ExampleIcon';
@@ -28,6 +30,7 @@ const descriptions = {
   'and allowing tabs to be swiped on touch devices.',
   icon: 'An example of tabs with icon.',
   iconText: 'An example of tabs with icon and text.',
+  fillWidth: 'An example of tabs filling the width of the Tabs component',
 };
 
 const TabsPage = () => (
@@ -68,6 +71,13 @@ const TabsPage = () => (
       code={tabsExampleIconTextCode}
     >
       <TabsExampleIconText />
+    </CodeExample>
+    <CodeExample
+      title="Fill width example"
+      description={descriptions.fillWidth}
+      code={tabsExampleFillWidthCode}
+    >
+      <TabsExampleFillWidth />
     </CodeExample>
     <PropTypeDescription code={tabsCode} header="### Tabs Properties" />
     <PropTypeDescription code={tabCode} header="### Tab Properties" />

--- a/src/Tabs/InkBar.js
+++ b/src/Tabs/InkBar.js
@@ -22,12 +22,12 @@ function getStyles(props, context) {
 class InkBar extends Component {
   static propTypes = {
     color: PropTypes.string,
-    left: PropTypes.string.isRequired,
+    left: PropTypes.number.isRequired,
     /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
-    width: PropTypes.string.isRequired,
+    width: PropTypes.number.isRequired,
   };
 
   static contextTypes = {

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -9,9 +9,9 @@ function getStyles(props, context) {
       color: props.selected ? tabs.selectedTextColor : tabs.textColor,
       fontWeight: 500,
       fontSize: 14,
-      width: props.width,
+      padding: props.padding,
       textTransform: 'uppercase',
-      padding: 0,
+      width: props.width,
     },
     button: {
       display: 'flex',
@@ -61,6 +61,14 @@ class Tab extends Component {
     onTouchTap: PropTypes.func,
     /**
      * @ignore
+     * This property is overriden by the Tabs component.
+     */
+    padding: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
+    /**
+     * @ignore
      * Defines if the current tab is selected or not.
      * The Tabs component is responsible for setting this property.
      */
@@ -103,6 +111,7 @@ class Tab extends Component {
       style,
       value, // eslint-disable-line no-unused-vars
       width, // eslint-disable-line no-unused-vars
+      padding,
       ...other
     } = this.props;
 
@@ -130,7 +139,7 @@ class Tab extends Component {
     return (
       <EnhancedButton
         {...other}
-        style={Object.assign(styles.root, style)}
+        style={Object.assign(styles.root, { padding }, style)}
         focusRippleColor={rippleColor}
         touchRippleColor={rippleColor}
         focusRippleOpacity={rippleOpacity}

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -139,7 +139,7 @@ class Tab extends Component {
     return (
       <EnhancedButton
         {...other}
-        style={Object.assign(styles.root, { padding }, style)}
+        style={Object.assign(styles.root, {padding}, style)}
         focusRippleColor={rippleColor}
         touchRippleColor={rippleColor}
         focusRippleOpacity={rippleOpacity}

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -97,7 +97,6 @@ class Tabs extends Component {
     inkBarWidth: 0,
     selectedIndex: 0,
   };
-  tabs = {};
 
   componentWillMount() {
     const valueLink = this.getValueLink(this.props);
@@ -134,6 +133,8 @@ class Tabs extends Component {
       this.updateInkBarPosition();
     }
   }
+
+  tabs = {};
 
   getTabs(props = this.props) {
     const tabs = [];
@@ -247,7 +248,9 @@ class Tabs extends Component {
 
       return cloneElement(tab, {
         key: index,
-        ref: (ref) => { this.tabs[index] = ReactDOM.findDOMNode(ref); },
+        ref: (ref) => {
+          this.tabs[index] = ReactDOM.findDOMNode(ref);
+        },
         index: index,
         padding: padding,
         selected: this.getSelected(tab, index),

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -5,6 +5,7 @@ import React, {Component,
   isValidElement,
   PropTypes,
 } from 'react';
+import ReactDOM from 'react-dom';
 import warning from 'warning';
 import TabTemplate from './TabTemplate';
 import InkBar from './InkBar';
@@ -14,10 +15,11 @@ function getStyles(props, context) {
 
   return {
     tabItemContainer: {
-      width: '100%',
       backgroundColor: tabs.backgroundColor,
-      whiteSpace: 'nowrap',
       display: 'flex',
+      position: 'relative',
+      whiteSpace: 'nowrap',
+      width: '100%',
     },
   };
 }
@@ -40,6 +42,10 @@ class Tabs extends Component {
      * Override the inline-styles of the content's container.
      */
     contentContainerStyle: PropTypes.object,
+    /**
+     * Forces tabs to fill the width of the Tabs component.
+     */
+    fillWidth: PropTypes.bool,
     /**
      * Specify initial visible tab index.
      * If `initialSelectedIndex` is set but larger than the total amount of specified tabs,
@@ -86,7 +92,12 @@ class Tabs extends Component {
     muiTheme: PropTypes.object.isRequired,
   };
 
-  state = {selectedIndex: 0};
+  state = {
+    inkBarLeft: 0,
+    inkBarWidth: 0,
+    selectedIndex: 0,
+  };
+  tabs = {};
 
   componentWillMount() {
     const valueLink = this.getValueLink(this.props);
@@ -101,6 +112,10 @@ class Tabs extends Component {
     });
   }
 
+  componentDidMount() {
+    this.updateInkBarPosition();
+  }
+
   componentWillReceiveProps(newProps, nextContext) {
     const valueLink = this.getValueLink(newProps);
     const newState = {
@@ -112,6 +127,12 @@ class Tabs extends Component {
     }
 
     this.setState(newState);
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (this.state.selectedIndex !== prevState.selectedIndex) {
+      this.updateInkBarPosition();
+    }
   }
 
   getTabs(props = this.props) {
@@ -173,10 +194,22 @@ class Tabs extends Component {
       this.state.selectedIndex === index;
   }
 
+  updateInkBarPosition() {
+    const activeTab = this.tabs[this.state.selectedIndex];
+    const inkBarLeft = activeTab.offsetLeft;
+    const inkBarWidth = activeTab.offsetWidth;
+
+    this.setState({
+      inkBarLeft,
+      inkBarWidth,
+    });
+  }
+
   render() {
     const {
       contentContainerClassName,
       contentContainerStyle,
+      fillWidth,
       initialSelectedIndex, // eslint-disable-line no-unused-vars
       inkBarStyle,
       onChange, // eslint-disable-line no-unused-vars
@@ -188,11 +221,12 @@ class Tabs extends Component {
     } = this.props;
 
     const {prepareStyles} = this.context.muiTheme;
+    const padding = fillWidth ? 0 : '0 20px';
     const styles = getStyles(this.props, this.context);
     const valueLink = this.getValueLink(this.props);
     const tabValue = valueLink.value;
     const tabContent = [];
-    const width = 100 / this.getTabCount();
+    const width = fillWidth ? 100 / this.getTabCount() : 'auto';
 
     const tabs = this.getTabs().map((tab, index) => {
       warning(tab.type && tab.type.muiName === 'Tab',
@@ -213,17 +247,19 @@ class Tabs extends Component {
 
       return cloneElement(tab, {
         key: index,
+        ref: (ref) => { this.tabs[index] = ReactDOM.findDOMNode(ref); },
         index: index,
+        padding: padding,
         selected: this.getSelected(tab, index),
-        width: `${width}%`,
+        width: typeof width === 'number' ? `${width}%` : width,
         onTouchTap: this.handleTabTouchTap,
       });
     });
 
     const inkBar = this.state.selectedIndex !== -1 ? (
       <InkBar
-        left={`${width * this.state.selectedIndex}%`}
-        width={`${width}%`}
+        left={this.state.inkBarLeft}
+        width={this.state.inkBarWidth}
         style={inkBarStyle}
       />
     ) : null;


### PR DESCRIPTION
- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Per the [Material Guidelines](https://material.io/guidelines/components/tabs.html), it is allowed for tabs with be `width: auto;`. On desktop, this seems to be the default. On mobile, the default seems to be the current behavior of Material UI's tabs.

Per the discussion in #3807, it sounds like the general preference is to default to `width: auto;`. The downside is that this is backwards incompatible. Happy to discuss and make changes if necessary.

From the Material Guidelines:

![Material Guidelines, Tabs, Desktop](https://storage.googleapis.com/material-design/publish/material_v_10/assets/0B6Okdz75tqQsSE9HZXVfTFl6dFk/components_tabs_usage_desktop1.png)

![Material Guidelines, Tabs, Mobile](https://storage.googleapis.com/material-design/publish/material_v_10/assets/0B6Okdz75tqQsOUdyb0FjQTJTdlk/components_tabs_usage_mobile3.png)

This PR changes the default behavior of tabs to be `width: auto;`. It also adds a new prop, `fillWidth`, that will give the current behavior.

This PR is missing tests, so it shouldn't be merged yet. I'm not sure what the best way to test this is. Adding a couple tabs and checking their width makes sense, but I'm not exactly sure how to get the width of an element in a test. I welcome any thoughts on this.

Fixes #3807.