### PR TITLE
[ListItem] Documents containerElement, changes ref to use callback

### DIFF
--- a/docs/src/app/components/PropTypeDescription.js
+++ b/docs/src/app/components/PropTypeDescription.js
@@ -38,8 +38,9 @@ function generatePropType(type) {
       return type.raw;
 
     case 'enum':
-      const values = type.value.map((v) => v.value).join('<br>&nbsp;');
-      return `enum:<br>&nbsp;${values}<br>`;
+    case 'union':
+      const values = type.value.map((v) => v.value || v.name).join('<br>&nbsp;');
+      return `${type.name}:<br>&nbsp;${values}<br>`;
 
     default:
       return type.name;

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -154,6 +154,17 @@ class ListItem extends Component {
      */
     children: PropTypes.node,
     /**
+     * The element to use as the container for the ListItem inside of. Either a
+     * string to use a DOM element or a ReactElement. This is useful for wrapping
+     * the ListItem in a custom Link component. If a ReactElement is given,
+     * ensure that it passes all of its given props through to the underlying
+     * DOM element and renders its children prop for proper integration.
+     */
+    containerElement: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element,
+    ]),
+    /**
      * If true, the element will not be able to be focused by the keyboard.
      */
     disableKeyboardFocus: PropTypes.bool,
@@ -335,10 +346,8 @@ class ListItem extends Component {
 
   // This method is needed by the `MenuItem` component.
   applyFocusState(focusState) {
-    const button = this.refs.enhancedButton;
-
-    if (button) {
-      const buttonEl = ReactDOM.findDOMNode(button);
+    if (this.button) {
+      const buttonEl = ReactDOM.findDOMNode(this.button);
 
       switch (focusState) {
         case 'none':
@@ -348,7 +357,7 @@ class ListItem extends Component {
           buttonEl.focus();
           break;
         case 'keyboard-focused':
-          button.setKeyboardFocus();
+          this.button.setKeyboardFocus();
           buttonEl.focus();
           break;
       }
@@ -522,6 +531,7 @@ class ListItem extends Component {
     const {
       autoGenerateNestedIndicator,
       children,
+      containerElement = 'span',
       disabled,
       disableKeyboardFocus,
       hoverColor, // eslint-disable-line no-unused-vars
@@ -676,8 +686,8 @@ class ListItem extends Component {
           simpleLabel ? this.createLabelElement(styles, contentChildren, other) :
           disabled ? this.createDisabledElement(styles, contentChildren, other) : (
             <EnhancedButton
-              containerElement="span"
               {...other}
+              containerElement={containerElement}
               disableKeyboardFocus={disableKeyboardFocus || this.state.rightIconButtonKeyboardFocused}
               onKeyboardFocus={this.handleKeyboardFocus}
               onMouseLeave={this.handleMouseLeave}
@@ -685,7 +695,7 @@ class ListItem extends Component {
               onTouchStart={this.handleTouchStart}
               onTouchEnd={this.handleTouchEnd}
               onTouchTap={primaryTogglesNestedList ? this.handleNestedListToggle : onTouchTap}
-              ref="enhancedButton"
+              ref={(node) => this.button = node}
               style={Object.assign({}, styles.root, style)}
             >
               <div style={prepareStyles(Object.assign(styles.innerDiv, innerDivStyle))}>

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -154,11 +154,11 @@ class ListItem extends Component {
      */
     children: PropTypes.node,
     /**
-     * The element to use as the container for the ListItem inside of. Either a
-     * string to use a DOM element or a ReactElement. This is useful for wrapping
-     * the ListItem in a custom Link component. If a ReactElement is given,
-     * ensure that it passes all of its given props through to the underlying
-     * DOM element and renders its children prop for proper integration.
+     * The element to use as the container for the ListItem. Either a string to
+     * use a DOM element or a ReactElement. This is useful for wrapping the
+     * ListItem in a custom Link component. If a ReactElement is given, ensure
+     * that it passes all of its given props through to the underlying DOM
+     * element and renders its children prop for proper integration.
      */
     containerElement: PropTypes.oneOfType([
       PropTypes.string,
@@ -292,6 +292,7 @@ class ListItem extends Component {
 
   static defaultProps = {
     autoGenerateNestedIndicator: true,
+    containerElement: 'span',
     disableKeyboardFocus: false,
     disabled: false,
     initiallyOpen: false,
@@ -531,7 +532,7 @@ class ListItem extends Component {
     const {
       autoGenerateNestedIndicator,
       children,
-      containerElement = 'span',
+      containerElement,
       disabled,
       disableKeyboardFocus,
       hoverColor, // eslint-disable-line no-unused-vars
@@ -686,8 +687,8 @@ class ListItem extends Component {
           simpleLabel ? this.createLabelElement(styles, contentChildren, other) :
           disabled ? this.createDisabledElement(styles, contentChildren, other) : (
             <EnhancedButton
-              {...other}
               containerElement={containerElement}
+              {...other}
               disableKeyboardFocus={disableKeyboardFocus || this.state.rightIconButtonKeyboardFocused}
               onKeyboardFocus={this.handleKeyboardFocus}
               onMouseLeave={this.handleMouseLeave}

--- a/src/List/ListItem.spec.js
+++ b/src/List/ListItem.spec.js
@@ -201,4 +201,29 @@ describe('<ListItem />', () => {
       assert.strictEqual(wrapper.state().hovered, false, 'should reset the state');
     });
   });
+
+  describe('prop: containerElement', () => {
+    it('should use the given string containerElement prop', () => {
+      const wrapper = shallowWithContext(
+        <ListItem
+          containerElement="a"
+          primaryText="Links are great"
+        />
+      );
+      const button = wrapper.find(EnhancedButton).dive({context: {muiTheme}});
+      assert.strictEqual(button.is('a'), true, 'should match an a element');
+    });
+
+    it('should use the given ReactElement containerElement', () => {
+      const CustomElement = (props) => <a {...props} />;
+      const wrapper = shallowWithContext(
+        <ListItem
+          containerElement={<CustomElement someProp="yuuuuuge" />}
+          primaryText="Custom links are even greater"
+        />
+      );
+      const button = wrapper.find(EnhancedButton).dive({context: {muiTheme}});
+      assert.strictEqual(button.is(CustomElement), true, 'should match the custom element');
+    });
+  });
 });

--- a/src/internal/EnhancedButton.js
+++ b/src/internal/EnhancedButton.js
@@ -97,7 +97,7 @@ class EnhancedButton extends Component {
     injectStyle();
     listenForTabPresses();
     if (this.state.isKeyboardFocused) {
-      this.refs.enhancedButton.focus();
+      this.button.focus();
       this.props.onKeyboardFocus(null, true);
     }
   }
@@ -316,7 +316,7 @@ class EnhancedButton extends Component {
     const buttonProps = {
       ...other,
       style: prepareStyles(mergedStyles),
-      ref: 'enhancedButton',
+      ref: (node) => this.button = node,
       disabled: disabled,
       href: href,
       onBlur: this.handleBlur,


### PR DESCRIPTION
- Makes updates to make it clear how to wrap a ListItem with a link.
- Using a string for refs is deprecated and was giving me a warning
about putting a ref on a functional component in some cases.