### PR TITLE
[Divider] Fix negative margin causes overflow/scrollbars

### DIFF
--- a/src/Divider/Divider.js
+++ b/src/Divider/Divider.js
@@ -11,7 +11,7 @@ export const styleSheet = createStyleSheet('MuiDivider', (theme) => {
   return {
     root: {
       height: 1,
-      margin: '0 -1px 0 0',
+      margin: 0,
       border: 'none',
     },
     default: {


### PR DESCRIPTION
Divider has a negative margin right of 1px which causes horizontal scrollbars to appear in List/Menu.

callemall/material-ui/issues/6138
