### PR TITLE
[SelectField] - Add menuEvents to selectField component handle DropDownMenu events

### DIFF
--- a/docs/src/app/components/pages/components/SelectField/ExampleMenuClose.js
+++ b/docs/src/app/components/pages/components/SelectField/ExampleMenuClose.js
@@ -1,0 +1,48 @@
+import React, {Component} from 'react';
+import SelectField from 'material-ui/SelectField';
+import MenuItem from 'material-ui/MenuItem';
+
+const styles = {
+  customWidth: {
+    width: 150,
+  },
+};
+
+/**
+ * `SelectField` is implemented as a controlled component,
+ * with the current selection set through the `value` property.
+ * The `SelectField` can be disabled with the `disabled` property.
+ */
+export default class SelectFieldExampleMenuClose extends Component {
+  state = {
+    value: 1,
+    closed: 0
+  };
+
+  handleChange = (event, index, value) => this.setState({value: value});
+
+  handleClose = () => this.setState({closed: this.state.closed++});
+
+  render() {
+    return (
+      <div>
+        <SelectField
+          floatingLabelText="Frequency"
+          value={this.state.value}
+          onChange={this.handleChange}
+          onClose={this.handleClose}
+        >
+          <MenuItem value={1} primaryText="Never" />
+          <MenuItem value={2} primaryText="Every Night" />
+          <MenuItem value={3} primaryText="Weeknights" />
+          <MenuItem value={4} primaryText="Weekends" />
+          <MenuItem value={5} primaryText="Weekly" />
+        </SelectField>
+        <br/>
+        <span id="spanClose">
+          {'This SelectField was closed ' + this.state.closed + ' times.'}
+        </span>
+      </div>
+    );
+  }
+}

