### PR TITLE
[Test] Integration of test suite to run on BrowserStack from next

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "json-loader": "^0.5.4",
     "karma": "^1.4.1",
     "karma-firefox-launcher": "^1.0.0",
+    "karma-browserstack-launcher": "^1.2.0",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.2",
     "karma-phantomjs-launcher": "^1.0.0",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,15 +1,18 @@
 // @flow weak
 const path = require('path');
 
+const timestamp = new Date();
+
 // Karma configuration
 module.exports = function setKarmaConfig(config) {
   config.set({
     basePath: '../',
-    browsers: ['PhantomJS_Sized'],
+    browsers: ['PhantomJS_Sized', 'BrowserStack_Chrome', 'BrowserStack_Firefox',
+      'BrowserStack_Safari', 'BrowserStack_IE'],
     // to avoid DISCONNECTED messages on travis
-    browserDisconnectTimeout: 10000, // default 2000
+    browserDisconnectTimeout: 60000, // default 2000
     browserDisconnectTolerance: 1, // default 0
-    browserNoActivityTimeout: 60000, // default 10000
+    browserNoActivityTimeout: 300000, // default 10000
     colors: true,
     frameworks: ['mocha'],
     files: [
@@ -24,6 +27,7 @@ module.exports = function setKarmaConfig(config) {
     plugins: [
       'karma-phantomjs-launcher',
       'karma-firefox-launcher',
+      'karma-browserstack-launcher',
       'karma-mocha',
       'karma-sourcemap-loader',
       'karma-webpack',
@@ -43,6 +47,11 @@ module.exports = function setKarmaConfig(config) {
       'test/karma.tests.js': ['webpack', 'sourcemap'],
     },
     reporters: ['dots'],
+    browserStack: {
+      username: process.env.BROWSERSTACK_USERNAME,
+      accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
+      build: `material-ui-build-${timestamp.toString()}`,
+    },
     webpack: {
       devtool: 'inline-source-map',
       module: {
@@ -91,6 +100,34 @@ module.exports = function setKarmaConfig(config) {
             height: 768,
           },
         },
+      },
+      BrowserStack_Chrome: {
+        base: 'BrowserStack',
+        os: 'OS X',
+        os_version: 'Sierra',
+        browser: 'chrome',
+        browser_version: 'latest',
+      },
+      BrowserStack_Firefox: {
+        base: 'BrowserStack',
+        os: 'Windows',
+        os_version: '10',
+        browser: 'firefox',
+        browser_version: 'latest',
+      },
+      BrowserStack_Safari: {
+        base: 'BrowserStack',
+        os: 'OS X',
+        os_version: 'Yosemite',
+        browser: 'safari',
+        browser_version: 'latest',
+      },
+      BrowserStack_IE: {
+        base: 'BrowserStack',
+        os: 'Windows',
+        os_version: '7',
+        browser: 'ie',
+        browser_version: 'latest',
       },
     },
   });


### PR DESCRIPTION
Hi.

As [suggested by @oliviertassinari](https://github.com/callemall/material-ui/pull/6189), made the changes for BrowserStack integration against _next_ branch. It will work on Circle CI.

Interestingly, we also found few tests breaking on IE. Would you like to check it? - [CircleCI build](https://circleci.com/gh/vedharish/material-ui/3).

Closing #6189. Let us know if you face any issues with this. Would love the feedback and discuss this. 

Thanks! :)
Ankur
\- BrowserStack Automate

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

