### PR TITLE
[Slide] fixed displaying when in=false at first

### DIFF
--- a/docs/site/src/components/AppFrame.js
+++ b/docs/site/src/components/AppFrame.js
@@ -171,7 +171,7 @@ class AppFrame extends Component {
           docked={drawerDocked}
           routes={routes}
           onRequestClose={this.handleDrawerClose}
-          open={this.state.drawerOpen}
+          open={drawerDocked || this.state.drawerOpen}
         />
         {children}
       </div>

--- a/src/transitions/Slide.js
+++ b/src/transitions/Slide.js
@@ -1,6 +1,7 @@
 // @flow weak
 
 import React, { Component, PropTypes } from 'react';
+import ReactDOM from 'react-dom';
 import Transition from '../internal/Transition';
 import customPropTypes from '../utils/customPropTypes';
 import { duration } from '../styles/transitions';
@@ -37,6 +38,10 @@ export default class Slide extends Component {
      * Duration of the animation when the element is entering the screen.
      */
     enterTransitionDuration: PropTypes.number,
+    /**
+     * Show the component; triggers the enter or exit animation.
+     */
+    in: PropTypes.bool,
     /**
      * Duration of the animation when the element is leaving the screen.
      */
@@ -80,6 +85,20 @@ export default class Slide extends Component {
   static contextTypes = {
     theme: customPropTypes.muiRequired,
   };
+
+  componentDidMount() {
+    if (!this.props.in) {
+      /* eslint-disable react/no-find-dom-node */
+      /* We need to set initial translate values of transition element
+       * otherwise component will be shown when in=false.
+       * transitions are handled by direct access to element,
+       * so we need to access that same element too here.
+       */
+      const element = ReactDOM.findDOMNode(this.transition);
+      /* eslint-enable react/no-find-dom-node */
+      element.style.transform = getTranslateValue(this.props, element);
+    }
+  }
 
   handleEnter = (element) => {
     element.style.transform = getTranslateValue(this.props, element);
@@ -132,6 +151,7 @@ export default class Slide extends Component {
         timeout={500}
         transitionAppear
         {...other}
+        ref={(ref) => { this.transition = ref; }}
       >
         {children}
       </Transition>

--- a/src/transitions/Slide.js
+++ b/src/transitions/Slide.js
@@ -100,6 +100,8 @@ export default class Slide extends Component {
     }
   }
 
+  transition = null;
+
   handleEnter = (element) => {
     element.style.transform = getTranslateValue(this.props, element);
     if (this.props.onEnter) {


### PR DESCRIPTION
Fixed displaying of initially hidden component in Slide (mentioned in #6181 - discovered in docked Drawer, which was not hidden as non docked, which is handled by Modal)

I could not think of any method how to test in, since even full `mount()` will only inject some default element with non testable dimensions (0). 
Tried to store transiton value in State (and change it in handleEnter and others, which would trigger re-render). But it seems, it changes order of actions somewhat and changes behavior. So it would be suited for some bigger PR.

