### PR TITLE
[Theme] Reintroduce `muiThemeable` as `withTheme`.

### DIFF
--- a/src/styles/withStyles.spec.js
+++ b/src/styles/withStyles.spec.js
@@ -7,7 +7,7 @@ import { createStyleSheet } from 'jss-theme-reactor';
 import withStyles from './withStyles';
 
 const Empty = () => <div />;
-Empty.propTypes = {}; // Breaks the referencial transparency for testing purposes.
+Empty.propTypes = {}; // Breaks the referential transparency for testing purposes.
 
 describe('withStyles', () => {
   let shallow;

--- a/src/styles/withTheme.js
+++ b/src/styles/withTheme.js
@@ -1,0 +1,33 @@
+// @flow weak
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import wrapDisplayName from 'recompose/wrapDisplayName';
+import { createMuiTheme } from './theme';
+
+let DEFAULT_THEME;
+
+function getDefaultTheme() {
+  if (!DEFAULT_THEME) {
+    DEFAULT_THEME = createMuiTheme();
+  }
+  return DEFAULT_THEME;
+}
+
+const withTheme = (BaseComponent) => {
+  const WithTheme = (ownerProps, context) => {
+    const { theme = getDefaultTheme() } = context;
+
+    return <BaseComponent theme={theme} {...ownerProps} />;
+  };
+
+  WithTheme.contextTypes = {
+    theme: PropTypes.object.isRequired,
+  };
+
+  WithTheme.displayName = wrapDisplayName(BaseComponent, 'withTheme');
+
+  return WithTheme;
+};
+
+export default withTheme;

--- a/src/styles/withTheme.js
+++ b/src/styles/withTheme.js
@@ -1,28 +1,18 @@
 // @flow weak
 
-import React from 'react';
-import PropTypes from 'prop-types';
+import createEagerFactory from 'recompose/createEagerFactory';
 import wrapDisplayName from 'recompose/wrapDisplayName';
-import { createMuiTheme } from './theme';
-
-let DEFAULT_THEME;
-
-function getDefaultTheme() {
-  if (!DEFAULT_THEME) {
-    DEFAULT_THEME = createMuiTheme();
-  }
-  return DEFAULT_THEME;
-}
+import customPropTypes from '../utils/customPropTypes';
 
 const withTheme = (BaseComponent) => {
-  const WithTheme = (ownerProps, context) => {
-    const { theme = getDefaultTheme() } = context;
+  const factory = createEagerFactory(BaseComponent);
 
-    return <BaseComponent theme={theme} {...ownerProps} />;
-  };
+  const WithTheme = (ownerProps, context) => (
+    factory({ theme: context.theme, ...ownerProps })
+  );
 
   WithTheme.contextTypes = {
-    theme: PropTypes.object.isRequired,
+    theme: customPropTypes.muiRequired,
   };
 
   WithTheme.displayName = wrapDisplayName(BaseComponent, 'withTheme');

--- a/src/styles/withTheme.spec.js
+++ b/src/styles/withTheme.spec.js
@@ -6,7 +6,7 @@ import { createShallow } from 'src/test-utils';
 import withTheme from './withTheme';
 
 const Empty = () => <div />;
-Empty.propTypes = {}; // Breaks the referencial transparency for testing purposes.
+Empty.propTypes = {}; // Breaks the referential transparency for testing purposes.
 
 describe('withTheme', () => {
   let shallow;
@@ -22,7 +22,9 @@ describe('withTheme', () => {
     const wrapper = shallow(<ThemedComponent />, { context });
 
     assert.property(wrapper.props(), 'theme');
-    assert.strictEqual(wrapper.props().theme, context.theme,
+    assert.strictEqual(
+      wrapper.props().theme,
+      context.theme,
       'Should use the theme provided by the context');
   });
 });

--- a/src/styles/withTheme.spec.js
+++ b/src/styles/withTheme.spec.js
@@ -1,0 +1,28 @@
+// @flow weak
+
+import React from 'react';
+import { assert } from 'chai';
+import { createShallow } from 'src/test-utils';
+import withTheme from './withTheme';
+
+const Empty = () => <div />;
+Empty.propTypes = {}; // Breaks the referencial transparency for testing purposes.
+
+describe('withTheme', () => {
+  let shallow;
+  let context;
+
+  before(() => {
+    shallow = createShallow();
+    context = { theme: { themeProperty: 'foo' } };
+  });
+
+  it('should use the theme provided by the context', () => {
+    const ThemedComponent = withTheme(Empty);
+    const wrapper = shallow(<ThemedComponent />, { context });
+
+    assert.property(wrapper.props(), 'theme');
+    assert.strictEqual(wrapper.props().theme, context.theme,
+      'Should use the theme provided by the context');
+  });
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Closes #6100

