### PR TITLE
[FormGroup] Add spec

### DIFF
--- a/src/Form/FormGroup.spec.js
+++ b/src/Form/FormGroup.spec.js
@@ -26,7 +26,7 @@ describe('<FormGroup />', () => {
 
   it('should render a div with a div child', () => {
     const wrapper = shallow(
-      <FormGroup><div className="woof"/></FormGroup>,
+      <FormGroup><div className="woof" /></FormGroup>,
     );
 
     assert.strictEqual(wrapper.children('span').length, 0);

--- a/src/Form/FormGroup.spec.js
+++ b/src/Form/FormGroup.spec.js
@@ -26,7 +26,7 @@ describe('<FormGroup />', () => {
 
   it('should render a div with a div child', () => {
     const wrapper = shallow(
-      <FormGroup><div className="woof"></div></FormGroup>,
+      <FormGroup><div className="woof"/></FormGroup>,
     );
 
     assert.strictEqual(wrapper.children('span').length, 0);

--- a/src/Form/FormGroup.spec.js
+++ b/src/Form/FormGroup.spec.js
@@ -1,0 +1,36 @@
+// @flow weak
+
+import React from 'react';
+import { assert } from 'chai';
+import { createShallow } from 'src/test-utils';
+import FormGroup, { styleSheet } from './FormGroup';
+
+describe('<FormGroup />', () => {
+  let shallow;
+  let classes;
+
+  before(() => {
+    shallow = createShallow();
+    classes = shallow.context.styleManager.render(styleSheet);
+  });
+
+  it('should render a div with the root and user classes', () => {
+    const wrapper = shallow(
+      <FormGroup className="woof" />,
+    );
+
+    assert.strictEqual(wrapper.is('div'), true);
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    assert.strictEqual(wrapper.hasClass('woof'), true);
+  });
+
+  it('should render a div with a div child', () => {
+    const wrapper = shallow(
+      <FormGroup><div className="woof"></div></FormGroup>,
+    );
+
+    assert.strictEqual(wrapper.children('span').length, 0);
+    assert.strictEqual(wrapper.children('div').length, 1);
+    assert.strictEqual(wrapper.children('div').first().hasClass('woof'), true);
+  });
+});


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Kind of simple testing, but FormGroup is used in `InteractiveList`, `Checkboxes` and `RadiogGroup` its better if its spec-ed, and not just left there.

