### PR TITLE
[docs] Add related project material-ui-scrollable-tabs

### DIFF
--- a/docs/src/app/components/pages/discover-more/related-projects.md
+++ b/docs/src/app/components/pages/discover-more/related-projects.md
@@ -15,6 +15,7 @@ A Formsy compatibility wrapper for Material-UI form components.
 Addon for storybook.
 - [crema](https://bitbucket.org/pinturic/crema/) CReMa: Cordova React Material-UI.
 - [babel-plugin-material-ui](https://github.com/umidbekkarimov/babel-plugin-material-ui) Babel plugin to cherry-pick used material-ui modules.
+- [material-ui-scrollable-tabs](https://github.com/STORIS/material-ui-scrollable-tabs) Extension of Material-UI `Tabs` component implementing [scrollable](https://material.io/guidelines/components/tabs.html#tabs-types-of-tabs) behavior.
 
 ### Complementary Projects
 


### PR DESCRIPTION
Adds material-ui-scrollable-tabs to documentation as related project per discussion in #1148.
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] ~~PR has tests / docs demo, and is linted.~~ (n/a)
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

