### PR TITLE
[FormControl] Add tests for internal functions

### DIFF
--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -68,6 +68,8 @@ export default class FormControl extends Component {
         required,
         onDirty: this.handleDirty,
         onClean: this.handleClean,
+        onFocus: this.handleFocus,
+        onBlur: this.handleBlur
       },
     };
   }

--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -69,7 +69,7 @@ export default class FormControl extends Component {
         onDirty: this.handleDirty,
         onClean: this.handleClean,
         onFocus: this.handleFocus,
-        onBlur: this.handleBlur
+        onBlur: this.handleBlur,
       },
     };
   }

--- a/src/Form/FormControl.spec.js
+++ b/src/Form/FormControl.spec.js
@@ -112,6 +112,8 @@ describe('<FormControl />', () => {
           muiFormControlContext.onDirty();
           loadChildContext();
           assert.strictEqual(muiFormControlContext.dirty, true);
+          muiFormControlContext.onDirty();
+          assert.strictEqual(muiFormControlContext.dirty, true);
         });
       });
 
@@ -123,6 +125,30 @@ describe('<FormControl />', () => {
           muiFormControlContext.onClean();
           loadChildContext();
           assert.strictEqual(muiFormControlContext.dirty, false);
+          muiFormControlContext.onClean();
+          assert.strictEqual(muiFormControlContext.dirty, false);
+        });
+      });
+
+      describe('handleFocus', () => {
+        it('should set the focused state', () => {
+          assert.strictEqual(wrapper.state('focused'), false);
+          muiFormControlContext.onFocus();
+          assert.strictEqual(wrapper.state('focused'), true);
+          muiFormControlContext.onFocus();
+          assert.strictEqual(wrapper.state('focused'), true);
+        });
+      });
+
+      describe('handleBlur', () => {
+        it('should clear the focused state', () => {
+          assert.strictEqual(wrapper.state('focused'), false);
+          muiFormControlContext.onFocus();
+          assert.strictEqual(wrapper.state('focused'), true);
+          muiFormControlContext.onBlur();
+          assert.strictEqual(wrapper.state('focused'), false);
+          muiFormControlContext.onBlur();
+          assert.strictEqual(wrapper.state('focused'), false);
         });
       });
     });


### PR DESCRIPTION
- blur
- focus
- onDirty when dirty is set to true

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

