### PR TITLE
[LinearProgress] Reduce delay before indeterminate animation begins

### DIFF
--- a/src/LinearProgress/LinearProgress.js
+++ b/src/LinearProgress/LinearProgress.js
@@ -109,13 +109,13 @@ class LinearProgress extends Component {
     this.timers.bar1 = this.barUpdate('bar1', 0, this.refs.bar1, [
       [-35, 100],
       [100, -90],
-    ]);
+    ], 0);
 
     this.timers.bar2 = setTimeout(() => {
       this.barUpdate('bar2', 0, this.refs.bar2, [
         [-200, 100],
         [107, -8],
-      ]);
+      ], 0);
     }, 850);
   }
 
@@ -124,9 +124,10 @@ class LinearProgress extends Component {
     clearTimeout(this.timers.bar2);
   }
 
-  barUpdate(id, step, barElement, stepValues) {
+  barUpdate(id, step, barElement, stepValues, timeToNextStep) {
     if (this.props.mode !== 'indeterminate') return;
 
+    timeToNextStep = timeToNextStep || 420;
     step = step || 0;
     step %= 4;
 
@@ -144,7 +145,7 @@ class LinearProgress extends Component {
     } else if (step === 3) {
       barElement.style.transitionDuration = '0ms';
     }
-    this.timers[id] = setTimeout(() => this.barUpdate(id, step + 1, barElement, stepValues), 420);
+    this.timers[id] = setTimeout(() => this.barUpdate(id, step + 1, barElement, stepValues), timeToNextStep);
   }
 
   render() {


### PR DESCRIPTION
With how the indeterminate linear progress is currently implemented, when the animation is kicked off at `componentDidMount`, there's a one-time extra 420ms delay added on before we see the first bar go by (which, to me, makes it look like an abnormally long time before it starts - compared with the rest of the animation cycle once it gets going).

This change shaves off this delay while not altering the timing of the rest of the animation.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

