### PR TITLE
[List] Fix ListItemIcon default color

### DIFF
--- a/docs/site/src/demos/lists/SwitchListSecondary.js
+++ b/docs/site/src/demos/lists/SwitchListSecondary.js
@@ -6,6 +6,7 @@ import customPropTypes from 'material-ui/utils/customPropTypes';
 import {
   List,
   ListItem,
+  ListItemIcon,
   ListItemText,
   ListItemSecondaryAction,
   ListSubheader,
@@ -54,7 +55,9 @@ export default class SwitchListSecondary extends Component {
       <div className={classes.root}>
         <List subheader={<ListSubheader>Settings</ListSubheader>}>
           <ListItem>
-            <WifiIcon />
+            <ListItemIcon>
+              <WifiIcon />
+            </ListItemIcon>
             <ListItemText primary="Wi-Fi" />
             <ListItemSecondaryAction>
               <Switch

--- a/src/List/ListItemIcon.js
+++ b/src/List/ListItemIcon.js
@@ -5,12 +5,13 @@ import classNames from 'classnames';
 import { createStyleSheet } from 'jss-theme-reactor';
 import customPropTypes from '../utils/customPropTypes';
 
-export const styleSheet = createStyleSheet('MuiListItemIcon', () => {
+export const styleSheet = createStyleSheet('MuiListItemIcon', (theme) => {
   return {
     root: {
       height: 24,
       marginRight: 16,
       width: 24,
+      color: theme.palette.action.active,
     },
   };
 });

--- a/src/styles/MuiThemeProvider.js
+++ b/src/styles/MuiThemeProvider.js
@@ -64,6 +64,7 @@ export const MUI_SHEET_ORDER = [
   'MuiListItemText',
   'MuiListItemSecondaryAction',
   'MuiListItemAvatar',
+  'MuiListItemIcon',
   'MuiListSubheader',
   'MuiList',
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

The PR sets the default color for `ListItemIcon`, and adds the stylesheet to the `SHEET_ORDER` to user stylesheets can override the icon color.
