### PR TITLE
[ButtonBase] Change tests to use faketimers

### DIFF
--- a/src/internal/ButtonBase.js
+++ b/src/internal/ButtonBase.js
@@ -114,6 +114,8 @@ export default class ButtonBase extends Component {
   keyDown = false; // Used to help track keyboard activation keyDown
   button = null;
   keyboardFocusTimeout = undefined;
+  keyboardFocusCheckTime = 40;
+  keyboardFocusMaxCheckTimes = 5;
 
   focus = () => this.button.focus();
 

--- a/src/internal/ButtonBase.spec.js
+++ b/src/internal/ButtonBase.spec.js
@@ -311,6 +311,10 @@ describe('<ButtonBase />', () => {
       window.dispatchEvent(event);
     });
 
+    after(() => {
+      clock.restore();
+    });
+
     it('should not set keyboard focus before time has passed', () => {
       assert.strictEqual(wrapper.state('keyboardFocused'), false, 'should not be keyboardFocused');
     });
@@ -318,10 +322,6 @@ describe('<ButtonBase />', () => {
     it('should listen for tab presses and set keyboard focus', () => {
       clock.tick(instance.keyboardFocusCheckTime * instance.keyboardFocusMaxCheckTimes);
       assert.strictEqual(wrapper.state('keyboardFocused'), true, 'should be keyboardFocused');
-    });
-
-    after(() => {
-      clock.restore();
     });
   });
 

--- a/src/internal/ButtonBase.spec.js
+++ b/src/internal/ButtonBase.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import keycode from 'keycode';
 import { assert } from 'chai';
-import { spy } from 'sinon';
+import { spy, useFakeTimers } from 'sinon';
 import { createShallow, createMount } from 'src/test-utils';
 import ButtonBase, { styleSheet } from './ButtonBase';
 
@@ -287,12 +287,20 @@ describe('<ButtonBase />', () => {
   });
 
   describe('mounted tab press listener', () => {
-    it('should listen for tab presses and set keyboard focus', (done) => {
-      const wrapper = mount(
+    let wrapper;
+    let instance;
+    let button;
+    let clock;
+
+    before(() => {
+      clock = useFakeTimers();
+      wrapper = mount(
         <ButtonBase id="test-button">Hello</ButtonBase>,
       );
+      instance = wrapper.instance();
 
-      const button = document.getElementById('test-button');
+      button = document.getElementById('test-button');
+
       if (!button) {
         throw new Error('missing button');
       }
@@ -301,15 +309,19 @@ describe('<ButtonBase />', () => {
       const event = new window.Event('keyup');
       event.which = keycode('tab');
       window.dispatchEvent(event);
+    });
 
-      setTimeout(() => {
-        assert.strictEqual(
-          wrapper.state('keyboardFocused'),
-          true,
-          'should be keyboardFocused',
-        );
-        done();
-      }, 200);
+    it('should not set keyboard focus before time has passed', () => {
+      assert.strictEqual(wrapper.state('keyboardFocused'), false, 'should not be keyboardFocused');
+    });
+
+    it('should listen for tab presses and set keyboard focus', () => {
+      clock.tick(instance.keyboardFocusCheckTime * instance.keyboardFocusMaxCheckTimes);
+      assert.strictEqual(wrapper.state('keyboardFocused'), true, 'should be keyboardFocused');
+    });
+
+    after(() => {
+      clock.restore();
     });
   });
 

--- a/src/utils/keyboardFocus.js
+++ b/src/utils/keyboardFocus.js
@@ -22,10 +22,10 @@ export function detectKeyboardFocus(instance, element, cb, attempt = 1) {
       (document.activeElement === element || contains(element, document.activeElement))
     ) {
       cb();
-    } else if (attempt < 5) {
+    } else if (attempt < instance.keyboardFocusMaxCheckTimes) {
       detectKeyboardFocus(instance, element, cb, attempt + 1);
     }
-  }, 40);
+  }, instance.keyboardFocusCheckTime);
 }
 
 export function listenForFocusKeys() {


### PR DESCRIPTION
Testing of keyboard focus on button base relied on a certain time gap.
This commit changes the test for this case to use sinon's fake timers

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

