### PR TITLE
[DropDownMenu] Fix miss alignment in ToolBar

### DIFF
--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -53,7 +53,7 @@ function getStyles(props, context) {
     root: {
       display: 'inline-block',
       fontSize: spacing.desktopDropDownMenuFontSize,
-      height: spacing.desktopSubheaderHeight,
+      height: spacing.desktopToolbarHeight,
       fontFamily: context.muiTheme.baseTheme.fontFamily,
       outline: 'none',
       position: 'relative',
@@ -64,7 +64,7 @@ function getStyles(props, context) {
     },
     underline: {
       borderTop: `solid 1px ${accentColor}`,
-      bottom: 1,
+      bottom: 9,
       left: 0,
       margin: `-1px ${spacing.desktopGutter}px`,
       right: 0,


### PR DESCRIPTION
For DropDownMenu component, I changed the hight of root to the same as label from 48px to 56px. Then move underline up by 8px.
This would correct the alignment when using DropDownMenu in ToolBar component.
Please check the ToolBar example on different version between v0.16.1 and v0.16.2~v0.17.1 to see the problem. And that's how I found this bug.

http://www.material-ui.com/v0.16.1/#/components/toolbar
http://www.material-ui.com/v0.16.2/#/components/toolbar


<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

