### PR TITLE
[style] transitions theme API reworked (next)

### DIFF
--- a/docs/site/src/demos/cards/RecipeReviewCard.js
+++ b/docs/site/src/demos/cards/RecipeReviewCard.js
@@ -22,7 +22,9 @@ const styleSheet = createStyleSheet('RecipeReviewCard', (theme) => ({
   card: { maxWidth: 400 },
   expand: {
     transform: 'rotate(0deg)',
-    transition: theme.transitions.create('transform', '150ms'),
+    transition: theme.transitions.create('transform', {
+      duration: theme.transitions.duration.shortest,
+    }),
   },
   expandOpen: {
     transform: 'rotate(180deg)',

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "dom-helpers": "^3.2.0",
+    "invariant": "^2.2.2",
     "jss-preset-default": "^1.3.1",
     "jss-theme-reactor": "^0.9.0",
     "keycode": "^2.1.8",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "dom-helpers": "^3.2.0",
-    "invariant": "^2.2.2",
     "jss-preset-default": "^1.3.1",
     "jss-theme-reactor": "^0.9.0",
     "keycode": "^2.1.8",

--- a/src/BottomNavigation/BottomNavigationButton.js
+++ b/src/BottomNavigation/BottomNavigationButton.js
@@ -8,11 +8,12 @@ import ButtonBase from '../internal/ButtonBase';
 import Icon from '../Icon';
 
 export const styleSheet = createStyleSheet('MuiBottomNavigationButton', (theme) => {
+  const { palette, typography, transitions } = theme;
   return {
     root: {
-      transition: `${
-        theme.transitions.create('color', '250ms')}, ${
-        theme.transitions.create('padding-top', '250ms')}`,
+      transition: `${transitions.create(['color', 'padding-top'], {
+        duration: transitions.duration.short,
+      })}`,
       paddingTop: 8,
       paddingBottom: 10,
       paddingLeft: 12,
@@ -20,25 +21,25 @@ export const styleSheet = createStyleSheet('MuiBottomNavigationButton', (theme) 
       minWidth: 80,
       maxWidth: 168,
       background: 'none',
-      color: theme.palette.text.secondary,
+      color: palette.text.secondary,
       flex: '1',
     },
     selected: {
       paddingTop: 6,
-      color: theme.palette.primary[500],
+      color: palette.primary[500],
     },
     selectedIconOnly: {
       paddingTop: 16,
     },
     label: {
-      fontFamily: theme.typography.fontFamily,
-      fontSize: theme.typography.fontSize - 2,
+      fontFamily: typography.fontFamily,
+      fontSize: typography.fontSize - 2,
       opacity: 1,
       transition: 'font-size 0.2s, opacity 0.2s',
       transitionDelay: '0.1s',
     },
     selectedLabel: {
-      fontSize: theme.typography.fontSize,
+      fontSize: typography.fontSize,
     },
     hiddenLabel: {
       opacity: 0,

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -24,7 +24,9 @@ export const styleSheet = createStyleSheet('MuiButton', (theme) => {
       borderRadius: 2,
       color: palette.text.primary,
       backgroundColor: 'transparent',
-      transition: transitions.multi(['background-color', 'box-shadow'], '250ms'),
+      transition: transitions.create(['background-color', 'box-shadow'], {
+        duration: transitions.duration.short,
+      }),
       '&:hover': {
         textDecoration: 'none',
         backgroundColor: palette.text.divider,

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -7,7 +7,7 @@ import Modal from '../internal/Modal';
 import customPropTypes from '../utils/customPropTypes';
 import Slide from '../transitions/Slide';
 import Paper from '../Paper';
-import { durations } from '../styles/transitions';
+import { duration } from '../styles/transitions';
 
 function getSlideDirection(anchor) {
   if (anchor === 'left') {
@@ -101,8 +101,8 @@ export default class Drawer extends Component {
 
   static defaultProps = {
     docked: false,
-    enterTransitionDuration: durations.enteringScreen,
-    leaveTransitionDuration: durations.leavingScreen,
+    enterTransitionDuration: duration.enteringScreen,
+    leaveTransitionDuration: duration.leavingScreen,
     open: false,
     elevation: 16,
   };

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -7,7 +7,7 @@ import { createShallowWithContext } from 'test/utils';
 import Drawer, { styleSheet } from './Drawer';
 import Slide from '../transitions/Slide';
 import Modal from '../internal/Modal';
-import { durations } from '../styles/transitions';
+import { duration } from '../styles/transitions';
 
 /**
  * An item that goes in lists.
@@ -55,7 +55,7 @@ describe('<Drawer />', () => {
     const leaveDuration = 2967;
 
     it('default value should be from standard timings', () => {
-      assert.strictEqual(Drawer.defaultProps.enterTransitionDuration, durations.enteringScreen);
+      assert.strictEqual(Drawer.defaultProps.enterTransitionDuration, duration.enteringScreen);
     });
 
     it('should be passed to Slide', () => {
@@ -80,7 +80,7 @@ describe('<Drawer />', () => {
     const leaveDuration = 1889;
 
     it('default value should be from standard timings', () => {
-      assert.strictEqual(Drawer.defaultProps.leaveTransitionDuration, durations.leavingScreen);
+      assert.strictEqual(Drawer.defaultProps.leaveTransitionDuration, duration.leavingScreen);
     });
 
     it('should be passed to Slide', () => {
@@ -101,9 +101,9 @@ describe('<Drawer />', () => {
   });
 
   it('should override Modal\'s backdropTransitionDuration from property when specified', () => {
-    const duration = 335;
-    const wrapper = shallow(<Drawer backdropTransitionDuration={duration} />);
-    assert.strictEqual(wrapper.find(Modal).props().backdropTransitionDuration, duration);
+    const testDuration = 335;
+    const wrapper = shallow(<Drawer backdropTransitionDuration={testDuration} />);
+    assert.strictEqual(wrapper.find(Modal).props().backdropTransitionDuration, testDuration);
   });
 
   it('should set the Paper className', () => {

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -25,7 +25,9 @@ export const styleSheet = createStyleSheet('MuiIconButton', (theme) => {
       backgroundColor: 'transparent',
       color: palette.action.active,
       zIndex: 1,
-      transition: transitions.create('background-color', '150ms'),
+      transition: transitions.create('background-color', {
+        duration: transitions.duration.shortest,
+      }),
     },
     disabled: {
       color: palette.action.disabled,

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -4,13 +4,13 @@ import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 import { createStyleSheet } from 'jss-theme-reactor';
 import customPropTypes from '../utils/customPropTypes';
-import { easing } from '../styles/transitions';
 
 function isDirty(obj) {
   return obj && obj.value && obj.value.length > 0;
 }
 
 export const styleSheet = createStyleSheet('MuiInput', (theme) => {
+  const { palette, transitions } = theme;
   return {
     wrapper: {
       // Mimics the default input display property used by browsers for an input.
@@ -23,7 +23,7 @@ export const styleSheet = createStyleSheet('MuiInput', (theme) => {
     },
     inkbar: {
       '&:after': {
-        backgroundColor: theme.palette.accent.A200,
+        backgroundColor: palette.accent.A200,
         left: 0,
         bottom: -1,
         // Doing the other way around crash on IE11 "''"" https://github.com/cssinjs/jss/issues/242
@@ -32,12 +32,10 @@ export const styleSheet = createStyleSheet('MuiInput', (theme) => {
         position: 'absolute',
         right: 0,
         transform: 'scaleX(0)',
-        transition: theme.transitions.create(
-          'transform',
-          '200ms',
-          null,
-          easing.easeOut,
-        ),
+        transition: transitions.create('transform', {
+          duration: transitions.duration.shorter,
+          easing: transitions.easing.easeOut,
+        }),
       },
       '&$focused:after': {
         transform: 'scaleX(1)',
@@ -46,7 +44,7 @@ export const styleSheet = createStyleSheet('MuiInput', (theme) => {
     focused: {},
     error: {
       '&:after': {
-        backgroundColor: theme.palette.error[500],
+        backgroundColor: palette.error[500],
         transform: 'scaleX(1)', // error is always underlined in red
       },
     },

--- a/src/Input/InputLabel.js
+++ b/src/Input/InputLabel.js
@@ -4,10 +4,10 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import { createStyleSheet } from 'jss-theme-reactor';
 import customPropTypes from '../utils/customPropTypes';
-import { easing } from '../styles/transitions';
 import { FormLabel } from '../Form';
 
 export const styleSheet = createStyleSheet('MuiInputLabel', (theme) => {
+  const { transitions } = theme;
   return {
     root: {
       transformOrigin: 'top left',
@@ -23,7 +23,10 @@ export const styleSheet = createStyleSheet('MuiInputLabel', (theme) => {
       transformOrigin: 'top left',
     },
     animated: {
-      transition: theme.transitions.create('transform', '200ms', null, easing.easeOut),
+      transition: transitions.create('transform', {
+        duration: transitions.duration.shorter,
+        easing: transitions.easing.easeOut,
+      }),
     },
   };
 });

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -40,7 +40,9 @@ export const styleSheet = createStyleSheet('MuiListItem', (theme) => {
       paddingRight: 16,
     },
     button: {
-      transition: transitions.create('background-color', '250ms'),
+      transition: transitions.create('background-color', {
+        duration: transitions.duration.short,
+      }),
       '&:hover': {
         textDecoration: 'none',
         backgroundColor: palette.text.divider,

--- a/src/Menu/MenuItem.js
+++ b/src/Menu/MenuItem.js
@@ -14,7 +14,9 @@ export const styleSheet = createStyleSheet('MuiMenuItem', (theme) => {
       height: 48,
       boxSizing: 'border-box',
       background: 'none',
-      transition: transitions.create('background-color', '250ms'),
+      transition: transitions.create('background-color', {
+        duration: transitions.duration.short,
+      }),
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',

--- a/src/Progress/CircularProgress.js
+++ b/src/Progress/CircularProgress.js
@@ -24,7 +24,7 @@ export const styleSheet = createStyleSheet('MuiCircularProgress', (theme) => {
       strokeDashoffset: '0%',
       stroke: 'currentColor',
       strokeLinecap: 'square',
-      transition: theme.transitions.create('all', '1.30s'),
+      transition: theme.transitions.create('all', { duration: 1300 }),
       animation: `scale-progress-circle 1300ms ${easing.easeInOut} infinite`,
     },
     '@keyframes rotate-progress-circle': {

--- a/src/SvgIcon/SvgIcon.js
+++ b/src/SvgIcon/SvgIcon.js
@@ -6,6 +6,7 @@ import { createStyleSheet } from 'jss-theme-reactor';
 import customPropTypes from '../utils/customPropTypes';
 
 export const styleSheet = createStyleSheet('MuiSvgIcon', (theme) => {
+  const { transitions } = theme;
   return {
     svgIcon: {
       display: 'inline-block',
@@ -13,7 +14,9 @@ export const styleSheet = createStyleSheet('MuiSvgIcon', (theme) => {
       height: 24,
       width: 24,
       userSelect: 'none',
-      transition: theme.transitions.create('fill', '200ms'),
+      transition: transitions.create('fill', {
+        duration: transitions.duration.shorter,
+      }),
     },
   };
 });

--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -8,7 +8,7 @@ import { createSwitch } from '../internal/SwitchBase';
 import withSwitchLabel from '../internal/withSwitchLabel';
 
 export const styleSheet = createStyleSheet('MuiSwitch', (theme) => {
-  const { palette } = theme;
+  const { palette, transitions } = theme;
   return {
     root: {
       display: 'inline-flex',
@@ -17,7 +17,9 @@ export const styleSheet = createStyleSheet('MuiSwitch', (theme) => {
     },
     default: {
       color: palette.type === 'light' ? palette.grey[50] : palette.grey[400],
-      transition: theme.transitions.create('transform', '150ms'),
+      transition: transitions.create('transform', {
+        duration: transitions.duration.shortest,
+      }),
     },
     checked: {
       color: palette.accent[500],
@@ -44,7 +46,9 @@ export const styleSheet = createStyleSheet('MuiSwitch', (theme) => {
       marginTop: -7,
       left: '50%',
       marginLeft: -17,
-      transition: theme.transitions.multi(['opacity', 'background-color'], '150ms'),
+      transition: transitions.create(['opacity', 'background-color'], {
+        duration: transitions.duration.shortest,
+      }),
       backgroundColor: palette.type === 'light' ? '#000' : '#fff',
       opacity: palette.type === 'light' ? 0.38 : 0.3,
     },

--- a/src/Table/TableSortLabel.js
+++ b/src/Table/TableSortLabel.js
@@ -8,6 +8,7 @@ import ButtonBase from '../internal/ButtonBase';
 import Icon from '../Icon';
 
 export const styleSheet = createStyleSheet('MuiTableSortLabel', (theme) => {
+  const { palette, transitions } = theme;
   return {
     sortLabel: {
       cursor: 'pointer',
@@ -17,14 +18,14 @@ export const styleSheet = createStyleSheet('MuiTableSortLabel', (theme) => {
       alignItems: 'center',
       background: 'transparent',
       '&:hover': {
-        color: theme.palette.text.primary,
+        color: palette.text.primary,
       },
       '&:focus': {
-        color: theme.palette.text.primary,
+        color: palette.text.primary,
       },
     },
     active: {
-      color: theme.palette.text.primary,
+      color: palette.text.primary,
       '& $icon': {
         opacity: 1,
       },
@@ -34,7 +35,9 @@ export const styleSheet = createStyleSheet('MuiTableSortLabel', (theme) => {
       marginRight: 4,
       marginLeft: 4,
       opacity: 0,
-      transition: theme.transitions.create(['opacity', 'transform'], '200ms'),
+      transition: transitions.create(['opacity', 'transform'], {
+        duration: transitions.duration.shorter,
+      }),
       userSelect: 'none',
     },
     desc: {

--- a/src/TextField/TextFieldLabel.js
+++ b/src/TextField/TextFieldLabel.js
@@ -4,10 +4,10 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import { createStyleSheet } from 'jss-theme-reactor';
 import customPropTypes from '../utils/customPropTypes';
-import { easing } from '../styles/transitions';
 import { FormLabel } from '../Form';
 
 export const styleSheet = createStyleSheet('MuiTextFieldLabel', (theme) => {
+  const { transitions } = theme;
   return {
     root: {
       position: 'absolute',
@@ -20,7 +20,10 @@ export const styleSheet = createStyleSheet('MuiTextFieldLabel', (theme) => {
       transform: 'translate(0, 0px) scale(0.75)',
     },
     animated: {
-      transition: theme.transitions.create('transform', '200ms', null, easing.easeOut),
+      transition: transitions.create('transform', {
+        duration: transitions.duration.shorter,
+        easing: transitions.easing.easeOut,
+      }),
     },
   };
 });

--- a/src/internal/Popover.js
+++ b/src/internal/Popover.js
@@ -205,8 +205,12 @@ export default class Popover extends Component {
     }
 
     element.style.transition = [
-      transitions.create('opacity', `${transitionDuration}ms`),
-      transitions.create('transform', `${transitionDuration * 0.666}ms`),
+      transitions.create('opacity', {
+        duration: transitionDuration,
+      }),
+      transitions.create('transform', {
+        duration: transitionDuration * 0.666,
+      }),
     ].join(',');
   };
 
@@ -229,9 +233,13 @@ export default class Popover extends Component {
     }
 
     element.style.transition = [
-      transitions.create('opacity', `${transitionDuration}ms`),
-      transitions.create('transform', `${transitionDuration * 0.666}ms`, `${
-        transitionDuration * 0.333}`),
+      transitions.create('opacity', {
+        duration: transitionDuration,
+      }),
+      transitions.create('transform', {
+        duration: transitionDuration * 0.666,
+        delay: transitionDuration * 0.333,
+      }),
     ].join(',');
 
     element.style.opacity = 0;

--- a/src/styles/transitions.js
+++ b/src/styles/transitions.js
@@ -1,9 +1,11 @@
 // @flow weak
 /* eslint-disable no-param-reassign */
 
+import invariant from 'invariant';
+
 // Follow https://material.google.com/motion/duration-easing.html#duration-easing-natural-easing-curves
 // to learn the context in which each easing should be used.
-export const easing = {
+const easingInternal = {
   // This is the most common easing curve.
   easeInOut: 'cubic-bezier(0.4, 0.0, 0.2, 1)',
   // Objects enter the screen at full velocity from off-screen and
@@ -17,7 +19,10 @@ export const easing = {
 
 // Follow https://material.io/guidelines/motion/duration-easing.html#duration-easing-common-durations
 // to learn when use what timing
-export const durations = {
+const durationIntenal = {
+  shortest: 150,
+  shorter: 200,
+  short: 250,
   // most basic recommended timing
   standard: 300,
   // this is to be used in complex animations
@@ -28,30 +33,39 @@ export const durations = {
   leavingScreen: 195,
 };
 
+/**
+ * @param {string|Array} props
+ * @param {object} param
+ * @param {string} param.prop
+ * @param {number} param.duration
+ * @param {string} param.easing
+ * @param {number} param.delay
+*/
 export default {
-  multi(property, duration, delay, easeFunction) {
-    easeFunction = easeFunction || easing.easeInOut;
+  easing: easingInternal,
 
-    if (property && Array.isArray(property)) {
-      let transitions = '';
-      for (let i = 0; i < property.length; i += 1) {
-        if (transitions) transitions += ',';
-        transitions += this.create(property[i], duration, delay, easeFunction);
-      }
+  duration: durationIntenal,
 
-      return transitions;
-    }
+  create(props = ['all'], {
+    duration = durationIntenal.standard,
+    easing = easingInternal.easeInOut,
+    delay = 0,
+    ...other
+  } = {}) {
+    invariant(typeof props === 'string' || Array.isArray(props),
+      'argument "props" must be a string or Array');
+    invariant(Number.isInteger(duration),
+      'argument "duration" must be a number');
+    invariant(typeof easing === 'string',
+      'argument "easing" must be a string');
+    invariant(Number.isInteger(delay),
+      'argument "delay" must be a string');
+    invariant(Object.keys(other).length === 0,
+      `unrecognized argument(s) [${Object.keys(other).join(',')}]`);
 
-    return this.create(duration, property, delay, easeFunction);
-  },
-
-  create(property, duration, delay, easeFunction) {
-    duration = duration || '300ms';
-    property = property || 'all';
-    delay = delay || '0ms';
-    easeFunction = easeFunction || easing.easeInOut;
-
-    return `${property} ${duration} ${easeFunction} ${delay}`;
+    return (Array.isArray(props) ? props : [props])
+      .map((value) => `${value} ${duration}ms ${easing} ${delay}ms`)
+      .join(',');
   },
 
   getAutoHeightDuration(height) {
@@ -65,3 +79,6 @@ export default {
     return Math.round(duration);
   },
 };
+
+export const easing = easingInternal;
+export const duration = durationIntenal;

--- a/src/styles/transitions.js
+++ b/src/styles/transitions.js
@@ -1,7 +1,7 @@
 // @flow weak
 /* eslint-disable no-param-reassign */
 
-import invariant from 'invariant';
+import warning from 'warning';
 
 // Follow https://material.google.com/motion/duration-easing.html#duration-easing-natural-easing-curves
 // to learn the context in which each easing should be used.
@@ -52,15 +52,15 @@ export default {
     delay = 0,
     ...other
   } = {}) {
-    invariant(typeof props === 'string' || Array.isArray(props),
+    warning(typeof props === 'string' || Array.isArray(props),
       'argument "props" must be a string or Array');
-    invariant(Number.isInteger(duration),
+    warning(Number.isInteger(duration),
       'argument "duration" must be a number');
-    invariant(typeof easing === 'string',
+    warning(typeof easing === 'string',
       'argument "easing" must be a string');
-    invariant(Number.isInteger(delay),
+    warning(Number.isInteger(delay),
       'argument "delay" must be a string');
-    invariant(Object.keys(other).length === 0,
+    warning(Object.keys(other).length === 0,
       `unrecognized argument(s) [${Object.keys(other).join(',')}]`);
 
     return (Array.isArray(props) ? props : [props])
@@ -80,5 +80,11 @@ export default {
   },
 };
 
+/**
+ * @deprecated Will be removed, please access via theme.transitions.easing
+ */
 export const easing = easingInternal;
+/**
+ * @deprecated Will be removed, please access via theme.transitions.duration
+ */
 export const duration = durationIntenal;

--- a/src/styles/transitions.spec.js
+++ b/src/styles/transitions.spec.js
@@ -2,18 +2,31 @@
 /* eslint-env mocha */
 
 import { assert } from 'chai';
+import { stub } from 'sinon';
 import transitions, { easing, duration } from './transitions';
 
 describe('transitions', () => {
+  let consoleErrorStub;
+
+  beforeEach(() => {
+    consoleErrorStub = stub(console, 'error');
+  });
+
+  afterEach(() => {
+    consoleErrorStub.restore();
+  });
+
   describe('create() function', () => {
     it('should create default transition withnout arguments', () => {
       const transition = transitions.create();
       assert.strictEqual(transition, `all ${duration.standard}ms ${easing.easeInOut} 0ms`);
+      assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
     });
 
     it('should take string props as a first argument', () => {
       const transition = transitions.create('color');
       assert.strictEqual(transition, `color ${duration.standard}ms ${easing.easeInOut} 0ms`);
+      assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
     });
 
     it('should also take array of props as first argument', () => {
@@ -23,21 +36,54 @@ describe('transitions', () => {
       const single2 = transitions.create('size', options);
       const expected = `${single1},${single2}`;
       assert.strictEqual(multiple, expected);
+      assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
+    });
+
+    it('should warn when first argument is of bad type', () => {
+      transitions.create(5554);
+      transitions.create({});
+      assert.strictEqual(consoleErrorStub.callCount, 2, 'Wrong number of calls of warning()');
     });
 
     it('should optionally accept number "duration" option in second argument', () => {
       const transition = transitions.create('font', { duration: 500 });
       assert.strictEqual(transition, `font 500ms ${easing.easeInOut} 0ms`);
+      assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
+    });
+
+    it('should warn when bad "duration" option type', () => {
+      transitions.create('font', { duration: '' });
+      transitions.create('font', { duration: {} });
+      assert.strictEqual(consoleErrorStub.callCount, 2, 'Wrong number of calls of warning()');
     });
 
     it('should optionally accept string "easing" option in second argument', () => {
       const transition = transitions.create('transform', { easing: easing.sharp });
       assert.strictEqual(transition, `transform ${duration.standard}ms ${easing.sharp} 0ms`);
+      assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
+    });
+
+    it('should warn when bad "easing" option type', () => {
+      transitions.create('transform', { easing: 123 });
+      transitions.create('transform', { easing: {} });
+      assert.strictEqual(consoleErrorStub.callCount, 2, 'Wrong number of calls of warning()');
     });
 
     it('should optionally accept number "delay" option in second argument', () => {
       const transition = transitions.create('size', { delay: 150 });
       assert.strictEqual(transition, `size ${duration.standard}ms ${easing.easeInOut} 150ms`);
+      assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
+    });
+
+    it('should warn when bad "delay" option type', () => {
+      transitions.create('size', { delay: '' });
+      transitions.create('size', { delay: {} });
+      assert.strictEqual(consoleErrorStub.callCount, 2, 'Wrong number of calls of warning()');
+    });
+
+    it('should warn when passed unrecognized option', () => {
+      transitions.create('size', { fffds: 'value' });
+      assert.strictEqual(consoleErrorStub.callCount, 1, 'Wrong number of calls of warning()');
     });
   });
 });

--- a/src/styles/transitions.spec.js
+++ b/src/styles/transitions.spec.js
@@ -1,0 +1,53 @@
+// @flow weak
+/* eslint-env mocha */
+
+import { assert } from 'chai';
+import transitions, { easing, duration } from './transitions';
+
+describe('transitions', () => {
+  describe('create() function', () => {
+    it('should create default transition withnout arguments', () => {
+      const transition = transitions.create();
+      assert.strictEqual(transition, `all ${duration.standard}ms ${easing.easeInOut} 0ms`);
+    });
+
+    it('should take string props as a first argument', () => {
+      const transition = transitions.create('color');
+      assert.strictEqual(transition, `color ${duration.standard}ms ${easing.easeInOut} 0ms`);
+    });
+
+    it('should also take array of props as first argument', () => {
+      const options = { delay: 20 };
+      const multiple = transitions.create(['color', 'size'], options);
+      const single1 = transitions.create('color', options);
+      const single2 = transitions.create('size', options);
+      const expected = `${single1},${single2}`;
+      assert.strictEqual(multiple, expected);
+    });
+
+    it('should optionally accept number "duration" option in second argument', () => {
+      const transition = transitions.create('font', { duration: 500 });
+      assert.strictEqual(transition, `font 500ms ${easing.easeInOut} 0ms`);
+      assert.throw(() => transitions.create('font', { duration: 'string' }));
+      assert.throw(() => transitions.create('font', { duration: {} }));
+    });
+
+    it('should optionally accept string "easing" option in second argument', () => {
+      const transition = transitions.create('transform', { easing: easing.sharp });
+      assert.strictEqual(transition, `transform ${duration.standard}ms ${easing.sharp} 0ms`);
+      assert.throw(() => transitions.create('transform', { easing: 123 }));
+      assert.throw(() => transitions.create('transform', { easing: {} }));
+    });
+
+    it('should optionally accept number "delay" option in second argument', () => {
+      const transition = transitions.create('size', { delay: 150 });
+      assert.strictEqual(transition, `size ${duration.standard}ms ${easing.easeInOut} 150ms`);
+      assert.throw(() => transitions.create('size', { delay: 'string' }));
+      assert.throw(() => transitions.create('size', { delay: {} }));
+    });
+
+    it('should throw error when unrecognized option passed in second argument', () => {
+      assert.throw(() => transitions.create('all', { something: 'something' }));
+    });
+  });
+});

--- a/src/styles/transitions.spec.js
+++ b/src/styles/transitions.spec.js
@@ -28,26 +28,16 @@ describe('transitions', () => {
     it('should optionally accept number "duration" option in second argument', () => {
       const transition = transitions.create('font', { duration: 500 });
       assert.strictEqual(transition, `font 500ms ${easing.easeInOut} 0ms`);
-      assert.throw(() => transitions.create('font', { duration: 'string' }));
-      assert.throw(() => transitions.create('font', { duration: {} }));
     });
 
     it('should optionally accept string "easing" option in second argument', () => {
       const transition = transitions.create('transform', { easing: easing.sharp });
       assert.strictEqual(transition, `transform ${duration.standard}ms ${easing.sharp} 0ms`);
-      assert.throw(() => transitions.create('transform', { easing: 123 }));
-      assert.throw(() => transitions.create('transform', { easing: {} }));
     });
 
     it('should optionally accept number "delay" option in second argument', () => {
       const transition = transitions.create('size', { delay: 150 });
       assert.strictEqual(transition, `size ${duration.standard}ms ${easing.easeInOut} 150ms`);
-      assert.throw(() => transitions.create('size', { delay: 'string' }));
-      assert.throw(() => transitions.create('size', { delay: {} }));
-    });
-
-    it('should throw error when unrecognized option passed in second argument', () => {
-      assert.throw(() => transitions.create('all', { something: 'something' }));
     });
   });
 });

--- a/src/transitions/Fade.js
+++ b/src/transitions/Fade.js
@@ -49,10 +49,9 @@ export default class Fade extends Component {
 
   handleEnter = (element) => {
     element.style.opacity = 0;
-    element.style.transition = this.context.theme.transitions.create(
-      'opacity',
-      `${this.props.transitionDuration}ms`,
-    );
+    element.style.transition = this.context.theme.transitions.create('opacity', {
+      duration: this.props.transitionDuration,
+    });
     if (this.props.onEnter) {
       this.props.onEnter();
     }

--- a/src/transitions/Slide.js
+++ b/src/transitions/Slide.js
@@ -3,7 +3,7 @@
 import React, { Component, PropTypes } from 'react';
 import Transition from '../internal/Transition';
 import customPropTypes from '../utils/customPropTypes';
-import { easing, durations } from '../styles/transitions';
+import { duration } from '../styles/transitions';
 
 function getTranslateValue(props, element) {
   const { direction } = props;
@@ -67,8 +67,8 @@ export default class Slide extends Component {
 
   static defaultProps = {
     direction: 'down',
-    enterTransitionDuration: durations.enteringScreen,
-    leaveTransitionDuration: durations.leavingScreen,
+    enterTransitionDuration: duration.enteringScreen,
+    leaveTransitionDuration: duration.leavingScreen,
   };
 
   static contextTypes = {
@@ -84,12 +84,10 @@ export default class Slide extends Component {
 
   handleEntering = (element) => {
     const { transitions } = this.context.theme;
-    element.style.transition = transitions.create(
-      'transform',
-      `${this.props.enterTransitionDuration}ms`,
-      '0ms',
-      easing.easeOut,
-    );
+    element.style.transition = transitions.create('transform', {
+      duration: this.props.enterTransitionDuration,
+      easing: transitions.easing.easeOut,
+    });
     element.style.transform = 'translate3d(0, 0, 0)';
     if (this.props.onEntering) {
       this.props.onEntering(element);
@@ -98,12 +96,10 @@ export default class Slide extends Component {
 
   handleExiting = (element) => {
     const { transitions } = this.context.theme;
-    element.style.transition = transitions.create(
-      'transform',
-      `${this.props.leaveTransitionDuration}ms`,
-      '0ms',
-      easing.sharp,
-    );
+    element.style.transition = transitions.create('transform', {
+      duration: this.props.leaveTransitionDuration,
+      easing: transitions.easing.sharp,
+    });
     element.style.transform = getTranslateValue(this.props, element);
     if (this.props.onExiting) {
       this.props.onExiting(element);

--- a/src/transitions/Slide.spec.js
+++ b/src/transitions/Slide.spec.js
@@ -6,7 +6,7 @@ import { assert } from 'chai';
 import { spy } from 'sinon';
 import { createShallowWithContext } from 'test/utils';
 import Slide from './Slide';
-import transitions, { easing, durations } from '../styles/transitions';
+import transitions, { easing, duration } from '../styles/transitions';
 
 describe('<Slide />', () => {
   let shallow;
@@ -21,11 +21,11 @@ describe('<Slide />', () => {
   });
 
   it('enterTransitionDuration prop should have default value from standard durations', () => {
-    assert.strictEqual(Slide.defaultProps.enterTransitionDuration, durations.enteringScreen);
+    assert.strictEqual(Slide.defaultProps.enterTransitionDuration, duration.enteringScreen);
   });
 
   it('leaveTransitionDuration prop should have default value from standard durations', () => {
-    assert.strictEqual(Slide.defaultProps.leaveTransitionDuration, durations.leavingScreen);
+    assert.strictEqual(Slide.defaultProps.leaveTransitionDuration, duration.leavingScreen);
   });
 
   describe('event callbacks', () => {
@@ -77,23 +77,19 @@ describe('<Slide />', () => {
 
     it('should create proper easeOut animation onEntering', () => {
       instance.handleEntering(element);
-      const animation = transitions.create(
-        'transform',
-        `${enterDuration}ms`,
-        '0ms',
-        easing.easeOut,
-      );
+      const animation = transitions.create('transform', {
+        duration: enterDuration,
+        easing: easing.easeOut,
+      });
       assert.strictEqual(element.style.transition, animation);
     });
 
     it('should create proper sharp animation onExiting', () => {
       instance.handleExiting(element);
-      const animation = transitions.create(
-        'transform',
-        `${leaveDuration}ms`,
-        '0ms',
-        easing.sharp,
-      );
+      const animation = transitions.create('transform', {
+        duration: leaveDuration,
+        easing: easing.sharp,
+      });
       assert.strictEqual(element.style.transition, animation);
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2675,7 +2675,7 @@ interpret@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.1.tgz#d579fb7f693b858004947af39fa0db49f795602c"
 
-invariant@^2.2.0:
+invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2675,7 +2675,7 @@ interpret@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.1.tgz#d579fb7f693b858004947af39fa0db49f795602c"
 
-invariant@^2.2.0, invariant@^2.2.2:
+invariant@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:


### PR DESCRIPTION
As @oliviertassinari suggested, created better transitions theme API. Objective of this PR was only to refactor things, without changing behavior or change things much. 

In future PR, i plan to have transition durations and easing to be customizable via theme as are colors or typography. Some things are bit prepare for this in this PR.

