### PR TITLE
[DatePicker] Add option to hide date display

### DIFF
--- a/src/DatePicker/Calendar.js
+++ b/src/DatePicker/Calendar.js
@@ -42,6 +42,7 @@ class Calendar extends Component {
     onTouchTapOk: PropTypes.func,
     open: PropTypes.bool,
     shouldDisableDate: PropTypes.func,
+    showDateDisplay: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -239,6 +240,7 @@ class Calendar extends Component {
 
   render() {
     const {prepareStyles} = this.context.muiTheme;
+    const {showDateDisplay} = this.props;
     const toolbarInteractions = this.getToolbarInteractions();
     const isLandscape = this.props.mode === 'landscape';
     const {calendarTextColor} = this.context.muiTheme.datePicker;
@@ -247,7 +249,7 @@ class Calendar extends Component {
       root: {
         color: calendarTextColor,
         userSelect: 'none',
-        width: isLandscape ? 479 : 310,
+        width: (showDateDisplay && isLandscape) ? 479 : 310,
       },
       calendar: {
         display: 'flex',
@@ -310,16 +312,18 @@ class Calendar extends Component {
           target="window"
           onKeyDown={this.handleWindowKeyDown}
         />
-        <DateDisplay
-          DateTimeFormat={DateTimeFormat}
-          disableYearSelection={this.props.disableYearSelection}
-          onTouchTapMonthDay={this.handleTouchTapDateDisplayMonthDay}
-          onTouchTapYear={this.handleTouchTapDateDisplayYear}
-          locale={locale}
-          monthDaySelected={this.state.displayMonthDay}
-          mode={this.props.mode}
-          selectedDate={this.state.selectedDate}
-        />
+        {showDateDisplay &&
+          <DateDisplay
+            DateTimeFormat={DateTimeFormat}
+            disableYearSelection={this.props.disableYearSelection}
+            onTouchTapMonthDay={this.handleTouchTapDateDisplayMonthDay}
+            onTouchTapYear={this.handleTouchTapDateDisplayYear}
+            locale={locale}
+            monthDaySelected={this.state.displayMonthDay}
+            mode={this.props.mode}
+            selectedDate={this.state.selectedDate}
+          />
+        }
         <div style={prepareStyles(styles.calendar)}>
           {this.state.displayMonthDay &&
             <div style={prepareStyles(styles.calendarContainer)}>

--- a/src/DatePicker/Calendar.js
+++ b/src/DatePicker/Calendar.js
@@ -31,6 +31,7 @@ class Calendar extends Component {
     cancelLabel: PropTypes.node,
     disableYearSelection: PropTypes.bool,
     firstDayOfWeek: PropTypes.number,
+    hideCalendarDate: PropTypes.bool,
     initialDate: PropTypes.object,
     locale: PropTypes.string.isRequired,
     maxDate: PropTypes.object,
@@ -42,7 +43,6 @@ class Calendar extends Component {
     onTouchTapOk: PropTypes.func,
     open: PropTypes.bool,
     shouldDisableDate: PropTypes.func,
-    showDateDisplay: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -240,7 +240,7 @@ class Calendar extends Component {
 
   render() {
     const {prepareStyles} = this.context.muiTheme;
-    const {showDateDisplay} = this.props;
+    const {hideCalendarDate} = this.props;
     const toolbarInteractions = this.getToolbarInteractions();
     const isLandscape = this.props.mode === 'landscape';
     const {calendarTextColor} = this.context.muiTheme.datePicker;
@@ -249,7 +249,7 @@ class Calendar extends Component {
       root: {
         color: calendarTextColor,
         userSelect: 'none',
-        width: (showDateDisplay && isLandscape) ? 479 : 310,
+        width: (!hideCalendarDate && isLandscape) ? 479 : 310,
       },
       calendar: {
         display: 'flex',
@@ -312,7 +312,7 @@ class Calendar extends Component {
           target="window"
           onKeyDown={this.handleWindowKeyDown}
         />
-        {showDateDisplay &&
+        {!hideCalendarDate &&
           <DateDisplay
             DateTimeFormat={DateTimeFormat}
             disableYearSelection={this.props.disableYearSelection}

--- a/src/DatePicker/Calendar.spec.js
+++ b/src/DatePicker/Calendar.spec.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import {assert} from 'chai';
 import Calendar from './Calendar';
+import DateDisplay from './DateDisplay';
 import {addMonths, dateTimeFormat} from './dateUtils';
 import getMuiTheme from '../styles/getMuiTheme';
 
@@ -191,6 +192,35 @@ describe('<Calendar />', () => {
       wrapper.update();
 
       assert.notOk(wrapper.find('CalendarToolbar').prop('prevMonth'));
+    });
+  });
+
+  describe('Date Display', () => {
+    it('should be visible by default', () => {
+      const wrapper = shallowWithContext(
+        <Calendar
+          DateTimeFormat={dateTimeFormat}
+          locale="en-US"
+          mode="landscape"
+        />
+      );
+
+      assert.strictEqual(wrapper.find(DateDisplay).length, 1, 'should show date display');
+      assert.strictEqual(wrapper.props().style.width, 479, 'should allow space for date display');
+    });
+
+    it('should be hidden when hideCalendarDate is set', () => {
+      const wrapper = shallowWithContext(
+        <Calendar
+          DateTimeFormat={dateTimeFormat}
+          locale="en-US"
+          mode="landscape"
+          hideCalendarDate={true}
+        />
+      );
+
+      assert.strictEqual(wrapper.find(DateDisplay).length, 0, 'should hide date display');
+      assert.strictEqual(wrapper.props().style.width, 310, 'should not allow space for date display');
     });
   });
 });

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -66,6 +66,10 @@ class DatePicker extends Component {
      */
     formatDate: PropTypes.func,
     /**
+     * Hide date display
+     */
+    hideCalendarDate: PropTypes.bool,
+    /**
      * Locale used for formatting the `DatePicker` date strings. Other than for 'en-US', you
      * must provide a `DateTimeFormat` that supports the chosen `locale`.
      */
@@ -122,10 +126,6 @@ class DatePicker extends Component {
      */
     shouldDisableDate: PropTypes.func,
     /**
-     * Show date display
-     */
-    showDateDisplay: PropTypes.bool,
-    /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
@@ -145,7 +145,7 @@ class DatePicker extends Component {
     disabled: false,
     disableYearSelection: false,
     firstDayOfWeek: 1,
-    showDateDisplay: true,
+    hideCalendarDate: false,
     style: {},
   };
 
@@ -280,7 +280,7 @@ class DatePicker extends Component {
       onShow,
       onTouchTap, // eslint-disable-line no-unused-vars
       shouldDisableDate,
-      showDateDisplay,
+      hideCalendarDate,
       style,
       textFieldStyle,
       ...other
@@ -318,7 +318,7 @@ class DatePicker extends Component {
           onDismiss={onDismiss}
           ref="dialogWindow"
           shouldDisableDate={shouldDisableDate}
-          showDateDisplay={showDateDisplay}
+          hideCalendarDate={hideCalendarDate}
         />
       </div>
     );

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -122,6 +122,10 @@ class DatePicker extends Component {
      */
     shouldDisableDate: PropTypes.func,
     /**
+     * Show date display
+     */
+    showDateDisplay: PropTypes.bool,
+    /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
@@ -141,6 +145,7 @@ class DatePicker extends Component {
     disabled: false,
     disableYearSelection: false,
     firstDayOfWeek: 1,
+    showDateDisplay: true,
     style: {},
   };
 
@@ -275,6 +280,7 @@ class DatePicker extends Component {
       onShow,
       onTouchTap, // eslint-disable-line no-unused-vars
       shouldDisableDate,
+      showDateDisplay,
       style,
       textFieldStyle,
       ...other
@@ -312,6 +318,7 @@ class DatePicker extends Component {
           onDismiss={onDismiss}
           ref="dialogWindow"
           shouldDisableDate={shouldDisableDate}
+          showDateDisplay={showDateDisplay}
         />
       </div>
     );

--- a/src/DatePicker/DatePickerDialog.js
+++ b/src/DatePicker/DatePickerDialog.js
@@ -28,6 +28,7 @@ class DatePickerDialog extends Component {
     onShow: PropTypes.func,
     open: PropTypes.bool,
     shouldDisableDate: PropTypes.func,
+    showDateDisplay: PropTypes.bool,
     style: PropTypes.object,
   };
 
@@ -118,6 +119,7 @@ class DatePickerDialog extends Component {
       onDismiss, // eslint-disable-line no-unused-vars
       onShow, // eslint-disable-line no-unused-vars
       shouldDisableDate,
+      showDateDisplay,
       style, // eslint-disable-line no-unused-vars
       animation,
       ...other
@@ -131,8 +133,8 @@ class DatePickerDialog extends Component {
       },
       dialogBodyContent: {
         padding: 0,
-        minHeight: mode === 'landscape' ? 330 : 434,
-        minWidth: mode === 'landscape' ? 479 : 310,
+        minHeight: (!showDateDisplay || mode === 'landscape') ? 330 : 434,
+        minWidth: (!showDateDisplay || mode !== 'landscape') ? 310 : 479,
       },
     };
 
@@ -173,6 +175,7 @@ class DatePickerDialog extends Component {
             onTouchTapOk={this.handleTouchTapOk}
             okLabel={okLabel}
             shouldDisableDate={shouldDisableDate}
+            showDateDisplay={showDateDisplay}
           />
         </Container>
       </div>

--- a/src/DatePicker/DatePickerDialog.js
+++ b/src/DatePicker/DatePickerDialog.js
@@ -17,6 +17,7 @@ class DatePickerDialog extends Component {
     containerStyle: PropTypes.object,
     disableYearSelection: PropTypes.bool,
     firstDayOfWeek: PropTypes.number,
+    hideCalendarDate: PropTypes.bool,
     initialDate: PropTypes.object,
     locale: PropTypes.string,
     maxDate: PropTypes.object,
@@ -28,7 +29,6 @@ class DatePickerDialog extends Component {
     onShow: PropTypes.func,
     open: PropTypes.bool,
     shouldDisableDate: PropTypes.func,
-    showDateDisplay: PropTypes.bool,
     style: PropTypes.object,
   };
 
@@ -119,7 +119,7 @@ class DatePickerDialog extends Component {
       onDismiss, // eslint-disable-line no-unused-vars
       onShow, // eslint-disable-line no-unused-vars
       shouldDisableDate,
-      showDateDisplay,
+      hideCalendarDate,
       style, // eslint-disable-line no-unused-vars
       animation,
       ...other
@@ -129,12 +129,12 @@ class DatePickerDialog extends Component {
 
     const styles = {
       dialogContent: {
-        width: mode === 'landscape' ? 479 : 310,
+        width: (!hideCalendarDate && mode === 'landscape') ? 479 : 310,
       },
       dialogBodyContent: {
         padding: 0,
-        minHeight: (!showDateDisplay || mode === 'landscape') ? 330 : 434,
-        minWidth: (!showDateDisplay || mode !== 'landscape') ? 310 : 479,
+        minHeight: (hideCalendarDate || mode === 'landscape') ? 330 : 434,
+        minWidth: (hideCalendarDate || mode !== 'landscape') ? 310 : 479,
       },
     };
 
@@ -175,7 +175,7 @@ class DatePickerDialog extends Component {
             onTouchTapOk={this.handleTouchTapOk}
             okLabel={okLabel}
             shouldDisableDate={shouldDisableDate}
-            showDateDisplay={showDateDisplay}
+            hideCalendarDate={hideCalendarDate}
           />
         </Container>
       </div>


### PR DESCRIPTION
This adds an option to hide the date display above the date picker (or on the side on portrait mode). I did not add any unit tests because this is purely a visual change, but the code has been linted and docs have been added.

Thanks for the awesome library!

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

<img width="319" alt="screen shot 2017-02-15 at 10 14 30 pm" src="https://cloud.githubusercontent.com/assets/268974/23009723/650d7e34-f3cc-11e6-81e5-d61261a2d8c7.png">

