### PR TITLE
[test] Add HTML reporting of coverage from npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ node_modules
 # Editor files
 .idea
 .vscode
+
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:unit": "cross-env NODE_ENV=test mocha",
     "test:watch": "cross-env NODE_ENV=test mocha -w",
     "test:coverage": "cross-env NODE_ENV=test BABEL_ENV=coverage nyc mocha && nyc report -r lcovonly",
+    "test:coverage:html": "cross-env NODE_ENV=test BABEL_ENV=coverage nyc mocha && nyc report --reporter=html",
     "test:karma": "cross-env NODE_ENV=test karma start test/karma.conf.js --single-run",
     "test:regressions": "webpack --config test/regressions/webpack.config.js && vrtest run --config test/vrtest.config.js",
     "flow": "flow",

--- a/test/README.md
+++ b/test/README.md
@@ -40,6 +40,11 @@ This virtual DOM is provided by [jsdom](https://github.com/tmpvar/jsdom).
 It's here to make sure components work together.
 Here is an [example](https://github.com/callemall/material-ui/blob/a3719a203515b1ad683e62085cb5065318c0c87f/test/integration/Menu.spec.js#L29) with the `<Menu />` component.
 
+#### Create HTML coverage reports
+`npm run test:coverage:html`
+
+When running this command you should get under `coverage/index.html` a full coverage report in HTML format. This is created using [Istanbul](http://istanbul-js.org)'s HTML reporter and gives good data such as line, branch and function coverage. 
+
 ### DOM API level
 
 #### Run the mocha test suite using the karma runner.


### PR DESCRIPTION
- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Kind of nice to be able to easily generate HTML reports of coverage locally. Helps finding the small parts that have not been tested yet.
