### PR TITLE
[core]  tap-event-plugin fails

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
 machine:
   node:
     version: 6.1.0
+
+dependencies:
+  post:
+    - npm ls react-tap-event-plugin react

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "test:unit:watch": "cross-env NODE_ENV=test babel-node test/watch.js unit"
   },
   "peerDependencies": {
-    "react": "^15.4.0",
-    "react-dom": "^15.4.0",
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2",
     "react-tap-event-plugin": "2.0.0"
   },
   "dependencies": {
@@ -101,9 +101,9 @@
     "mocha": "^3.1.2",
     "nodemon": "^1.11.0",
     "phantomjs-prebuilt": "^2.1.13",
-    "react": "^15.4.0",
-    "react-addons-test-utils": "^15.4.0",
-    "react-dom": "^15.4.0",
+    "react": "^15.4.2",
+    "react-addons-test-utils": "^15.4.2",
+    "react-dom": "^15.4.2",
     "react-tap-event-plugin": "2.0.0",
     "recursive-readdir-sync": "^1.0.6",
     "rimraf": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "peerDependencies": {
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
-    "react-tap-event-plugin": "2.0.0"
+    "react-tap-event-plugin": "^2.0.1"
   },
   "dependencies": {
     "babel-runtime": "^6.18.0",
@@ -104,7 +104,7 @@
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2",
-    "react-tap-event-plugin": "2.0.0",
+    "react-tap-event-plugin": "^2.0.1",
     "recursive-readdir-sync": "^1.0.6",
     "rimraf": "^2.5.3",
     "sinon": "^1.17.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "peerDependencies": {
     "react": "^15.4.0",
     "react-dom": "^15.4.0",
-    "react-tap-event-plugin": "^2.0.1"
+    "react-tap-event-plugin": "2.0.0"
   },
   "dependencies": {
     "babel-runtime": "^6.18.0",
@@ -104,7 +104,7 @@
     "react": "^15.4.0",
     "react-addons-test-utils": "^15.4.0",
     "react-dom": "^15.4.0",
-    "react-tap-event-plugin": "^2.0.0",
+    "react-tap-event-plugin": "2.0.0",
     "recursive-readdir-sync": "^1.0.6",
     "rimraf": "^2.5.3",
     "sinon": "^1.17.3",


### PR DESCRIPTION
WIP

Debugging/comparing circleci results which pass with local OSX test results which fail.

#5646

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

