### PR TITLE
[SelectField] [DropDownMenu] Support multi select

### DIFF
--- a/docs/src/app/components/pages/components/SelectField/ExampleMultiSelect.js
+++ b/docs/src/app/components/pages/components/SelectField/ExampleMultiSelect.js
@@ -1,29 +1,29 @@
-import React, {Component} from "react";
-import SelectField from "material-ui/SelectField";
-import MenuItem from "material-ui/MenuItem";
+import React, {Component} from 'react';
+import SelectField from 'material-ui/SelectField';
+import MenuItem from 'material-ui/MenuItem';
 
 const names = [
-  "Oliver Hansen",
-  "Van Henry",
-  "April Tucker",
-  "Ralph Hubbard",
-  "Omar Alexander",
-  "Carlos Abbott",
-  "Miriam Wagner",
-  "Bradley Wilkerson",
-  "Virginia Andrews",
-  "Kelly Snyder"
+  'Oliver Hansen',
+  'Van Henry',
+  'April Tucker',
+  'Ralph Hubbard',
+  'Omar Alexander',
+  'Carlos Abbott',
+  'Miriam Wagner',
+  'Bradley Wilkerson',
+  'Virginia Andrews',
+  'Kelly Snyder',
 ];
 
 export default class SelectFieldExampleMultiSelect extends Component {
   state = {
-    values: []
+    values: [],
   };
 
   handleChange = (event, index, values) => this.setState({values});
 
   menuItems(values) {
-    return names.map(name => (
+    return names.map((name) => (
       <MenuItem
         key={name}
         insetChildren={true}

--- a/docs/src/app/components/pages/components/SelectField/ExampleMultiSelect.js
+++ b/docs/src/app/components/pages/components/SelectField/ExampleMultiSelect.js
@@ -15,6 +15,9 @@ const names = [
   'Kelly Snyder',
 ];
 
+/**
+ * `SelectField` can handle multiple selections. It is enabled with the `multiple` property.
+ */
 export default class SelectFieldExampleMultiSelect extends Component {
   state = {
     values: [],

--- a/docs/src/app/components/pages/components/SelectField/ExampleMultiSelect.js
+++ b/docs/src/app/components/pages/components/SelectField/ExampleMultiSelect.js
@@ -23,6 +23,8 @@ export default class SelectFieldExampleMultiSelect extends Component {
     values: [],
   };
 
+  handleChange = (event, index, values) => this.setState({values});
+
   menuItems(values) {
     return names.map((name) => (
       <MenuItem
@@ -37,13 +39,12 @@ export default class SelectFieldExampleMultiSelect extends Component {
 
   render() {
     const {values} = this.state;
-
     return (
       <SelectField
         multiple={true}
         hintText="Select a name"
-        value={this.state.values}
-        onChange={(event, index, values) => this.setState({values})}
+        value={values}
+        onChange={this.handleChange}
       >
         {this.menuItems(values)}
       </SelectField>

--- a/docs/src/app/components/pages/components/SelectField/ExampleMultiSelect.js
+++ b/docs/src/app/components/pages/components/SelectField/ExampleMultiSelect.js
@@ -20,8 +20,6 @@ export default class SelectFieldExampleMultiSelect extends Component {
     values: [],
   };
 
-  handleChange = (event, index, values) => this.setState({values});
-
   menuItems(values) {
     return names.map((name) => (
       <MenuItem
@@ -41,8 +39,8 @@ export default class SelectFieldExampleMultiSelect extends Component {
       <SelectField
         multiple={true}
         hintText="Select a name"
-        value={values}
-        onChange={this.handleChange}
+        value={this.state.values}
+        onChange={(event, index, values) => this.setState({values})}
       >
         {this.menuItems(values)}
       </SelectField>

--- a/docs/src/app/components/pages/components/SelectField/ExampleMultiSelect.js
+++ b/docs/src/app/components/pages/components/SelectField/ExampleMultiSelect.js
@@ -1,0 +1,51 @@
+import React, {Component} from "react";
+import SelectField from "material-ui/SelectField";
+import MenuItem from "material-ui/MenuItem";
+
+const names = [
+  "Oliver Hansen",
+  "Van Henry",
+  "April Tucker",
+  "Ralph Hubbard",
+  "Omar Alexander",
+  "Carlos Abbott",
+  "Miriam Wagner",
+  "Bradley Wilkerson",
+  "Virginia Andrews",
+  "Kelly Snyder"
+];
+
+export default class SelectFieldExampleMultiSelect extends Component {
+  state = {
+    values: []
+  };
+
+  handleChange = (event, index, values) => this.setState({values});
+
+  menuItems(values) {
+    return names.map(name => (
+      <MenuItem
+        key={name}
+        insetChildren={true}
+        checked={values && values.includes(name)}
+        value={name}
+        primaryText={name}
+      />
+    ));
+  }
+
+  render() {
+    const {values} = this.state;
+
+    return (
+      <SelectField
+        multiple={true}
+        hintText="Select a name"
+        value={values}
+        onChange={this.handleChange}
+      >
+        {this.menuItems(values)}
+      </SelectField>
+    );
+  }
+}

--- a/docs/src/app/components/pages/components/SelectField/ExampleSelectionRenderer.js
+++ b/docs/src/app/components/pages/components/SelectField/ExampleSelectionRenderer.js
@@ -1,0 +1,64 @@
+import React, {Component} from 'react';
+import SelectField from 'material-ui/SelectField';
+import MenuItem from 'material-ui/MenuItem';
+
+const persons = [
+  {value: 0, name: 'Oliver Hansen'},
+  {value: 1, name: 'Van Henry'},
+  {value: 2, name: 'April Tucker'},
+  {value: 3, name: 'Ralph Hubbard'},
+  {value: 4, name: 'Omar Alexander'},
+  {value: 5, name: 'Carlos Abbott'},
+  {value: 6, name: 'Miriam Wagner'},
+  {value: 7, name: 'Bradley Wilkerson'},
+  {value: 8, name: 'Virginia Andrews'},
+  {value: 9, name: 'Kelly Snyder'},
+];
+
+/**
+ * The rendering of selected items can be customized by providing a `selectionRenderer`.
+ */
+export default class SelectFieldExampleSelectionRenderer extends Component {
+  state = {
+    values: [],
+  };
+
+  handleChange = (event, index, values) => this.setState({values});
+
+  selectionRenderer = (values) => {
+    switch (values.length) {
+      case 0:
+        return '';
+      case 1:
+        return persons[values[0]].name;
+      default:
+        return `${values.length} names selected`;
+    }
+  }
+
+  menuItems(persons) {
+    return persons.map((person) => (
+      <MenuItem
+        key={person.value}
+        insetChildren={true}
+        checked={this.state.values.includes(person.value)}
+        value={person.value}
+        primaryText={person.name}
+      />
+    ));
+  }
+
+  render() {
+    return (
+      <SelectField
+        multiple={true}
+        hintText="Select a name"
+        value={this.state.values}
+        onChange={this.handleChange}
+        selectionRenderer={this.selectionRenderer}
+      >
+        {this.menuItems(persons)}
+      </SelectField>
+    );
+  }
+}

--- a/docs/src/app/components/pages/components/SelectField/Page.js
+++ b/docs/src/app/components/pages/components/SelectField/Page.js
@@ -63,7 +63,7 @@ const SelectFieldPage = () => (
       <SelectFieldExampleError />
     </CodeExample>
     <CodeExample
-      title="MultiSelect example"
+      title="Multiple selection example"
       code={selectFieldExampleMultiSelectCode}
     >
       <SelectFieldExampleMultiSelect />

--- a/docs/src/app/components/pages/components/SelectField/Page.js
+++ b/docs/src/app/components/pages/components/SelectField/Page.js
@@ -18,6 +18,8 @@ import SelectFieldExampleError from './ExampleError';
 import selectFieldExampleErrorCode from '!raw!./ExampleError';
 import SelectFieldExampleNullable from './ExampleNullable';
 import SelectFieldExampleNullableCode from '!raw!./ExampleNullable';
+import SelectFieldExampleMultiSelect from './ExampleMultiSelect';
+import selectFieldExampleMultiSelectCode from '!raw!./ExampleMultiSelect';
 import selectFieldCode from '!raw!material-ui/SelectField/SelectField';
 
 const SelectFieldPage = () => (
@@ -60,6 +62,14 @@ const SelectFieldPage = () => (
     >
       <SelectFieldExampleError />
     </CodeExample>
+
+    <CodeExample
+      title="MultiSelect example"
+      code={selectFieldExampleMultiSelectCode}
+    >
+      <SelectFieldExampleMultiSelect />
+    </CodeExample>
+
     <PropTypeDescription code={selectFieldCode} />
   </div>
 );

--- a/docs/src/app/components/pages/components/SelectField/Page.js
+++ b/docs/src/app/components/pages/components/SelectField/Page.js
@@ -62,14 +62,12 @@ const SelectFieldPage = () => (
     >
       <SelectFieldExampleError />
     </CodeExample>
-
     <CodeExample
       title="MultiSelect example"
       code={selectFieldExampleMultiSelectCode}
     >
       <SelectFieldExampleMultiSelect />
     </CodeExample>
-
     <PropTypeDescription code={selectFieldCode} />
   </div>
 );

--- a/docs/src/app/components/pages/components/SelectField/Page.js
+++ b/docs/src/app/components/pages/components/SelectField/Page.js
@@ -20,6 +20,8 @@ import SelectFieldExampleNullable from './ExampleNullable';
 import SelectFieldExampleNullableCode from '!raw!./ExampleNullable';
 import SelectFieldExampleMultiSelect from './ExampleMultiSelect';
 import selectFieldExampleMultiSelectCode from '!raw!./ExampleMultiSelect';
+import SelectFieldExampleSelectionRenderer from './ExampleSelectionRenderer';
+import selectFieldExampleSelectionRendererCode from '!raw!./ExampleSelectionRenderer';
 import selectFieldCode from '!raw!material-ui/SelectField/SelectField';
 
 const SelectFieldPage = () => (
@@ -67,6 +69,12 @@ const SelectFieldPage = () => (
       code={selectFieldExampleMultiSelectCode}
     >
       <SelectFieldExampleMultiSelect />
+    </CodeExample>
+    <CodeExample
+      title="Selection renderer example"
+      code={selectFieldExampleSelectionRendererCode}
+    >
+      <SelectFieldExampleSelectionRenderer />
     </CodeExample>
     <PropTypeDescription code={selectFieldCode} />
   </div>

--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -261,7 +261,7 @@ class DropDownMenu extends Component {
 
   handleTouchTapControl = (event) => {
     event.preventDefault();
-    if (!this.props.disabled && !(this.props.multiple && this.state.open)) {
+    if (!this.props.disabled) {
       this.setState({
         open: !this.state.open,
         anchorEl: this.rootNode,

--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -155,15 +155,6 @@ class DropDownMenu extends Component {
      */
     onChange: PropTypes.func,
     /**
-     * Callback function fired when a menu item is clicked, other than the one currently selected.
-     *
-     * @param {any} value If `multiple` is true, the menu's `value`
-     * array with either the menu item's `value` added (if
-     * it wasn't already selected) or omitted (if it was already selected).
-     * Otherwise, the `value` of the menu item.
-     */
-    onChangeRenderer: PropTypes.func,
-    /**
      * Callback function fired when the menu is closed.
      */
     onClose: PropTypes.func,
@@ -175,6 +166,15 @@ class DropDownMenu extends Component {
      * Override the inline-styles of selected menu items.
      */
     selectedMenuItemStyle: PropTypes.object,
+    /**
+     * Callback function fired when a menu item is clicked, other than the one currently selected.
+     *
+     * @param {any} value If `multiple` is true, the menu's `value`
+     * array with either the menu item's `value` added (if
+     * it wasn't already selected) or omitted (if it was already selected).
+     * Otherwise, the `value` of the menu item.
+     */
+    selectionRenderer: PropTypes.func,
     /**
      * Override the inline-styles of the root element.
      */
@@ -349,7 +349,7 @@ class DropDownMenu extends Component {
       listStyle,
       maxHeight,
       menuStyle: menuStyleProp,
-      onChangeRenderer,
+      selectionRenderer,
       onClose, // eslint-disable-line no-unused-vars
       openImmediately, // eslint-disable-line no-unused-vars
       menuItemStyle,
@@ -372,8 +372,8 @@ class DropDownMenu extends Component {
     if (!multiple) {
       React.Children.forEach(children, (child) => {
         if (child && value === child.props.value) {
-          if (onChangeRenderer) {
-            displayValue = onChangeRenderer(value);
+          if (selectionRenderer) {
+            displayValue = selectionRenderer(value);
           } else {
             // This will need to be improved (in case primaryText is a node)
             displayValue = child.props.label || child.props.primaryText;
@@ -387,8 +387,8 @@ class DropDownMenu extends Component {
           displayValue.push(child.props.label || child.props.primaryText);
         }
       });
-      if (onChangeRenderer) {
-        displayValue = onChangeRenderer(displayValue);
+      if (selectionRenderer) {
+        displayValue = selectionRenderer(displayValue);
       } else {
         displayValue = displayValue.join(', ');
       }

--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -381,16 +381,22 @@ class DropDownMenu extends Component {
         }
       });
     } else {
-      displayValue = [];
+      const values = [];
       React.Children.forEach(children, (child) => {
         if (child && value && value.includes(child.props.value)) {
-          displayValue.push(child.props.label || child.props.primaryText);
+          if (selectionRenderer) {
+            values.push(child.props.value);
+          } else {
+            values.push(child.props.label || child.props.primaryText);
+          }
         }
       });
+
+      displayValue = [];
       if (selectionRenderer) {
-        displayValue = selectionRenderer(displayValue);
+        displayValue = selectionRenderer(values);
       } else {
-        displayValue = displayValue.join(', ');
+        displayValue = values.join(', ');
       }
     }
 

--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -148,12 +148,21 @@ class DropDownMenu extends Component {
      *
      * @param {object} event TouchTap event targeting the menu item that was clicked.
      * @param {number} key The index of the clicked menu item in the `children` collection.
-     * @param {any} payload If `multiple` is true, the menu's `value`
+     * @param {any} value If `multiple` is true, the menu's `value`
      * array with either the menu item's `value` added (if
      * it wasn't already selected) or omitted (if it was already selected).
      * Otherwise, the `value` of the menu item.
      */
     onChange: PropTypes.func,
+    /**
+     * Callback function fired when a menu item is clicked, other than the one currently selected.
+     *
+     * @param {any} value If `multiple` is true, the menu's `value`
+     * array with either the menu item's `value` added (if
+     * it wasn't already selected) or omitted (if it was already selected).
+     * Otherwise, the `value` of the menu item.
+     */
+    onChangeRenderer: PropTypes.func,
     /**
      * Callback function fired when the menu is closed.
      */
@@ -340,6 +349,7 @@ class DropDownMenu extends Component {
       listStyle,
       maxHeight,
       menuStyle: menuStyleProp,
+      onChangeRenderer,
       onClose, // eslint-disable-line no-unused-vars
       openImmediately, // eslint-disable-line no-unused-vars
       menuItemStyle,
@@ -362,18 +372,26 @@ class DropDownMenu extends Component {
     if (!multiple) {
       React.Children.forEach(children, (child) => {
         if (child && value === child.props.value) {
-          // This will need to be improved (in case primaryText is a node)
-          displayValue = child.props.label || child.props.primaryText;
+          if (onChangeRenderer) {
+            displayValue = onChangeRenderer(value);
+          } else {
+            // This will need to be improved (in case primaryText is a node)
+            displayValue = child.props.label || child.props.primaryText;
+          }
         }
       });
     } else {
       displayValue = [];
       React.Children.forEach(children, (child) => {
-        if (child && value.indexOf(child.props.value) !== -1) {
+        if (child && value.includes(child.props.value)) {
           displayValue.push(child.props.label || child.props.primaryText);
         }
       });
-      displayValue = displayValue.join(', ');
+      if (onChangeRenderer) {
+        displayValue = onChangeRenderer(displayValue);
+      } else {
+        displayValue = displayValue.join(', ');
+      }
     }
 
     let menuStyle;

--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -312,7 +312,7 @@ class DropDownMenu extends Component {
     }
   };
 
-  handleOnChange = (event, value) => {
+  handleChange = (event, value) => {
     if (this.props.multiple && this.props.onChange) {
       this.props.onChange(event, undefined, value);
     }
@@ -446,7 +446,7 @@ class DropDownMenu extends Component {
             style={menuStyle}
             listStyle={listStyle}
             onItemTouchTap={this.handleItemTouchTap}
-            onChange={this.handleOnChange}
+            onChange={this.handleChange}
             menuItemStyle={menuItemStyle}
             selectedMenuItemStyle={selectedMenuItemStyle}
           >

--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -293,13 +293,12 @@ class DropDownMenu extends Component {
   };
 
   handleItemTouchTap = (event, child, index) => {
-    event.persist();
-
     if (this.props.multiple) {
       if (!this.state.open) {
         this.setState({open: true});
       }
     } else {
+      event.persist();
       this.setState({
         open: false,
       }, () => {

--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -383,7 +383,7 @@ class DropDownMenu extends Component {
     } else {
       displayValue = [];
       React.Children.forEach(children, (child) => {
-        if (child && value.includes(child.props.value)) {
+        if (child && value && value.includes(child.props.value)) {
           displayValue.push(child.props.label || child.props.primaryText);
         }
       });

--- a/src/DropDownMenu/DropDownMenu.spec.js
+++ b/src/DropDownMenu/DropDownMenu.spec.js
@@ -188,6 +188,8 @@ describe('<DropDownMenu />', () => {
   });
 
   describe('MultiSelect', () => {
+    let wrapper;
+
     it('should multi select 2 items after selecting 3 and deselecting 1', () => {
       class MyComponent1 extends Component {
         state = {
@@ -212,7 +214,7 @@ describe('<DropDownMenu />', () => {
           );
         }
       }
-      const wrapper = mountWithContext(<MyComponent1 />);
+      wrapper = mountWithContext(<MyComponent1 />);
       wrapper.find('IconButton').simulate('touchTap');   // open
 
       const item1 = document.getElementsByClassName('item1')[0];
@@ -229,6 +231,10 @@ describe('<DropDownMenu />', () => {
 
       TestUtils.Simulate.touchTap(item1);  // deselect
       assert.deepEqual(wrapper.state().value, ['item2', 'item3']);
+    });
+
+    afterEach(function() {
+      if (wrapper) wrapper.unmount();
     });
   });
 });

--- a/src/DropDownMenu/DropDownMenu.spec.js
+++ b/src/DropDownMenu/DropDownMenu.spec.js
@@ -225,8 +225,9 @@ describe('<DropDownMenu />', () => {
       TestUtils.Simulate.touchTap(item1);
       TestUtils.Simulate.touchTap(item2);
       TestUtils.Simulate.touchTap(item3);
-      TestUtils.Simulate.touchTap(item1);  // deselect
+      assert.deepEqual(wrapper.state().value, ['item1', 'item2', 'item3']);
 
+      TestUtils.Simulate.touchTap(item1);  // deselect
       assert.deepEqual(wrapper.state().value, ['item2', 'item3']);
     });
   });

--- a/src/DropDownMenu/DropDownMenu.spec.js
+++ b/src/DropDownMenu/DropDownMenu.spec.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-import React, {PropTypes} from 'react';
+import React, {PropTypes, Component} from 'react';
 import {shallow, mount} from 'enzyme';
 import {assert} from 'chai';
 import keycode from 'keycode';
@@ -9,6 +9,7 @@ import getMuiTheme from '../styles/getMuiTheme';
 import MenuItem from '../MenuItem';
 import Menu from '../Menu/Menu';
 import IconButton from '../IconButton';
+import TestUtils from 'react-addons-test-utils';
 
 describe('<DropDownMenu />', () => {
   const muiTheme = getMuiTheme();
@@ -183,6 +184,50 @@ describe('<DropDownMenu />', () => {
         keyCode: keycode('enter'),
       });
       assert.strictEqual(wrapper.state().open, true, 'it should open the menu');
+    });
+  });
+
+  describe('MultiSelect', () => {
+    it('should multi select 2 items after selecting 3 and deselecting 1', () => {
+      class MyComponent1 extends Component {
+        state = {
+          value: null,
+        }
+
+        handleChange = (event, key, value) => {
+          this.setState({value});
+        }
+
+        render() {
+          return (
+            <DropDownMenu
+              multiple={true}
+              value={this.state.value}
+              onChange={this.handleChange}
+            >
+              <MenuItem className="item1" value="item1" primaryText="item 1" />
+              <MenuItem className="item2" value="item2" primaryText="item 2" />
+              <MenuItem className="item3" value="item3" primaryText="item 3" />
+            </DropDownMenu>
+          );
+        }
+      }
+      const wrapper = mountWithContext(<MyComponent1 />);
+      wrapper.find('IconButton').simulate('touchTap');   // open
+
+      const item1 = document.getElementsByClassName('item1')[0];
+      assert.ok(item1);
+      const item2 = document.getElementsByClassName('item2')[0];
+      assert.ok(item2);
+      const item3 = document.getElementsByClassName('item3')[0];
+      assert.ok(item3);
+
+      TestUtils.Simulate.touchTap(item1);
+      TestUtils.Simulate.touchTap(item2);
+      TestUtils.Simulate.touchTap(item3);
+      TestUtils.Simulate.touchTap(item1);  // deselect
+
+      assert.deepEqual(wrapper.state().value, ['item2', 'item3']);
     });
   });
 });

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -381,13 +381,15 @@ class Menu extends Component {
     const children = this.props.children;
     const multiple = this.props.multiple;
     const valueLink = this.getValueLink(this.props);
-    const menuValue = valueLink.value;
+    let menuValue = valueLink.value;
     const itemValue = item.props.value;
     const focusIndex = React.isValidElement(children) ? 0 : children.indexOf(item);
 
     this.setFocusIndex(event, focusIndex, false);
 
     if (multiple) {
+      menuValue = menuValue || [];
+
       const itemIndex = menuValue.indexOf(itemValue);
       const [...newMenuValue] = menuValue;
       if (itemIndex === -1) {
@@ -419,7 +421,7 @@ class Menu extends Component {
     const childValue = child.props.value;
 
     if (props.multiple) {
-      return menuValue.length && menuValue.indexOf(childValue) !== -1;
+      return menuValue && menuValue.length && menuValue.indexOf(childValue) !== -1;
     } else {
       return child.props.hasOwnProperty('value') && menuValue === childValue;
     }

--- a/src/Menu/Menu.spec.js
+++ b/src/Menu/Menu.spec.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-import React from 'react';
+import React, {PropTypes, Component} from 'react';
 import {mount, shallow} from 'enzyme';
 import {spy} from 'sinon';
 import {assert} from 'chai';
@@ -12,7 +12,10 @@ import keycode from 'keycode';
 describe('<Menu />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
-  const mountWithContext = (node) => mount(node, {context: {muiTheme}});
+  const mountWithContext = (node) => mount(node, {
+    context: {muiTheme},
+    childContextTypes: {muiTheme: PropTypes.object},
+  });
   const keycodeEvent = (key) => ({keyCode: keycode(key)});
 
   describe('onMenuItemFocusChange', () => {
@@ -211,6 +214,43 @@ describe('<Menu />', () => {
         </Menu>
       );
       assert.strictEqual(wrapper.contains(child), true);
+    });
+  });
+
+  describe('MultiSelect', () => {
+    it('should multi select 2 items after selecting 3 and deselecting 1', () => {
+      class MyComponent1 extends Component {
+        state = {
+          value: null,
+        }
+
+        handleChange = (event, value) => {
+          this.setState({value: value});
+        }
+
+        render() {
+          return (
+            <Menu
+              multiple={true}
+              value={this.state.value}
+              onChange={this.handleChange}
+            >
+              <MenuItem className="item1" value="item1" primaryText="item 1" />
+              <MenuItem className="item2" value="item2" primaryText="item 2" />
+              <MenuItem className="item3" value="item3" primaryText="item 3" />
+            </Menu>
+          );
+        }
+      }
+
+      const wrapper = mountWithContext(<MyComponent1 />);
+
+      wrapper.find('.item1').simulate('touchTap');
+      wrapper.find('.item2').simulate('touchTap');
+      wrapper.find('.item3').simulate('touchTap');
+      wrapper.find('.item1').simulate('touchTap');   // deselect
+
+      assert.deepEqual(wrapper.state().value, ['item2', 'item3']);
     });
   });
 });

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -119,6 +119,12 @@ class SelectField extends Component {
      * Otherwise, the `value` of the menu item.
      */
     onChange: PropTypes.func,
+    /** @ignore */
+    onFocus: PropTypes.func,
+    /**
+     * Override the inline-styles of selected menu items.
+     */
+    selectedMenuItemStyle: PropTypes.object,
     /**
      * Callback function fired when a menu item is clicked, other than the one currently selected.
      *
@@ -127,13 +133,7 @@ class SelectField extends Component {
      * it wasn't already selected) or omitted (if it was already selected).
      * Otherwise, the `value` of the menu item.
      */
-    onChangeRenderer: PropTypes.func,
-    /** @ignore */
-    onFocus: PropTypes.func,
-    /**
-     * Override the inline-styles of selected menu items.
-     */
-    selectedMenuItemStyle: PropTypes.object,
+    selectionRenderer: PropTypes.func,
     /**
      * Override the inline-styles of the root element.
      */
@@ -200,7 +200,7 @@ class SelectField extends Component {
       onFocus,
       onBlur,
       onChange,
-      onChangeRenderer,
+      selectionRenderer,
       value,
       ...other
     } = this.props;
@@ -239,9 +239,9 @@ class SelectField extends Component {
           autoWidth={autoWidth}
           value={value}
           onChange={onChange}
-          onChangeRenderer={onChangeRenderer}
           maxHeight={maxHeight}
           multiple={multiple}
+          selectionRenderer={selectionRenderer}
         >
           {children}
         </DropDownMenu>

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -119,6 +119,15 @@ class SelectField extends Component {
      * Otherwise, the `value` of the menu item.
      */
     onChange: PropTypes.func,
+    /**
+     * Callback function fired when a menu item is clicked, other than the one currently selected.
+     *
+     * @param {any} value If `multiple` is true, the menu's `value`
+     * array with either the menu item's `value` added (if
+     * it wasn't already selected) or omitted (if it was already selected).
+     * Otherwise, the `value` of the menu item.
+     */
+    onChangeRenderer: PropTypes.func,
     /** @ignore */
     onFocus: PropTypes.func,
     /**
@@ -191,6 +200,7 @@ class SelectField extends Component {
       onFocus,
       onBlur,
       onChange,
+      onChangeRenderer,
       value,
       ...other
     } = this.props;
@@ -229,6 +239,7 @@ class SelectField extends Component {
           autoWidth={autoWidth}
           value={value}
           onChange={onChange}
+          onChangeRenderer={onChangeRenderer}
           maxHeight={maxHeight}
           multiple={multiple}
         >

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -99,6 +99,11 @@ class SelectField extends Component {
      * Override the inline-styles of the underlying `DropDownMenu` element.
      */
     menuStyle: PropTypes.object,
+    /**
+     * If true, `value` must be an array and the menu will support
+     * multiple selections.
+     */
+    multiple: PropTypes.bool,
     /** @ignore */
     onBlur: PropTypes.func,
     /**
@@ -106,8 +111,12 @@ class SelectField extends Component {
      *
      * @param {object} event TouchTap event targeting the menu item
      * that was selected.
-     * @param {number} key The index of the selected menu item.
-     * @param {any} payload The `value` prop of the selected menu item.
+     * @param {number} key The index of the selected menu item, or undefined
+     * if `multiple` is true.
+     * @param {any} payload If `multiple` is true, the menu's `value`
+     * array with either the menu item's `value` added (if
+     * it wasn't already selected) or omitted (if it was already selected).
+     * Otherwise, the `value` of the menu item.
      */
     onChange: PropTypes.func,
     /** @ignore */
@@ -135,7 +144,9 @@ class SelectField extends Component {
      */
     underlineStyle: PropTypes.object,
     /**
-     * The value that is currently selected.
+     * If `multiple` is true, an array of the `value`s of the selected
+     * menu items. Otherwise, the `value` of the selected menu item.
+     * If provided, the menu will be a controlled component.
      */
     value: PropTypes.any,
   };
@@ -144,6 +155,7 @@ class SelectField extends Component {
     autoWidth: false,
     disabled: false,
     fullWidth: false,
+    multiple: false,
   };
 
   static contextTypes = {
@@ -153,6 +165,7 @@ class SelectField extends Component {
   render() {
     const {
       autoWidth,
+      multiple,
       children,
       style,
       labelStyle,
@@ -217,6 +230,7 @@ class SelectField extends Component {
           value={value}
           onChange={onChange}
           maxHeight={maxHeight}
+          multiple={multiple}
         >
           {children}
         </DropDownMenu>

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -126,7 +126,7 @@ class SelectField extends Component {
      */
     selectedMenuItemStyle: PropTypes.object,
     /**
-     * Callback function fired when a menu item is clicked, other than the one currently selected.
+     * Customize the rendering of the selected item.
      *
      * @param {any} value If `multiple` is true, the menu's `value`
      * array with either the menu item's `value` added (if

--- a/src/SelectField/SelectField.spec.js
+++ b/src/SelectField/SelectField.spec.js
@@ -70,6 +70,54 @@ describe('<SelectField />', () => {
       assert.deepEqual(wrapper.state().value, ['item2', 'item3']);
     });
 
+    it('should multi select 3 items and render their values colon separated', () => {
+      class MyComponent2 extends Component {
+        state = {
+          value: null,
+        }
+
+        selectionRenderer(value) {
+          return <span id="selection1">{value.join(';')}</span>;
+        }
+
+        handleChange = (event, key, value) => {
+          this.setState({value});
+        }
+
+        render() {
+          return (
+            <SelectField
+              multiple={true}
+              value={this.state.value}
+              onChange={this.handleChange}
+              selectionRenderer={this.selectionRenderer}
+            >
+              <MenuItem className="item1" value="item1" primaryText="item 1" />
+              <MenuItem className="item2" value="item2" primaryText="item 2" />
+              <MenuItem className="item3" value="item3" primaryText="item 3" />
+            </SelectField>
+          );
+        }
+      }
+      wrapper = mountWithContext(<MyComponent2 />);
+      wrapper.find('IconButton').simulate('touchTap');   // open
+
+      const item1 = document.getElementsByClassName('item1')[0];
+      assert.ok(item1);
+      const item2 = document.getElementsByClassName('item2')[0];
+      assert.ok(item2);
+      const item3 = document.getElementsByClassName('item3')[0];
+      assert.ok(item3);
+
+      TestUtils.Simulate.touchTap(item1);
+      TestUtils.Simulate.touchTap(item2);
+      TestUtils.Simulate.touchTap(item3);
+      assert.deepEqual(wrapper.state().value, ['item1', 'item2', 'item3']);
+
+      wrapper.find('IconButton').simulate('touchTap');   // close
+      assert.deepEqual(wrapper.find('#selection1').text(), 'item1;item2;item3');
+    });
+
     afterEach(function() {
       if (wrapper) wrapper.unmount();
     });

--- a/src/SelectField/SelectField.spec.js
+++ b/src/SelectField/SelectField.spec.js
@@ -25,6 +25,8 @@ describe('<SelectField />', () => {
   });
 
   describe('MultiSelect', () => {
+    let wrapper;
+
     it('should multi select 2 items after selecting 3 and deselecting 1', () => {
       class MyComponent2 extends Component {
         state = {
@@ -49,7 +51,7 @@ describe('<SelectField />', () => {
           );
         }
       }
-      const wrapper = mountWithContext(<MyComponent2 />);
+      wrapper = mountWithContext(<MyComponent2 />);
       wrapper.find('IconButton').simulate('touchTap');   // open
 
       const item1 = document.getElementsByClassName('item1')[0];
@@ -66,6 +68,10 @@ describe('<SelectField />', () => {
 
       TestUtils.Simulate.touchTap(item1);  // deselect
       assert.deepEqual(wrapper.state().value, ['item2', 'item3']);
+    });
+
+    afterEach(function() {
+      if (wrapper) wrapper.unmount();
     });
   });
 });

--- a/src/SelectField/SelectField.spec.js
+++ b/src/SelectField/SelectField.spec.js
@@ -1,10 +1,12 @@
 /* eslint-env mocha */
-import React, {PropTypes} from 'react';
+import React, {PropTypes, Component} from 'react';
 import {mount} from 'enzyme';
 import {assert} from 'chai';
 import getMuiTheme from '../styles/getMuiTheme';
 import SelectField from './SelectField';
 import TouchRipple from '../internal/TouchRipple';
+import MenuItem from '../MenuItem';
+import TestUtils from 'react-addons-test-utils';
 
 describe('<SelectField />', () => {
   const muiTheme = getMuiTheme();
@@ -19,6 +21,50 @@ describe('<SelectField />', () => {
         <SelectField disabled={true} />
       );
       assert.strictEqual(wrapper.find(TouchRipple).length, 0, 'should not contain a TouchRipple');
+    });
+  });
+
+  describe('MultiSelect', () => {
+    it('should multi select 2 items after selecting 3 and deselecting 1', () => {
+      class MyComponent2 extends Component {
+        state = {
+          value: null,
+        }
+
+        handleChange = (event, key, value) => {
+          this.setState({value});
+        }
+
+        render() {
+          return (
+            <SelectField
+              multiple={true}
+              value={this.state.value}
+              onChange={this.handleChange}
+            >
+              <MenuItem className="item1" value="item1" primaryText="item 1" />
+              <MenuItem className="item2" value="item2" primaryText="item 2" />
+              <MenuItem className="item3" value="item3" primaryText="item 3" />
+            </SelectField>
+          );
+        }
+      }
+      const wrapper = mountWithContext(<MyComponent2 />);
+      wrapper.find('IconButton').simulate('touchTap');   // open
+
+      const item1 = document.getElementsByClassName('item1')[0];
+      assert.ok(item1);
+      const item2 = document.getElementsByClassName('item2')[0];
+      assert.ok(item2);
+      const item3 = document.getElementsByClassName('item3')[0];
+      assert.ok(item3);
+
+      TestUtils.Simulate.touchTap(item1);
+      TestUtils.Simulate.touchTap(item2);
+      TestUtils.Simulate.touchTap(item3);
+      TestUtils.Simulate.touchTap(item1);  // deselect
+
+      assert.deepEqual(wrapper.state().value, ['item2', 'item3']);
     });
   });
 });

--- a/src/SelectField/SelectField.spec.js
+++ b/src/SelectField/SelectField.spec.js
@@ -62,8 +62,9 @@ describe('<SelectField />', () => {
       TestUtils.Simulate.touchTap(item1);
       TestUtils.Simulate.touchTap(item2);
       TestUtils.Simulate.touchTap(item3);
-      TestUtils.Simulate.touchTap(item1);  // deselect
+      assert.deepEqual(wrapper.state().value, ['item1', 'item2', 'item3']);
 
+      TestUtils.Simulate.touchTap(item1);  // deselect
       assert.deepEqual(wrapper.state().value, ['item2', 'item3']);
     });
   });

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -105,7 +105,7 @@ const getStyles = (props, context, state) => {
  * @returns True if the string provided is valid, false otherwise.
  */
 function isValid(value) {
-  return value !== '' && value !== undefined && value !== null;
+  return value !== '' && value !== undefined && value !== null && !(Array.isArray(value) && value.length === 0);
 }
 
 class TextField extends Component {

--- a/test/karma.tests.js
+++ b/test/karma.tests.js
@@ -1,3 +1,5 @@
+const injectTapEventPlugin = require('react-tap-event-plugin');
+injectTapEventPlugin();
 const integrationContext = require.context('./integration', true, /\.(js|jsx)$/);
 integrationContext.keys().forEach(integrationContext);
 const unitContext = require.context('../src/', true, /\.spec\.(js|jsx)$/);


### PR DESCRIPTION
Multi select in SelectField is requested in #1956, but progress doesn't seem to have been made (I'm new to material-ui so I might just be uninformed :-).

To get the ball rolling, this PR simply makes `Menu`s multi select support available in `SelectField` and `DropDownMenu`. A demo of what it looks like can be seen here: http://thrysoee.dk/material-ui/

I haven't looked into updating docs/tests/... yet. I thought I'd hear what you guys think before going any further. 
