### PR TITLE
[Button] make the node isRequired

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -125,7 +125,7 @@ export default class Button extends Component {
     /**
      * The content of the button.
      */
-    children: PropTypes.node,
+    children: PropTypes.node.isRequired,
     /**
      * The CSS class name of the root element.
      */

--- a/src/Button/Button.spec.js
+++ b/src/Button/Button.spec.js
@@ -38,7 +38,7 @@ describe('<Button />', () => {
 
   it('should render the custom className and the root class', () => {
     const wrapper = shallow(
-      <Button className="test-class-name" />,
+      <Button className="test-class-name">Hello World</Button>,
     );
     assert.strictEqual(wrapper.is('.test-class-name'), true, 'should pass the test className');
     assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
@@ -107,7 +107,7 @@ describe('<Button />', () => {
 
   it('should render a floating action button', () => {
     const wrapper = shallow(
-      <Button fab />,
+      <Button fab>Hello World</Button>,
     );
     assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
     assert.strictEqual(wrapper.hasClass(classes.raised), true, 'should have the raised class');
@@ -119,7 +119,7 @@ describe('<Button />', () => {
 
   it('should render a primary floating action button', () => {
     const wrapper = shallow(
-      <Button fab primary />,
+      <Button fab primary>Hello World</Button>,
     );
     assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
     assert.strictEqual(wrapper.hasClass(classes.raised), true, 'should have the raised class');
@@ -132,7 +132,7 @@ describe('<Button />', () => {
 
   it('should render an accent floating action button', () => {
     const wrapper = shallow(
-      <Button fab accent />,
+      <Button fab accent>Hello World</Button>,
     );
     assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
     assert.strictEqual(wrapper.hasClass(classes.raised), true, 'should have the raised class');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

I'm not sure about the point of rendering a button without any children. That could help new users quicker understanding how to provide a label.

This one is for you @julien-meichelbeck.