### PR TITLE
[Drawer] Proper placement for anchor other than left

### DIFF
--- a/docs/src/pages/component-demos/drawers/UndockedDrawer.js
+++ b/docs/src/pages/component-demos/drawers/UndockedDrawer.js
@@ -60,54 +60,78 @@ export default class UndockedDrawer extends Component {
   render() {
     const classes = this.context.styleManager.render(styleSheet);
 
-    const mailFolderList = (
+    const mailFolderListItems = (
+      <div>
+        <ListItem button>
+          <ListItemIcon>
+            <InboxIcon />
+          </ListItemIcon>
+          <ListItemText primary="Inbox" />
+        </ListItem>
+        <ListItem button>
+          <ListItemIcon>
+            <StarIcon />
+          </ListItemIcon>
+          <ListItemText primary="Starred" />
+        </ListItem>
+        <ListItem button>
+          <ListItemIcon>
+            <SendIcon />
+          </ListItemIcon>
+          <ListItemText primary="Send mail" />
+        </ListItem>
+        <ListItem button>
+          <ListItemIcon>
+            <DraftsIcon />
+          </ListItemIcon>
+          <ListItemText primary="Drafts" />
+        </ListItem>
+      </div>
+    );
+
+    const otherMailFolderListItems = (
+      <div>
+        <ListItem button>
+          <ListItemIcon>
+            <MailIcon />
+          </ListItemIcon>
+          <ListItemText primary="All mail" />
+        </ListItem>
+        <ListItem button>
+          <ListItemIcon>
+            <DeleteIcon />
+          </ListItemIcon>
+          <ListItemText primary="Trash" />
+        </ListItem>
+        <ListItem button>
+          <ListItemIcon>
+            <ReportIcon />
+          </ListItemIcon>
+          <ListItemText primary="Spam" />
+        </ListItem>
+      </div>
+    );
+
+    const sideList = (
       <div>
         <List className={classes.list} disablePadding>
-          <ListItem button>
-            <ListItemIcon>
-              <InboxIcon />
-            </ListItemIcon>
-            <ListItemText primary="Inbox" />
-          </ListItem>
-          <ListItem button>
-            <ListItemIcon>
-              <StarIcon />
-            </ListItemIcon>
-            <ListItemText primary="Starred" />
-          </ListItem>
-          <ListItem button>
-            <ListItemIcon>
-              <SendIcon />
-            </ListItemIcon>
-            <ListItemText primary="Send mail" />
-          </ListItem>
-          <ListItem button>
-            <ListItemIcon>
-              <DraftsIcon />
-            </ListItemIcon>
-            <ListItemText primary="Drafts" />
-          </ListItem>
+          {mailFolderListItems}
         </List>
         <Divider />
         <List className={classes.list} disablePadding>
-          <ListItem button>
-            <ListItemIcon>
-              <MailIcon />
-            </ListItemIcon>
-            <ListItemText primary="All mail" />
-          </ListItem>
-          <ListItem button>
-            <ListItemIcon>
-              <DeleteIcon />
-            </ListItemIcon>
-            <ListItemText primary="Trash" />
-          </ListItem>
-          <ListItem button>
-            <ListItemIcon>
-              <ReportIcon />
-            </ListItemIcon>
-            <ListItemText primary="Spam" />
-          </ListItem>
+          {otherMailFolderListItems}
+        </List>
+      </div>
+    );
+
+    const fullList = (
+      <div>
+        <List className={classes.listFull} disablePadding>
+          {mailFolderListItems}
+        </List>
+        <Divider />
+        <List className={classes.listFull} disablePadding>
+          {otherMailFolderListItems}
         </List>
       </div>
     );
@@ -123,7 +147,7 @@ export default class UndockedDrawer extends Component {
           onRequestClose={this.handleLeftClose}
           onClick={this.handleLeftClose}
         >
-          {mailFolderList}
+          {sideList}
         </Drawer>
         <Drawer
           anchor="top"
@@ -131,7 +155,7 @@ export default class UndockedDrawer extends Component {
           onRequestClose={this.handleTopClose}
           onClick={this.handleTopClose}
         >
-          {mailFolderList}
+          {fullList}
         </Drawer>
         <Drawer
           anchor="bottom"
@@ -139,7 +163,7 @@ export default class UndockedDrawer extends Component {
           onRequestClose={this.handleBottomClose}
           onClick={this.handleBottomClose}
         >
-          {mailFolderList}
+          {fullList}
         </Drawer>
         <Drawer
           anchor="right"
@@ -147,7 +171,7 @@ export default class UndockedDrawer extends Component {
           onRequestClose={this.handleRightClose}
           onClick={this.handleRightClose}
         >
-          {mailFolderList}
+          {sideList}
         </Drawer>
       </div>
     );

--- a/docs/src/pages/component-demos/drawers/UndockedDrawer.js
+++ b/docs/src/pages/component-demos/drawers/UndockedDrawer.js
@@ -30,9 +30,6 @@ const styleSheet = createStyleSheet('UndockedDrawer', () => ({
     width: 'auto',
     flex: 'initial',
   },
-  remainder: {
-    flex: 1,
-  },
 }));
 
 export default class UndockedDrawer extends Component {
@@ -62,65 +59,71 @@ export default class UndockedDrawer extends Component {
 
   render() {
     const classes = this.context.styleManager.render(styleSheet);
+
+    const mailFolderList = (
+      <div>
+        <List className={classes.list} disablePadding>
+          <ListItem button>
+            <ListItemIcon>
+              <InboxIcon />
+            </ListItemIcon>
+            <ListItemText primary="Inbox" />
+          </ListItem>
+          <ListItem button>
+            <ListItemIcon>
+              <StarIcon />
+            </ListItemIcon>
+            <ListItemText primary="Starred" />
+          </ListItem>
+          <ListItem button>
+            <ListItemIcon>
+              <SendIcon />
+            </ListItemIcon>
+            <ListItemText primary="Send mail" />
+          </ListItem>
+          <ListItem button>
+            <ListItemIcon>
+              <DraftsIcon />
+            </ListItemIcon>
+            <ListItemText primary="Drafts" />
+          </ListItem>
+        </List>
+        <Divider />
+        <List className={classes.list} disablePadding>
+          <ListItem button>
+            <ListItemIcon>
+              <MailIcon />
+            </ListItemIcon>
+            <ListItemText primary="All mail" />
+          </ListItem>
+          <ListItem button>
+            <ListItemIcon>
+              <DeleteIcon />
+            </ListItemIcon>
+            <ListItemText primary="Trash" />
+          </ListItem>
+          <ListItem button>
+            <ListItemIcon>
+              <ReportIcon />
+            </ListItemIcon>
+            <ListItemText primary="Spam" />
+          </ListItem>
+        </List>
+      </div>
+    );
+
     return (
       <div>
-        <Button onClick={this.handleTopOpen}>Open Top Drawer</Button>
-        <Button onClick={this.handleLeftOpen}>Open Left Drawer</Button>
-        <Button onClick={this.handleBottomOpen}>Open Bottom Drawer</Button>
-        <Button onClick={this.handleRightOpen}>Open Right Drawer</Button>
+        <Button onClick={this.handleLeftOpen}>Open Left</Button>
+        <Button onClick={this.handleRightOpen}>Open Right</Button>
+        <Button onClick={this.handleTopOpen}>Open Top</Button>
+        <Button onClick={this.handleBottomOpen}>Open Bottom</Button>
         <Drawer
           open={this.state.open.left}
           onRequestClose={this.handleLeftClose}
           onClick={this.handleLeftClose}
         >
-          <List className={classes.list} padding={false}>
-            <ListItem button>
-              <ListItemIcon>
-                <InboxIcon />
-              </ListItemIcon>
-              <ListItemText primary="Inbox" />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <StarIcon />
-              </ListItemIcon>
-              <ListItemText primary="Starred" />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <SendIcon />
-              </ListItemIcon>
-              <ListItemText primary="Send mail" />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <DraftsIcon />
-              </ListItemIcon>
-              <ListItemText primary="Drafts" />
-            </ListItem>
-          </List>
-          <Divider />
-          <List className={classes.list} padding={false}>
-            <ListItem button>
-              <ListItemIcon>
-                <MailIcon />
-              </ListItemIcon>
-              <ListItemText primary="All mail" />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <DeleteIcon />
-              </ListItemIcon>
-              <ListItemText primary="Trash" />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <ReportIcon />
-              </ListItemIcon>
-              <ListItemText primary="Spam" />
-            </ListItem>
-          </List>
-          <div className={classes.remainder} />
+          {mailFolderList}
         </Drawer>
         <Drawer
           anchor="top"
@@ -128,54 +131,7 @@ export default class UndockedDrawer extends Component {
           onRequestClose={this.handleTopClose}
           onClick={this.handleTopClose}
         >
-          <List className={classes.listFull} padding={false}>
-            <ListItem button>
-              <ListItemIcon>
-                <InboxIcon />
-              </ListItemIcon>
-              <ListItemText primary="Inbox" />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <StarIcon />
-              </ListItemIcon>
-              <ListItemText primary="Starred" />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <SendIcon />
-              </ListItemIcon>
-              <ListItemText primary="Send mail" />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <DraftsIcon />
-              </ListItemIcon>
-              <ListItemText primary="Drafts" />
-            </ListItem>
-          </List>
-          <Divider />
-          <List className={classes.listFull} padding={false}>
-            <ListItem button>
-              <ListItemIcon>
-                <MailIcon />
-              </ListItemIcon>
-              <ListItemText primary="All mail" />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <DeleteIcon />
-              </ListItemIcon>
-              <ListItemText primary="Trash" />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <ReportIcon />
-              </ListItemIcon>
-              <ListItemText primary="Spam" />
-            </ListItem>
-          </List>
-          <div className={classes.remainder} />
+          {mailFolderList}
         </Drawer>
         <Drawer
           anchor="bottom"
@@ -183,54 +139,7 @@ export default class UndockedDrawer extends Component {
           onRequestClose={this.handleBottomClose}
           onClick={this.handleBottomClose}
         >
-          <List className={classes.listFull} padding={false}>
-            <ListItem button>
-              <ListItemIcon>
-                <InboxIcon />
-              </ListItemIcon>
-              <ListItemText primary="Inbox" />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <StarIcon />
-              </ListItemIcon>
-              <ListItemText primary="Starred" />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <SendIcon />
-              </ListItemIcon>
-              <ListItemText primary="Send mail" />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <DraftsIcon />
-              </ListItemIcon>
-              <ListItemText primary="Drafts" />
-            </ListItem>
-          </List>
-          <Divider />
-          <List className={classes.listFull} padding={false}>
-            <ListItem button>
-              <ListItemIcon>
-                <MailIcon />
-              </ListItemIcon>
-              <ListItemText primary="All mail" />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <DeleteIcon />
-              </ListItemIcon>
-              <ListItemText primary="Trash" />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <ReportIcon />
-              </ListItemIcon>
-              <ListItemText primary="Spam" />
-            </ListItem>
-          </List>
-          <div className={classes.remainder} />
+          {mailFolderList}
         </Drawer>
         <Drawer
           anchor="right"
@@ -238,54 +147,7 @@ export default class UndockedDrawer extends Component {
           onRequestClose={this.handleRightClose}
           onClick={this.handleRightClose}
         >
-          <List className={classes.list} padding={false}>
-            <ListItem button>
-              <ListItemIcon>
-                <InboxIcon />
-              </ListItemIcon>
-              <ListItemText primary="Inbox" />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <StarIcon />
-              </ListItemIcon>
-              <ListItemText primary="Starred" />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <SendIcon />
-              </ListItemIcon>
-              <ListItemText primary="Send mail" />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <DraftsIcon />
-              </ListItemIcon>
-              <ListItemText primary="Drafts" />
-            </ListItem>
-          </List>
-          <Divider />
-          <List className={classes.list} padding={false}>
-            <ListItem button>
-              <ListItemIcon>
-                <MailIcon />
-              </ListItemIcon>
-              <ListItemText primary="All mail" />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <DeleteIcon />
-              </ListItemIcon>
-              <ListItemText primary="Trash" />
-            </ListItem>
-            <ListItem button>
-              <ListItemIcon>
-                <ReportIcon />
-              </ListItemIcon>
-              <ListItemText primary="Spam" />
-            </ListItem>
-          </List>
-          <div className={classes.remainder} />
+          {mailFolderList}
         </Drawer>
       </div>
     );

--- a/docs/src/pages/component-demos/drawers/UndockedDrawer.js
+++ b/docs/src/pages/component-demos/drawers/UndockedDrawer.js
@@ -26,6 +26,10 @@ const styleSheet = createStyleSheet('UndockedDrawer', () => ({
     width: 250,
     flex: 'initial',
   },
+  listFull: {
+    width: 'auto',
+    flex: 'initial',
+  },
   remainder: {
     flex: 1,
   },
@@ -33,21 +37,206 @@ const styleSheet = createStyleSheet('UndockedDrawer', () => ({
 
 export default class UndockedDrawer extends Component {
   state = {
-    open: false,
+    open: {
+      top: false,
+      left: false,
+      bottom: false,
+      right: false,
+    },
   };
 
-  handleOpen = () => this.setState({ open: true });
-  handleClose = () => this.setState({ open: false });
+  toggleDrawer = (side, open) => {
+    const drawerState = {};
+    drawerState[side] = open;
+    this.setState({ open: drawerState });
+  };
+
+  handleTopOpen = () => this.toggleDrawer('top', true);
+  handleTopClose = () => this.toggleDrawer('top', false);
+  handleLeftOpen = () => this.toggleDrawer('left', true);
+  handleLeftClose = () => this.toggleDrawer('left', false);
+  handleBottomOpen = () => this.toggleDrawer('bottom', true);
+  handleBottomClose = () => this.toggleDrawer('bottom', false);
+  handleRightOpen = () => this.toggleDrawer('right', true);
+  handleRightClose = () => this.toggleDrawer('right', false);
 
   render() {
     const classes = this.context.styleManager.render(styleSheet);
     return (
       <div>
-        <Button onClick={this.handleOpen}>Open Drawer</Button>
+        <Button onClick={this.handleTopOpen}>Open Top Drawer</Button>
+        <Button onClick={this.handleLeftOpen}>Open Left Drawer</Button>
+        <Button onClick={this.handleBottomOpen}>Open Bottom Drawer</Button>
+        <Button onClick={this.handleRightOpen}>Open Right Drawer</Button>
         <Drawer
-          open={this.state.open}
-          onRequestClose={this.handleClose}
-          onClick={this.handleClose}
+          open={this.state.open.left}
+          onRequestClose={this.handleLeftClose}
+          onClick={this.handleLeftClose}
+        >
+          <List className={classes.list} padding={false}>
+            <ListItem button>
+              <ListItemIcon>
+                <InboxIcon />
+              </ListItemIcon>
+              <ListItemText primary="Inbox" />
+            </ListItem>
+            <ListItem button>
+              <ListItemIcon>
+                <StarIcon />
+              </ListItemIcon>
+              <ListItemText primary="Starred" />
+            </ListItem>
+            <ListItem button>
+              <ListItemIcon>
+                <SendIcon />
+              </ListItemIcon>
+              <ListItemText primary="Send mail" />
+            </ListItem>
+            <ListItem button>
+              <ListItemIcon>
+                <DraftsIcon />
+              </ListItemIcon>
+              <ListItemText primary="Drafts" />
+            </ListItem>
+          </List>
+          <Divider />
+          <List className={classes.list} padding={false}>
+            <ListItem button>
+              <ListItemIcon>
+                <MailIcon />
+              </ListItemIcon>
+              <ListItemText primary="All mail" />
+            </ListItem>
+            <ListItem button>
+              <ListItemIcon>
+                <DeleteIcon />
+              </ListItemIcon>
+              <ListItemText primary="Trash" />
+            </ListItem>
+            <ListItem button>
+              <ListItemIcon>
+                <ReportIcon />
+              </ListItemIcon>
+              <ListItemText primary="Spam" />
+            </ListItem>
+          </List>
+          <div className={classes.remainder} />
+        </Drawer>
+        <Drawer
+          anchor="top"
+          open={this.state.open.top}
+          onRequestClose={this.handleTopClose}
+          onClick={this.handleTopClose}
+        >
+          <List className={classes.listFull} padding={false}>
+            <ListItem button>
+              <ListItemIcon>
+                <InboxIcon />
+              </ListItemIcon>
+              <ListItemText primary="Inbox" />
+            </ListItem>
+            <ListItem button>
+              <ListItemIcon>
+                <StarIcon />
+              </ListItemIcon>
+              <ListItemText primary="Starred" />
+            </ListItem>
+            <ListItem button>
+              <ListItemIcon>
+                <SendIcon />
+              </ListItemIcon>
+              <ListItemText primary="Send mail" />
+            </ListItem>
+            <ListItem button>
+              <ListItemIcon>
+                <DraftsIcon />
+              </ListItemIcon>
+              <ListItemText primary="Drafts" />
+            </ListItem>
+          </List>
+          <Divider />
+          <List className={classes.listFull} padding={false}>
+            <ListItem button>
+              <ListItemIcon>
+                <MailIcon />
+              </ListItemIcon>
+              <ListItemText primary="All mail" />
+            </ListItem>
+            <ListItem button>
+              <ListItemIcon>
+                <DeleteIcon />
+              </ListItemIcon>
+              <ListItemText primary="Trash" />
+            </ListItem>
+            <ListItem button>
+              <ListItemIcon>
+                <ReportIcon />
+              </ListItemIcon>
+              <ListItemText primary="Spam" />
+            </ListItem>
+          </List>
+          <div className={classes.remainder} />
+        </Drawer>
+        <Drawer
+          anchor="bottom"
+          open={this.state.open.bottom}
+          onRequestClose={this.handleBottomClose}
+          onClick={this.handleBottomClose}
+        >
+          <List className={classes.listFull} padding={false}>
+            <ListItem button>
+              <ListItemIcon>
+                <InboxIcon />
+              </ListItemIcon>
+              <ListItemText primary="Inbox" />
+            </ListItem>
+            <ListItem button>
+              <ListItemIcon>
+                <StarIcon />
+              </ListItemIcon>
+              <ListItemText primary="Starred" />
+            </ListItem>
+            <ListItem button>
+              <ListItemIcon>
+                <SendIcon />
+              </ListItemIcon>
+              <ListItemText primary="Send mail" />
+            </ListItem>
+            <ListItem button>
+              <ListItemIcon>
+                <DraftsIcon />
+              </ListItemIcon>
+              <ListItemText primary="Drafts" />
+            </ListItem>
+          </List>
+          <Divider />
+          <List className={classes.listFull} padding={false}>
+            <ListItem button>
+              <ListItemIcon>
+                <MailIcon />
+              </ListItemIcon>
+              <ListItemText primary="All mail" />
+            </ListItem>
+            <ListItem button>
+              <ListItemIcon>
+                <DeleteIcon />
+              </ListItemIcon>
+              <ListItemText primary="Trash" />
+            </ListItem>
+            <ListItem button>
+              <ListItemIcon>
+                <ReportIcon />
+              </ListItemIcon>
+              <ListItemText primary="Spam" />
+            </ListItem>
+          </List>
+          <div className={classes.remainder} />
+        </Drawer>
+        <Drawer
+          anchor="right"
+          open={this.state.open.right}
+          onRequestClose={this.handleRightClose}
+          onClick={this.handleRightClose}
         >
           <List className={classes.list} padding={false}>
             <ListItem button>

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -38,6 +38,30 @@ export const styleSheet = createStyleSheet('MuiDrawer', (theme) => {
       },
       WebkitOverflowScrolling: 'touch', // Add iOS momentum scrolling.
     },
+    paperLeft: {
+      left: 0,
+      right: 'auto',
+    },
+    paperRight: {
+      left: 'auto',
+      right: 0,
+    },
+    paperTop: {
+      top: 0,
+      left: 0,
+      bottom: 'auto',
+      right: 0,
+      height: 'auto',
+      maxHeight: '100vh',
+    },
+    paperBottom: {
+      top: 'auto',
+      left: 0,
+      bottom: 0,
+      right: 0,
+      height: 'auto',
+      maxHeight: '100vh',
+    },
     docked: {
       flex: '0 0 auto',
       '& $paper': {
@@ -98,6 +122,7 @@ export default class Drawer extends Component {
   };
 
   static defaultProps = {
+    anchor: 'left',
     docked: false,
     enterTransitionDuration: duration.enteringScreen,
     leaveTransitionDuration: duration.leavingScreen,
@@ -126,7 +151,18 @@ export default class Drawer extends Component {
     const { theme: { dir }, render } = this.context.styleManager;
     const classes = render(styleSheet);
     const rtl = dir === 'rtl';
-    const anchor = anchorProp || (rtl ? 'right' : 'left');
+    const anchorClasses = {
+      top: classes.paperTop,
+      left: classes.paperLeft,
+      bottom: classes.paperBottom,
+      right: classes.paperRight,
+    };
+
+    let anchor = anchorProp;
+    if (rtl && ['left', 'right'].includes(anchor)) {
+      anchor = (anchor === 'left') ? 'right' : 'left';
+    }
+
     const slideDirection = getSlideDirection(anchor);
 
     const drawer = (
@@ -140,7 +176,7 @@ export default class Drawer extends Component {
         <Paper
           elevation={docked ? 0 : elevation}
           square
-          className={classNames(classes.paper, paperClassName)}
+          className={classNames(classes.paper, anchorClasses[anchor], paperClassName)}
         >
           {children}
         </Paper>

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -38,15 +38,15 @@ export const styleSheet = createStyleSheet('MuiDrawer', (theme) => {
       },
       WebkitOverflowScrolling: 'touch', // Add iOS momentum scrolling.
     },
-    paperLeft: {
+    left: {
       left: 0,
       right: 'auto',
     },
-    paperRight: {
+    right: {
       left: 'auto',
       right: 0,
     },
-    paperTop: {
+    top: {
       top: 0,
       left: 0,
       bottom: 'auto',
@@ -54,7 +54,7 @@ export const styleSheet = createStyleSheet('MuiDrawer', (theme) => {
       height: 'auto',
       maxHeight: '100vh',
     },
-    paperBottom: {
+    bottom: {
       top: 'auto',
       left: 0,
       bottom: 0,
@@ -151,13 +151,6 @@ export default class Drawer extends Component {
     const { theme: { dir }, render } = this.context.styleManager;
     const classes = render(styleSheet);
     const rtl = dir === 'rtl';
-    const anchorClasses = {
-      top: classes.paperTop,
-      left: classes.paperLeft,
-      bottom: classes.paperBottom,
-      right: classes.paperRight,
-    };
-
     let anchor = anchorProp;
     if (rtl && ['left', 'right'].includes(anchor)) {
       anchor = (anchor === 'left') ? 'right' : 'left';
@@ -176,7 +169,7 @@ export default class Drawer extends Component {
         <Paper
           elevation={docked ? 0 : elevation}
           square
-          className={classNames(classes.paper, anchorClasses[anchor], paperClassName)}
+          className={classNames(classes.paper, classes[anchor], paperClassName)}
         >
           {children}
         </Paper>

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { createShallow } from 'src/test-utils';
 import Drawer, { styleSheet } from './Drawer';
+import Paper from '../Paper';
 import Slide from '../transitions/Slide';
 import Modal from '../internal/Modal';
 import { duration } from '../styles/transitions';
@@ -203,6 +204,31 @@ describe('<Drawer />', () => {
         anchor: 'bottom',
       });
       assert.strictEqual(wrapper.find(Slide).props().direction, 'up');
+    });
+  });
+
+  describe('right-to-left', () => {
+    let wrapper;
+
+    before(() => {
+      wrapper = shallow(<Drawer />);
+      const styleManager = wrapper.context('styleManager');
+      styleManager.theme.dir = 'rtl';
+      wrapper.setContext({ styleManager });
+    });
+
+    it('should switch left and right anchor when theme is right-to-left', () => {
+      wrapper.setProps({
+        anchor: 'left',
+      });
+      // slide direction for left is right, if left is switched to right, we should get left
+      assert.strictEqual(wrapper.find(Slide).props().direction, 'left');
+
+      wrapper.setProps({
+        anchor: 'right',
+      });
+      // slide direction for right is left, if right is switched to left, we should get right
+      assert.strictEqual(wrapper.find(Slide).props().direction, 'right');
     });
   });
 });

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -4,7 +4,6 @@ import React from 'react';
 import { assert } from 'chai';
 import { createShallow } from 'src/test-utils';
 import Drawer, { styleSheet } from './Drawer';
-import Paper from '../Paper';
 import Slide from '../transitions/Slide';
 import Modal from '../internal/Modal';
 import { duration } from '../styles/transitions';


### PR DESCRIPTION
The anchor property is not fully implemented.  It appropriately sets the direction that the drawer should slide, but the drawer is always placed at the left of the viewport.  This is because the initial position and height is not changed when anchor is right, top, or bottom.

Resolution:

- Assume a default of 'left'.
- If we are right-to-left (based on the theme), swap 'right' and 'left'.
- Create classes that extend paper for left, top, right, and bottom anchoring and apply them after possibly changing anchor in consideration of right-to-left.
- For right anchored drawers, left is set to auto and right is set to zero.  This follows the functionality employed in the master branch.
- For top and bottom anchored drawers, height is set to auto, left and right are set to zero.  The max height is left for the consumer of this component since Material Design does not prohibit a full-height bottom sheet.
- A future PR may be required to ensure complete compliance with MD's standards for modal bottom sheets and ;ack of specification for modal top sheets.
- Added top, bottom, right drawers to component demo.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [X] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

