### PR TITLE
[DropDownMenu] Pass autoWidth property to Menu component

### DIFF
--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -476,6 +476,7 @@ class DropDownMenu extends Component {
             onChange={this.handleChange}
             menuItemStyle={menuItemStyle}
             selectedMenuItemStyle={selectedMenuItemStyle}
+            autoWidth={autoWidth}
           >
             {children}
           </Menu>

--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -477,6 +477,7 @@ class DropDownMenu extends Component {
             menuItemStyle={menuItemStyle}
             selectedMenuItemStyle={selectedMenuItemStyle}
             autoWidth={autoWidth}
+            width={!autoWidth && menuStyle ? menuStyle.width : null}
           >
             {children}
           </Menu>


### PR DESCRIPTION
Fixes [3923](https://github.com/callemall/material-ui/issues/3923) 

Just passing `autoWidth` property from `DropDownMenu` to `Menu`.  So now `Menu` component uses width, that passed in `style` property, instead of calculate width itself.


