### PR TITLE
[EnhancedTextArea] Fixes height bug for IE11

### DIFF
--- a/src/TextField/EnhancedTextarea.js
+++ b/src/TextField/EnhancedTextarea.js
@@ -24,7 +24,7 @@ function getStyles(props, context, state) {
       // Visibility needed to hide the extra text area on ipads
       visibility: 'hidden',
       position: 'absolute',
-      height: 'initial',
+      height: 'auto',
     },
   };
 }


### PR DESCRIPTION
`initial` is [not supported in Internet Explorer](https://developer.mozilla.org/en-US/docs/Web/CSS/initial), so it's been changed to `auto` as [suggested on StackOverflow](http://stackoverflow.com/questions/20823105/use-initial-width-for-element-not-working-in-ie). This fixes a bug when calculating the height for components that use it.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] ~~PR has tests / docs demo~~ **(n/a)**, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

