### PR TITLE
[Button] Fix boxSizing when not rending a native button

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -18,6 +18,7 @@ export const styleSheet = createStyleSheet('MuiButton', (theme) => {
       display: 'inline-flex',
       alignItems: 'center',
       justifyContent: 'center',
+      boxSizing: 'border-box',
       minWidth: 88,
       height: 36,
       padding: '0px 16px',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

The native `<button />` inherit from a default `box-sizing: border-box` model from the browser style. That's not true with a `<a />` for instance. As always when the box dimension can vary depending on the box-sizing model, we **reset** it.
