### PR TITLE
[Layout] Revise default value for aligns-items

### DIFF
--- a/src/Layout/Layout.js
+++ b/src/Layout/Layout.js
@@ -108,11 +108,11 @@ export const styleSheet = createStyleSheet('MuiLayout', (theme) => {
     'align-xs-center': {
       alignItems: 'center',
     },
+    'align-xs-flex-start': {
+      alignItems: 'flex-start',
+    },
     'align-xs-flex-end': {
       alignItems: 'flex-end',
-    },
-    'align-xs-stretch': {
-      alignItems: 'stretch',
     },
     'justify-xs-center': {
       justifyContent: 'center',
@@ -289,7 +289,7 @@ Layout.defaultProps = {
   component: 'div',
   container: false,
   item: false,
-  align: 'flex-start',
+  align: 'stretch',
   direction: 'row',
   gutter: 16,
   justify: 'flex-start',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

It was caused to the fact that `stretch` is the default value for `align-items` 
source:  https://www.w3schools.com/cssref/css3_pr_align-items.asp

Close #6333
