### PR TITLE
[FlatButton] Expose disableTouchRipple

### DIFF
--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -47,6 +47,10 @@ class FlatButton extends Component {
       PropTypes.element,
     ]),
     /**
+     * If true, the element's ripple effect will be disabled.
+     */
+    disableTouchRipple: React.PropTypes.bool,
+    /**
      * Disables the button if set to true.
      */
     disabled: PropTypes.bool,


### PR DESCRIPTION
- The enhanced button wrapper exposes an option to disable
  touch ripples.  This is the case with the IconButton and
  should be persisted to the FlatButton.
- In addition to exposing the prop, the documentation page
  will be automatically updated with the new prop for Icon Button
  as well, since the documentation for the props is pulled strictly
  from the FlatButton component

If you guys don't agree that we should expose this, we should then refactor the the documentation pages to pull IconButton props separate to the FlatButton props so that it is clear what is available on one or the other.

Additional reference:
https://github.com/callemall/material-ui/blob/master/docs/src/app/components/pages/components/FlatButton/Page.js#L15

