### PR TITLE
[FlatButton] Expose enhancedButton as RaisedButton does.

### DIFF
--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -290,6 +290,7 @@ class FlatButton extends Component {
     return (
       <EnhancedButton
         {...other}
+        ref={ eBtn => this.enhancedButton = eBtn }
         disabled={disabled}
         focusRippleColor={buttonRippleColor}
         focusRippleOpacity={0.3}

--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -290,7 +290,7 @@ class FlatButton extends Component {
     return (
       <EnhancedButton
         {...other}
-        ref={ eBtn => this.enhancedButton = eBtn }
+        ref={(eBtn) => this.enhancedButton = eBtn}
         disabled={disabled}
         focusRippleColor={buttonRippleColor}
         focusRippleOpacity={0.3}


### PR DESCRIPTION
1. Raised Button access their internal enhancedButton object exposing it trough "container" variable.
2. Flat button should do the same as well.

Exposing EnhancedButton by "enhancedButton" object. EnhancedButton does the same with the actual button node. In order to be able to access Enhanced button to setKeyboardFocus() or EnhancedButton.button to focus().

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [no ] PR has tests / docs demo, and is linted.
- [ yes] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

