### PR TITLE
[transitions] Remove useless default parameter value

### DIFF
--- a/src/styles/transitions.js
+++ b/src/styles/transitions.js
@@ -23,7 +23,6 @@ export default {
     duration = duration || '450ms';
     property = property || 'all';
     delay = delay || '0ms';
-    easeFunction = easeFunction || 'linear';
 
     return `${property} ${duration} ${easeFunction} ${delay}`;
   },


### PR DESCRIPTION
Since `easeFunction` is already defaulted to `easeOutFunction` one, there is no need to have another default value in `create` method.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

