### PR TITLE
[ToolbarGroup] Add more tests for other child components

### DIFF
--- a/test/integration/Toolbar/ToolbarGroup.spec.js
+++ b/test/integration/Toolbar/ToolbarGroup.spec.js
@@ -79,8 +79,8 @@ describe('<Toolbar />', () => {
     );
     const [raised, flat, separator] = wrapper.find(ToolbarGroup).node.props.children;
 
-    assert.strictEqual(raised.label), 'RaisedButton', 'RaisedButton should have proper label';
-    assert.strictEqual(flat.label), 'FlatButton', 'FlatButton should have proper label';
-    assert.strictEqual(separator.label), 'ToolbarSeparator', 'ToolbarSeparator should have proper label';
+    assert.strictEqual(raised.props.label, 'RaisedButton', 'RaisedButton should have proper label');
+    assert.strictEqual(flat.props.label, 'FlatButton', 'FlatButton should have proper label');
+    assert.strictEqual(separator.props.label, 'ToolbarSeparator', 'ToolbarSeparator should have proper label');
   });
 });

--- a/test/integration/Toolbar/ToolbarGroup.spec.js
+++ b/test/integration/Toolbar/ToolbarGroup.spec.js
@@ -3,8 +3,13 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import {assert} from 'chai';
 import Toolbar from 'src/Toolbar';
+import ToolbarTitle from 'src/Toolbar/ToolbarTitle';
 import ToolbarGroup from 'src/Toolbar/ToolbarGroup';
+import ToolbarSeparator from 'src/Toolbar/ToolbarSeparator';
+import DropDownMenu from 'src/DropDownMenu';
 import FontIcon from 'src/FontIcon';
+import RaisedButton from 'src/RaisedButton';
+import FlatButton from 'src/FlatButton';
 import getMuiTheme from 'src/styles/getMuiTheme';
 
 describe('<Toolbar />', () => {
@@ -21,6 +26,21 @@ describe('<Toolbar />', () => {
     assert.strictEqual(wrapper.find(ToolbarGroup).length, 1, 'should contain the ToolbarGroup child');
   });
 
+  it('should render DropDownMenu with underlineStyle props', () => {
+    const customStyles = {
+      borderColor: 'orange'
+    };
+    const wrapper = shallowWithContext(
+      <Toolbar>
+        <ToolbarGroup firstChild={true}>
+          <DropDownMenu underlineStyle={customStyles} />
+        </ToolbarGroup>
+      </Toolbar>
+    );
+
+    assert.strictEqual(wrapper.find(DropDownMenu).node.props.underlineStyle, customStyles, 'DropDownMenu should have border color set to orange');
+  });
+
   it('should render FontIcon with custom color', () => {
     const wrapper = shallowWithContext(
       <Toolbar>
@@ -31,5 +51,34 @@ describe('<Toolbar />', () => {
     );
 
     assert.strictEqual(wrapper.find(FontIcon).node.props.color, 'red', 'FontIcon should have the color set to red');
+  });
+
+  it('should render ToolbarTitle with its text', () => {
+    const wrapper = shallowWithContext(
+      <Toolbar>
+        <ToolbarGroup firstChild={true}>
+          <ToolbarTitle text="Toolbar Title text"/>
+        </ToolbarGroup>
+      </Toolbar>
+    );
+
+    assert.strictEqual(wrapper.find(ToolbarTitle).node.props.text, 'Toolbar Title text', 'ToolbarTitle should have text set to "Toolbar Title text"');
+  });
+
+  it('should render RaisedButton, FlatButton and ToolbarSeparator with labels', () => {
+    const wrapper = shallowWithContext(
+      <Toolbar>
+        <ToolbarGroup >
+          <RaisedButton label='RaisedButton'/>
+          <FlatButton label='FlatButton'/>
+          <ToolbarSeparator label='ToolbarSeparator'/>
+        </ToolbarGroup>
+      </Toolbar>
+    );
+    const [ raised, flat, separator ] = wrapper.find(ToolbarGroup).node.props.children;
+
+    assert.strictEqual(raised.label), 'RaisedButton', 'RaisedButton should have proper label';
+    assert.strictEqual(flat.label), 'FlatButton', 'FlatButton should have proper label';
+    assert.strictEqual(separator.label), 'ToolbarSeparator', 'ToolbarSeparator should have proper label';
   });
 });

--- a/test/integration/Toolbar/ToolbarGroup.spec.js
+++ b/test/integration/Toolbar/ToolbarGroup.spec.js
@@ -28,7 +28,7 @@ describe('<Toolbar />', () => {
 
   it('should render DropDownMenu with underlineStyle props', () => {
     const customStyles = {
-      borderColor: 'orange'
+      borderColor: 'orange',
     };
     const wrapper = shallowWithContext(
       <Toolbar>
@@ -38,7 +38,8 @@ describe('<Toolbar />', () => {
       </Toolbar>
     );
 
-    assert.strictEqual(wrapper.find(DropDownMenu).node.props.underlineStyle, customStyles, 'DropDownMenu should have border color set to orange');
+    assert.strictEqual(wrapper.find(DropDownMenu).node.props.underlineStyle, customStyles,
+      'DropDownMenu should have border color set to orange');
   });
 
   it('should render FontIcon with custom color', () => {
@@ -56,26 +57,27 @@ describe('<Toolbar />', () => {
   it('should render ToolbarTitle with its text', () => {
     const wrapper = shallowWithContext(
       <Toolbar>
-        <ToolbarGroup firstChild={true}>
-          <ToolbarTitle text="Toolbar Title text"/>
+        <ToolbarGroup firstChild={true} >
+          <ToolbarTitle text="Toolbar Title text" />
         </ToolbarGroup>
       </Toolbar>
     );
 
-    assert.strictEqual(wrapper.find(ToolbarTitle).node.props.text, 'Toolbar Title text', 'ToolbarTitle should have text set to "Toolbar Title text"');
+    assert.strictEqual(wrapper.find(ToolbarTitle).node.props.text, 'Toolbar Title text',
+      'ToolbarTitle should have text set to "Toolbar Title text"');
   });
 
   it('should render RaisedButton, FlatButton and ToolbarSeparator with labels', () => {
     const wrapper = shallowWithContext(
       <Toolbar>
         <ToolbarGroup >
-          <RaisedButton label='RaisedButton'/>
-          <FlatButton label='FlatButton'/>
-          <ToolbarSeparator label='ToolbarSeparator'/>
+          <RaisedButton label="RaisedButton" />
+          <FlatButton label="FlatButton" />
+          <ToolbarSeparator label="ToolbarSeparator" />
         </ToolbarGroup>
       </Toolbar>
     );
-    const [ raised, flat, separator ] = wrapper.find(ToolbarGroup).node.props.children;
+    const [raised, flat, separator] = wrapper.find(ToolbarGroup).node.props.children;
 
     assert.strictEqual(raised.label), 'RaisedButton', 'RaisedButton should have proper label';
     assert.strictEqual(flat.label), 'FlatButton', 'FlatButton should have proper label';


### PR DESCRIPTION
## Summary:
- Add more tests to spec of ToolbarGroup component
- These tests cover other cases when rendering child components for ToolbarGroup (not only FontIcon component like before)

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

