### PR TITLE
[TableBody] revert willReceiveProps to respect selected property on TableRow

### DIFF
--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -130,11 +130,11 @@ class TableBody extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.props.allRowsSelected && !nextProps.allRowsSelected) {
-      this.setState({
-        selectedRows: this.state.selectedRows.length > 0 ?
-          [this.state.selectedRows[this.state.selectedRows.length - 1]] : [],
-      });
-      // TODO: should else be conditional, not run any time props other than allRowsSelected change?
+      if (!nextProps.allRowsSelected) {
+        this.setState({
+          selectedRows: [],
+        });
+      } 
     } else {
       this.setState({
         selectedRows: this.calculatePreselectedRows(nextProps),

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -129,16 +129,16 @@ class TableBody extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.allRowsSelected !== nextProps.allRowsSelected) {
-      if (!nextProps.allRowsSelected) {
-        this.setState({
-          selectedRows: [],
-        });
-      } else {
-        this.setState({
-          selectedRows: this.calculatePreselectedRows(nextProps),
-        });
-      }
+    if (this.props.allRowsSelected && !nextProps.allRowsSelected) {
+      this.setState({
+        selectedRows: this.state.selectedRows.length > 0 ?
+          [this.state.selectedRows[this.state.selectedRows.length - 1]] : [],
+      });
+      // TODO: should else be conditional, not run any time props other than allRowsSelected change?
+    } else {
+      this.setState({
+        selectedRows: this.calculatePreselectedRows(nextProps),
+      });
     }
   }
 

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -2,6 +2,7 @@ import React, {Component, PropTypes} from 'react';
 import Checkbox from '../Checkbox';
 import TableRowColumn from './TableRowColumn';
 import ClickAwayListener from '../internal/ClickAwayListener';
+import shallowEqual from 'recompose/shallowEqual';
 
 class TableBody extends Component {
   static muiName = 'TableBody';
@@ -134,9 +135,13 @@ class TableBody extends Component {
         selectedRows: [],
       });
     } else {
-      this.setState({
-        selectedRows: this.calculatePreselectedRows(nextProps),
-      });
+      const oldRows = this.calculatePreselectedRows(this.props)
+      const nextRows = this.calculatePreselectedRows(nextProps)
+      if (!shallowEqual(oldRows, nextRows)) {
+        this.setState({
+          selectedRows: nextRows,
+        });
+      }
     }
   }
 

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -130,11 +130,9 @@ class TableBody extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.props.allRowsSelected && !nextProps.allRowsSelected) {
-      if (!nextProps.allRowsSelected) {
-        this.setState({
-          selectedRows: [],
-        });
-      } 
+      this.setState({
+        selectedRows: [],
+      });
     } else {
       this.setState({
         selectedRows: this.calculatePreselectedRows(nextProps),

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -135,8 +135,8 @@ class TableBody extends Component {
         selectedRows: [],
       });
     } else {
-      const oldRows = this.calculatePreselectedRows(this.props)
-      const nextRows = this.calculatePreselectedRows(nextProps)
+      const oldRows = this.calculatePreselectedRows(this.props);
+      const nextRows = this.calculatePreselectedRows(nextProps);
       if (!shallowEqual(oldRows, nextRows)) {
         this.setState({
           selectedRows: nextRows,

--- a/test/integration/Table/MultiSelectTable.js
+++ b/test/integration/Table/MultiSelectTable.js
@@ -19,6 +19,7 @@ const tableData = [
   },
   {
     name: 'Olivier',
+    selected: true,
   },
 ];
 

--- a/test/integration/Table/MultiSelectTable.js
+++ b/test/integration/Table/MultiSelectTable.js
@@ -38,4 +38,8 @@ function TableMutliSelect(props) {
   );
 }
 
+TableMutliSelect.propTypes = {
+  data: React.PropTypes.array,
+};
+
 export default TableMutliSelect;

--- a/test/integration/Table/MultiSelectTable.js
+++ b/test/integration/Table/MultiSelectTable.js
@@ -19,7 +19,6 @@ const tableData = [
   },
   {
     name: 'Olivier',
-    selected: true,
   },
 ];
 

--- a/test/integration/Table/MultiSelectTable.js
+++ b/test/integration/Table/MultiSelectTable.js
@@ -8,7 +8,7 @@ import {
   TableRowColumn,
 } from 'src/Table';
 
-function TableMutliSelect(props) {
+function TableMultiSelect(props) {
   return (
     <Table
       selectable={true}
@@ -38,8 +38,8 @@ function TableMutliSelect(props) {
   );
 }
 
-TableMutliSelect.propTypes = {
+TableMultiSelect.propTypes = {
   data: React.PropTypes.array,
 };
 
-export default TableMutliSelect;
+export default TableMultiSelect;

--- a/test/integration/Table/MultiSelectTable.js
+++ b/test/integration/Table/MultiSelectTable.js
@@ -8,21 +8,7 @@ import {
   TableRowColumn,
 } from 'src/Table';
 
-const tableData = [
-  {
-    name: 'John Smith',
-    selected: true,
-  },
-  {
-    name: 'Randal White',
-    selected: true,
-  },
-  {
-    name: 'Olivier',
-  },
-];
-
-function TableMutliSelect() {
+function TableMutliSelect(props) {
   return (
     <Table
       selectable={true}
@@ -40,7 +26,7 @@ function TableMutliSelect() {
         </TableRow>
       </TableHeader>
       <TableBody displayRowCheckbox={true}>
-        {tableData.map( (row, index) => (
+        {props.data.map( (row, index) => (
           <TableRow key={index} selected={row.selected}>
             <TableRowColumn>
               {row.name}

--- a/test/integration/Table/MultiSelectTable.spec.js
+++ b/test/integration/Table/MultiSelectTable.spec.js
@@ -42,7 +42,7 @@ describe('<MultiSelectTable />', () => {
     ];
 
     const wrapper = mountWithContext(
-      <MultiSelectTable data={tableData}/>
+      <MultiSelectTable data={tableData} />
     );
 
     assert.deepEqual(
@@ -99,7 +99,7 @@ describe('<MultiSelectTable />', () => {
       'should be invariant to update'
     );
 
-    wrapper.setProps({data: tableData2})
+    wrapper.setProps({data: tableData2});
     assert.deepEqual(
       wrapper.find('Checkbox').map((checkbox) => checkbox.props().checked),
       [
@@ -110,6 +110,5 @@ describe('<MultiSelectTable />', () => {
       ],
       'should be update if selected props change'
     );
-
   });
 });

--- a/test/integration/Table/MultiSelectTable.spec.js
+++ b/test/integration/Table/MultiSelectTable.spec.js
@@ -13,8 +13,36 @@ describe('<MultiSelectTable />', () => {
       childContextTypes: {muiTheme: React.PropTypes.object},
     });
 
+    const tableData = [
+      {
+        name: 'John Smith',
+        selected: true,
+      },
+      {
+        name: 'Randal White',
+        selected: true,
+      },
+      {
+        name: 'Olivier',
+      },
+    ];
+
+    const tableData2 = [
+      {
+        name: 'John Smith',
+        selected: false,
+      },
+      {
+        name: 'Randal White',
+        selected: true,
+      },
+      {
+        name: 'Olivier',
+      },
+    ];
+
     const wrapper = mountWithContext(
-      <MultiSelectTable />
+      <MultiSelectTable data={tableData}/>
     );
 
     assert.deepEqual(
@@ -70,5 +98,18 @@ describe('<MultiSelectTable />', () => {
       ],
       'should be invariant to update'
     );
+
+    wrapper.setProps({data: tableData2})
+    assert.deepEqual(
+      wrapper.find('Checkbox').map((checkbox) => checkbox.props().checked),
+      [
+        false,
+        false,
+        true,
+        false,
+      ],
+      'should be update if selected props change'
+    );
+
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

This PR regards issue #6006. TableRow does not respect `selected` property, making it impossible to programmatically select a row. The code in this PR is the same code that was present as late as version 0.16.6, and resolves the issue.

N.B. `Props` where `props` are due: @mquandvr found the fix, but I decided to make the PR, because I am in need of this feature working. 