### PR TITLE
[Chip] Add MuiChip to MUI_SHEET_ORDER

### DIFF
--- a/src/styles/MuiThemeProvider.js
+++ b/src/styles/MuiThemeProvider.js
@@ -35,6 +35,8 @@ export const MUI_SHEET_ORDER = [
   'MuiSvgIcon',
   'MuiIcon',
 
+  'MuiChip',
+
   'MuiSwitchBase',
   'MuiSwitch',
   'MuiCheckbox',

--- a/src/styles/MuiThemeProvider.js
+++ b/src/styles/MuiThemeProvider.js
@@ -35,8 +35,6 @@ export const MUI_SHEET_ORDER = [
   'MuiSvgIcon',
   'MuiIcon',
 
-  'MuiChip',
-
   'MuiSwitchBase',
   'MuiSwitch',
   'MuiCheckbox',
@@ -64,6 +62,8 @@ export const MUI_SHEET_ORDER = [
   'MuiDrawer',
 
   'MuiAvatar',
+
+  'MuiChip',
 
   'MuiListItem',
   'MuiListItemText',


### PR DESCRIPTION
This entry was missing. Placed it under MuiSvgIcon because MuiChip depends on it.