### PR TITLE
[build] babel & eslint caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ coverage
 /dist
 /test/regressions/screenshots/output
 /test/selenium-output
+.eslintcache
 
 # OS files
 .DS_STORE
@@ -12,3 +13,6 @@ coverage
 # npm files
 node_modules
 *.log
+
+# Editor files
+.idea

--- a/docs/site/webpack.dev.config.js
+++ b/docs/site/webpack.dev.config.js
@@ -28,8 +28,8 @@ module.exports = {
         exclude: /node_modules/,
         loader: 'babel',
         query: {
-          cacheDirectory: true
-        }
+          cacheDirectory: true,
+        },
       },
       {
         test: /\.svg$/,

--- a/docs/site/webpack.dev.config.js
+++ b/docs/site/webpack.dev.config.js
@@ -26,7 +26,10 @@ module.exports = {
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        loaders: ['babel-loader'],
+        loader: 'babel',
+        query: {
+          cacheDirectory: true
+        }
       },
       {
         test: /\.svg$/,

--- a/docs/site/webpack.prod.config.js
+++ b/docs/site/webpack.prod.config.js
@@ -22,8 +22,8 @@ module.exports = {
         exclude: /node_modules/,
         loader: 'babel',
         query: {
-          cacheDirectory: true
-        }
+          cacheDirectory: true,
+        },
       },
       {
         test: /\.svg$/,

--- a/docs/site/webpack.prod.config.js
+++ b/docs/site/webpack.prod.config.js
@@ -20,7 +20,10 @@ module.exports = {
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        loaders: ['babel'],
+        loader: 'babel',
+        query: {
+          cacheDirectory: true
+        }
       },
       {
         test: /\.svg$/,

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "clean:docs": "rimraf docs/api/*",
     "clean:build": "rimraf build",
     "docs:start": "(cd docs/site; npm start)",
-    "lint": "eslint . && echo \"eslint: no lint errors\"",
+    "lint": "eslint . --cache && echo \"eslint: no lint errors\"",
     "lint:find-rules": "eslint-find-rules -u .eslintrc.js",
     "prebuild": "npm run clean:build",
     "test": "node test mocha",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,6 +45,9 @@ const config = {
         test: /\.js$/,
         loader: 'babel',
         exclude: /(node_modules)/,
+        query: {
+          cacheDirectory: true,
+        },
       },
     ],
   },


### PR DESCRIPTION
(This is for NEXT branch)
That caches can reduce dev experience significantly.
 - docs/site dev server second startup is (on my computer) from 35s to 16s
 - npm run lint second and above run is around 2s instead of many seconds (actually, never versions of eslint-plugin-import are quite slow comparing 1.16 to 2.2)


