### PR TITLE
[github] Revise ISSUE_TEMPLATE.d (again!)

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,19 +1,9 @@
-<!-- Have a QUESTION? Please ask in [StackOverflow or gitter](http://tr.im/77pVj before opening an issue.
+<!-- Have a QUESTION? Please ask in [StackOverflow or gitter](http://tr.im/77pVj. -->
 
-If you are having an issue with click events, please re-read the [README](http://tr.im/410Fg) (you did read the README, right? :-) ).
-
-If you think you have found a _new_ issue that hasn't already been reported or fixed in HEAD, please complete the template below.
-
-For feature requests, please delete the template below and use this one instead:
-
-### Description
-### Images & references
-
--->
 
 ### Problem description
 
-### Link to minimally-working code that reproduces the issue
+### Link to minimal working code that reproduces the issue
 
 <!-- You may provide a repository or use our template-ready webpackbin https://www.webpackbin.com/bins/-KepJp0H0vicrdnos5RZ -->
 
@@ -22,3 +12,15 @@ For feature requests, please delete the template below and use this one instead:
 - Material-UI:
 - React:
 - Browser:
+
+
+<!-- If you are having an issue with click events, please re-read the [README](http://tr.im/410Fg) (you did read the README, right? :-) ).
+
+If you think you have found a _new_ issue that hasn't already been reported or fixed in HEAD, please complete the template above.
+
+For feature requests, please delete the template above and use this one instead:
+
+### Description
+### Images & references
+
+-->


### PR DESCRIPTION
IMO issue submission quality has gone down since the template was moved back to the bottom (below the comments).  It was originally at the bottom (@mbrookes), then moved to the top (@mbrookes), then back to the bottom again (@oliviertassinari).

This PR puts it back near the top, but _after_ the "Qestion? comment. Also removed some words. 

I'm tempted to also remove the feature-request template as not aren't relevant to the majority of issues, and hopefully common sense otherwise.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

