### PR TITLE
[TextField] (multiline) Fixed wrapped hintText rendering outside of container

### DIFF
--- a/src/TextField/EnhancedTextarea.js
+++ b/src/TextField/EnhancedTextarea.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, {Component, PropTypes} from 'react';
 import EventListener from 'react-event-listener';
 
 const rowsHeight = 24;

--- a/src/TextField/EnhancedTextarea.js
+++ b/src/TextField/EnhancedTextarea.js
@@ -91,11 +91,10 @@ class EnhancedTextarea extends Component {
 
   syncHeightWithShadow(newValue, event) {
     const shadow = this.refs.shadow;
+    const displayText = this.props.hintText && (newValue === '' || newValue === undefined || newValue === null) ? this.props.hintText : newValue;
 
-    if (newValue !== undefined) {
-      shadow.value = newValue;
-    } else if (this.props.hintText !== undefined) {
-      shadow.value = this.props.hintText;
+    if (displayText !== undefined) {
+      shadow.value = displayText;
     }
 
     let newHeight = shadow.scrollHeight;

--- a/src/TextField/EnhancedTextarea.js
+++ b/src/TextField/EnhancedTextarea.js
@@ -91,7 +91,8 @@ class EnhancedTextarea extends Component {
 
   syncHeightWithShadow(newValue, event) {
     const shadow = this.refs.shadow;
-    const displayText = this.props.hintText && (newValue === '' || newValue === undefined || newValue === null) ? this.props.hintText : newValue;
+    const displayText = this.props.hintText && (newValue === '' || newValue === undefined || newValue === null) ?
+      this.props.hintText : newValue;
 
     if (displayText !== undefined) {
       shadow.value = displayText;

--- a/src/TextField/EnhancedTextarea.js
+++ b/src/TextField/EnhancedTextarea.js
@@ -141,6 +141,7 @@ class EnhancedTextarea extends Component {
       rowsMax, // eslint-disable-line no-unused-vars
       shadowStyle,
       style,
+      hintText, // eslint-disable-line no-unused-vars
       textareaStyle,
       valueLink, // eslint-disable-line no-unused-vars
       ...other

--- a/src/TextField/EnhancedTextarea.js
+++ b/src/TextField/EnhancedTextarea.js
@@ -1,4 +1,4 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component, PropTypes } from 'react';
 import EventListener from 'react-event-listener';
 
 const rowsHeight = 24;
@@ -33,6 +33,7 @@ class EnhancedTextarea extends Component {
   static propTypes = {
     defaultValue: PropTypes.any,
     disabled: PropTypes.bool,
+    hintText: PropTypes.string,
     onChange: PropTypes.func,
     onHeightChange: PropTypes.func,
     rows: PropTypes.number,
@@ -93,6 +94,8 @@ class EnhancedTextarea extends Component {
 
     if (newValue !== undefined) {
       shadow.value = newValue;
+    } else if (this.props.hintText !== undefined) {
+      shadow.value = this.props.hintText;
     }
 
     let newHeight = shadow.scrollHeight;

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -462,6 +462,7 @@ class TextField extends Component {
           textareaStyle={Object.assign(styles.textarea, styles.inputNative, textareaStyle)}
           rows={rows}
           rowsMax={rowsMax}
+          hintText={hintText}
           {...other}
           {...inputProps}
           onHeightChange={this.handleHeightChange}


### PR DESCRIPTION
When using a TextField with the multiline option, if the hintText occupies more than one line it renders outside of the container. The container does not take into account the hintText when calculating it's height.

![Bug](https://cloud.githubusercontent.com/assets/3081676/14460261/379b84fc-0082-11e6-854e-cdb0a0b55e6d.png)