### PR TITLE
[EnhancedButton] Speed up unmount

### DIFF
--- a/src/internal/EnhancedButton.js
+++ b/src/internal/EnhancedButton.js
@@ -114,7 +114,7 @@ class EnhancedButton extends Component {
 
   componentWillUnmount() {
     if (this.focusTimeout) {
-        clearTimeout(this.focusTimeout);
+      clearTimeout(this.focusTimeout);
     }
   }
 

--- a/src/internal/EnhancedButton.js
+++ b/src/internal/EnhancedButton.js
@@ -113,7 +113,9 @@ class EnhancedButton extends Component {
   }
 
   componentWillUnmount() {
-    clearTimeout(this.focusTimeout);
+    if (this.focusTimeout) {
+        clearTimeout(this.focusTimeout);
+    }
   }
 
   isKeyboardFocused() {


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

While profiling a moderate size page built with material-ui, I noticed that a significant amount of time is spent *unmounting* mui components. The culprit is `EnhancedButton`, which calls `clearTimeout()` in `componentWillUnmount()`. This represents 30% of the unmount time, about 25ms on a page with less than a dozen buttons: 

![unmount_initial](https://cloud.githubusercontent.com/assets/99944/23017516/e0d3753c-f43a-11e6-8a3e-d082e7ef8783.png)

It turns out that most of the time, the timeout that `EnhancedButton` wants to clean doesn't exist (it's the one created for the hover ripple effect). Adding an `if` before the call to `clearTimeout` reduces the time spent in  `EnhancedButton` to something insignificant, and reduces the overall unmount time by 50%:

![unmount_improved](https://cloud.githubusercontent.com/assets/99944/23017865/35a25c6c-f43c-11e6-956b-8b2d7951d61f.png)

This may look like a small change, but as `EnhancedButton` powers many other components, it has important effects.
