### PR TITLE
[AppBar] Add test for iconElementRight gets FlatButton

### DIFF
--- a/src/AppBar/AppBar.spec.js
+++ b/src/AppBar/AppBar.spec.js
@@ -104,7 +104,7 @@ describe('<AppBar />', () => {
 
     it('renders the FlatButton with a correct style', () => {
       const wrapper = shallowWithContext(
-        <AppBar iconElementRight={<FlatButton><div /></FlatButton>}/>
+        <AppBar iconElementRight={<FlatButton><div /></FlatButton>} />
       );
 
       assert.strictEqual(
@@ -114,7 +114,6 @@ describe('<AppBar />', () => {
         'should add some properties to the style'
       );
     });
-
   });
 
   describe('onLeftIconButtonTouchTap', () => {

--- a/src/AppBar/AppBar.spec.js
+++ b/src/AppBar/AppBar.spec.js
@@ -6,6 +6,7 @@ import {assert} from 'chai';
 import AppBar, {getStyles} from './AppBar';
 import getMuiTheme from '../styles/getMuiTheme';
 import IconButton from '../IconButton';
+import FlatButton from '../FlatButton';
 
 describe('<AppBar />', () => {
   const muiTheme = getMuiTheme();
@@ -92,12 +93,28 @@ describe('<AppBar />', () => {
     });
   });
 
-  it('renders iconElementRight', () => {
-    const wrapper = shallowWithContext(
-      <AppBar iconElementRight={<span className="icon" />} />
-    );
+  describe('iconElementRight', () => {
+    it('renders the node', () => {
+      const wrapper = shallowWithContext(
+        <AppBar iconElementRight={<span className="icon" />} />
+      );
 
-    assert.strictEqual(wrapper.find('.icon').length, 1, 'should contain iconElementRight');
+      assert.strictEqual(wrapper.find('.icon').length, 1, 'should contain iconElementRight');
+    });
+
+    it('renders the FlatButton with a correct style', () => {
+      const wrapper = shallowWithContext(
+        <AppBar iconElementRight={<FlatButton><div /></FlatButton>}/>
+      );
+
+      assert.strictEqual(
+
+        Object.keys(wrapper.find(FlatButton).get(0).props.style).length > 1,
+        true,
+        'should add some properties to the style'
+      );
+    });
+
   });
 
   describe('onLeftIconButtonTouchTap', () => {


### PR DESCRIPTION
Test checks that AppBar sets the style correctly

Currently the AppBar tests do not test the case of when AppBar receives FlatButton as the iconElementRight prop. This is important as the style is set differently in this case. Added a test that tests this case.

This does not solve #5753.

