### PR TITLE
[FloatingActionButton] Fix disabledColor warning in console

### DIFF
--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -252,6 +252,7 @@ class FloatingActionButton extends Component {
       className,
       children: childrenProp,
       disabled,
+      disabledColor, // eslint-disable-line no-unused-vars
       mini,
       secondary, // eslint-disable-line no-unused-vars
       iconStyle,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
Solves the unknown prop warning in console pointed. 

Closes #4897

