### PR TITLE
[AutoComplete] Fix overriding TextField event props

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -401,7 +401,10 @@ class AutoComplete extends Component {
       menuProps,
       listStyle,
       targetOrigin,
+      onBlur, // eslint-disable-line no-unused-vars
       onClose, // eslint-disable-line no-unused-vars
+      onFocus, // eslint-disable-line no-unused-vars
+      onKeyDown, // eslint-disable-line no-unused-vars
       onNewRequest, // eslint-disable-line no-unused-vars
       onUpdateInput, // eslint-disable-line no-unused-vars
       openOnFocus, // eslint-disable-line no-unused-vars


### PR DESCRIPTION
Fixes #6560 (got it wrong previously, my "6" key is broken :sweat_smile:)

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

