### PR TITLE
[Tab] Add lazy loading for Tab's children

### DIFF
--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -79,6 +79,10 @@ class Tab extends Component {
      * This property is overriden by the Tabs component.
      */
     width: PropTypes.string,
+    /**
+     * Lazy loading children components
+     */
+    lazy: PropTypes.bool,
   };
 
   static contextTypes = {
@@ -103,6 +107,7 @@ class Tab extends Component {
       style,
       value, // eslint-disable-line no-unused-vars
       width, // eslint-disable-line no-unused-vars
+      lazy, // eslint-disable-line no-unused-vars
       ...other
     } = this.props;
 

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -48,6 +48,10 @@ class Tab extends Component {
      */
     label: PropTypes.node,
     /**
+     * Lazy loading children components
+     */
+    lazy: PropTypes.bool,
+    /**
      * Fired when the active tab changes by touch or tap.
      * Use this event to specify any functionality when an active tab changes.
      * For example - we are using this to route to home when the third tab becomes active.
@@ -79,10 +83,6 @@ class Tab extends Component {
      * This property is overriden by the Tabs component.
      */
     width: PropTypes.string,
-    /**
-     * Lazy loading children components
-     */
-    lazy: PropTypes.bool,
   };
 
   static contextTypes = {

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -204,7 +204,7 @@ class Tabs extends Component {
         does not have a value prop. Needs value if Tabs is going
         to be a controlled component.`);
 
-      tabContent.push(tab.props.children ?
+      tabContent.push((tab.props.children && (!tab.props.lazy || this.getSelected(tab, index))) ?
         createElement(tabTemplate || TabTemplate, {
           key: index,
           selected: this.getSelected(tab, index),


### PR DESCRIPTION
Load Tab's children each time Tab is activated if Tab.props.lazy=true (<Tab lazy ... />)


- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

