### PR TITLE
[TextField] Fix first character composition issue

### DIFF
--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -348,7 +348,9 @@ class TextField extends Component {
   };
 
   handleInputChange = (event) => {
-    this.setState({hasValue: isValid(event.target.value)});
+    if (!this.props.hasOwnProperty('value')) {
+      this.setState({hasValue: isValid(event.target.value)});
+    }
     if (this.props.onChange) {
       this.props.onChange(event, event.target.value);
     }

--- a/src/TextField/TextField.spec.js
+++ b/src/TextField/TextField.spec.js
@@ -172,4 +172,39 @@ describe('<TextField />', () => {
       assert.strictEqual(errorWrapper.props().style.bottom, 10, 'Users should have the higher priority');
     });
   });
+
+  describe('state: hasValue', () => {
+    describe('of uncontrolled component', () => {
+      it('should change depending on the input', () => {
+        const wrapper = shallowWithContext(
+          <TextField id="unique" />
+        );
+        const input = wrapper.find('input');
+        assert.strictEqual(wrapper.state().hasValue, false);
+        input.simulate('change', {target: {value: 'a'}});
+        assert.strictEqual(wrapper.state().hasValue, true);
+        input.simulate('change', {target: {value: ''}});
+        assert.strictEqual(wrapper.state().hasValue, false);
+      });
+    });
+
+    describe('of controlled component', () => {
+      it('should be false if onChange does nothing despite the input', () => {
+        const wrapper = shallowWithContext(
+          <TextField value="" id="unique" />
+        );
+        wrapper.find('input').simulate('change', {target: {value: 'a'}});
+        assert.strictEqual(wrapper.state().hasValue, false, 'because props.value is still invalid.');
+      });
+
+      it('should be true if and only if props.value is set', () => {
+        const wrapper = shallowWithContext(
+          <TextField value="" id="unique" />
+        );
+        assert.strictEqual(wrapper.state().hasValue, false);
+        wrapper.setProps({value: 'a'});
+        assert.strictEqual(wrapper.state().hasValue, true, 'it is consistent with props.value');
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".


Tiny change. It seems to me that, when the component is conrolled,
'value' needs to be checked only in componentWillReceiveProps,
and event.target.value in handleInputChange has nothing to do with
hasValue state.

At least, this PR can fix #3394 issue which, still remaining despite #5540,
breaks 'first' character composition of CJK or other input methods
when used with, for example, redux-form.

Closes #3394.