### PR TITLE
[react] Use React 15.5 and prop-types lib

### DIFF
--- a/docs/src/app/app.native.js
+++ b/docs/src/app/app.native.js
@@ -1,4 +1,6 @@
-import React, {Component, PropTypes} from 'react-native';
+import React, {Component} from 'react-native';
+
+import PropTypes from 'prop-types';
 
 const {
   Platform,

--- a/docs/src/app/app.native.js
+++ b/docs/src/app/app.native.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react-native';
-
 import PropTypes from 'prop-types';
 
 const {

--- a/docs/src/app/components/AppNavDrawer.js
+++ b/docs/src/app/components/AppNavDrawer.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Drawer from 'material-ui/Drawer';
 import {List, ListItem, makeSelectable} from 'material-ui/List';
 import Divider from 'material-ui/Divider';

--- a/docs/src/app/components/CodeExample/CodeBlock.js
+++ b/docs/src/app/components/CodeExample/CodeBlock.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import MarkdownElement from '../MarkdownElement';
 import transitions from 'material-ui/styles/transitions';
 import CodeBlockTitle from './CodeBlockTitle';

--- a/docs/src/app/components/CodeExample/CodeBlockTitle.js
+++ b/docs/src/app/components/CodeExample/CodeBlockTitle.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import IconButton from 'material-ui/IconButton';
 import CodeIcon from 'material-ui/svg-icons/action/code';
 import {Toolbar, ToolbarGroup, ToolbarTitle} from 'material-ui/Toolbar';

--- a/docs/src/app/components/CodeExample/index.js
+++ b/docs/src/app/components/CodeExample/index.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {parse} from 'react-docgen';
 import CodeBlock from './CodeBlock';
 import ClearFix from 'material-ui/internal/ClearFix';
@@ -10,7 +11,7 @@ class CodeExample extends Component {
     code: PropTypes.string.isRequired,
     component: PropTypes.bool,
     description: PropTypes.string,
-    exampleBlockStyle: React.PropTypes.object,
+    exampleBlockStyle: PropTypes.object,
     layoutSideBySide: PropTypes.bool,
     title: PropTypes.string,
   };

--- a/docs/src/app/components/FullWidthSection.js
+++ b/docs/src/app/components/FullWidthSection.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ClearFix from 'material-ui/internal/ClearFix';
 import spacing from 'material-ui/styles/spacing';
 import withWidth, {SMALL, LARGE} from 'material-ui/utils/withWidth';

--- a/docs/src/app/components/MarkdownElement.js
+++ b/docs/src/app/components/MarkdownElement.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import marked from 'marked';
 
 require('./mui-github-markdown.css');

--- a/docs/src/app/components/Master.js
+++ b/docs/src/app/components/Master.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Title from 'react-title-component';
 import AppBar from 'material-ui/AppBar';
 import IconButton from 'material-ui/IconButton';

--- a/docs/src/app/components/MobileTearSheet.js
+++ b/docs/src/app/components/MobileTearSheet.js
@@ -1,4 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+
+import PropTypes from 'prop-types';
 
 class MobileTearSheet extends Component {
 

--- a/docs/src/app/components/MobileTearSheet.js
+++ b/docs/src/app/components/MobileTearSheet.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-
 import PropTypes from 'prop-types';
 
 class MobileTearSheet extends Component {

--- a/docs/src/app/components/PropTypeDescription.js
+++ b/docs/src/app/components/PropTypeDescription.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {parse} from 'react-docgen';
 import {parse as parseDoctrine} from 'doctrine';
 import MarkdownElement from './MarkdownElement';

--- a/docs/src/app/components/pages/Home.js
+++ b/docs/src/app/components/pages/Home.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import HomeFeature from './HomeFeature';
 import FullWidthSection from '../FullWidthSection';
 import RaisedButton from 'material-ui/RaisedButton';

--- a/docs/src/app/components/pages/HomeFeature.js
+++ b/docs/src/app/components/pages/HomeFeature.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {Link} from 'react-router';
 import withWidth, {MEDIUM, LARGE} from 'material-ui/utils/withWidth';
 import spacing from 'material-ui/styles/spacing';

--- a/docs/src/app/components/pages/components/List/ExampleSelectable.js
+++ b/docs/src/app/components/pages/components/List/ExampleSelectable.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import MobileTearSheet from '../../../MobileTearSheet';
 import {List, ListItem, makeSelectable} from 'material-ui/List';
 import Avatar from 'material-ui/Avatar';

--- a/docs/src/app/components/pages/customization/Colors.js
+++ b/docs/src/app/components/pages/customization/Colors.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Title from 'react-title-component';
 import withWidth, {MEDIUM, LARGE} from 'material-ui/utils/withWidth';
 import ClearFix from 'material-ui/internal/ClearFix';

--- a/docs/src/app/components/pages/customization/Themes.js
+++ b/docs/src/app/components/pages/customization/Themes.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Title from 'react-title-component';
 import MarkdownElement from '../../MarkdownElement';
 import muiThemeable from 'material-ui/styles/muiThemeable';

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "nodemon": "^1.11.0",
     "phantomjs-prebuilt": "^2.1.14",
     "react": "^15.5.0",
-    "react-addons-test-utils": "^15.5.0",
     "react-dom": "^15.5.0",
     "react-tap-event-plugin": "^2.0.0",
     "recursive-readdir-sync": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "coveralls": "^2.13.0",
     "create-react-class": "^15.5.0",
     "cross-env": "^4.0.0",
-    "enzyme": "^2.8.0",
+    "enzyme": "^2.8.1",
     "eslint": "^3.19.0",
     "eslint-find-rules": "^1.14.3",
     "eslint-plugin-babel": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,9 @@
     "test:unit:watch": "cross-env NODE_ENV=test babel-node test/watch.js unit"
   },
   "peerDependencies": {
-    "react": "^15.4.0",
-    "react-dom": "^15.4.0",
+    "react": "^15.5.0",
+    "react-dom": "^15.5.0",
+    "react-prop-types": "^15.5.0",
     "react-tap-event-plugin": "^2.0.1"
   },
   "dependencies": {
@@ -51,8 +52,8 @@
     "keycode": "^2.1.8",
     "lodash.merge": "^4.6.0",
     "lodash.throttle": "^4.1.1",
-    "react-addons-create-fragment": "^15.4.0",
-    "react-addons-transition-group": "^15.4.0",
+    "react-addons-create-fragment": "^15.5.0",
+    "react-addons-transition-group": "^15.5.0",
     "react-event-listener": "^0.4.5",
     "recompose": "^0.23.0",
     "simple-assign": "^0.1.0",
@@ -101,9 +102,9 @@
     "mocha": "^3.1.2",
     "nodemon": "^1.11.0",
     "phantomjs-prebuilt": "^2.1.14",
-    "react": "^15.4.2",
-    "react-addons-test-utils": "^15.4.2",
-    "react-dom": "^15.4.2",
+    "react": "^15.5.0",
+    "react-addons-test-utils": "^15.5.0",
+    "react-dom": "^15.5.0",
     "react-tap-event-plugin": "^2.0.0",
     "recursive-readdir-sync": "^1.0.6",
     "rimraf": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "keycode": "^2.1.8",
     "lodash.merge": "^4.6.0",
     "lodash.throttle": "^4.1.1",
-    "prop-types": "^15.5.0",
+    "prop-types": "^15.5.7",
     "react-addons-create-fragment": "^15.5.0",
     "react-addons-transition-group": "^15.5.0",
     "react-event-listener": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "test:unit:watch": "cross-env NODE_ENV=test babel-node test/watch.js unit"
   },
   "peerDependencies": {
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
+    "react": "^15.4.0",
+    "react-dom": "^15.4.0",
     "react-tap-event-plugin": "^2.0.1"
   },
   "dependencies": {
@@ -52,8 +52,8 @@
     "lodash.merge": "^4.6.0",
     "lodash.throttle": "^4.1.1",
     "prop-types": "^15.5.7",
-    "react-addons-create-fragment": "^15.4.2",
-    "react-addons-transition-group": "^15.4.2",
+    "react-addons-create-fragment": "^15.4.0",
+    "react-addons-transition-group": "^15.4.0",
     "react-event-listener": "^0.4.5",
     "recompose": "^0.23.0",
     "simple-assign": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "test:unit:watch": "cross-env NODE_ENV=test babel-node test/watch.js unit"
   },
   "peerDependencies": {
-    "react": "^15.5.0",
-    "react-dom": "^15.5.0",
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2",
     "react-tap-event-plugin": "^2.0.1"
   },
   "dependencies": {
@@ -52,8 +52,8 @@
     "lodash.merge": "^4.6.0",
     "lodash.throttle": "^4.1.1",
     "prop-types": "^15.5.7",
-    "react-addons-create-fragment": "^15.5.0",
-    "react-addons-transition-group": "^15.5.0",
+    "react-addons-create-fragment": "^15.4.2",
+    "react-addons-transition-group": "^15.4.2",
     "react-event-listener": "^0.4.5",
     "recompose": "^0.23.0",
     "simple-assign": "^0.1.0",
@@ -77,6 +77,7 @@
     "babel-preset-stage-1": "^6.24.1",
     "chai": "^3.5.0",
     "coveralls": "^2.13.0",
+    "create-react-class": "^15.5.0",
     "cross-env": "^4.0.0",
     "enzyme": "^2.8.0",
     "eslint": "^3.19.0",
@@ -104,6 +105,7 @@
     "phantomjs-prebuilt": "^2.1.14",
     "react": "^15.5.0",
     "react-dom": "^15.5.0",
+    "react-test-renderer": "^15.5.0",
     "react-tap-event-plugin": "^2.0.0",
     "recursive-readdir-sync": "^1.0.6",
     "rimraf": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "peerDependencies": {
     "react": "^15.5.0",
     "react-dom": "^15.5.0",
-    "react-prop-types": "^15.5.0",
     "react-tap-event-plugin": "^2.0.1"
   },
   "dependencies": {
@@ -52,6 +51,7 @@
     "keycode": "^2.1.8",
     "lodash.merge": "^4.6.0",
     "lodash.throttle": "^4.1.1",
+    "prop-types": "^15.5.0",
     "react-addons-create-fragment": "^15.5.0",
     "react-addons-transition-group": "^15.5.0",
     "react-event-listener": "^0.4.5",

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes, cloneElement} from 'react';
+import React, {Component, cloneElement} from 'react';
+import PropTypes from 'prop-types';
 import IconButton from '../IconButton';
 import NavigationMenu from '../svg-icons/navigation/menu';
 import Paper from '../Paper';

--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import keycode from 'keycode';
 import TextField from '../TextField';

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -1,4 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+
+import PropTypes from 'prop-types';
 
 function getStyles(props, context) {
   const {

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-
 import PropTypes from 'prop-types';
 
 function getStyles(props, context) {

--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -1,4 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+
+import PropTypes from 'prop-types';
 
 function getStyles(props, context) {
   const {primary, secondary} = props;

--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-
 import PropTypes from 'prop-types';
 
 function getStyles(props, context) {

--- a/src/BottomNavigation/BottomNavigation.js
+++ b/src/BottomNavigation/BottomNavigation.js
@@ -1,4 +1,6 @@
-import React, {PropTypes, Children, cloneElement} from 'react';
+import React, {Children, cloneElement} from 'react';
+
+import PropTypes from 'prop-types';
 
 function getStyles(props, context) {
   const {

--- a/src/BottomNavigation/BottomNavigation.js
+++ b/src/BottomNavigation/BottomNavigation.js
@@ -1,5 +1,4 @@
 import React, {Children, cloneElement} from 'react';
-
 import PropTypes from 'prop-types';
 
 function getStyles(props, context) {

--- a/src/BottomNavigation/BottomNavigationItem.js
+++ b/src/BottomNavigation/BottomNavigationItem.js
@@ -1,4 +1,5 @@
-import React, {PropTypes, cloneElement} from 'react';
+import React, {cloneElement} from 'react';
+import PropTypes from 'prop-types';
 import EnhancedButton from '../internal/EnhancedButton';
 
 function getStyles(props, context) {

--- a/src/Card/Card.js
+++ b/src/Card/Card.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Paper from '../Paper';
 import CardExpandable from './CardExpandable';
 

--- a/src/Card/CardActions.js
+++ b/src/Card/CardActions.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-
 import PropTypes from 'prop-types';
 
 function getStyles() {

--- a/src/Card/CardActions.js
+++ b/src/Card/CardActions.js
@@ -1,4 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+
+import PropTypes from 'prop-types';
 
 function getStyles() {
   return {

--- a/src/Card/CardExpandable.js
+++ b/src/Card/CardExpandable.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import OpenIcon from '../svg-icons/hardware/keyboard-arrow-up';
 import CloseIcon from '../svg-icons/hardware/keyboard-arrow-down';
 import IconButton from '../IconButton';

--- a/src/Card/CardHeader.js
+++ b/src/Card/CardHeader.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes, isValidElement} from 'react';
+import React, {Component, isValidElement} from 'react';
+import PropTypes from 'prop-types';
 import Avatar from '../Avatar';
 
 function getStyles(props, context) {

--- a/src/Card/CardMedia.js
+++ b/src/Card/CardMedia.js
@@ -1,4 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+
+import PropTypes from 'prop-types';
 
 function getStyles(props, context) {
   const {cardMedia} = context.muiTheme;

--- a/src/Card/CardMedia.js
+++ b/src/Card/CardMedia.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-
 import PropTypes from 'prop-types';
 
 function getStyles(props, context) {

--- a/src/Card/CardText.js
+++ b/src/Card/CardText.js
@@ -1,4 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+
+import PropTypes from 'prop-types';
 
 function getStyles(props, context) {
   const {cardText} = context.muiTheme;

--- a/src/Card/CardText.js
+++ b/src/Card/CardText.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-
 import PropTypes from 'prop-types';
 
 function getStyles(props, context) {

--- a/src/Card/CardTitle.js
+++ b/src/Card/CardTitle.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-
 import PropTypes from 'prop-types';
 
 function getStyles(props, context) {

--- a/src/Card/CardTitle.js
+++ b/src/Card/CardTitle.js
@@ -1,4 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+
+import PropTypes from 'prop-types';
 
 function getStyles(props, context) {
   const {card} = context.muiTheme;

--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import EnhancedSwitch from '../internal/EnhancedSwitch';
 import transitions from '../styles/transitions';
 import CheckboxOutline from '../svg-icons/toggle/check-box-outline-blank';

--- a/src/Checkbox/Checkbox.spec.js
+++ b/src/Checkbox/Checkbox.spec.js
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {shallow, mount} from 'enzyme';
 import {assert} from 'chai';
 import Checkbox from './Checkbox';

--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import keycode from 'keycode';
 import {fade, emphasize} from '../utils/colorManipulator';
 import EnhancedButton from '../internal/EnhancedButton';

--- a/src/CircularProgress/CircularProgress.js
+++ b/src/CircularProgress/CircularProgress.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import autoPrefix from '../utils/autoPrefix';
 import transitions from '../styles/transitions';
 

--- a/src/DatePicker/Calendar.js
+++ b/src/DatePicker/Calendar.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import EventListener from 'react-event-listener';
 import keycode from 'keycode';
 import transitions from '../styles/transitions';

--- a/src/DatePicker/CalendarActionButtons.js
+++ b/src/DatePicker/CalendarActionButtons.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import FlatButton from '../FlatButton';
 
 class CalendarActionButton extends Component {

--- a/src/DatePicker/CalendarMonth.js
+++ b/src/DatePicker/CalendarMonth.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {isBetweenDates, isEqualDate, getWeekArray} from './dateUtils';
 import DayButton from './DayButton';
 

--- a/src/DatePicker/CalendarToolbar.js
+++ b/src/DatePicker/CalendarToolbar.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import IconButton from '../IconButton';
 import NavigationChevronLeft from '../svg-icons/navigation/chevron-left';
 import NavigationChevronRight from '../svg-icons/navigation/chevron-right';

--- a/src/DatePicker/CalendarYear.js
+++ b/src/DatePicker/CalendarYear.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import YearButton from './YearButton';
 import {cloneDate} from './dateUtils';

--- a/src/DatePicker/DateDisplay.js
+++ b/src/DatePicker/DateDisplay.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import transitions from '../styles/transitions';
 import SlideInTransitionGroup from '../internal/SlideIn';
 

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {dateTimeFormat, formatIso, isEqualDate} from './dateUtils';
 import DatePickerDialog from './DatePickerDialog';
 import TextField from '../TextField';

--- a/src/DatePicker/DatePickerDialog.js
+++ b/src/DatePicker/DatePickerDialog.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import EventListener from 'react-event-listener';
 import keycode from 'keycode';
 import Calendar from './Calendar';

--- a/src/DatePicker/DayButton.js
+++ b/src/DatePicker/DayButton.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Transition from '../styles/transitions';
 import {isEqualDate} from './dateUtils';
 import EnhancedButton from '../internal/EnhancedButton';

--- a/src/DatePicker/YearButton.js
+++ b/src/DatePicker/YearButton.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import EnhancedButton from '../internal/EnhancedButton';
 
 function getStyles(props, context, state) {

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import EventListener from 'react-event-listener';
 import keycode from 'keycode';

--- a/src/Dialog/Dialog.spec.js
+++ b/src/Dialog/Dialog.spec.js
@@ -4,7 +4,7 @@ import Dialog from './Dialog';
 import {spy} from 'sinon';
 import {mount} from 'enzyme';
 import {assert} from 'chai';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import getMuiTheme from '../styles/getMuiTheme';
 
 describe('<Dialog />', () => {

--- a/src/Divider/Divider.js
+++ b/src/Divider/Divider.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 const Divider = (props, context) => {

--- a/src/Divider/Divider.js
+++ b/src/Divider/Divider.js
@@ -1,4 +1,6 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+
+import PropTypes from 'prop-types';
 
 const Divider = (props, context) => {
   const {

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import EventListener from 'react-event-listener';
 import keycode from 'keycode';

--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import transitions from '../styles/transitions';
 import DropDownArrow from '../svg-icons/navigation/arrow-drop-down';

--- a/src/DropDownMenu/DropDownMenu.spec.js
+++ b/src/DropDownMenu/DropDownMenu.spec.js
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {shallow, mount} from 'enzyme';
 import {assert} from 'chai';
 import keycode from 'keycode';

--- a/src/DropDownMenu/DropDownMenu.spec.js
+++ b/src/DropDownMenu/DropDownMenu.spec.js
@@ -10,7 +10,7 @@ import getMuiTheme from '../styles/getMuiTheme';
 import MenuItem from '../MenuItem';
 import Menu from '../Menu/Menu';
 import IconButton from '../IconButton';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 
 describe('<DropDownMenu />', () => {
   const muiTheme = getMuiTheme();

--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import transitions from '../styles/transitions';
 import {createChildFragment} from '../utils/childUtils';
 import {fade} from '../utils/colorManipulator';
@@ -49,7 +50,7 @@ class FlatButton extends Component {
     /**
      * If true, the element's ripple effect will be disabled.
      */
-    disableTouchRipple: React.PropTypes.bool,
+    disableTouchRipple: PropTypes.bool,
     /**
      * Disables the button if set to true.
      */

--- a/src/FlatButton/FlatButtonLabel.js
+++ b/src/FlatButton/FlatButtonLabel.js
@@ -1,4 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+
+import PropTypes from 'prop-types';
 
 function getStyles(props, context) {
   const {baseTheme} = context.muiTheme;

--- a/src/FlatButton/FlatButtonLabel.js
+++ b/src/FlatButton/FlatButtonLabel.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-
 import PropTypes from 'prop-types';
 
 function getStyles(props, context) {

--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import transitions from '../styles/transitions';
 import {fade} from '../utils/colorManipulator';
 import EnhancedButton from '../internal/EnhancedButton';

--- a/src/FontIcon/FontIcon.js
+++ b/src/FontIcon/FontIcon.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import transitions from '../styles/transitions';
 
 function getStyles(props, context, state) {

--- a/src/GridList/GridList.js
+++ b/src/GridList/GridList.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-
 import PropTypes from 'prop-types';
 
 function getStyles(props) {

--- a/src/GridList/GridList.js
+++ b/src/GridList/GridList.js
@@ -1,4 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+
+import PropTypes from 'prop-types';
 
 function getStyles(props) {
   return {

--- a/src/GridList/GridTile.js
+++ b/src/GridList/GridTile.js
@@ -1,4 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+
+import PropTypes from 'prop-types';
 
 function getStyles(props, context) {
   const {

--- a/src/GridList/GridTile.js
+++ b/src/GridList/GridTile.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-
 import PropTypes from 'prop-types';
 
 function getStyles(props, context) {

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import transitions from '../styles/transitions';
 import propTypes from '../utils/propTypes';
 import EnhancedButton from '../internal/EnhancedButton';

--- a/src/IconButton/IconButton.spec.js
+++ b/src/IconButton/IconButton.spec.js
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {mount, shallow} from 'enzyme';
 import {assert} from 'chai';
 import IconButton from './IconButton';

--- a/src/IconMenu/IconMenu.js
+++ b/src/IconMenu/IconMenu.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import Events from '../utils/events';
 import propTypes from '../utils/propTypes';

--- a/src/LinearProgress/LinearProgress.js
+++ b/src/LinearProgress/LinearProgress.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import transitions from '../styles/transitions';
 
 function getRelativeValue(value, min, max) {

--- a/src/List/List.js
+++ b/src/List/List.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes, Children, isValidElement} from 'react';
+import React, {Component, Children, isValidElement} from 'react';
+import PropTypes from 'prop-types';
 import Subheader from '../Subheader';
 
 class List extends Component {

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import shallowEqual from 'recompose/shallowEqual';
 import {fade} from '../utils/colorManipulator';

--- a/src/List/NestedList.js
+++ b/src/List/NestedList.js
@@ -1,9 +1,5 @@
-import React, {
-  Children,
-  PropTypes,
-  isValidElement,
-  cloneElement,
-} from 'react';
+import React, {Children, isValidElement, cloneElement} from 'react';
+import PropTypes from 'prop-types';
 import List from './List';
 
 const NestedList = (props) => {

--- a/src/List/makeSelectable.js
+++ b/src/List/makeSelectable.js
@@ -1,4 +1,5 @@
-import React, {Component, Children, PropTypes} from 'react';
+import React, {Component, Children} from 'react';
+import PropTypes from 'prop-types';
 import {fade} from '../utils/colorManipulator';
 
 export const makeSelectable = (MyComponent) => {

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import shallowEqual from 'recompose/shallowEqual';
 import ClickAwayListener from '../internal/ClickAwayListener';

--- a/src/Menu/Menu.spec.js
+++ b/src/Menu/Menu.spec.js
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {mount, shallow} from 'enzyme';
 import {spy} from 'sinon';
 import {assert} from 'chai';

--- a/src/MenuItem/MenuItem.js
+++ b/src/MenuItem/MenuItem.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import shallowEqual from 'recompose/shallowEqual';
 import Popover from '../Popover/Popover';

--- a/src/Paper/Paper.js
+++ b/src/Paper/Paper.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import propTypes from '../utils/propTypes';
 import transitions from '../styles/transitions';
 

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import EventListener from 'react-event-listener';
 import RenderToLayer from '../internal/RenderToLayer';

--- a/src/Popover/PopoverAnimationDefault.js
+++ b/src/Popover/PopoverAnimationDefault.js
@@ -1,5 +1,6 @@
 import transitions from '../styles/transitions';
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import propTypes from '../utils/propTypes';
 import Paper from '../Paper';
 

--- a/src/Popover/PopoverAnimationVertical.js
+++ b/src/Popover/PopoverAnimationVertical.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Paper from '../Paper';
 import transitions from '../styles/transitions';
 import propTypes from '../utils/propTypes';

--- a/src/RadioButton/RadioButton.js
+++ b/src/RadioButton/RadioButton.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import transitions from '../styles/transitions';
 import EnhancedSwitch from '../internal/EnhancedSwitch';
 import RadioButtonOff from '../svg-icons/toggle/radio-button-unchecked';

--- a/src/RadioButton/RadioButtonGroup.js
+++ b/src/RadioButton/RadioButtonGroup.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import RadioButton from './RadioButton';
 import warning from 'warning';
 

--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -1,4 +1,5 @@
-import React, {Component, cloneElement, PropTypes} from 'react';
+import React, {Component, cloneElement} from 'react';
+import PropTypes from 'prop-types';
 import transitions from '../styles/transitions';
 import {fade} from '../utils/colorManipulator';
 import {createChildFragment} from '../utils/childUtils';
@@ -147,7 +148,7 @@ class RaisedButton extends Component {
     /**
      * If true, the element's ripple effect will be disabled.
      */
-    disableTouchRipple: React.PropTypes.bool,
+    disableTouchRipple: PropTypes.bool,
     /**
      * If true, the button will be disabled.
      */

--- a/src/RaisedButton/RaisedButton.spec.js
+++ b/src/RaisedButton/RaisedButton.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import React from 'react';
 import ReactDOM from 'react-dom';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import {mount, shallow} from 'enzyme';
 import {assert} from 'chai';
 

--- a/src/RefreshIndicator/RefreshIndicator.js
+++ b/src/RefreshIndicator/RefreshIndicator.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import autoPrefix from '../utils/autoPrefix';
 import transitions from '../styles/transitions';
 import Paper from '../Paper';

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import TextField from '../TextField';
 import DropDownMenu from '../DropDownMenu';
 

--- a/src/SelectField/SelectField.spec.js
+++ b/src/SelectField/SelectField.spec.js
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {mount} from 'enzyme';
 import {assert} from 'chai';
 import getMuiTheme from '../styles/getMuiTheme';

--- a/src/SelectField/SelectField.spec.js
+++ b/src/SelectField/SelectField.spec.js
@@ -7,7 +7,7 @@ import getMuiTheme from '../styles/getMuiTheme';
 import SelectField from './SelectField';
 import TouchRipple from '../internal/TouchRipple';
 import MenuItem from '../MenuItem';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 
 describe('<SelectField />', () => {
   const muiTheme = getMuiTheme();

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import keycode from 'keycode';
 import warning from 'warning';
 import transitions from '../styles/transitions';

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -1,4 +1,5 @@
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import transitions from '../styles/transitions';
 import ClickAwayListener from '../internal/ClickAwayListener';
 import SnackbarBody from './SnackbarBody';

--- a/src/Snackbar/SnackbarBody.js
+++ b/src/Snackbar/SnackbarBody.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import transitions from '../styles/transitions';
 import withWidth, {SMALL} from '../utils/withWidth';
 import FlatButton from '../FlatButton';

--- a/src/Stepper/Step.js
+++ b/src/Stepper/Step.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 
 const getStyles = ({index}, {stepper}) => {
   const {orientation} = stepper;

--- a/src/Stepper/StepButton.js
+++ b/src/Stepper/StepButton.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import transitions from '../styles/transitions';
 import EnhancedButton from '../internal/EnhancedButton';
 import StepLabel from './StepLabel';

--- a/src/Stepper/StepConnector.js
+++ b/src/Stepper/StepConnector.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import pure from 'recompose/pure';
 
 const propTypes = {

--- a/src/Stepper/StepContent.js
+++ b/src/Stepper/StepContent.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import TransitionComponent from '../internal/ExpandTransition';
 import warning from 'warning';
 

--- a/src/Stepper/StepLabel.js
+++ b/src/Stepper/StepLabel.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import CheckCircle from '../svg-icons/action/check-circle';
 import SvgIcon from '../SvgIcon';
 

--- a/src/Stepper/Stepper.js
+++ b/src/Stepper/Stepper.js
@@ -1,4 +1,5 @@
-import React, {Component, Children, PropTypes} from 'react';
+import React, {Component, Children} from 'react';
+import PropTypes from 'prop-types';
 import StepConnector from './StepConnector';
 
 const getStyles = (props) => {

--- a/src/Subheader/Subheader.js
+++ b/src/Subheader/Subheader.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 const Subheader = (props, context) => {

--- a/src/Subheader/Subheader.js
+++ b/src/Subheader/Subheader.js
@@ -1,4 +1,6 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+
+import PropTypes from 'prop-types';
 
 const Subheader = (props, context) => {
   const {

--- a/src/SvgIcon/SvgIcon.js
+++ b/src/SvgIcon/SvgIcon.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import transitions from '../styles/transitions';
 
 class SvgIcon extends Component {

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import warning from 'warning';
 
 function getStyles(props, context) {

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Checkbox from '../Checkbox';
 import TableRowColumn from './TableRowColumn';
 import ClickAwayListener from '../internal/ClickAwayListener';

--- a/src/Table/TableFooter.js
+++ b/src/Table/TableFooter.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import TableRowColumn from './TableRowColumn';
 
 function getStyles(props, context) {

--- a/src/Table/TableHeader.js
+++ b/src/Table/TableHeader.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Checkbox from '../Checkbox';
 import TableHeaderColumn from './TableHeaderColumn';
 

--- a/src/Table/TableHeaderColumn.js
+++ b/src/Table/TableHeaderColumn.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Tooltip from '../internal/Tooltip';
 
 function getStyles(props, context) {

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-
 import PropTypes from 'prop-types';
 
 function getStyles(props, context, state) {

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -1,4 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+
+import PropTypes from 'prop-types';
 
 function getStyles(props, context, state) {
   const {tableRow} = context.muiTheme;

--- a/src/Table/TableRowColumn.js
+++ b/src/Table/TableRowColumn.js
@@ -1,4 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+
+import PropTypes from 'prop-types';
 
 function getStyles(props, context) {
   const {tableRowColumn} = context.muiTheme;

--- a/src/Tabs/InkBar.js
+++ b/src/Tabs/InkBar.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import transitions from '../styles/transitions';
 
 function getStyles(props, context) {

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import EnhancedButton from '../internal/EnhancedButton';
 
 function getStyles(props, context) {

--- a/src/Tabs/TabTemplate.js
+++ b/src/Tabs/TabTemplate.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const styles = {
   width: '100%',

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -1,10 +1,5 @@
-import React, {Component,
-  createElement,
-  cloneElement,
-  Children,
-  isValidElement,
-  PropTypes,
-} from 'react';
+import React, {Component, createElement, cloneElement, Children, isValidElement} from 'react';
+import PropTypes from 'prop-types';
 import warning from 'warning';
 import TabTemplate from './TabTemplate';
 import InkBar from './InkBar';

--- a/src/TextField/EnhancedTextarea.js
+++ b/src/TextField/EnhancedTextarea.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import EventListener from 'react-event-listener';
 
 const rowsHeight = 24;

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import shallowEqual from 'recompose/shallowEqual';
 import transitions from '../styles/transitions';

--- a/src/TextField/TextField.spec.js
+++ b/src/TextField/TextField.spec.js
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
-import React, {PropTypes, Component} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {shallow, mount} from 'enzyme';
 import {assert} from 'chai';
 import TextField from './TextField';

--- a/src/TextField/TextFieldHint.js
+++ b/src/TextField/TextFieldHint.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import transitions from '../styles/transitions';
 
 function getStyles(props) {

--- a/src/TextField/TextFieldLabel.js
+++ b/src/TextField/TextFieldLabel.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import transitions from '../styles/transitions';
 
 function getStyles(props) {

--- a/src/TextField/TextFieldUnderline.js
+++ b/src/TextField/TextFieldUnderline.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import transitions from '../styles/transitions';
 
 const propTypes = {

--- a/src/TimePicker/Clock.js
+++ b/src/TimePicker/Clock.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import TimeDisplay from './TimeDisplay';
 import ClockHours from './ClockHours';
 import ClockMinutes from './ClockMinutes';

--- a/src/TimePicker/ClockHours.js
+++ b/src/TimePicker/ClockHours.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import ClockNumber from './ClockNumber';
 import ClockPointer from './ClockPointer';

--- a/src/TimePicker/ClockMinutes.js
+++ b/src/TimePicker/ClockMinutes.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ClockNumber from './ClockNumber';
 import ClockPointer from './ClockPointer';
 import {getTouchEventOffsetValues, rad2deg} from './timeUtils';

--- a/src/TimePicker/ClockNumber.js
+++ b/src/TimePicker/ClockNumber.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {isInner} from './timeUtils';
 
 function getStyles(props, context) {

--- a/src/TimePicker/ClockPointer.js
+++ b/src/TimePicker/ClockPointer.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {isInner} from './timeUtils';
 
 function calcAngle(value, base) {

--- a/src/TimePicker/TimeDisplay.js
+++ b/src/TimePicker/TimeDisplay.js
@@ -1,4 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+
+import PropTypes from 'prop-types';
 
 class TimeDisplay extends Component {
   static propTypes = {

--- a/src/TimePicker/TimeDisplay.js
+++ b/src/TimePicker/TimeDisplay.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-
 import PropTypes from 'prop-types';
 
 class TimeDisplay extends Component {

--- a/src/TimePicker/TimePicker.js
+++ b/src/TimePicker/TimePicker.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import TimePickerDialog from './TimePickerDialog';
 import TextField from '../TextField';
 import {formatTime} from './timeUtils';

--- a/src/TimePicker/TimePickerDialog.js
+++ b/src/TimePicker/TimePickerDialog.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import EventListener from 'react-event-listener';
 import keycode from 'keycode';
 import Clock from './Clock';

--- a/src/Toggle/Toggle.js
+++ b/src/Toggle/Toggle.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import transitions from '../styles/transitions';
 import Paper from '../Paper';
 import EnhancedSwitch from '../internal/EnhancedSwitch';

--- a/src/Toolbar/Toolbar.js
+++ b/src/Toolbar/Toolbar.js
@@ -1,4 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+
+import PropTypes from 'prop-types';
 
 function getStyles(props, context) {
   const {noGutter} = props;

--- a/src/Toolbar/Toolbar.js
+++ b/src/Toolbar/Toolbar.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-
 import PropTypes from 'prop-types';
 
 function getStyles(props, context) {

--- a/src/Toolbar/ToolbarGroup.js
+++ b/src/Toolbar/ToolbarGroup.js
@@ -1,4 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+
+import PropTypes from 'prop-types';
 
 function getStyles(props, context) {
   const {

--- a/src/Toolbar/ToolbarGroup.js
+++ b/src/Toolbar/ToolbarGroup.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-
 import PropTypes from 'prop-types';
 
 function getStyles(props, context) {

--- a/src/Toolbar/ToolbarSeparator.js
+++ b/src/Toolbar/ToolbarSeparator.js
@@ -1,4 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+
+import PropTypes from 'prop-types';
 
 function getStyles(props, context) {
   const {

--- a/src/Toolbar/ToolbarSeparator.js
+++ b/src/Toolbar/ToolbarSeparator.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-
 import PropTypes from 'prop-types';
 
 function getStyles(props, context) {

--- a/src/Toolbar/ToolbarTitle.js
+++ b/src/Toolbar/ToolbarTitle.js
@@ -1,4 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+
+import PropTypes from 'prop-types';
 
 function getStyles(props, context) {
   const {

--- a/src/Toolbar/ToolbarTitle.js
+++ b/src/Toolbar/ToolbarTitle.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-
 import PropTypes from 'prop-types';
 
 function getStyles(props, context) {

--- a/src/internal/AppCanvas.js
+++ b/src/internal/AppCanvas.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-
 import PropTypes from 'prop-types';
 
 class AppCanvas extends Component {

--- a/src/internal/AppCanvas.js
+++ b/src/internal/AppCanvas.js
@@ -1,4 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+
+import PropTypes from 'prop-types';
 
 class AppCanvas extends Component {
   static propTypes = {

--- a/src/internal/AutoLockScrolling.js
+++ b/src/internal/AutoLockScrolling.js
@@ -1,4 +1,5 @@
-import {Component, PropTypes} from 'react';
+import {Component} from 'react';
+import PropTypes from 'prop-types';
 
 let originalBodyOverflow = null;
 let lockingCounter = 0;

--- a/src/internal/BeforeAfterWrapper.js
+++ b/src/internal/BeforeAfterWrapper.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-
 import PropTypes from 'prop-types';
 
 /**

--- a/src/internal/BeforeAfterWrapper.js
+++ b/src/internal/BeforeAfterWrapper.js
@@ -1,4 +1,6 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+
+import PropTypes from 'prop-types';
 
 /**
  *  BeforeAfterWrapper

--- a/src/internal/CircleRipple.js
+++ b/src/internal/CircleRipple.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import shallowEqual from 'recompose/shallowEqual';
 import autoPrefix from '../utils/autoPrefix';

--- a/src/internal/ClearFix.js
+++ b/src/internal/ClearFix.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import BeforeAfterWrapper from './BeforeAfterWrapper';
 
 const styles = {

--- a/src/internal/ClickAwayListener.js
+++ b/src/internal/ClickAwayListener.js
@@ -1,4 +1,5 @@
-import {Component, PropTypes} from 'react';
+import {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import events from '../utils/events';
 

--- a/src/internal/EnhancedButton.js
+++ b/src/internal/EnhancedButton.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {createChildFragment} from '../utils/childUtils';
 import Events from '../utils/events';
 import keycode from 'keycode';

--- a/src/internal/EnhancedSwitch.js
+++ b/src/internal/EnhancedSwitch.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import EventListener from 'react-event-listener';
 import keycode from 'keycode';
 import transitions from '../styles/transitions';

--- a/src/internal/ExpandTransition.js
+++ b/src/internal/ExpandTransition.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactTransitionGroup from 'react-addons-transition-group';
 import ExpandTransitionChild from './ExpandTransitionChild';
 

--- a/src/internal/ExpandTransitionChild.js
+++ b/src/internal/ExpandTransitionChild.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import transitions from '../styles/transitions';
 

--- a/src/internal/FocusRipple.js
+++ b/src/internal/FocusRipple.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import shallowEqual from 'recompose/shallowEqual';
 import autoPrefix from '../utils/autoPrefix';

--- a/src/internal/Overlay.js
+++ b/src/internal/Overlay.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import transitions from '../styles/transitions';
 import AutoLockScrolling from './AutoLockScrolling';
 

--- a/src/internal/RenderToLayer.js
+++ b/src/internal/RenderToLayer.js
@@ -1,4 +1,5 @@
-import {Component, PropTypes} from 'react';
+import {Component} from 'react';
+import PropTypes from 'prop-types';
 import {unstable_renderSubtreeIntoContainer, unmountComponentAtNode} from 'react-dom';
 
 import Dom from '../utils/dom';

--- a/src/internal/ScaleIn.js
+++ b/src/internal/ScaleIn.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactTransitionGroup from 'react-addons-transition-group';
 import ScaleInChild from './ScaleInChild';
 

--- a/src/internal/ScaleInChild.js
+++ b/src/internal/ScaleInChild.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import autoPrefix from '../utils/autoPrefix';
 import transitions from '../styles/transitions';

--- a/src/internal/SlideIn.js
+++ b/src/internal/SlideIn.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactTransitionGroup from 'react-addons-transition-group';
 import SlideInChild from './SlideInChild';
 

--- a/src/internal/SlideInChild.js
+++ b/src/internal/SlideInChild.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import autoPrefix from '../utils/autoPrefix';
 import transitions from '../styles/transitions';

--- a/src/internal/Tooltip.js
+++ b/src/internal/Tooltip.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import transitions from '../styles/transitions';
 
 function getStyles(props, context, state) {

--- a/src/internal/TouchRipple.js
+++ b/src/internal/TouchRipple.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import ReactTransitionGroup from 'react-addons-transition-group';
 import Dom from '../utils/dom';

--- a/src/styles/MuiThemeProvider.js
+++ b/src/styles/MuiThemeProvider.js
@@ -1,4 +1,5 @@
-import {Component, PropTypes} from 'react';
+import {Component} from 'react';
+import PropTypes from 'prop-types';
 import getMuiTheme from './getMuiTheme';
 
 class MuiThemeProvider extends Component {

--- a/src/styles/muiThemeable.js
+++ b/src/styles/muiThemeable.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import getMuiTheme from './getMuiTheme';
 
 let DEFAULT_THEME;

--- a/src/utils/propTypes.js
+++ b/src/utils/propTypes.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 
 const horizontal = PropTypes.oneOf(['left', 'middle', 'right']);
 const vertical = PropTypes.oneOf(['top', 'center', 'bottom']);

--- a/test/integration/Card/Card.spec.js
+++ b/test/integration/Card/Card.spec.js
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 import React from 'react';
+import PropTypes from 'prop-types';
 import {mount} from 'enzyme';
 import {assert} from 'chai';
 import getMuiTheme from 'src/styles/getMuiTheme';
@@ -12,7 +13,7 @@ describe('<Card />', () => {
   const muiTheme = getMuiTheme();
   const mountWithContext = (node) => mount(node, {
     context: {muiTheme},
-    childContextTypes: {muiTheme: React.PropTypes.object},
+    childContextTypes: {muiTheme: PropTypes.object},
   });
 
   it('renders a openIcon inside the CardHeader with custom color', () => {

--- a/test/integration/List/selectableList.spec.js
+++ b/test/integration/List/selectableList.spec.js
@@ -6,7 +6,7 @@ import ListItem from 'src/List/ListItem';
 import makeSelectable from 'src/List/makeSelectable';
 import injectTheme from '../fixtures/inject-theme';
 import getMuiTheme from 'src/styles/getMuiTheme';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 
 describe('makeSelectable', () => {
   const muiTheme = getMuiTheme();

--- a/test/integration/RenderToLayer/RenderToLayer.spec.js
+++ b/test/integration/RenderToLayer/RenderToLayer.spec.js
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {assert} from 'chai';
 import {mount} from 'enzyme';
 import RenderToLayer from 'src/internal/RenderToLayer';

--- a/test/integration/Stepper/VerticalLinearStepper.js
+++ b/test/integration/Stepper/VerticalLinearStepper.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {
   Step,
   Stepper,

--- a/test/integration/Table/MultiSelectTable.spec.js
+++ b/test/integration/Table/MultiSelectTable.spec.js
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 import React from 'react';
+import PropTypes from 'prop-types';
 import {mount} from 'enzyme';
 import {assert} from 'chai';
 import getMuiTheme from 'src/styles/getMuiTheme';
@@ -10,7 +11,7 @@ describe('<MultiSelectTable />', () => {
     const muiTheme = getMuiTheme();
     const mountWithContext = (node) => mount(node, {
       context: {muiTheme},
-      childContextTypes: {muiTheme: React.PropTypes.object},
+      childContextTypes: {muiTheme: PropTypes.object},
     });
 
     const wrapper = mountWithContext(

--- a/test/integration/fixtures/react-stub-context.js
+++ b/test/integration/fixtures/react-stub-context.js
@@ -3,6 +3,7 @@
 
 const React = require('react');
 const PropTypes = require('prop-types');
+const createReactClass = require('create-react-class');
 
 function stubContext(BaseComponent, context) {
   if (typeof context === 'undefined' || context === null) context = {};
@@ -17,7 +18,7 @@ function stubContext(BaseComponent, context) {
     throw new TypeError('createdStubbedContextComponent requires an object');
   }
 
-  const StubbedContextParent = React.createClass({
+  const StubbedContextParent = createReactClass({
     displayName: 'StubbedContextParent',
     propTypes: {
       children: PropTypes.node,
@@ -32,7 +33,7 @@ function stubContext(BaseComponent, context) {
     },
   });
 
-  const StubbedContextHandler = React.createClass({
+  const StubbedContextHandler = createReactClass({
     displayName: 'StubbedContextHandler',
     childContextTypes: contextTypes,
     getChildContext() {

--- a/test/integration/fixtures/react-stub-context.js
+++ b/test/integration/fixtures/react-stub-context.js
@@ -2,7 +2,7 @@
 // "react-stub-context": "^0.3.0",
 
 const React = require('react');
-const {PropTypes} = require('prop-types');
+const PropTypes = require('prop-types');
 
 function stubContext(BaseComponent, context) {
   if (typeof context === 'undefined' || context === null) context = {};

--- a/test/integration/fixtures/react-stub-context.js
+++ b/test/integration/fixtures/react-stub-context.js
@@ -2,6 +2,7 @@
 // "react-stub-context": "^0.3.0",
 
 const React = require('react');
+const {PropTypes} = require('prop-types');
 
 function stubContext(BaseComponent, context) {
   if (typeof context === 'undefined' || context === null) context = {};
@@ -10,7 +11,7 @@ function stubContext(BaseComponent, context) {
 
   try {
     Object.keys(context).forEach(function(key) {
-      contextTypes[key] = React.PropTypes.any;
+      contextTypes[key] = PropTypes.any;
     });
   } catch (err) {
     throw new TypeError('createdStubbedContextComponent requires an object');
@@ -19,7 +20,7 @@ function stubContext(BaseComponent, context) {
   const StubbedContextParent = React.createClass({
     displayName: 'StubbedContextParent',
     propTypes: {
-      children: React.PropTypes.node,
+      children: PropTypes.node,
     },
     contextTypes: contextTypes,
     childContextTypes: contextTypes,

--- a/test/integration/theming.spec.js
+++ b/test/integration/theming.spec.js
@@ -4,6 +4,7 @@
 // Modifying any of the above files will break these tests!
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import TestUtils from 'react-addons-test-utils';
 import {expect} from 'chai';
 import AppBar from 'src/AppBar';
@@ -87,7 +88,7 @@ describe('Theming', () => {
 const AppBarDarkUsingContext = React.createClass({
 
   childContextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: PropTypes.object,
   },
 
   getChildContext() {
@@ -104,7 +105,7 @@ const AppBarDarkUsingContext = React.createClass({
 const AppBarDarkUsingContextWithOverride = React.createClass({
 
   childContextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: PropTypes.object,
   },
 
   getInitialState() {
@@ -157,7 +158,7 @@ const AppBarDarkThemeOverride = React.createClass({
 const ButtonToUpdateThemeWithAppBar = React.createClass({
 
   childContextTypes: {
-    muiTheme: React.PropTypes.object,
+    muiTheme: PropTypes.object,
   },
 
   getInitialState() {

--- a/test/integration/theming.spec.js
+++ b/test/integration/theming.spec.js
@@ -6,6 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import TestUtils from 'react-dom/test-utils';
+import createReactClass from 'create-react-class';
 import {expect} from 'chai';
 import AppBar from 'src/AppBar';
 import RaisedButton from 'src/RaisedButton';
@@ -85,7 +86,7 @@ describe('Theming', () => {
 });
 
 // react components used for context-theme-passing testing
-const AppBarDarkUsingContext = React.createClass({
+const AppBarDarkUsingContext = createReactClass({
 
   childContextTypes: {
     muiTheme: PropTypes.object,
@@ -102,7 +103,7 @@ const AppBarDarkUsingContext = React.createClass({
   },
 });
 
-const AppBarDarkUsingContextWithOverride = React.createClass({
+const AppBarDarkUsingContextWithOverride = createReactClass({
 
   childContextTypes: {
     muiTheme: PropTypes.object,
@@ -129,7 +130,7 @@ const AppBarDarkUsingContextWithOverride = React.createClass({
 });
 
 const darkMuiTheme = getMuiTheme(darkBaseTheme);
-const AppBarDarkTheme = React.createClass({
+const AppBarDarkTheme = createReactClass({
   render() {
     return (
       <MuiThemeProvider muiTheme={darkMuiTheme}>
@@ -144,7 +145,7 @@ const darkMuiThemeWithOverride = getMuiTheme(darkBaseTheme, {
     textColor: deepPurpleA700,
   },
 });
-const AppBarDarkThemeOverride = React.createClass({
+const AppBarDarkThemeOverride = createReactClass({
   render() {
     return (
       <MuiThemeProvider muiTheme={darkMuiThemeWithOverride}>
@@ -155,7 +156,7 @@ const AppBarDarkThemeOverride = React.createClass({
 });
 
 // react component used to test whether or not theme updates down the hierarchy
-const ButtonToUpdateThemeWithAppBar = React.createClass({
+const ButtonToUpdateThemeWithAppBar = createReactClass({
 
   childContextTypes: {
     muiTheme: PropTypes.object,

--- a/test/integration/theming.spec.js
+++ b/test/integration/theming.spec.js
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import {expect} from 'chai';
 import AppBar from 'src/AppBar';
 import RaisedButton from 'src/RaisedButton';

--- a/test/utils/consoleError.js
+++ b/test/utils/consoleError.js
@@ -6,7 +6,10 @@
 function consoleError() {
   console.error = (...args) => {
     console.log(...args);
-    throw new Error(...args);
+
+    // @TODO: Uncomment this when this PR is released to Enzyme (> v2.8.0)
+    // https://github.com/airbnb/enzyme/issues/875
+    // throw new Error(...args);
   };
 }
 

--- a/test/utils/consoleError.js
+++ b/test/utils/consoleError.js
@@ -6,10 +6,7 @@
 function consoleError() {
   console.error = (...args) => {
     console.log(...args);
-
-    // @TODO: Uncomment this when this PR is released to Enzyme (> v2.8.0)
-    // https://github.com/airbnb/enzyme/issues/875
-    // throw new Error(...args);
+    throw new Error(...args);
   };
 }
 


### PR DESCRIPTION
Use new `prop-types` lib instead of the deprecated `React.PropTypes`.

Fixes #6542

Note that the `react-title-component` lib references in `docs` still uses `React.PropTypes`, so you'll still get the error there.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

