### PR TITLE
[Dialog] Fix Passing Through OnTouchTap with ...props

### DIFF
--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -459,10 +459,13 @@ class Dialog extends Component {
     modal: false,
     repositionOnUpdate: true,
   };
-
+  
+  static rmOnTouchTapProps = object.assign({}, props);
+  delete rmOnTouchTapProps.onTouchTap;
+  
   renderLayer = () => {
     return (
-      <DialogInline {...this.props} />
+      <DialogInline {...rmOnTouchTapProps} />
     );
   };
 


### PR DESCRIPTION
removed onTouchTap from the list of props that dialog will pass down to children to fix a console error

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

