### PR TITLE
[CardHeader] Subheader doesn't go to a new line if there's no avatar

### DIFF
--- a/docs/src/pages/component-demos/cards/RecipeReviewCard.js
+++ b/docs/src/pages/component-demos/cards/RecipeReviewCard.js
@@ -54,7 +54,7 @@ export default class RecipeReviewCard extends Component {
           <CardHeader
             avatar={<Avatar aria-label="Recipe" className={classes.avatar}>R</Avatar>}
             title="Shrimp and Chorizo Paella"
-            subhead="September 14, 2016"
+            subheader="September 14, 2016"
           />
           <CardMedia>
             <img src={paellaImage} alt="Contemplative Reptile" />

--- a/src/Card/CardHeader.js
+++ b/src/Card/CardHeader.js
@@ -37,32 +37,25 @@ export default function CardHeader(props, context) {
   const classes = context.styleManager.render(styleSheet);
   const className = classNames(classes.cardHeader, classNameProp);
 
-  if (avatar) {
-    return (
-      <CardContent className={className} {...other}>
-        <div className={classes.avatar}>
-          {avatar}
-        </div>
-        <div className={classes.content}>
-          <Text type="body2" gutterBottom>
-            {title}
-          </Text>
-          <Text type="body2" secondary className={classes.contentSecondary}>
-            {subheader}
-          </Text>
-        </div>
-      </CardContent>
-    );
-  }
+  // adjustments that depend on the presence of an avatar
+  const titleType = avatar ? 'body2' : 'headline';
+  const subheaderType = avatar ? 'body2' : 'body1';
 
   return (
     <CardContent className={className} {...other}>
-      <Text type="headline">
-        {title}
-      </Text>
-      <Text type="body1" secondary>
-        {subheader}
-      </Text>
+      {avatar &&
+        <div className={classes.avatar}>
+          {avatar}
+        </div>
+      }
+      <div className={classes.content}>
+        <Text type={titleType}>
+          {title}
+        </Text>
+        <Text type={subheaderType} secondary className={classes.contentSecondary}>
+          {subheader}
+        </Text>
+      </div>
     </CardContent>
   );
 }

--- a/src/Card/CardHeader.spec.js
+++ b/src/Card/CardHeader.spec.js
@@ -41,13 +41,15 @@ describe('<CardHeader />', () => {
     });
 
     it('should render the title as headline text', () => {
-      const title = wrapper.childAt(0);
+      const container = wrapper.childAt(0);
+      const title = container.childAt(0);
       assert.strictEqual(title.is('Text'), true);
       assert.strictEqual(title.prop('type'), 'headline');
     });
 
     it('should render the subead as body1 secondary text', () => {
-      const subhead = wrapper.childAt(1);
+      const container = wrapper.childAt(0);
+      const subhead = container.childAt(1);
       assert.strictEqual(subhead.is('Text'), true);
       assert.strictEqual(subhead.prop('type'), 'body1');
       assert.strictEqual(subhead.prop('secondary'), true);


### PR DESCRIPTION
When CardHeader is not given an avatar, the title and subheader are on the same line.  This is because they are contained within a flexbox, items aligned center.  This configuration works when an avatar is present because the title and subheader are wrapped, so their container flexes and each Text component is presented on its own line.  (Closes #6371)

Wrapping the title and subheading, as is currently done when an avatar is present, fixes this issue.
- Updated CardHeader to wrap title and subheader (which simplifies the rendering of this component)
- Updated the CardHeader tests to account for the addition of this wrapper.
- Also fixed a typo in the demo on the paella recipe.  The subheader property was being specified as subhead.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [X] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

