### PR TITLE
[Button] Flat button hover color matches text color (#6293)

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -28,11 +28,29 @@ export const styleSheet = createStyleSheet('MuiButton', (theme) => {
       transition: transitions.create(['background-color', 'box-shadow'], {
         duration: transitions.duration.short,
       }),
+      '&:before': {
+        backgroundColor: 'transparent',
+        borderRadius: 2,
+        content: '""',
+        display: 'block',
+        height: '100%',
+        opacity: 0.12,
+        position: 'absolute',
+        transition: transitions.create(['background-color'], {
+          duration: transitions.duration.short,
+        }),
+        width: '100%',
+      },
       '&:hover': {
-        textDecoration: 'none',
-        backgroundColor: palette.text.divider,
+        '&:before': {
+          textDecoration: 'none',
+          backgroundColor: 'currentColor',
+        },
         '&$disabled': {
           backgroundColor: 'transparent',
+          '&:before': {
+            backgroundColor: 'transparent',
+          },
         },
       },
     },
@@ -75,6 +93,9 @@ export const styleSheet = createStyleSheet('MuiButton', (theme) => {
           backgroundColor: palette.text.divider,
         },
       },
+      '&:before': {
+        display: 'none',
+      }
     },
     keyboardFocused: {},
     raisedPrimary: {

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -42,8 +42,9 @@ export const styleSheet = createStyleSheet('MuiButton', (theme) => {
         width: '100%',
       },
       '&:hover': {
+        textDecoration: 'none',
+        backgroundColor: 'transparent',
         '&:before': {
-          textDecoration: 'none',
           backgroundColor: 'currentColor',
         },
         '&$disabled': {

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -96,7 +96,7 @@ export const styleSheet = createStyleSheet('MuiButton', (theme) => {
       },
       '&:before': {
         display: 'none',
-      }
+      },
     },
     keyboardFocused: {},
     raisedPrimary: {


### PR DESCRIPTION
fix #6293
Now it looks on hover like this:
![image](https://cloud.githubusercontent.com/assets/4588778/23645585/924ecf94-0315-11e7-899c-2eb4cf0525f7.png)
