### PR TITLE
[breakpoints] fix down function, eliminate 1px overlap with specified breakpoint

### DIFF
--- a/src/styles/breakpoints.js
+++ b/src/styles/breakpoints.js
@@ -29,7 +29,7 @@ export default function createBreakpoints(
 
   function down(name) {
     const value = breakpoints[name] || name;
-    return `@media (max-width:${value - 1}${unit})`;
+    return `@media (max-width:${value - step}${unit})`;
   }
 
   function between(start, end) {

--- a/src/styles/breakpoints.js
+++ b/src/styles/breakpoints.js
@@ -29,14 +29,14 @@ export default function createBreakpoints(
 
   function down(name) {
     const value = breakpoints[name] || name;
-    return `@media (max-width:${value - step}${unit})`;
+    return `@media (max-width:${value - (step / 100)}${unit})`;
   }
 
   function between(start, end) {
     const startIndex = keys.indexOf(start);
     const endIndex = keys.indexOf(end);
     return `@media (min-width:${values[startIndex]}${unit}) and (max-width:${
-      values[endIndex + 1] - step}${unit})`;
+      values[endIndex + 1] - (step / 100)}${unit})`;
   }
 
   function only(name) {

--- a/src/styles/breakpoints.js
+++ b/src/styles/breakpoints.js
@@ -29,7 +29,7 @@ export default function createBreakpoints(
 
   function down(name) {
     const value = breakpoints[name] || name;
-    return `@media (max-width:${value}${unit})`;
+    return `@media (max-width:${value - 1}${unit})`;
   }
 
   function between(start, end) {

--- a/src/styles/breakpoints.spec.js
+++ b/src/styles/breakpoints.spec.js
@@ -18,7 +18,7 @@ describe('createBreakpoints', () => {
 
   describe('down', () => {
     it('should work', () => {
-      assert.strictEqual(breakpoints.down('md'), '@media (max-width:960px)');
+      assert.strictEqual(breakpoints.down('md'), '@media (max-width:959px)');
     });
   });
 

--- a/src/styles/breakpoints.spec.js
+++ b/src/styles/breakpoints.spec.js
@@ -18,21 +18,21 @@ describe('createBreakpoints', () => {
 
   describe('down', () => {
     it('should work', () => {
-      assert.strictEqual(breakpoints.down('md'), '@media (max-width:959px)');
+      assert.strictEqual(breakpoints.down('md'), '@media (max-width:959.99px)');
     });
   });
 
   describe('between', () => {
     it('should work', () => {
       assert.strictEqual(breakpoints.between('sm', 'md'),
-        '@media (min-width:600px) and (max-width:1279px)');
+        '@media (min-width:600px) and (max-width:1279.99px)');
     });
   });
 
   describe('only', () => {
     it('should work', () => {
       assert.strictEqual(breakpoints.only('md'),
-        '@media (min-width:960px) and (max-width:1279px)');
+        '@media (min-width:960px) and (max-width:1279.99px)');
     });
 
     it('on xl should call up', () => {


### PR DESCRIPTION
Consider the following:

```jsx
   [theme.breakpoints.down('sm')]: {
      content: {
         margin: 0,
      },
   },
   [theme.breakpoints.only('sm')]: {
      content: {
         margin: 12,
      },
   },
```

- The first rule states that the content class will apply a margin of 0 when the viewport ranges in size from 0-600.
- The second rule states that the content class will apply a margin of 12 when the viewport ranges in size from 600-959.

There is a 1px overlap because *down* sets a max-width equal to the size defined for the specified breakpoint.  This is inconsistent with *only* which defines a max-width which is 1px less than the size defined for the next breakpoint.

This has been submitted as issue #6503.

This PR fixes the down function so that the max-width is set to 1px less than the size defined for the specified breakpoint and updates the test in the spec so that this change is accounted for.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [X] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

