### PR TITLE
[Menu] Fix disabled MenuItem with props.menuItemStyle

### DIFF
--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -256,38 +256,40 @@ class Menu extends Component {
   }
 
   cloneMenuItem(child, childIndex, styles, index) {
-    const {
-      desktop,
-      menuItemStyle,
-      selectedMenuItemStyle,
-    } = this.props;
+    const childIsDisabled = child.props.disabled;
 
-    const selected = this.isChildSelected(child, this.props);
-    let selectedChildrenStyles = {};
+    const selectedChildStyles = {};
+    if (!childIsDisabled) {
+      const selected = this.isChildSelected(child, this.props);
 
-    if (selected) {
-      selectedChildrenStyles = Object.assign(styles.selectedMenuItem, selectedMenuItemStyle);
+      if (selected) {
+        Object.assign(selectedChildStyles, styles.selectedMenuItem, this.props.selectedMenuItemStyle);
+      }
     }
+    const mergedChildStyles = Object.assign({}, child.props.style, this.props.menuItemStyle, selectedChildStyles);
 
-    const mergedChildrenStyles = Object.assign({}, child.props.style, menuItemStyle, selectedChildrenStyles);
+    const extraProps = {
+      desktop: this.props.desktop,
+      style: mergedChildStyles,
+    };
+    if (!childIsDisabled) {
+      const isFocused = childIndex === this.state.focusIndex;
+      let focusState = 'none';
+      if (isFocused) {
+        focusState = this.state.isKeyboardFocused ?
+          'keyboard-focused' : 'focused';
+      }
 
-    const isFocused = childIndex === this.state.focusIndex;
-    let focusState = 'none';
-    if (isFocused) {
-      focusState = this.state.isKeyboardFocused ?
-        'keyboard-focused' : 'focused';
+      Object.assign(extraProps, {
+        focusState: focusState,
+        onTouchTap: (event) => {
+          this.handleMenuItemTouchTap(event, child, index);
+          if (child.props.onTouchTap) child.props.onTouchTap(event);
+        },
+        ref: isFocused ? 'focusedMenuItem' : null,
+      });
     }
-
-    return React.cloneElement(child, {
-      desktop: desktop,
-      focusState: focusState,
-      onTouchTap: (event) => {
-        this.handleMenuItemTouchTap(event, child, index);
-        if (child.props.onTouchTap) child.props.onTouchTap(event);
-      },
-      ref: isFocused ? 'focusedMenuItem' : null,
-      style: mergedChildrenStyles,
-    });
+    return React.cloneElement(child, extraProps);
   }
 
   decrementKeyboardFocusIndex(event) {
@@ -497,7 +499,7 @@ class Menu extends Component {
     const {
       autoWidth, // eslint-disable-line no-unused-vars
       children,
-      desktop,
+      desktop, // eslint-disable-line no-unused-vars
       disableAutoFocus, // eslint-disable-line no-unused-vars
       initiallyKeyboardFocused, // eslint-disable-line no-unused-vars
       listStyle,
@@ -531,8 +533,7 @@ class Menu extends Component {
 
       switch (childName) {
         case 'MenuItem':
-          newChild = childIsDisabled ? React.cloneElement(child, {desktop: desktop}) :
-            this.cloneMenuItem(child, menuItemIndex, styles, index);
+          newChild = this.cloneMenuItem(child, menuItemIndex, styles, index);
           break;
 
         case 'Divider':

--- a/src/Menu/Menu.spec.js
+++ b/src/Menu/Menu.spec.js
@@ -162,6 +162,24 @@ describe('<Menu />', () => {
   });
 
   describe('prop: children', () => {
+    it("should render disabled MenuItem with the Menu's menuItemStyle", () => {
+      const wrapper = shallowWithContext(
+        <Menu menuItemStyle={{fontSize: 60}}>
+          <MenuItem style={{fontSize: 10}} primaryText="item 1" />
+          <MenuItem disabled={true} style={{fontSize: 10}} primaryText="item 2" />
+        </Menu>
+      );
+
+      const menuItemsAndDividers = wrapper.children().children().children();
+      assert.strictEqual(menuItemsAndDividers.length, 2, 'there should be two children');
+      assert.strictEqual(menuItemsAndDividers.get(0).type, MenuItem, 'first child should be a MenuItem');
+      assert.strictEqual(menuItemsAndDividers.get(1).type, MenuItem, 'second child should be a MenuItem');
+      assert.strictEqual(menuItemsAndDividers.get(0).props.style.fontSize, 60,
+        'the normal MenuItem should merge styles with menuItemStyle');
+      assert.strictEqual(menuItemsAndDividers.get(1).props.style.fontSize, 60,
+        'the disabled MenuItem should merge styles with menuItemStyle');
+    });
+
     it("should merge the Divider's styles over the Menu's default divider styles", () => {
       const style = {
         color: 'red',


### PR DESCRIPTION
Hi,

I've fixed the issue that `Menu.props.menuItemStyle` not merged with disabled `MenuItem` children. I also added a failing test case first:

<img width="890" alt="screen shot 2017-02-21 at 5 11 32 pm" src="https://cloud.githubusercontent.com/assets/922234/23158258/82693b4e-f859-11e6-81db-c29530d08f98.png">


*Checklist*

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

