### PR TITLE
[TableRow] Fix typo in comment

### DIFF
--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -40,7 +40,7 @@ class TableRow extends Component {
      */
     displayBorder: PropTypes.bool,
     /**
-     * Controls whether or not the row reponseds to hover events.
+     * Controls whether or not the row responds to hover events.
      */
     hoverable: PropTypes.bool,
     /**


### PR DESCRIPTION
`reponseds` --> `responds`
