### PR TITLE
[SelectField] [DropDownMenu] Prevent label from resizing parents

### DIFF
--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -38,6 +38,7 @@ function getStyles(props, context) {
     },
     label: {
       color: disabled ? palette.disabledColor : palette.textColor,
+      height: `${spacing.desktopToolbarHeight}px`,
       lineHeight: `${spacing.desktopToolbarHeight}px`,
       overflow: 'hidden',
       opacity: 1,


### PR DESCRIPTION
When the first selection is made in SelectField with no previous selection, it affects the size of the parent elements. This can be seen in the Nullable, Floating label, and ErrorText examples on http://www.material-ui.com/#/components/select-field 

Here are side-by-side screenshots of the difference. Both the size of the box and the position of the underline has changed: 
![labelresizingparent](https://cloud.githubusercontent.com/assets/238102/23145226/3bd9a4de-f7cd-11e6-991b-fce7f07cac77.png)

This can be prevented by positioning the label absolutely instead of relatively.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

