### PR TITLE
[TextField] Add maxLength prop

### DIFF
--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -396,6 +396,7 @@ class TextField extends Component {
       hintStyle,
       id,
       inputStyle,
+      maxLength,
       multiLine,
       onBlur, // eslint-disable-line no-unused-vars
       onChange, // eslint-disable-line no-unused-vars
@@ -446,6 +447,7 @@ class TextField extends Component {
       onBlur: this.handleInputBlur,
       onChange: this.handleInputChange,
       onFocus: this.handleInputFocus,
+      maxlength: this.props.maxLength,
     };
 
     const childStyleMerged = Object.assign(styles.input, inputStyle);


### PR DESCRIPTION
html inputs support a maxlength property:
<form action="/action_page.php">
  Username: <input type="text" name="usrname" maxlength="10"><br>
  <input type="submit" value="Submit">
</form>

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

