### PR TITLE
[Dialog] Improves borders behavior in scrollable Dialog 

### DIFF
--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -122,7 +122,6 @@ function getStyles(props, context) {
       width: '100%',
       textAlign: 'right',
       marginTop: autoScrollBodyContent ? -1 : 0,
-      borderTop: autoScrollBodyContent ? borderScroll : 'none',
     },
     overlay: {
       zIndex: zIndex.dialogOverlay,
@@ -135,7 +134,6 @@ function getStyles(props, context) {
       lineHeight: '32px',
       fontWeight: 400,
       marginBottom: autoScrollBodyContent ? -1 : 0,
-      borderBottom: autoScrollBodyContent ? borderScroll : 'none',
     },
     body: {
       fontSize: dialog.bodyFontSize,
@@ -143,6 +141,8 @@ function getStyles(props, context) {
       padding: `${props.title ? 0 : gutter}px ${gutter}px ${gutter}px`,
       boxSizing: 'border-box',
       overflowY: autoScrollBodyContent ? 'auto' : 'hidden',
+      borderTop: autoScrollBodyContent ? borderScroll : 'none',
+      borderBottom: autoScrollBodyContent ? borderScroll : 'none',
     },
   };
 }
@@ -232,6 +232,10 @@ class DialogInline extends Component {
       }
 
       dialogContent.style.maxHeight = `${maxDialogContentHeight}px`;
+      if (maxDialogContentHeight > dialogWindowHeight) {
+        dialogContent.style.borderBottom = 'none';
+        dialogContent.style.borderTop = 'none';
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

When Dialog is scrollable show borders around its content only when content is bigger than calculated max height.
Address https://github.com/callemall/material-ui/issues/4310.
