### PR TITLE
[Toolbar] Allow objects/components to be used in text property

### DIFF
--- a/src/Toolbar/ToolbarTitle.js
+++ b/src/Toolbar/ToolbarTitle.js
@@ -35,10 +35,12 @@ class ToolbarTitle extends Component {
     /**
      * The text to be displayed.
      */
-    text: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.object,
-    ]),
+    text: PropTypes.string,
+    /**
+     * Alternatively, the object(s)/component(s) to be displayed.
+     */
+    node: PropTypes.object,
+    children: PropTypes.object,
   };
 
   static contextTypes = {
@@ -50,6 +52,8 @@ class ToolbarTitle extends Component {
       className,
       style,
       text,
+      node,
+      children,
       ...other
     } = this.props;
 
@@ -58,7 +62,7 @@ class ToolbarTitle extends Component {
 
     return (
       <span {...other} className={className} style={prepareStyles(Object.assign({}, styles.root, style))}>
-        {text}
+        {children || node || text || null}
       </span>
     );
   }

--- a/src/Toolbar/ToolbarTitle.js
+++ b/src/Toolbar/ToolbarTitle.js
@@ -25,6 +25,10 @@ class ToolbarTitle extends Component {
 
   static propTypes = {
     /**
+     * The component(s) to be displayed.
+     */
+    children: PropTypes.node,
+    /**
      * The css class name of the root element.
      */
     className: PropTypes.string,
@@ -35,12 +39,7 @@ class ToolbarTitle extends Component {
     /**
      * The text to be displayed.
      */
-    text: PropTypes.string,
-    /**
-     * Alternatively, the object(s)/component(s) to be displayed.
-     */
-    node: PropTypes.object,
-    children: PropTypes.object,
+    text: PropTypes.node,
   };
 
   static contextTypes = {
@@ -49,11 +48,10 @@ class ToolbarTitle extends Component {
 
   render() {
     const {
+      children,
       className,
       style,
       text,
-      node,
-      children,
       ...other
     } = this.props;
 
@@ -62,7 +60,7 @@ class ToolbarTitle extends Component {
 
     return (
       <span {...other} className={className} style={prepareStyles(Object.assign({}, styles.root, style))}>
-        {children || node || text || null}
+        {children || text || null}
       </span>
     );
   }

--- a/src/Toolbar/ToolbarTitle.js
+++ b/src/Toolbar/ToolbarTitle.js
@@ -35,7 +35,10 @@ class ToolbarTitle extends Component {
     /**
      * The text to be displayed.
      */
-    text: PropTypes.string,
+    text: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object,
+    ]),
   };
 
   static contextTypes = {


### PR DESCRIPTION
> Using the <ToolbarTitle /> component and setting the text prop to anything other than a string throws errors - in my case Invalid prop Text of type Object

This PR resolves the issue.

However, a point for discussion:
- Should we change the ToolbarTitle component to make use of the `children` property in addition to the currently used `text` property?

This would allow users of the material-ui library to structure their code like this:
```
<ToolbarTitle>
  <span className="specialTitleComponent">Some title text...</span>
</ToolbarTitle>
```

As opposed to this:
```
<ToolbarTitle text={
  <span className="specialTitleComponent">Some title text...</span>
} />
```

Obviously some glue will be written to maintain backwards compatibility (use of the `text` property).

If the maintainers/community would prefer that, I am happy to make the necessary changes and update this PR.

Close #5175.