### PR TITLE
[test] Fix import paths for theme and MuiThemeProvider

### DIFF
--- a/src/test-utils/createMount.js
+++ b/src/test-utils/createMount.js
@@ -5,7 +5,7 @@ import jssPreset from 'jss-preset-default';
 import { createStyleManager } from 'jss-theme-reactor';
 import { PropTypes } from 'react';
 import { mount as enzymeMount } from 'enzyme';
-import { createMuiTheme } from 'src/styles/theme';
+import { createMuiTheme } from '../styles/theme';
 
 function cleanStyles() {
   const head = window.document.head;

--- a/src/test-utils/createRenderToString.js
+++ b/src/test-utils/createRenderToString.js
@@ -5,8 +5,8 @@ import jssPreset from 'jss-preset-default';
 import { createStyleManager } from 'jss-theme-reactor';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
-import { createMuiTheme } from 'src/styles/theme';
-import MuiThemeProvider from 'src/styles/MuiThemeProvider';
+import { createMuiTheme } from '../styles/theme';
+import MuiThemeProvider from '../styles/MuiThemeProvider';
 
 export default function createRenderToString() {
   const theme = createMuiTheme();


### PR DESCRIPTION
This is an extension of https://github.com/callemall/material-ui/commit/444c60392550fe73bb3492ba0ebb63473c73162a and resolves three additional issues with import paths in `test-utils`.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

