### PR TITLE
[Layout] Backport a fix at Doctolib for Chrome

### DIFF
--- a/src/Layout/Layout.js
+++ b/src/Layout/Layout.js
@@ -66,6 +66,7 @@ function generateGutter(theme, breakpoint) {
 
     styles[`gutter-${breakpoint}-${gutter}`] = {
       margin: -gutter / 2,
+      width: `calc(100% + ${gutter}px)`,
       '& > $typeItem': {
         padding: gutter / 2,
       },
@@ -88,6 +89,7 @@ export const styleSheet = createStyleSheet('MuiLayout', (theme) => {
       boxSizing: 'border-box',
       display: 'flex',
       flexWrap: 'wrap',
+      width: '100%',
     },
     typeItem: {
       boxSizing: 'border-box',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Chrome is having issue computing the right width when text measurement is involved.
The fix was originally made by @neoziro.