### PR TITLE
[DatePicker] allow year selecton to be open before month/day selection

### DIFF
--- a/docs/src/app/components/pages/components/DatePicker/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/DatePicker/ExampleSimple.js
@@ -4,7 +4,7 @@ import DatePicker from 'material-ui/DatePicker';
 /**
  * The Date Picker defaults to a portrait dialog. The `mode` property can be set to `landscape`.
  * You can also disable the Dialog passing `true` to the `disabled` property.
- * To display the year selection first, set the `initialView` property to "year".
+ * To display the year selection first, set the `openToYearSelection` property to `true`.
  */
 const DatePickerExampleSimple = () => (
   <div>

--- a/docs/src/app/components/pages/components/DatePicker/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/DatePicker/ExampleSimple.js
@@ -11,7 +11,7 @@ const DatePickerExampleSimple = () => (
     <DatePicker hintText="Portrait Dialog" />
     <DatePicker hintText="Landscape Dialog" mode="landscape" />
     <DatePicker hintText="Dialog Disabled" disabled={true} />
-    <DatePicker hintText="Open to Year" initialView="year" />
+    <DatePicker hintText="Open to Year" openToYearSelection={true} />
   </div>
 );
 

--- a/docs/src/app/components/pages/components/DatePicker/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/DatePicker/ExampleSimple.js
@@ -4,12 +4,14 @@ import DatePicker from 'material-ui/DatePicker';
 /**
  * The Date Picker defaults to a portrait dialog. The `mode` property can be set to `landscape`.
  * You can also disable the Dialog passing `true` to the `disabled` property.
+ * To display the year selection first, set the `initialView` property to "year".
  */
 const DatePickerExampleSimple = () => (
   <div>
     <DatePicker hintText="Portrait Dialog" />
     <DatePicker hintText="Landscape Dialog" mode="landscape" />
     <DatePicker hintText="Dialog Disabled" disabled={true} />
+    <DatePicker hintText="Open to Year" initialView="year" />
   </div>
 );
 

--- a/src/DatePicker/Calendar.js
+++ b/src/DatePicker/Calendar.js
@@ -33,7 +33,6 @@ class Calendar extends Component {
     firstDayOfWeek: PropTypes.number,
     hideCalendarDate: PropTypes.bool,
     initialDate: PropTypes.object,
-    initialView: PropTypes.oneOf(['monthDay', 'year']),
     locale: PropTypes.string.isRequired,
     maxDate: PropTypes.object,
     minDate: PropTypes.object,
@@ -43,6 +42,7 @@ class Calendar extends Component {
     onTouchTapDay: PropTypes.func,
     onTouchTapOk: PropTypes.func,
     open: PropTypes.bool,
+    openToYearSelection: PropTypes.bool,
     shouldDisableDate: PropTypes.func,
   };
 
@@ -53,7 +53,7 @@ class Calendar extends Component {
     locale: 'en-US',
     minDate: addYears(new Date(), -100),
     maxDate: addYears(new Date(), 100),
-    initialView: 'monthDay',
+    openToYearSelection: false,
   };
 
   static contextTypes = {
@@ -72,7 +72,7 @@ class Calendar extends Component {
     this.setState({
       displayDate: getFirstDayOfMonth(this.props.initialDate),
       selectedDate: this.props.initialDate,
-      displayMonthDay: this.props.initialView === 'monthDay',
+      displayMonthDay: !this.props.openToYearSelection,
     });
   }
 

--- a/src/DatePicker/Calendar.js
+++ b/src/DatePicker/Calendar.js
@@ -43,6 +43,7 @@ class Calendar extends Component {
     onTouchTapOk: PropTypes.func,
     open: PropTypes.bool,
     shouldDisableDate: PropTypes.func,
+    initialView: PropTypes.oneOf(['monthDay', 'year']),
   };
 
   static defaultProps = {
@@ -52,6 +53,7 @@ class Calendar extends Component {
     locale: 'en-US',
     minDate: addYears(new Date(), -100),
     maxDate: addYears(new Date(), 100),
+    initialView: 'monthDay',
   };
 
   static contextTypes = {
@@ -60,7 +62,7 @@ class Calendar extends Component {
 
   state = {
     displayDate: undefined,
-    displayMonthDay: true,
+    displayMonthDay: undefined,
     selectedDate: undefined,
     transitionDirection: 'left',
     transitionEnter: true,
@@ -70,6 +72,7 @@ class Calendar extends Component {
     this.setState({
       displayDate: getFirstDayOfMonth(this.props.initialDate),
       selectedDate: this.props.initialDate,
+      displayMonthDay: this.props.initialView === 'monthDay',
     });
   }
 

--- a/src/DatePicker/Calendar.js
+++ b/src/DatePicker/Calendar.js
@@ -33,6 +33,7 @@ class Calendar extends Component {
     firstDayOfWeek: PropTypes.number,
     hideCalendarDate: PropTypes.bool,
     initialDate: PropTypes.object,
+    initialView: PropTypes.oneOf(['monthDay', 'year']),
     locale: PropTypes.string.isRequired,
     maxDate: PropTypes.object,
     minDate: PropTypes.object,
@@ -43,7 +44,6 @@ class Calendar extends Component {
     onTouchTapOk: PropTypes.func,
     open: PropTypes.bool,
     shouldDisableDate: PropTypes.func,
-    initialView: PropTypes.oneOf(['monthDay', 'year']),
   };
 
   static defaultProps = {

--- a/src/DatePicker/Calendar.spec.js
+++ b/src/DatePicker/Calendar.spec.js
@@ -238,12 +238,12 @@ describe('<Calendar />', () => {
       assert.strictEqual(wrapper.find(CalendarMonth).length, 1, 'should have the calendar month select');
     });
 
-    it('should display the year pick view when initialView is set to year', () => {
+    it('should display the year selection view when openToYearSelection is true', () => {
       const wrapper = shallowWithContext(
         <Calendar
           DateTimeFormat={dateTimeFormat}
           locale="en-US"
-          initialView="year"
+          openToYearSelection={true}
         />
       );
 

--- a/src/DatePicker/Calendar.spec.js
+++ b/src/DatePicker/Calendar.spec.js
@@ -3,6 +3,8 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import {assert} from 'chai';
 import Calendar from './Calendar';
+import CalendarMonth from './CalendarMonth';
+import CalendarYear from './CalendarYear';
 import DateDisplay from './DateDisplay';
 import {addMonths, dateTimeFormat} from './dateUtils';
 import getMuiTheme from '../styles/getMuiTheme';
@@ -221,6 +223,30 @@ describe('<Calendar />', () => {
 
       assert.strictEqual(wrapper.find(DateDisplay).length, 0, 'should hide date display');
       assert.strictEqual(wrapper.props().style.width, 310, 'should not allow space for date display');
+    });
+  });
+
+  describe('Initial State', () => {
+    it('should display the month day pick view by default', () => {
+      const wrapper = shallowWithContext(
+        <Calendar
+          DateTimeFormat={dateTimeFormat}
+          locale="en-US"
+        />
+      );
+
+      assert.strictEqual(wrapper.find(CalendarMonth).length, 1, 'should have the calendar month select');
+    });
+    it('should display the year pick view when initialView is set to year', () => {
+      const wrapper = shallowWithContext(
+        <Calendar
+          DateTimeFormat={dateTimeFormat}
+          locale="en-US"
+          initialView="year"
+        />
+      );
+
+      assert.strictEqual(wrapper.find(CalendarYear).length, 1, 'should have the year select');
     });
   });
 });

--- a/src/DatePicker/Calendar.spec.js
+++ b/src/DatePicker/Calendar.spec.js
@@ -226,7 +226,7 @@ describe('<Calendar />', () => {
     });
   });
 
-  describe('Initial State', () => {
+  describe('initial state', () => {
     it('should display the month day pick view by default', () => {
       const wrapper = shallowWithContext(
         <Calendar
@@ -237,6 +237,7 @@ describe('<Calendar />', () => {
 
       assert.strictEqual(wrapper.find(CalendarMonth).length, 1, 'should have the calendar month select');
     });
+
     it('should display the year pick view when initialView is set to year', () => {
       const wrapper = shallowWithContext(
         <Calendar

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -119,7 +119,7 @@ class DatePicker extends Component {
      */
     onTouchTap: PropTypes.func,
     /**
-     * If true sets the datepicker to open to year selection first
+     * If true sets the datepicker to open to year selection first.
      */
     openToYearSelection: PropTypes.bool,
     /**

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -137,6 +137,10 @@ class DatePicker extends Component {
      * Sets the date for the Date Picker programmatically.
      */
     value: PropTypes.object,
+    /**
+     * Sets which view you would like to display initially
+     */
+    initialView: PropTypes.oneOf(['monthDay', 'year']),
   };
 
   static defaultProps = {
@@ -147,6 +151,7 @@ class DatePicker extends Component {
     firstDayOfWeek: 1,
     hideCalendarDate: false,
     style: {},
+    initialView: 'monthDay',
   };
 
   static contextTypes = {
@@ -283,6 +288,7 @@ class DatePicker extends Component {
       hideCalendarDate,
       style,
       textFieldStyle,
+      initialView,
       ...other
     } = this.props;
 
@@ -319,6 +325,7 @@ class DatePicker extends Component {
           ref="dialogWindow"
           shouldDisableDate={shouldDisableDate}
           hideCalendarDate={hideCalendarDate}
+          initialView={initialView}
         />
       </div>
     );

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -70,10 +70,6 @@ class DatePicker extends Component {
      */
     hideCalendarDate: PropTypes.bool,
     /**
-     * Sets which view you would like to display initially
-     */
-    initialView: PropTypes.oneOf(['monthDay', 'year']),
-    /**
      * Locale used for formatting the `DatePicker` date strings. Other than for 'en-US', you
      * must provide a `DateTimeFormat` that supports the chosen `locale`.
      */
@@ -123,6 +119,10 @@ class DatePicker extends Component {
      */
     onTouchTap: PropTypes.func,
     /**
+     * If true sets the datepicker to open to year selection first
+     */
+    openToYearSelection: PropTypes.bool,
+    /**
      * Callback function used to determine if a day's entry should be disabled on the calendar.
      *
      * @param {object} day Date object of a day.
@@ -151,7 +151,7 @@ class DatePicker extends Component {
     firstDayOfWeek: 1,
     hideCalendarDate: false,
     style: {},
-    initialView: 'monthDay',
+    openToYearSelection: false,
   };
 
   static contextTypes = {
@@ -284,11 +284,11 @@ class DatePicker extends Component {
       onFocus, // eslint-disable-line no-unused-vars
       onShow,
       onTouchTap, // eslint-disable-line no-unused-vars
+      openToYearSelection,
       shouldDisableDate,
       hideCalendarDate,
       style,
       textFieldStyle,
-      initialView,
       ...other
     } = this.props;
 
@@ -325,7 +325,7 @@ class DatePicker extends Component {
           ref="dialogWindow"
           shouldDisableDate={shouldDisableDate}
           hideCalendarDate={hideCalendarDate}
-          initialView={initialView}
+          openToYearSelection={openToYearSelection}
         />
       </div>
     );

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -70,6 +70,10 @@ class DatePicker extends Component {
      */
     hideCalendarDate: PropTypes.bool,
     /**
+     * Sets which view you would like to display initially
+     */
+    initialView: PropTypes.oneOf(['monthDay', 'year']),
+    /**
      * Locale used for formatting the `DatePicker` date strings. Other than for 'en-US', you
      * must provide a `DateTimeFormat` that supports the chosen `locale`.
      */
@@ -137,10 +141,6 @@ class DatePicker extends Component {
      * Sets the date for the Date Picker programmatically.
      */
     value: PropTypes.object,
-    /**
-     * Sets which view you would like to display initially
-     */
-    initialView: PropTypes.oneOf(['monthDay', 'year']),
   };
 
   static defaultProps = {

--- a/src/DatePicker/DatePickerDialog.js
+++ b/src/DatePicker/DatePickerDialog.js
@@ -19,6 +19,7 @@ class DatePickerDialog extends Component {
     firstDayOfWeek: PropTypes.number,
     hideCalendarDate: PropTypes.bool,
     initialDate: PropTypes.object,
+    initialView: PropTypes.oneOf(['monthDay', 'year']),
     locale: PropTypes.string,
     maxDate: PropTypes.object,
     minDate: PropTypes.object,
@@ -30,7 +31,6 @@ class DatePickerDialog extends Component {
     open: PropTypes.bool,
     shouldDisableDate: PropTypes.func,
     style: PropTypes.object,
-    initialView: PropTypes.oneOf(['monthDay', 'year']),
   };
 
   static defaultProps = {

--- a/src/DatePicker/DatePickerDialog.js
+++ b/src/DatePicker/DatePickerDialog.js
@@ -19,7 +19,6 @@ class DatePickerDialog extends Component {
     firstDayOfWeek: PropTypes.number,
     hideCalendarDate: PropTypes.bool,
     initialDate: PropTypes.object,
-    initialView: PropTypes.oneOf(['monthDay', 'year']),
     locale: PropTypes.string,
     maxDate: PropTypes.object,
     minDate: PropTypes.object,
@@ -29,6 +28,7 @@ class DatePickerDialog extends Component {
     onDismiss: PropTypes.func,
     onShow: PropTypes.func,
     open: PropTypes.bool,
+    openToYearSelection: PropTypes.bool,
     shouldDisableDate: PropTypes.func,
     style: PropTypes.object,
   };
@@ -39,7 +39,7 @@ class DatePickerDialog extends Component {
     container: 'dialog',
     locale: 'en-US',
     okLabel: 'OK',
-    initialView: 'monthDay',
+    openToYearSelection: false,
   };
 
   static contextTypes = {
@@ -120,11 +120,11 @@ class DatePickerDialog extends Component {
       onAccept, // eslint-disable-line no-unused-vars
       onDismiss, // eslint-disable-line no-unused-vars
       onShow, // eslint-disable-line no-unused-vars
+      openToYearSelection,
       shouldDisableDate,
       hideCalendarDate,
       style, // eslint-disable-line no-unused-vars
       animation,
-      initialView,
       ...other
     } = this.props;
 
@@ -177,9 +177,9 @@ class DatePickerDialog extends Component {
             onTouchTapCancel={this.handleTouchTapCancel}
             onTouchTapOk={this.handleTouchTapOk}
             okLabel={okLabel}
+            openToYearSelection={openToYearSelection}
             shouldDisableDate={shouldDisableDate}
             hideCalendarDate={hideCalendarDate}
-            initialView={initialView}
           />
         </Container>
       </div>

--- a/src/DatePicker/DatePickerDialog.js
+++ b/src/DatePicker/DatePickerDialog.js
@@ -30,6 +30,7 @@ class DatePickerDialog extends Component {
     open: PropTypes.bool,
     shouldDisableDate: PropTypes.func,
     style: PropTypes.object,
+    initialView: PropTypes.oneOf(['monthDay', 'year']),
   };
 
   static defaultProps = {
@@ -38,6 +39,7 @@ class DatePickerDialog extends Component {
     container: 'dialog',
     locale: 'en-US',
     okLabel: 'OK',
+    initialView: 'monthDay',
   };
 
   static contextTypes = {
@@ -122,6 +124,7 @@ class DatePickerDialog extends Component {
       hideCalendarDate,
       style, // eslint-disable-line no-unused-vars
       animation,
+      initialView,
       ...other
     } = this.props;
 
@@ -176,6 +179,7 @@ class DatePickerDialog extends Component {
             okLabel={okLabel}
             shouldDisableDate={shouldDisableDate}
             hideCalendarDate={hideCalendarDate}
+            initialView={initialView}
           />
         </Container>
       </div>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

The DatePicker component does not have the ability to open the year selection by default, this PR allows a user to specify an attribute to allow the DatePicker to open to year by default.

Closes #4949 

