### PR TITLE
[style] Expose createStyleSheet to reduce boilerplate

### DIFF
--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -1,3 +1,5 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 
 export MuiThemeProvider from './MuiThemeProvider';
+export { createStyleSheet } from 'jss-theme-reactor';
+export withStyles from './withStyles';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

It should save me some boilerplate when styling a new component on my app.
#### Before
```jsx
import { createStyleSheet } from 'jss-theme-reactor';
import withStyles from 'material-ui/styles/withStyles';

const styleSheet = createStyleSheet('MyComponent', () => ({
});

export default withStyles(styleSheet)(MyComponent);
```

#### After
```jsx
import { withStyles, createStyleSheet } from 'material-ui/styles';

const styleSheet = createStyleSheet('MyComponent', () => ({
});

export default withStyles(styleSheet)(MyComponent);
```