### PR TITLE
[Button] Expose disableTouchRipple

### DIFF
--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -47,6 +47,10 @@ class FlatButton extends Component {
       PropTypes.element,
     ]),
     /**
+     * If true, the element's ripple effect will be disabled.
+     */
+    disableTouchRipple: React.PropTypes.bool,
+    /**
      * Disables the button if set to true.
      */
     disabled: PropTypes.bool,

--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -145,6 +145,10 @@ class RaisedButton extends Component {
       PropTypes.element,
     ]),
     /**
+     * If true, the element's ripple effect will be disabled.
+     */
+    disableTouchRipple: React.PropTypes.bool,
+    /**
      * If true, the button will be disabled.
      */
     disabled: PropTypes.bool,


### PR DESCRIPTION
This PR directly references:
https://github.com/callemall/material-ui/pull/6232

* The enhanced button wrapper exposes the option to
disable touch ripples.  This is the case with the FlatButton
component and should be exposed on RaisedButton for consistency.
* In addition to exposing the prop, the documentation will be updated
  automatically with the newly defined prop from the RaisedButton Component.

Please wait to merge this until the previous PR is merged and this PR is rebased.
