### PR TITLE
[RadioButton] Fix circular dependency

### DIFF
--- a/src/RadioButton/RadioButtonGroup.js
+++ b/src/RadioButton/RadioButtonGroup.js
@@ -1,5 +1,5 @@
 import React, {Component, PropTypes} from 'react';
-import RadioButton from '../RadioButton';
+import RadioButton from './RadioButton';
 import warning from 'warning';
 
 class RadioButtonGroup extends Component {


### PR DESCRIPTION
This fixes a circular dependency on `RadioButtonGroup` component, which was importing _RadioButton/index.js_ instead of _RadioButton/RadioButton.js_.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).