### PR TITLE
[Popover] Fix re-opening animated popover

### DIFF
--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -132,7 +132,9 @@ class Popover extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.open === this.props.open) { return }
+    if (nextProps.open === this.props.open) { 
+      return;
+    }
 
     if (nextProps.open) {
       clearTimeout(this.timeout);

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -132,7 +132,7 @@ class Popover extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.open === this.props.open) { 
+    if (nextProps.open === this.props.open) {
       return;
     }
 

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -132,29 +132,31 @@ class Popover extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.open !== this.state.open) {
-      if (nextProps.open) {
-        this.anchorEl = nextProps.anchorEl || this.props.anchorEl;
-        this.setState({
-          open: true,
-          closing: false,
-        });
-      } else {
-        if (nextProps.animated) {
-          if (this.timeout !== null) return;
-          this.setState({closing: true});
-          this.timeout = setTimeout(() => {
-            this.setState({
-              open: false,
-            }, () => {
-              this.timeout = null;
-            });
-          }, 500);
-        } else {
+    if (nextProps.open === this.props.open) { return }
+
+    if (nextProps.open) {
+      clearTimeout(this.timeout);
+      this.timeout = null;
+      this.anchorEl = nextProps.anchorEl || this.props.anchorEl;
+      this.setState({
+        open: true,
+        closing: false,
+      });
+    } else {
+      if (nextProps.animated) {
+        if (this.timeout !== null) return;
+        this.setState({closing: true});
+        this.timeout = setTimeout(() => {
           this.setState({
             open: false,
+          }, () => {
+            this.timeout = null;
           });
-        }
+        }, 500);
+      } else {
+        this.setState({
+          open: false,
+        });
       }
     }
   }


### PR DESCRIPTION
When using popover with animation and re-opening it while closing animation running, popover not opens. This change fixes that behaviour.
Also reduced 'if' nesting

