### PR TITLE
[TouchRipple] Remove react-addons-transition-group

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "keycode": "^2.1.8",
     "lodash": "^4.17.4",
     "object-assign": "^4.1.1",
-    "react-addons-transition-group": "^15.0.0",
     "react-event-listener": "^0.4.3",
+    "react-transition-group": "^1.1.1",
     "recompose": "^0.22.0",
     "warning": "^3.0.0"
   },

--- a/src/Ripple/TouchRipple.js
+++ b/src/Ripple/TouchRipple.js
@@ -2,7 +2,7 @@
 
 import React, { Component, PropTypes } from 'react';
 import ReactDOM from 'react-dom';
-import ReactTransitionGroup from 'react-addons-transition-group';
+import ReactTransitionGroup from 'react-transition-group/TransitionGroup';
 import shallowEqual from 'recompose/shallowEqual';
 import classNames from 'classnames';
 import { createStyleSheet } from 'jss-theme-reactor';

--- a/src/Ripple/TouchRipple.spec.js
+++ b/src/Ripple/TouchRipple.spec.js
@@ -16,7 +16,7 @@ describe('<TouchRipple />', () => {
 
   it('should render a <ReactTransitionGroup> component', () => {
     const wrapper = shallow(<TouchRipple />);
-    assert.strictEqual(wrapper.is('ReactTransitionGroup'), true, 'should be a transition group');
+    assert.strictEqual(wrapper.is('TransitionGroup'), true, 'should be a transition group');
     assert.strictEqual(wrapper.props().component, 'span', 'should be pass a span as the component');
   });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,8 +16,7 @@ const baseConfig = {
     umdNamedDefine: true,
   },
   externals: [
-    'react-addons-create-fragment',
-    'react-addons-transition-group',
+    'react-transition-group/TransitionGroup',
     {
       react: {
         root: 'React',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1339,6 +1339,10 @@ chai@^3.5.0:
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
 
+chain-function@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.0.tgz#0d4ab37e7e18ead0bdc47b920764118ce58733dc"
+
 chainsaw@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/chainsaw/-/chainsaw-0.1.0.tgz#5eab50b28afe58074d0d58291388828b5e5fbc98"
@@ -1880,7 +1884,7 @@ doctrine@^2.0.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-dom-helpers@^3.2.1:
+dom-helpers@^3.2.0, dom-helpers@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
 
@@ -4663,13 +4667,6 @@ react-addons-test-utils@^15.4.2:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-addons-transition-group@^15.0.0:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-addons-transition-group/-/react-addons-transition-group-15.4.2.tgz#4c42fa1c2ce024acab2924316c0f11268ded1af3"
-  dependencies:
-    fbjs "^0.8.4"
-    object-assign "^4.1.0"
-
 react-docgen@^2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-2.13.0.tgz#7fcc4a3104ea8d4fd428383ba38df11166837be9"
@@ -4696,6 +4693,14 @@ react-event-listener@^0.4.3:
   dependencies:
     babel-runtime "^6.20.0"
     react-addons-shallow-compare "^15.4.2"
+    warning "^3.0.0"
+
+react-transition-group@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.1.1.tgz#f9d0f0dff82f52574fc5ab30684add24948d0f23"
+  dependencies:
+    chain-function "^1.0.0"
+    dom-helpers "^3.2.0"
     warning "^3.0.0"
 
 react@^15.4.2:
@@ -5724,17 +5729,13 @@ utils-merge@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
 
-uuid@3.0.0:
+uuid@3.0.0, uuid@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.0.tgz#6728fc0459c450d796a99c31837569bdf672d728"
 
 uuid@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
-
-uuid@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
 v8flags@^2.0.10, v8flags@^2.0.11:
   version "2.0.11"


### PR DESCRIPTION
react-addons-transition-group will be deprecated at React v15.5 (https://github.com/facebook/react/issues/9207).

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

