### PR TITLE
[docs] Add links to material palette generator

### DIFF
--- a/docs/style/color/palette.md
+++ b/docs/style/color/palette.md
@@ -1,0 +1,6 @@
+###Awesome tools for generating material palettes.
+Below are some links to few of very handy tools to generate palettes.
+
+[`https://www.materialpalette.com`](https://www.materialpalette.com)
+
+[`http://mcg.mbitson.com/`](http://mcg.mbitson.com/) 


### PR DESCRIPTION
Added reference links to generating material palettes in the documentation.
Close issue #6009 

