### PR TITLE
[Docs] Update Flat/Raised Button with SVG's description

### DIFF
--- a/docs/src/app/components/pages/components/FlatButton/Page.js
+++ b/docs/src/app/components/pages/components/FlatButton/Page.js
@@ -16,8 +16,8 @@ import flatButtonCode from '!raw!material-ui/FlatButton/FlatButton';
 
 const descriptions = {
   simple: '`FlatButton` with default color, `primary`, `secondary` and `disabled` props applied.',
-  complex: 'The first example uses an `input` as a child component, ' +
-  'the next has next has an [SVG Icon](/#/components/svg-icon), with the label positioned after. ' +
+  complex: 'The first example uses an `input` as a child component. ' +
+  'The second example has an [SVG Icon](/#/components/svg-icon), with the label positioned after. ' +
   'The final example uses a [Font Icon](/#/components/font-icon), and is wrapped in an anchor tag.',
   icon: 'Examples of Flat Buttons using an icon without a label. The first example uses an' +
   ' [SVG Icon](/#/components/svg-icon), and has the default color. The second example shows' +

--- a/docs/src/app/components/pages/components/RaisedButton/Page.js
+++ b/docs/src/app/components/pages/components/RaisedButton/Page.js
@@ -16,8 +16,8 @@ import raisedButtonCode from '!raw!material-ui/RaisedButton/RaisedButton';
 
 const descriptions = {
   simple: '`RaisedButton` with default color, `primary`, `secondary` and and `disabled` props applied.',
-  complex: 'The first example uses an `input` as a child component, ' +
-  'the next has next has an [SVG Icon](/#/components/svg-icon), with the label positioned after. ' +
+  complex: 'The first example uses an `input` as a child component. ' +
+  'The second example has an [SVG Icon](/#/components/svg-icon), with the label positioned after. ' +
   'The final example uses a [Font Icon](/#/components/font-icon), and is wrapped in an anchor tag.',
   icon: 'Examples of Raised Buttons using an icon without a label. The first example uses an' +
   ' [SVG Icon](/#/components/svg-icon), and has the default color. The second example shows' +


### PR DESCRIPTION
- The description around the Raised and
  Flat buttons was a bit difficult to read
  and needed to be updated.
- This change should not affect any actual
  source code, but only address the documentation
  to be clearer around how to use buttons with
  SVG icons.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

