### PR TITLE
[Drawer] Remove unreachable code in `getSlideDirection`

### DIFF
--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -16,9 +16,9 @@ function getSlideDirection(anchor) {
     return 'left';
   } else if (anchor === 'top') {
     return 'down';
-  } else if (anchor === 'bottom') {
-    return 'up';
   }
+  //(anchor === 'bottom')
+  return 'up';
 }
 
 export const styleSheet = createStyleSheet('MuiDrawer', (theme) => {

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -19,8 +19,6 @@ function getSlideDirection(anchor) {
   } else if (anchor === 'bottom') {
     return 'up';
   }
-
-  return 'left';
 }
 
 export const styleSheet = createStyleSheet('MuiDrawer', (theme) => {

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -17,7 +17,7 @@ function getSlideDirection(anchor) {
   } else if (anchor === 'top') {
     return 'down';
   }
-  //(anchor === 'bottom')
+  // (anchor === 'bottom')
   return 'up';
 }
 


### PR DESCRIPTION
The function getSlideDirection gets one parameter. Its branches cover all of the options for an anchor prop for Drawer. Yet it still has a default return line which is unreachable because of the PropType set for the anchor prop.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

