### PR TITLE
[SelectField] Update SelectField React examples

### DIFF
--- a/docs/src/app/components/pages/components/SelectField/ExampleCustomLabel.js
+++ b/docs/src/app/components/pages/components/SelectField/ExampleCustomLabel.js
@@ -7,9 +7,15 @@ import MenuItem from 'material-ui/MenuItem';
  * a complementary description of the selected item.
  */
 export default class SelectFieldExampleCustomLabel extends Component {
-  state = {
-    value: 1,
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      value: 1,
+    };
+
+    this.handleChange = this.handleChange.bind(this);
+  }
 
   handleChange = (event, index, value) => this.setState({value});
 

--- a/docs/src/app/components/pages/components/SelectField/ExampleError.js
+++ b/docs/src/app/components/pages/components/SelectField/ExampleError.js
@@ -15,9 +15,15 @@ const items = [
  * This can be customised with the `errorStyle` property.
  */
 export default class SelectFieldExampleError extends Component {
-  state = {
-    value: null,
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      value: null,
+    };
+
+    this.handleChange = this.handleChange.bind(this);
+  }
 
   handleChange = (event, index, value) => this.setState({value});
 

--- a/docs/src/app/components/pages/components/SelectField/ExampleFloatingLabel.js
+++ b/docs/src/app/components/pages/components/SelectField/ExampleFloatingLabel.js
@@ -16,9 +16,15 @@ const items = [
  * and can be customised with the `floatingLabelText` property.
  */
 export default class SelectFieldExampleFloatingLabel extends Component {
-  state = {
-    value: null,
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      value: null,
+    };
+
+    this.handleChange = this.handleChange.bind(this);
+  }
 
   handleChange = (event, index, value) => this.setState({value});
 

--- a/docs/src/app/components/pages/components/SelectField/ExampleLongMenu.js
+++ b/docs/src/app/components/pages/components/SelectField/ExampleLongMenu.js
@@ -3,7 +3,7 @@ import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 
 const items = [];
-for (let i = 0; i < 100; i++ ) {
+for (let i = 0; i < 100; i++) {
   items.push(<MenuItem value={i} key={i} primaryText={`Item ${i}`} />);
 }
 
@@ -12,13 +12,17 @@ for (let i = 0; i < 100; i++ ) {
  * if the number of items causes the height to exceed this limit.
  */
 export default class DropDownMenuLongMenuExample extends Component {
-  state = {
-    value: 10,
-  };
+  constructor(props) {
+    super(props);
 
-  handleChange = (event, index, value) => {
-    this.setState({value});
-  };
+    this.state = {
+      value: 10,
+    };
+
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange = (event, index, value) => this.setState({value});
 
   render() {
     return (

--- a/docs/src/app/components/pages/components/SelectField/ExampleNullable.js
+++ b/docs/src/app/components/pages/components/SelectField/ExampleNullable.js
@@ -7,9 +7,15 @@ import MenuItem from 'material-ui/MenuItem';
  * with no text and with a `null` value. For instance, for a boolean:
  */
 export default class SelectFieldExampleNullable extends Component {
-  state = {
-    value: null,
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      value: null,
+    };
+
+    this.handleChange = this.handleChange.bind(this);
+  }
 
   handleChange = (event, index, value) => this.setState({value});
 

--- a/docs/src/app/components/pages/components/SelectField/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/SelectField/ExampleSimple.js
@@ -14,9 +14,15 @@ const styles = {
  * The `SelectField` can be disabled with the `disabled` property.
  */
 export default class SelectFieldExampleSimple extends Component {
-  state = {
-    value: 1,
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      value: 1,
+    };
+
+    this.handleChange = this.handleChange.bind(this);
+  }
 
   handleChange = (event, index, value) => this.setState({value});
 

--- a/src/RadioButton/RadioButton.js
+++ b/src/RadioButton/RadioButton.js
@@ -173,13 +173,13 @@ class RadioButton extends Component {
       React.cloneElement(uncheckedIcon, {
         style: Object.assign(uncheckedStyles, uncheckedIcon.props.style),
       }) :
-        <RadioButtonOff style={uncheckedStyles} />;
+      <RadioButtonOff style={uncheckedStyles} />;
 
     const checkedElement = React.isValidElement(checkedIcon) ?
       React.cloneElement(checkedIcon, {
         style: Object.assign(checkedStyles, checkedIcon.props.style),
       }) :
-        <RadioButtonOn style={checkedStyles} />;
+      <RadioButtonOn style={checkedStyles} />;
 
     const mergedIconStyle = Object.assign(styles.icon, iconStyle);
     const mergedLabelStyle = Object.assign(styles.label, labelStyle);


### PR DESCRIPTION
* The examples were updated to represent valid
  JavaScript React components which would allow
  users to quickly grab the snippets and introduce
  them on their applications.
* Controlled components should define the state
  within the constructor followed by explicit
  binding of any functions that are used within
  the render call.
* For more information in regards to controlled
  components, please reference:
  https://facebook.github.io/react/docs/forms.html\#controlled-components

There is another commit within this PR that addresses linting rules in regards to `RadioButton.js`.  Interestingly, the Travis build was not passing until the spacing was fixed.

For more information:
![image](https://cloud.githubusercontent.com/assets/7675942/22194913/00babeae-e0fa-11e6-91fd-b9a76eb91173.png)



<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

