### PR TITLE
[Drawer] docked prop + example

### DIFF
--- a/docs/site/src/components/AppDrawer.js
+++ b/docs/site/src/components/AppDrawer.js
@@ -101,6 +101,7 @@ export default class AppDrawer extends Component {
         open={this.props.open}
         onRequestClose={this.props.onRequestClose}
         docked={this.props.docked}
+        transitionAppear={!this.props.docked}
       >
         <div className={classes.nav}>
           <Toolbar>

--- a/docs/site/src/components/AppFrame.js
+++ b/docs/site/src/components/AppFrame.js
@@ -147,6 +147,8 @@ class AppFrame extends Component {
       navIconClassName += ` ${classes.navIconHide}`;
       appBarClassName += ` ${classes.appBarShift}`;
     }
+    // when docked, always open
+    const drawerOpen = drawerDocked || this.state.drawerOpen;
 
     return (
       <div className={classes.appFrame}>
@@ -171,7 +173,7 @@ class AppFrame extends Component {
           docked={drawerDocked}
           routes={routes}
           onRequestClose={this.handleDrawerClose}
-          open={this.state.drawerOpen}
+          open={drawerOpen}
         />
         {children}
       </div>

--- a/docs/site/src/demos/drawers/DockedDrawer.js
+++ b/docs/site/src/demos/drawers/DockedDrawer.js
@@ -21,7 +21,7 @@ import DeleteIcon from 'material-ui/svg-icons/delete';
 import ReportIcon from 'material-ui/svg-icons/report';
 
 
-const styleSheet = createStyleSheet('UndockedDrawer', () => ({
+const styleSheet = createStyleSheet('DockedDrawer', () => ({
   list: {
     width: 250,
     flex: 'initial',
@@ -31,7 +31,7 @@ const styleSheet = createStyleSheet('UndockedDrawer', () => ({
   },
 }));
 
-export default class UndockedDrawer extends Component {
+export default class DockedDrawer extends Component {
   state = {
     open: false,
   };
@@ -47,6 +47,7 @@ export default class UndockedDrawer extends Component {
         <Drawer
           open={this.state.open}
           onRequestClose={this.handleClose}
+          docked
         >
           <List className={classes.list} padding={false} onClick={this.handleClose}>
             <ListItem button>
@@ -102,6 +103,6 @@ export default class UndockedDrawer extends Component {
   }
 }
 
-UndockedDrawer.contextTypes = {
+DockedDrawer.contextTypes = {
   styleManager: customPropTypes.muiRequired,
 };

--- a/docs/site/src/demos/drawers/drawers.md
+++ b/docs/site/src/demos/drawers/drawers.md
@@ -2,11 +2,15 @@
 
 The [Drawer](https://material.io/guidelines/patterns/navigation-drawer.html) slides in from the side. It is a common pattern found in Google apps and follows the keylines and metrics for lists.
 
-There are no examples for uncontrolled mode because an uncontrolled `Drawer` can only be opened with a swipe. The doc site has an uncontrolled `Drawer`. Swipe from the left on a touch device to see it.
+## Docked example
+
+A simple controlled `Drawer`. The Drawer is docked, it is not closed by clicking anywhere else.
+
+{{demo='demos/drawers/DockedDrawer.js'}}
 
 ## Undocked example
 
-An undocked controlled `Drawer` with custom width. The Drawer can be cancelled by clicking the overlay or pressing the Esc key. It closes when an item is selected, handled by controlling the `open` prop.
+An undocked controlled `Drawer`. The Drawer can be cancelled by clicking the overlay or pressing the Esc key. It closes when an item is selected, handled by controlling the `open` prop.
 
 {{demo='demos/drawers/UndockedDrawer.js'}}
 

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -41,7 +41,8 @@ export const styleSheet = createStyleSheet('MuiDrawer', (theme) => {
       WebkitOverflowScrolling: 'touch', // Add iOS momentum scrolling.
     },
     docked: {
-      flex: '0 0 auto',
+      position: 'fixed',
+      left: 0,
       '& $paper': {
         borderRight: `1px solid ${theme.palette.text.divider}`,
       },
@@ -97,6 +98,11 @@ export default class Drawer extends Component {
      * The CSS class name of the paper element.
      */
     paperClassName: PropTypes.string,
+    /**
+     * Run the enter animation when the component mounts, if it is initially
+     * open.
+     */
+    transitionAppear: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -105,6 +111,7 @@ export default class Drawer extends Component {
     leaveTransitionDuration: duration.leavingScreen,
     open: false,
     elevation: 16,
+    transitionAppear: true,
   };
 
   static contextTypes = {
@@ -122,6 +129,7 @@ export default class Drawer extends Component {
       open,
       paperClassName,
       elevation,
+      transitionAppear,
       ...other
     } = this.props;
 
@@ -137,7 +145,7 @@ export default class Drawer extends Component {
         direction={slideDirection}
         enterTransitionDuration={enterTransitionDuration}
         leaveTransitionDuration={leaveTransitionDuration}
-        transitionAppear
+        transitionAppear={transitionAppear}
       >
         <Paper
           elevation={docked ? 0 : elevation}

--- a/src/transitions/Slide.js
+++ b/src/transitions/Slide.js
@@ -1,6 +1,7 @@
 // @flow weak
 
 import React, { Component, PropTypes } from 'react';
+import ReactDOM from 'react-dom';
 import Transition from '../internal/Transition';
 import customPropTypes from '../utils/customPropTypes';
 import { duration } from '../styles/transitions';
@@ -37,6 +38,10 @@ export default class Slide extends Component {
      * Duration of the animation when the element is entering the screen.
      */
     enterTransitionDuration: PropTypes.number,
+    /**
+     * Show the component; triggers the enter or exit animation
+     */
+    in: PropTypes.bool,
     /**
      * Duration of the animation when the element is leaving the screen.
      */
@@ -80,6 +85,18 @@ export default class Slide extends Component {
   static contextTypes = {
     theme: customPropTypes.muiRequired,
   };
+
+  componentDidMount() {
+    if (!this.props.in) {
+      /* We need to set initial translate values of trabsition element
+       * otherwise component will be shown when in=false
+       */
+      /* eslint-disable react/no-find-dom-node */
+      const element = ReactDOM.findDOMNode(this.transition);
+      /* eslint-enable react/no-find-dom-node */
+      element.style.transform = getTranslateValue(this.props, element);
+    }
+  }
 
   handleEnter = (element) => {
     element.style.transform = getTranslateValue(this.props, element);
@@ -126,6 +143,7 @@ export default class Slide extends Component {
 
     return (
       <Transition
+        ref={(ref) => { this.transition = ref; }}
         onEnter={this.handleEnter}
         onEntering={this.handleEntering}
         onExiting={this.handleExiting}


### PR DESCRIPTION
Added worked docked property and example for Drawer - it should behave as in old docs.
Also, fixed "bug" with Slide, when in=false at start, it wasnt hidden.
