### PR TITLE
[Table] Fixed paddings according to guidelines

### DIFF
--- a/docs/site/src/demos/tables/EnhancedTable.js
+++ b/docs/site/src/demos/tables/EnhancedTable.js
@@ -84,7 +84,7 @@ class EnhancedTableHead extends Component {
 
 const toolbarStyleSheet = createStyleSheet('EnhancedTableToolbar', (theme) => {
   return {
-    root: { paddingRight: 12 },
+    root: { paddingRight: 2 },
     highlight: (
       theme.palette.type === 'light' ? {
         color: theme.palette.accent[800],

--- a/src/Table/TableCell.js
+++ b/src/Table/TableCell.js
@@ -32,7 +32,7 @@ export const styleSheet = createStyleSheet('MuiTableCell', (theme) => {
     },
     checkbox: {
       paddingLeft: 12,
-      paddingRight: 0,
+      paddingRight: 12,
     },
     footer: {},
   };


### PR DESCRIPTION
Checkbox column should have 24px padding next to text column.
![example1](https://storage.googleapis.com/material-design/publish/material_v_10/assets/0B3mOPoJlxiFhckNvQzhHaWI5Ulk/components_datatables_specs_02_horizontalspacing.png)

Toolbar should have 14px padding to icon on the right side
![example2](https://storage.googleapis.com/material-design/publish/material_v_10/assets/0B3mOPoJlxiFhTV91bEF3cWl5eG8/components_datatables_specs_01_horizontalspacing.png)
