### PR TITLE
[DropDownMenu] Expose targetOrigin and anchorOrigin properties

### DIFF
--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -9,6 +9,7 @@ import PopoverAnimationVertical from '../Popover/PopoverAnimationVertical';
 import keycode from 'keycode';
 import Events from '../utils/events';
 import IconButton from '../IconButton';
+import propTypes from '../utils/propTypes';
 
 
 function getStyles(props, context) {
@@ -79,6 +80,14 @@ class DropDownMenu extends Component {
   // other user components, so it will give full access to its js styles rather
   // than just the parent.
   static propTypes = {
+    /**
+     * This is the point on the anchor where the popover's
+     * `targetOrigin` will attach to.
+     * Options:
+     * vertical: [top, center, bottom]
+     * horizontal: [left, middle, right].
+     */
+    anchorOrigin: propTypes.origin,
     /**
      * If true, the popover will apply transitions when
      * it gets added to the DOM.
@@ -177,6 +186,14 @@ class DropDownMenu extends Component {
      */
     style: PropTypes.object,
     /**
+     * This is the point on the popover which will attach to
+     * the anchor's origin.
+     * Options:
+     * vertical: [top, center, bottom]
+     * horizontal: [left, middle, right].
+     */
+    targetOrigin: propTypes.origin,
+    /**
      * Overrides the inline-styles of the underline.
      */
     underlineStyle: PropTypes.object,
@@ -186,22 +203,6 @@ class DropDownMenu extends Component {
      * If provided, the menu will be a controlled component.
      */
     value: PropTypes.any,
-    /**
-     * This is the point on the anchor where the popover's
-     * `targetOrigin` will attach to.
-     * Options:
-     * vertical: [top, center, bottom]
-     * horizontal: [left, middle, right].
-     */
-    anchorOrigin: propTypes.origin,
-    /**
-     * This is the point on the popover which will attach to
-     * the anchor's origin.
-     * Options:
-     * vertical: [top, center, bottom]
-     * horizontal: [left, middle, right].
-     */
-    targetOrigin: propTypes.origin,
   };
 
   static defaultProps = {
@@ -212,6 +213,10 @@ class DropDownMenu extends Component {
     openImmediately: false,
     maxHeight: 500,
     multiple: false,
+    anchorOrigin: {
+      vertical: 'bottom',
+      horizontal: 'left',
+    },
   };
 
   static contextTypes = {

--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -10,10 +10,6 @@ import keycode from 'keycode';
 import Events from '../utils/events';
 import IconButton from '../IconButton';
 
-const anchorOrigin = {
-  vertical: 'top',
-  horizontal: 'left',
-};
 
 function getStyles(props, context) {
   const {disabled} = props;
@@ -190,6 +186,22 @@ class DropDownMenu extends Component {
      * If provided, the menu will be a controlled component.
      */
     value: PropTypes.any,
+    /**
+     * This is the point on the anchor where the popover's
+     * `targetOrigin` will attach to.
+     * Options:
+     * vertical: [top, center, bottom]
+     * horizontal: [left, middle, right].
+     */
+    anchorOrigin: propTypes.origin,
+    /**
+     * This is the point on the popover which will attach to
+     * the anchor's origin.
+     * Options:
+     * vertical: [top, center, bottom]
+     * horizontal: [left, middle, right].
+     */
+    targetOrigin: propTypes.origin,
   };
 
   static defaultProps = {
@@ -358,6 +370,8 @@ class DropDownMenu extends Component {
       underlineStyle,
       value,
       iconButton,
+      anchorOrigin,
+      targetOrigin,
       ...other
     } = this.props;
     const {
@@ -437,6 +451,7 @@ class DropDownMenu extends Component {
         </ClearFix>
         <Popover
           anchorOrigin={anchorOrigin}
+          targetOrigin={targetOrigin}
           anchorEl={anchorEl}
           animation={animation || PopoverAnimationVertical}
           open={open}

--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -81,7 +81,7 @@ class DropDownMenu extends Component {
   // than just the parent.
   static propTypes = {
     /**
-     * This is the point on the anchor where the popover's
+     * This is the point on the anchor that the popover's
      * `targetOrigin` will attach to.
      * Options:
      * vertical: [top, center, bottom]


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

add DorpDownMenu anchorOrigin and targetOrigin props
