### PR TITLE
[Docs] Update api.md

### DIFF
--- a/docs/src/pages/customization/api.md
+++ b/docs/src/pages/customization/api.md
@@ -26,7 +26,7 @@ Aside from the above composition trade-off, we use the following rules:
 
 - Undocumented properties supplied are spread to the root element.
 - Internal components have:
- - their own `xxxClassName` property when style customization makes sense. For instance, we expose an `inputClassName` property.
- - their own `xxxProps` property when users might need to tweak internal render method's components. For instance, we expose an `inputProps` property.
- - their own flattened properties when they are key to the abstraction. For instance, we expose a `value` property.
+  - their own `xxxClassName` property when style customization makes sense. For instance, we expose an `inputClassName` property.
+  - their own `xxxProps` property when users might need to tweak internal render method's components. For instance, we expose an `inputProps` property.
+  - their own flattened properties when they are key to the abstraction. For instance, we expose a `value` property.
 - The name of the boolean properties should be chosen based on the default value. We are following the HTML specification. For instance, the `disabled` attribute on an input element. This choice allows the shorthand notation.


### PR DESCRIPTION
Fix the list bullet points in api.md to use two spaces instead of one to render sub-points

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Before: 
<img width="929" alt="screen shot 2017-03-30 at 1 37 49 pm" src="https://cloud.githubusercontent.com/assets/10211603/24520459/264d42c6-154e-11e7-96e6-0880e7cb2429.png">

After:
<img width="905" alt="screen shot 2017-03-30 at 1 37 09 pm" src="https://cloud.githubusercontent.com/assets/10211603/24520461/2ac1eb7c-154e-11e7-9824-9998fb8faddb.png">