--- a/docs/src/app/components/pages/components/SelectField/ExampleMenuEvents.js
+++ b/docs/src/app/components/pages/components/SelectField/ExampleMenuEvents.js
@@ -16,12 +16,15 @@ const styles = {
 export default class SelectFieldExampleMenuClose extends Component {
   state = {
     value: 1,
-    closed: 0
+    closed: 0,
+    selected: 0
   };
 
   handleChange = (event, index, value) => this.setState({value: value});
 
   handleClose = () => this.setState({closed: this.state.closed++});
+
+  handleSelectionRenderer = (value) => this.setState({selected: value});
 
   render() {
     return (
@@ -29,8 +32,7 @@ export default class SelectFieldExampleMenuClose extends Component {
         <SelectField
           floatingLabelText="Frequency"
           value={this.state.value}
-          onChange={this.handleChange}
-          onClose={this.handleClose}
+          menuEvents={{onchange: this.handleChange, onClose: this.handleClose}}
         >
           <MenuItem value={1} primaryText="Never" />
           <MenuItem value={2} primaryText="Every Night" />
@@ -41,6 +43,9 @@ export default class SelectFieldExampleMenuClose extends Component {
         <br/>
         <span id="spanClose">
           {'This SelectField was closed ' + this.state.closed + ' times.'}
+        </span>
+        <span id="spanSelect">
+          {'The value selected is ' + this.state.selected + '.'}
         </span>
       </div>
     );

--- a/docs/src/app/components/pages/components/SelectField/Page.js
+++ b/docs/src/app/components/pages/components/SelectField/Page.js
@@ -7,7 +7,7 @@ import MarkdownElement from '../../../MarkdownElement';
 
 import selectFieldReadmeText from './README';
 import SelectFieldExampleSimple from './ExampleSimple';
-import SelectFieldExampleMenuClose from './ExampleMenuClose';
+import SelectFieldExampleMenuEvents from './ExampleMenuEvents';
 import selectFieldExampleSimpleCode from '!raw!./ExampleSimple';
 import SelectFieldLongMenuExample from './ExampleLongMenu';
 import selectFieldLongMenuExampleCode from '!raw!./ExampleLongMenu';
@@ -37,9 +37,9 @@ const SelectFieldPage = () => (
     </CodeExample>
     <CodeExample
       title="Nullable select"
-      code={SelectFieldExampleMenuClose}
+      code={SelectFieldExampleMenuEvents}
     >
-      <SelectFieldExampleMenuClose/>
+      <SelectFieldExampleMenuEvents/>
     </CodeExample>
     <CodeExample
       title="Nullable select"

--- a/docs/src/app/components/pages/components/SelectField/Page.js
+++ b/docs/src/app/components/pages/components/SelectField/Page.js
@@ -7,6 +7,7 @@ import MarkdownElement from '../../../MarkdownElement';
 
 import selectFieldReadmeText from './README';
 import SelectFieldExampleSimple from './ExampleSimple';
+import SelectFieldExampleMenuClose from './ExampleMenuClose';
 import selectFieldExampleSimpleCode from '!raw!./ExampleSimple';
 import SelectFieldLongMenuExample from './ExampleLongMenu';
 import selectFieldLongMenuExampleCode from '!raw!./ExampleLongMenu';
@@ -33,6 +34,12 @@ const SelectFieldPage = () => (
       code={selectFieldExampleSimpleCode}
     >
       <SelectFieldExampleSimple />
+    </CodeExample>
+    <CodeExample
+      title="Nullable select"
+      code={SelectFieldExampleMenuClose}
+    >
+      <SelectFieldExampleMenuClose/>
     </CodeExample>
     <CodeExample
       title="Nullable select"

--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -141,6 +141,10 @@ class DropDownMenu extends Component {
      */
     menuItemStyle: PropTypes.object,
     /**
+     * Define all event callback implemented by user to component DropDownMenu
+     */
+    menuProps: PropTypes.object,
+    /**
      * Overrides the styles of `Menu` when the `DropDownMenu` is displayed.
      */
     menuStyle: PropTypes.object,
@@ -365,13 +369,14 @@ class DropDownMenu extends Component {
       labelStyle,
       listStyle,
       maxHeight,
+      menuItemStyle,
+      menuProps,
       menuStyle: menuStyleProp,
+      selectedMenuItemStyle,
       selectionRenderer,
+      style,
       onClose, // eslint-disable-line no-unused-vars
       openImmediately, // eslint-disable-line no-unused-vars
-      menuItemStyle,
-      selectedMenuItemStyle,
-      style,
       underlineStyle,
       value,
       iconButton,
@@ -475,6 +480,7 @@ class DropDownMenu extends Component {
             onChange={this.handleChange}
             menuItemStyle={menuItemStyle}
             selectedMenuItemStyle={selectedMenuItemStyle}
+            {...menuProps}
           >
             {children}
           </Menu>

--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -141,10 +141,6 @@ class DropDownMenu extends Component {
      */
     menuItemStyle: PropTypes.object,
     /**
-     * Define all event callback implemented by user to component DropDownMenu
-     */
-    menuProps: PropTypes.object,
-    /**
      * Overrides the styles of `Menu` when the `DropDownMenu` is displayed.
      */
     menuStyle: PropTypes.object,
@@ -370,7 +366,6 @@ class DropDownMenu extends Component {
       listStyle,
       maxHeight,
       menuItemStyle,
-      menuProps,
       menuStyle: menuStyleProp,
       selectedMenuItemStyle,
       selectionRenderer,
@@ -480,7 +475,6 @@ class DropDownMenu extends Component {
             onChange={this.handleChange}
             menuItemStyle={menuItemStyle}
             selectedMenuItemStyle={selectedMenuItemStyle}
-            {...menuProps}
           >
             {children}
           </Menu>

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -106,6 +106,8 @@ class SelectField extends Component {
     multiple: PropTypes.bool,
     /** @ignore */
     onBlur: PropTypes.func,
+    /** @ignore */
+    onClose: PropTypes.func,
     /**
      * Callback function fired when a menu item is selected.
      *
@@ -199,6 +201,7 @@ class SelectField extends Component {
       menuStyle,
       onFocus,
       onBlur,
+      onClose,
       onChange,
       selectionRenderer,
       value,
@@ -239,6 +242,7 @@ class SelectField extends Component {
           autoWidth={autoWidth}
           value={value}
           onChange={onChange}
+          onClose={onClose}
           maxHeight={maxHeight}
           multiple={multiple}
           selectionRenderer={selectionRenderer}

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -205,7 +205,6 @@ class SelectField extends Component {
       onFocus,
       onBlur,
       onChange,
-      onClose,
       selectionRenderer,
       value,
       ...other
@@ -245,7 +244,6 @@ class SelectField extends Component {
           autoWidth={autoWidth}
           value={value}
           onChange={onChange}
-          onClose={onClose}
           maxHeight={maxHeight}
           menuProps={menuProps}
           multiple={multiple}

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -96,6 +96,10 @@ class SelectField extends Component {
      */
     menuItemStyle: PropTypes.object,
     /**
+     * Define all events callback implemented by user to component DropDownMenu
+     */
+    menuProps: PropTypes.object,
+    /**
      * Override the inline-styles of the underlying `DropDownMenu` element.
      */
     menuStyle: PropTypes.object,
@@ -119,10 +123,6 @@ class SelectField extends Component {
      * Otherwise, the `value` of the menu item.
      */
     onChange: PropTypes.func,
-    /**
-     * Callback function fired when a menu is closed.
-     */
-    onClose: PropTypes.func,
     /** @ignore */
     onFocus: PropTypes.func,
     /**
@@ -200,6 +200,7 @@ class SelectField extends Component {
       errorText,
       listStyle,
       maxHeight,
+      menuProps,
       menuStyle,
       onFocus,
       onBlur,
@@ -246,6 +247,7 @@ class SelectField extends Component {
           onChange={onChange}
           onClose={onClose}
           maxHeight={maxHeight}
+          menuProps={menuProps}
           multiple={multiple}
           selectionRenderer={selectionRenderer}
         >

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -201,8 +201,8 @@ class SelectField extends Component {
       menuStyle,
       onFocus,
       onBlur,
-      onClose,
       onChange,
+      onClose,
       selectionRenderer,
       value,
       ...other

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -106,8 +106,6 @@ class SelectField extends Component {
     multiple: PropTypes.bool,
     /** @ignore */
     onBlur: PropTypes.func,
-    /** @ignore */
-    onClose: PropTypes.func,
     /**
      * Callback function fired when a menu item is selected.
      *
@@ -121,6 +119,8 @@ class SelectField extends Component {
      * Otherwise, the `value` of the menu item.
      */
     onChange: PropTypes.func,
+    /** @ignore */
+    onClose: PropTypes.func,
     /** @ignore */
     onFocus: PropTypes.func,
     /**

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -119,7 +119,9 @@ class SelectField extends Component {
      * Otherwise, the `value` of the menu item.
      */
     onChange: PropTypes.func,
-    /** @ignore */
+    /**
+     * Callback function fired when a menu is closed.
+     */
     onClose: PropTypes.func,
     /** @ignore */
     onFocus: PropTypes.func,

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -92,13 +92,14 @@ class SelectField extends Component {
      */
     maxHeight: PropTypes.number,
     /**
+     * Define all events callback implemented by user to component DropDownMenu
+     * Events: onClose, onChange e selectionRenderer
+     */
+    menuEvents: PropTypes.object,
+    /**
      * Override the inline-styles of menu items.
      */
     menuItemStyle: PropTypes.object,
-    /**
-     * Define all events callback implemented by user to component DropDownMenu
-     */
-    menuProps: PropTypes.object,
     /**
      * Override the inline-styles of the underlying `DropDownMenu` element.
      */
@@ -200,7 +201,7 @@ class SelectField extends Component {
       errorText,
       listStyle,
       maxHeight,
-      menuProps,
+      menuEvents,
       menuStyle,
       onFocus,
       onBlur,
@@ -243,11 +244,11 @@ class SelectField extends Component {
           listStyle={listStyle}
           autoWidth={autoWidth}
           value={value}
-          onChange={onChange}
+          onChange={onChange || (menuEvents ? menuEvents.onChange : menuEvents)}
+          onClose={menuEvents ? menuEvents.onClose : menuEvents}
           maxHeight={maxHeight}
-          menuProps={menuProps}
           multiple={multiple}
-          selectionRenderer={selectionRenderer}
+          selectionRenderer={selectionRenderer || (menuEvents ? menuEvents.selectionRenderer : menuEvents)}
         >
           {children}
         </DropDownMenu>


### PR DESCRIPTION
[SelectField] - Add menuEvents to selectField component is an object that can carry all callback handlers fired by events on component DropDownMenu - Events onChange, onClose and selectionRenderer

