### PR TITLE
[IconButton] Fixes #6023 console error about undefined onTouchStart

### DIFF
--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -84,8 +84,6 @@ class IconButton extends Component {
     onMouseLeave: PropTypes.func,
     /** @ignore */
     onMouseOut: PropTypes.func,
-    /** @ignore */
-    onTouchStart: PropTypes.func,
     /**
      * Override the inline-styles of the root element.
      */
@@ -193,14 +191,6 @@ class IconButton extends Component {
     }
   };
 
-  handleTouchStart = (event) => {
-    this.setState({touch: true});
-
-    if (this.props.onTouchStart) {
-      this.props.onTouchStart(event);
-    }
-  };
-
   handleKeyboardFocus = (event, isKeyboardFocused) => {
     const {disabled, onFocus, onBlur, onKeyboardFocus} = this.props;
     if (isKeyboardFocused && !disabled) {
@@ -290,7 +280,6 @@ class IconButton extends Component {
         {...other}
         centerRipple={true}
         disabled={disabled}
-        onTouchStart={this.handleTouchStart}
         style={mergedRootStyles}
         disableTouchRipple={disableTouchRipple}
         onBlur={this.handleBlur}


### PR DESCRIPTION
Ran tests, lint, and built. Copied built IconButton.js file into project and verified issue is resolved. onTouchStart was being passed to EnhancedButton, but was removed in commit [359b8e4](https://github.com/callemall/material-ui/commit/359b8e463fe766beae27108da0f164fd84cd9ab2)