### PR TITLE
[Menu] focus handling fix

### DIFF
--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -111,6 +111,14 @@ export default class Menu extends Component {
     return false;
   };
 
+  handleMouseEnter = (event) => {
+    if (event.target && this.menuList && this.menuList.list) {
+      if (this.menuList.list.contains(event.target)) {
+        event.target.focus();
+      }
+    }
+  };
+
   getContentAnchorEl = () => {
     if (!this.menuList || !this.menuList.selectedItem) {
       return findDOMNode(this.menuList).firstChild;
@@ -140,6 +148,7 @@ export default class Menu extends Component {
 
     return (
       <Popover
+        onMouseOver={this.handleMouseEnter}
         anchorEl={anchorEl}
         getContentAnchorEl={this.getContentAnchorEl}
         className={classes.popover}


### PR DESCRIPTION
Fixes #5186

My idea for proper behavior is, that Menu changes focus every time, mouse enters some of the children. This seems to be better that user can use keys after leaving menu instead of removing focus on mouse motion.

