### PR TITLE
[Theme] Move borderRadius into a theme constant

### DIFF
--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -191,6 +191,7 @@ class FlatButton extends Component {
     } = this.props;
 
     const {
+      borderRadius,
       button: {
         height: buttonHeight,
         minWidth: buttonMinWidth,
@@ -226,7 +227,7 @@ class FlatButton extends Component {
       minWidth: fullWidth ? '100%' : buttonMinWidth,
       color: defaultTextColor,
       transition: transitions.easeOut(),
-      borderRadius: 2,
+      borderRadius,
       userSelect: 'none',
       overflow: 'hidden',
       backgroundColor: hovered ? buttonHoverColor : buttonBackgroundColor,

--- a/src/LinearProgress/LinearProgress.js
+++ b/src/LinearProgress/LinearProgress.js
@@ -15,7 +15,7 @@ function getStyles(props, context) {
     value,
   } = props;
 
-  const {baseTheme: {palette}} = context.muiTheme;
+  const {baseTheme: {palette}, borderRadius} = context.muiTheme;
 
   const styles = {
     root: {
@@ -24,7 +24,7 @@ function getStyles(props, context) {
       display: 'block',
       width: '100%',
       backgroundColor: palette.primary3Color,
-      borderRadius: 2,
+      borderRadius,
       margin: 0,
       overflow: 'hidden',
     },

--- a/src/Paper/Paper.js
+++ b/src/Paper/Paper.js
@@ -13,6 +13,7 @@ function getStyles(props, context) {
   const {
     baseTheme,
     paper,
+    borderRadius,
   } = context.muiTheme;
 
   return {
@@ -24,7 +25,7 @@ function getStyles(props, context) {
       fontFamily: baseTheme.fontFamily,
       WebkitTapHighlightColor: 'rgba(0,0,0,0)', // Remove mobile color flashing (deprecated)
       boxShadow: paper.zDepthShadows[zDepth - 1], // No shadow for 0 depth papers
-      borderRadius: circle ? '50%' : rounded ? '2px' : '0px',
+      borderRadius: circle ? '50%' : rounded ? borderRadius : '0px',
     },
   };
 }

--- a/src/Paper/Paper.spec.js
+++ b/src/Paper/Paper.spec.js
@@ -24,7 +24,7 @@ describe('<Paper />', () => {
     );
 
     assert.ok(wrapper.contains(testChildren), 'should contain the children');
-    assert.strictEqual(wrapper.prop('style').borderRadius, '2px', 'should have round corner');
+    assert.strictEqual(wrapper.prop('style').borderRadius, 2, 'should have round corner');
   });
 
   it('renders children and should be a circle', () => {

--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -18,6 +18,7 @@ function getStyles(props, context, state) {
     baseTheme,
     button,
     raisedButton,
+    borderRadius,
   } = context.muiTheme;
 
   const {
@@ -57,7 +58,6 @@ function getStyles(props, context, state) {
   }
 
   const buttonHeight = style && style.height || button.height;
-  const borderRadius = 2;
 
   return {
     root: {
@@ -70,7 +70,7 @@ function getStyles(props, context, state) {
       lineHeight: `${buttonHeight}px`,
       width: '100%',
       padding: 0,
-      borderRadius: borderRadius,
+      borderRadius,
       transition: transitions.easeOut(),
       backgroundColor: backgroundColor,
       // That's the default value for a button but not a link
@@ -96,7 +96,7 @@ function getStyles(props, context, state) {
     },
     overlay: {
       height: buttonHeight,
-      borderRadius: borderRadius,
+      borderRadius,
       backgroundColor: (state.keyboardFocused || state.hovered) && !disabled &&
         fade(labelColor, amount),
       transition: transitions.easeOut(),

--- a/src/Snackbar/SnackbarBody.js
+++ b/src/Snackbar/SnackbarBody.js
@@ -23,6 +23,7 @@ function getStyles(props, context) {
         textColor,
         actionColor,
       },
+      borderRadius,
     },
   } = context;
 
@@ -35,7 +36,7 @@ function getStyles(props, context) {
       padding: `0 ${desktopGutter}px`,
       height: desktopSubheaderHeight,
       lineHeight: `${desktopSubheaderHeight}px`,
-      borderRadius: isSmall ? 0 : 2,
+      borderRadius: isSmall ? 0 : borderRadius,
       maxWidth: isSmall ? 'inherit' : 568,
       minWidth: isSmall ? 'inherit' : 288,
       width: isSmall ? `calc(100vw - ${desktopGutter * 2}px)` : 'auto',

--- a/src/internal/Tooltip.js
+++ b/src/internal/Tooltip.js
@@ -13,6 +13,7 @@ function getStyles(props, context, state) {
     baseTheme,
     zIndex,
     tooltip,
+    borderRadius,
   } = context.muiTheme;
 
   const styles = {
@@ -26,7 +27,7 @@ function getStyles(props, context, state) {
       color: tooltip.color,
       overflow: 'hidden',
       top: -10000,
-      borderRadius: 2,
+      borderRadius,
       userSelect: 'none',
       opacity: 0,
       right: horizontalPosition === 'left' ? 12 : null,

--- a/src/styles/baseThemes/darkBaseTheme.js
+++ b/src/styles/baseThemes/darkBaseTheme.js
@@ -10,6 +10,7 @@ import spacing from '../spacing';
 export default {
   spacing: spacing,
   fontFamily: 'Roboto, sans-serif',
+  borderRadius: 2,
   palette: {
     primary1Color: cyan700,
     primary2Color: cyan700,

--- a/src/styles/baseThemes/lightBaseTheme.js
+++ b/src/styles/baseThemes/lightBaseTheme.js
@@ -19,6 +19,7 @@ import spacing from '../spacing';
 export default {
   spacing: spacing,
   fontFamily: 'Roboto, sans-serif',
+  borderRadius: 2,
   palette: {
     primary1Color: cyan500,
     primary2Color: cyan700,


### PR DESCRIPTION
The borderRadius = 2px constant is used a lot around the codebase.  It
is better to move it out to a constant, but it also allows for theming
it - for example to have a larger borderRadius for a different style.

https://github.com/samdroid-apps/material-ui