### PR TITLE
[ListItem] Add isKeyboardFocused prop

### DIFF
--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -34,9 +34,12 @@ function getStyles(props, context, state) {
   const twoLine = secondaryText && secondaryTextLines === 1;
   const threeLine = secondaryText && secondaryTextLines > 1;
 
+  const isKeyboardFocused =
+    (props.isKeyboardFocused !== undefined ? props : state).isKeyboardFocused;
+
   const styles = {
     root: {
-      backgroundColor: (state.isKeyboardFocused || state.hovered) &&
+      backgroundColor: (isKeyboardFocused || state.hovered) &&
       !state.rightIconButtonHovered &&
       !state.rightIconButtonKeyboardFocused ? hoverColor : null,
       color: textColor,
@@ -192,6 +195,14 @@ class ListItem extends Component {
      * This is useful if there is no left avatar or left icon.
      */
     insetChildren: PropTypes.bool,
+    /**
+     * Use to control if the list item should render as keyboard focused.  If
+     * undefined (default), this will be automatically managed.  If provided,
+     * it will change the components style.  Note that this will not change the
+     * actual focus - and should only be used when you want to simulate
+     * keyboard focus (eg. in a rich text input autocomplete).
+     */
+    isKeyboardFocused: PropTypes.bool,
     /**
      * This is the `Avatar` element to be displayed on the left side.
      */
@@ -546,6 +557,7 @@ class ListItem extends Component {
       nestedLevel,
       nestedListStyle,
       onKeyboardFocus, // eslint-disable-line no-unused-vars
+      isKeyboardFocused, // eslint-disable-line no-unused-vars
       onMouseEnter, // eslint-disable-line no-unused-vars
       onMouseLeave, // eslint-disable-line no-unused-vars
       onNestedListToggle, // eslint-disable-line no-unused-vars

--- a/src/List/ListItem.spec.js
+++ b/src/List/ListItem.spec.js
@@ -177,12 +177,20 @@ describe('<ListItem />', () => {
   });
 
   describe('prop: hoverColor', () => {
+    const testColor = '#ededed';
+
     it('should use a background color on hover if hoverColor is specified', () => {
-      const testColor = '#ededed';
       const wrapper = shallowWithContext(
         <ListItem hoverColor={testColor} />
       );
       wrapper.find(EnhancedButton).simulate('mouseEnter');
+      assert.strictEqual(wrapper.find(EnhancedButton).props().style.backgroundColor, testColor);
+    });
+
+    it('should use a background color if isKeyboardFocused is true', () => {
+      const wrapper = shallowWithContext(
+        <ListItem hoverColor={testColor} isKeyboardFocused={true} />
+      );
       assert.strictEqual(wrapper.find(EnhancedButton).props().style.backgroundColor, testColor);
     });
   });


### PR DESCRIPTION
This allows the user to manually opt for the ListItem to use the
keyboard focused styling.  This is very useful for in rich text editors,
where you often want to give the appearance that something is keyboard
focused when the focus is kept in the rich text editor.

This prop allows for that to be achieved.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.  - not sure if this warrants a test case.   If you feel it does, just tell me.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

