### PR TITLE
[transitions][Slide] (next) Fix getTranslateValue for left & up cases 

### DIFF
--- a/src/transitions/Slide.js
+++ b/src/transitions/Slide.js
@@ -11,11 +11,11 @@ function getTranslateValue(props, element) {
   const rect = element.getBoundingClientRect();
 
   if (direction === 'left') {
-    return `translate3d(${rect.right + rect.width}px, 0, 0)`;
+    return `translate3d(calc(100vw - ${rect.left}px), 0, 0)`;
   } else if (direction === 'right') {
     return `translate3d(${0 - (rect.left + rect.width)}px, 0, 0)`;
   } else if (direction === 'up') {
-    return `translate3d(0, ${rect.bottom + rect.height}px, 0)`;
+    return `translate3d(0, calc(100vh - ${rect.top}px), 0)`;
   } else if (direction === 'down') {
     return `translate3d(0, ${0 - (rect.top + rect.height)}px, 0)`;
   }

--- a/src/transitions/Slide.spec.js
+++ b/src/transitions/Slide.spec.js
@@ -111,9 +111,9 @@ describe('<Slide />', () => {
             width: 500,
             height: 300,
             left: 300,
-            right: 500,
+            right: 800,
             top: 200,
-            bottom: 100,
+            bottom: 500,
           }),
           style: {},
         };

--- a/src/transitions/Slide.spec.js
+++ b/src/transitions/Slide.spec.js
@@ -122,13 +122,13 @@ describe('<Slide />', () => {
       it('should set element transform and transition according to the direction', () => {
         wrapper.setProps({ direction: 'left' });
         instance.handleEnter(element);
-        assert.strictEqual(element.style.transform, 'translate3d(1000px, 0, 0)');
+        assert.strictEqual(element.style.transform, 'translate3d(calc(100vw - 300px), 0, 0)');
         wrapper.setProps({ direction: 'right' });
         instance.handleEnter(element);
         assert.strictEqual(element.style.transform, 'translate3d(-800px, 0, 0)');
         wrapper.setProps({ direction: 'up' });
         instance.handleEnter(element);
-        assert.strictEqual(element.style.transform, 'translate3d(0, 400px, 0)');
+        assert.strictEqual(element.style.transform, 'translate3d(0, calc(100vh - 200px), 0)');
         wrapper.setProps({ direction: 'down' });
         instance.handleEnter(element);
         assert.strictEqual(element.style.transform, 'translate3d(0, -500px, 0)');
@@ -168,13 +168,13 @@ describe('<Slide />', () => {
       it('should set element transform and transition according to the direction', () => {
         wrapper.setProps({ direction: 'left' });
         instance.handleEnter(element);
-        assert.strictEqual(element.style.transform, 'translate3d(1000px, 0, 0)');
+        assert.strictEqual(element.style.transform, 'translate3d(calc(100vw - 300px), 0, 0)');
         wrapper.setProps({ direction: 'right' });
         instance.handleEnter(element);
         assert.strictEqual(element.style.transform, 'translate3d(-800px, 0, 0)');
         wrapper.setProps({ direction: 'up' });
         instance.handleEnter(element);
-        assert.strictEqual(element.style.transform, 'translate3d(0, 400px, 0)');
+        assert.strictEqual(element.style.transform, 'translate3d(0, calc(100vh - 200px), 0)');
         wrapper.setProps({ direction: 'down' });
         instance.handleEnter(element);
         assert.strictEqual(element.style.transform, 'translate3d(0, -500px, 0)');

--- a/src/transitions/Slide.spec.js
+++ b/src/transitions/Slide.spec.js
@@ -157,9 +157,9 @@ describe('<Slide />', () => {
             width: 500,
             height: 300,
             left: 300,
-            right: 500,
+            right: 800,
             top: 200,
-            bottom: 100,
+            bottom: 500,
           }),
           style: {},
         };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

**Slide:next** 

The offscreen getTranslateValue() returned for the left & up case don't position the element directly offscreen like the down & right cases do. Visually, elements slide more rapidly the further offscreen they are positioned. For modals centered in the viewport, this is not very noticeable (for example when comparing a slide up with a slide down).  Ideally, the up|down slides & left|right slides should be visual mirrors of each other. This change fixes that.

Also, it makes modal positioning much more flexible if the user desires to override modal positioning via css (flex-start, flex-end, etc). Currently, the issue mentioned above is very noticeable in these scenarios. A modal positioned at the bottom edge of the screen, flies rapidly offscreen because the calculated offscreen positioning is huge. 

I'm overriding modal position in an implementation of a next:Snackbar I created (with fix version):
https://next-snackbar.firebaseapp.com/#/component-demos/snackbars
https://github.com/josulliv101/material-ui/blob/snackbar/src/Snackbar/Snackbar.js

The change uses calc() which seemed well-enough supported to use. I wanted to avoid reference to window.innerHeight/innerWidth for SSR (though modals wouldn't be displayed on the server anyhow). 

On the Slide transition test, in the element's mock getBoundingClientRect() -- the 'right' & 'bottom' properties should always be 

- right = left + width, 
- and bottom = top + height.