### PR TITLE
[Table] Fix controlled behavior

### DIFF
--- a/docs/src/app/components/pages/components/Table/ExampleComplex.js
+++ b/docs/src/app/components/pages/components/Table/ExampleComplex.js
@@ -1,6 +1,13 @@
-import React from 'react';
-import {Table, TableBody, TableFooter, TableHeader, TableHeaderColumn, TableRow, TableRowColumn}
-  from 'material-ui/Table';
+import React, {Component} from 'react';
+import {
+  Table,
+  TableBody,
+  TableFooter,
+  TableHeader,
+  TableHeaderColumn,
+  TableRow,
+  TableRowColumn,
+} from 'material-ui/Table';
 import TextField from 'material-ui/TextField';
 import Toggle from 'material-ui/Toggle';
 
@@ -19,7 +26,6 @@ const tableData = [
   {
     name: 'John Smith',
     status: 'Employed',
-    selected: true,
   },
   {
     name: 'Randal White',
@@ -28,7 +34,6 @@ const tableData = [
   {
     name: 'Stephanie Sanders',
     status: 'Employed',
-    selected: true,
   },
   {
     name: 'Steve Brown',
@@ -48,24 +53,22 @@ const tableData = [
   },
 ];
 
-export default class TableExampleComplex extends React.Component {
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      fixedHeader: true,
-      fixedFooter: true,
-      stripedRows: false,
-      showRowHover: false,
-      selectable: true,
-      multiSelectable: false,
-      enableSelectAll: false,
-      deselectOnClickaway: true,
-      showCheckboxes: true,
-      height: '300px',
-    };
-  }
+/**
+ * A more complex example, allowing the table height to be set, and key boolean properties to be toggled.
+ */
+export default class TableExampleComplex extends Component {
+  state = {
+    fixedHeader: true,
+    fixedFooter: true,
+    stripedRows: false,
+    showRowHover: false,
+    selectable: true,
+    multiSelectable: false,
+    enableSelectAll: false,
+    deselectOnClickaway: true,
+    showCheckboxes: true,
+    height: '300px',
+  };
 
   handleToggle = (event, toggled) => {
     this.setState({
@@ -110,7 +113,7 @@ export default class TableExampleComplex extends React.Component {
             stripedRows={this.state.stripedRows}
           >
             {tableData.map( (row, index) => (
-              <TableRow key={index} selected={row.selected}>
+              <TableRow key={index}>
                 <TableRowColumn>{index}</TableRowColumn>
                 <TableRowColumn>{row.name}</TableRowColumn>
                 <TableRowColumn>{row.status}</TableRowColumn>

--- a/docs/src/app/components/pages/components/Table/ExampleControlled.js
+++ b/docs/src/app/components/pages/components/Table/ExampleControlled.js
@@ -1,0 +1,61 @@
+import React, {Component} from 'react';
+import {
+  Table,
+  TableBody,
+  TableHeader,
+  TableHeaderColumn,
+  TableRow,
+  TableRowColumn,
+} from 'material-ui/Table';
+
+export default class TableExampleControlled extends Component {
+  state = {
+    selected: [1],
+  };
+
+  isSelected = (index) => {
+    return this.state.selected.indexOf(index) !== -1;
+  };
+
+  handleRowSelection = (selectedRows) => {
+    this.setState({
+      selected: selectedRows,
+    });
+  };
+
+  render() {
+    return (
+      <Table onRowSelection={this.handleRowSelection}>
+        <TableHeader>
+          <TableRow>
+            <TableHeaderColumn>ID</TableHeaderColumn>
+            <TableHeaderColumn>Name</TableHeaderColumn>
+            <TableHeaderColumn>Status</TableHeaderColumn>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow selected={this.isSelected(0)}>
+            <TableRowColumn>1</TableRowColumn>
+            <TableRowColumn>John Smith</TableRowColumn>
+            <TableRowColumn>Employed</TableRowColumn>
+          </TableRow>
+          <TableRow selected={this.isSelected(1)}>
+            <TableRowColumn>2</TableRowColumn>
+            <TableRowColumn>Randal White</TableRowColumn>
+            <TableRowColumn>Unemployed</TableRowColumn>
+          </TableRow>
+          <TableRow selected={this.isSelected(2)}>
+            <TableRowColumn>3</TableRowColumn>
+            <TableRowColumn>Stephanie Sanders</TableRowColumn>
+            <TableRowColumn>Employed</TableRowColumn>
+          </TableRow>
+          <TableRow>
+            <TableRowColumn selected={this.isSelected(3)}>4</TableRowColumn>
+            <TableRowColumn>Steve Brown</TableRowColumn>
+            <TableRowColumn>Employed</TableRowColumn>
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+  }
+}

--- a/docs/src/app/components/pages/components/Table/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/Table/ExampleSimple.js
@@ -1,7 +1,16 @@
 import React from 'react';
-import {Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColumn} from 'material-ui/Table';
+import {
+  Table,
+  TableBody,
+  TableHeader,
+  TableHeaderColumn,
+  TableRow,
+  TableRowColumn,
+} from 'material-ui/Table';
 
-
+/**
+ * A simple table demonstrating the hierarchy of the `Table` component and its sub-components.
+ */
 const TableExampleSimple = () => (
   <Table>
     <TableHeader>
@@ -31,6 +40,11 @@ const TableExampleSimple = () => (
         <TableRowColumn>4</TableRowColumn>
         <TableRowColumn>Steve Brown</TableRowColumn>
         <TableRowColumn>Employed</TableRowColumn>
+      </TableRow>
+      <TableRow>
+        <TableRowColumn>5</TableRowColumn>
+        <TableRowColumn>Christopher Nolan</TableRowColumn>
+        <TableRowColumn>Unemployed</TableRowColumn>
       </TableRow>
     </TableBody>
   </Table>

--- a/docs/src/app/components/pages/components/Table/Page.js
+++ b/docs/src/app/components/pages/components/Table/Page.js
@@ -8,6 +8,8 @@ import MarkdownElement from '../../../MarkdownElement';
 import tableReadmeText from './README';
 import TableExampleSimple from './ExampleSimple';
 import tableExampleSimpleCode from '!raw!./ExampleSimple';
+import TableExampleControlled from './ExampleControlled';
+import tableExampleControlledCode from '!raw!./ExampleControlled';
 import TableExampleComplex from './ExampleComplex';
 import tableExampleComplexCode from '!raw!./ExampleComplex';
 
@@ -19,25 +21,24 @@ import tableHeaderColumnCode from '!raw!material-ui/Table/TableHeaderColumn';
 import tableBodyCode from '!raw!material-ui/Table/TableBody';
 import tableFooterCode from '!raw!material-ui/Table/TableFooter';
 
-const descriptions = {
-  simple: 'A simple table demonstrating the hierarchy of the `Table` component and its sub-components.',
-  complex: 'A more complex example, allowing the table height to be set, and key boolean properties to be toggled.',
-};
-
 const TablePage = () => (
   <div>
     <Title render={(previousTitle) => `Table - ${previousTitle}`} />
     <MarkdownElement text={tableReadmeText} />
     <CodeExample
       title="Simple example"
-      description={descriptions.simple}
       code={tableExampleSimpleCode}
     >
       <TableExampleSimple />
     </CodeExample>
     <CodeExample
+      title="Controlled example"
+      code={tableExampleControlledCode}
+    >
+      <TableExampleControlled />
+    </CodeExample>
+    <CodeExample
       title="Complex example"
-      description={descriptions.complex}
       code={tableExampleComplexCode}
     >
       <TableExampleComplex />

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -210,8 +210,13 @@ class Table extends Component {
   };
 
   onRowSelection = (selectedRows) => {
-    if (this.state.allRowsSelected) this.setState({allRowsSelected: false});
-    if (this.props.onRowSelection) this.props.onRowSelection(selectedRows);
+    if (this.state.allRowsSelected) {
+      this.setState({allRowsSelected: false});
+    }
+
+    if (this.props.onRowSelection) {
+      this.props.onRowSelection(selectedRows);
+    }
   };
 
   onSelectAll = () => {

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -72,7 +72,7 @@ class TableBody extends Component {
     /**
      * @ignore
      * Called when a row is selected. selectedRows is an
-     * array of all row selections. IF all rows have been selected,
+     * array of all row selections. If all rows have been selected,
      * the string "all" will be returned instead to indicate that
      * all rows have been selected.
      */
@@ -126,7 +126,9 @@ class TableBody extends Component {
   };
 
   componentWillMount() {
-    this.setState({selectedRows: this.calculatePreselectedRows(this.props)});
+    this.setState({
+      selectedRows: this.getSelectedRows(this.props),
+    });
   }
 
   componentWillReceiveProps(nextProps) {
@@ -135,21 +137,23 @@ class TableBody extends Component {
         this.setState({
           selectedRows: [],
         });
-      } else {
-        this.setState({
-          selectedRows: this.calculatePreselectedRows(nextProps),
-        });
+        return;
       }
     }
+
+    this.setState({
+      selectedRows: this.getSelectedRows(nextProps),
+    });
   }
 
+  isControlled = false
+
   handleClickAway = () => {
-    if (this.props.deselectOnClickaway && this.state.selectedRows.length) {
-      this.setState({
-        selectedRows: [],
-      });
+    if (this.props.deselectOnClickaway && this.state.selectedRows.length > 0) {
+      const selectedRows = [];
+      this.setState({selectedRows});
       if (this.props.onRowSelection) {
-        this.props.onRowSelection([]);
+        this.props.onRowSelection(selectedRows);
       }
     }
   };
@@ -197,42 +201,41 @@ class TableBody extends Component {
       return null;
     }
 
-    const key = `${rowProps.rowNumber}-cb`;
+    const name = `${rowProps.rowNumber}-cb`;
     const disabled = !this.props.selectable;
-    const checkbox = (
-      <Checkbox
-        ref="rowSelectCB"
-        name={key}
-        value="selected"
-        disabled={disabled}
-        checked={rowProps.selected}
-      />
-    );
 
     return (
       <TableRowColumn
-        key={key}
+        key={name}
         columnNumber={0}
         style={{
           width: 24,
           cursor: disabled ? 'not-allowed' : 'inherit',
         }}
       >
-        {checkbox}
+        <Checkbox
+          name={name}
+          value="selected"
+          disabled={disabled}
+          checked={rowProps.selected}
+        />
       </TableRowColumn>
     );
   }
 
-  calculatePreselectedRows(props) {
-    // Determine what rows are 'pre-selected'.
-    const preSelectedRows = [];
+  getSelectedRows(props) {
+    const selectedRows = [];
 
     if (props.selectable && props.preScanRows) {
       let index = 0;
       React.Children.forEach(props.children, (child) => {
         if (React.isValidElement(child)) {
-          if (child.props.selected && (preSelectedRows.length === 0 || props.multiSelectable)) {
-            preSelectedRows.push(index);
+          if (child.props.selected !== undefined) {
+            this.isControlled = true;
+          }
+
+          if (child.props.selected && (selectedRows.length === 0 || props.multiSelectable)) {
+            selectedRows.push(index);
           }
 
           index++;
@@ -240,7 +243,7 @@ class TableBody extends Component {
       });
     }
 
-    return preSelectedRows;
+    return selectedRows;
   }
 
   isRowSelected(rowNumber) {
@@ -248,17 +251,19 @@ class TableBody extends Component {
       return true;
     }
 
-    for (let i = 0; i < this.state.selectedRows.length; i++) {
-      const selection = this.state.selectedRows[i];
-
-      if (typeof selection === 'object') {
-        if (this.isValueInRange(rowNumber, selection)) return true;
+    return this.state.selectedRows.some((row) => {
+      if (typeof row === 'object') {
+        if (this.isValueInRange(rowNumber, row)) {
+          return true;
+        }
       } else {
-        if (selection === rowNumber) return true;
+        if (row === rowNumber) {
+          return true;
+        }
       }
-    }
 
-    return false;
+      return false;
+    });
   }
 
   isValueInRange(value, range) {
@@ -282,16 +287,19 @@ class TableBody extends Component {
   };
 
   processRowSelection(event, rowNumber) {
-    let selectedRows = this.state.selectedRows;
+    let selectedRows = [...this.state.selectedRows];
 
-    if (event.shiftKey && this.props.multiSelectable && selectedRows.length) {
+    if (event.shiftKey && this.props.multiSelectable && selectedRows.length > 0) {
       const lastIndex = selectedRows.length - 1;
       const lastSelection = selectedRows[lastIndex];
 
       if (typeof lastSelection === 'object') {
         lastSelection.end = rowNumber;
       } else {
-        selectedRows.splice(lastIndex, 1, {start: lastSelection, end: rowNumber});
+        selectedRows.splice(lastIndex, 1, {
+          start: lastSelection,
+          end: rowNumber,
+        });
       }
     } else if (((event.ctrlKey && !event.metaKey) || (event.metaKey && !event.ctrlKey)) && this.props.multiSelectable) {
       const idx = selectedRows.indexOf(rowNumber);
@@ -320,8 +328,13 @@ class TableBody extends Component {
       }
     }
 
-    this.setState({selectedRows: selectedRows});
-    if (this.props.onRowSelection) this.props.onRowSelection(this.flattenRanges(selectedRows));
+    if (!this.isControlled) {
+      this.setState({selectedRows});
+    }
+
+    if (this.props.onRowSelection) {
+      this.props.onRowSelection(this.flattenRanges(selectedRows));
+    }
   }
 
   splitRange(range, splitPoint) {
@@ -350,17 +363,18 @@ class TableBody extends Component {
   }
 
   flattenRanges(selectedRows) {
-    const rows = [];
-    for (const selection of selectedRows) {
-      if (typeof selection === 'object') {
-        const values = this.genRangeOfValues(selection.end, selection.start - selection.end);
-        rows.push(selection.end, ...values);
-      } else {
-        rows.push(selection);
-      }
-    }
+    return selectedRows
+      .reduce((rows, row) => {
+        if (typeof row === 'object') {
+          const values = this.genRangeOfValues(row.end, row.start - row.end);
+          rows.push(row.end, ...values);
+        } else {
+          rows.push(row);
+        }
 
-    return rows.sort();
+        return rows;
+      }, [])
+      .sort();
   }
 
   onCellClick = (event, rowNumber, columnNumber) => {
@@ -407,15 +421,29 @@ class TableBody extends Component {
 
   render() {
     const {
-      className,
       style,
+      allRowsSelected, // eslint-disable-line no-unused-vars
+      multiSelectable, // eslint-disable-line no-unused-vars
+      onCellClick, // eslint-disable-line no-unused-vars
+      onCellHover, // eslint-disable-line no-unused-vars
+      onCellHoverExit, // eslint-disable-line no-unused-vars
+      onRowHover, // eslint-disable-line no-unused-vars
+      onRowHoverExit, // eslint-disable-line no-unused-vars
+      onRowSelection, // eslint-disable-line no-unused-vars
+      selectable, // eslint-disable-line no-unused-vars
+      deselectOnClickaway, // eslint-disable-line no-unused-vars
+      showRowHover, // eslint-disable-line no-unused-vars
+      stripedRows, // eslint-disable-line no-unused-vars
+      displayRowCheckbox, // eslint-disable-line no-unused-vars
+      preScanRows, // eslint-disable-line no-unused-vars
+      ...other
     } = this.props;
 
     const {prepareStyles} = this.context.muiTheme;
 
     return (
       <ClickAwayListener onClickAway={this.handleClickAway}>
-        <tbody className={className} style={prepareStyles(Object.assign({}, style))}>
+        <tbody style={prepareStyles(Object.assign({}, style))} {...other}>
           {this.createRows()}
         </tbody>
       </ClickAwayListener>

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -120,7 +120,6 @@ class TableRow extends Component {
     hoverable: false,
     hovered: false,
     selectable: true,
-    selected: false,
     striped: false,
   };
 
@@ -133,15 +132,21 @@ class TableRow extends Component {
   };
 
   onRowClick(event) {
-    if (this.props.selectable && this.props.onRowClick) this.props.onRowClick(event, this.props.rowNumber);
+    if (this.props.selectable && this.props.onRowClick) {
+      this.props.onRowClick(event, this.props.rowNumber);
+    }
   }
 
   onRowHover(event) {
-    if (this.props.onRowHover) this.props.onRowHover(event, this.props.rowNumber);
+    if (this.props.onRowHover) {
+      this.props.onRowHover(event, this.props.rowNumber);
+    }
   }
 
   onRowHoverExit(event) {
-    if (this.props.onRowHoverExit) this.props.onRowHoverExit(event, this.props.rowNumber);
+    if (this.props.onRowHoverExit) {
+      this.props.onRowHoverExit(event, this.props.rowNumber);
+    }
   }
 
   onCellClick = (event, columnIndex) => {

--- a/test/integration/Table/MultiSelectTable.js
+++ b/test/integration/Table/MultiSelectTable.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {
   Table,
   TableBody,
@@ -8,48 +9,51 @@ import {
   TableRowColumn,
 } from 'src/Table';
 
-const tableData = [
-  {
-    name: 'John Smith',
-    selected: true,
-  },
-  {
-    name: 'Randal White',
-    selected: true,
-  },
-  {
-    name: 'Olivier',
-  },
-];
+class TableMutliSelect extends Component {
+  isSelected = (index) => {
+    if (!this.props.selected) {
+      return undefined;
+    }
 
-function TableMutliSelect() {
-  return (
-    <Table
-      selectable={true}
-      multiSelectable={true}
-    >
-      <TableHeader
-        displaySelectAll={true}
-        adjustForCheckbox={true}
-        enableSelectAll={true}
+    return this.props.selected.indexOf(index) !== -1;
+  };
+
+  render() {
+    return (
+      <Table
+        selectable={true}
+        multiSelectable={true}
+        onRowSelection={this.props.onRowSelection}
       >
-        <TableRow>
-          <TableHeaderColumn>
-            Name
-          </TableHeaderColumn>
-        </TableRow>
-      </TableHeader>
-      <TableBody displayRowCheckbox={true}>
-        {tableData.map( (row, index) => (
-          <TableRow key={index} selected={row.selected}>
-            <TableRowColumn>
-              {row.name}
-            </TableRowColumn>
+        <TableHeader
+          displaySelectAll={true}
+          adjustForCheckbox={true}
+          enableSelectAll={true}
+        >
+          <TableRow>
+            <TableHeaderColumn>
+              Name
+            </TableHeaderColumn>
           </TableRow>
-        ))}
-      </TableBody>
-    </Table>
-  );
+        </TableHeader>
+        <TableBody displayRowCheckbox={true}>
+          {this.props.rows.map( (row, index) => (
+            <TableRow key={index} selected={this.isSelected(index)}>
+              <TableRowColumn>
+                {row.name}
+              </TableRowColumn>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    );
+  }
 }
+
+TableMutliSelect.propTypes = {
+  onRowSelection: PropTypes.func,
+  rows: PropTypes.array.isRequired,
+  selected: PropTypes.array,
+};
 
 export default TableMutliSelect;

--- a/test/integration/Table/MultiSelectTable.spec.js
+++ b/test/integration/Table/MultiSelectTable.spec.js
@@ -3,73 +3,98 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {mount} from 'enzyme';
 import {assert} from 'chai';
+import {spy} from 'sinon';
 import getMuiTheme from 'src/styles/getMuiTheme';
 import MultiSelectTable from './MultiSelectTable';
 
+function getCheckboxStates(wrapper) {
+  return wrapper.find('Checkbox').map((checkbox) => checkbox.props().checked);
+}
+
 describe('<MultiSelectTable />', () => {
-  it('should select and unselect every checkboxes', () => {
-    const muiTheme = getMuiTheme();
-    const mountWithContext = (node) => mount(node, {
+  let muiTheme;
+  let mountWithContext;
+
+  before(() => {
+    window.getSelection = () => ({
+      removeAllRanges: () => {},
+    });
+    muiTheme = getMuiTheme();
+    mountWithContext = (node) => mount(node, {
       context: {muiTheme},
       childContextTypes: {muiTheme: PropTypes.object},
     });
+  });
 
-    const wrapper = mountWithContext(
-      <MultiSelectTable />
-    );
+  describe('uncontrolled', () => {
+    it('should select and unselect every checkboxes', () => {
+      const rows = [
+        'John Smith',
+        'Randal White',
+        'Christopher Nolan',
+      ];
 
-    assert.deepEqual(
-      wrapper.find('Checkbox').map((checkbox) => checkbox.props().checked),
-      [
-        false,
-        true,
-        true,
-        false,
-      ],
-      'should use the selected property for the initial value'
-    );
+      const wrapper = mountWithContext(
+        <MultiSelectTable rows={rows} />
+      );
 
-    let input;
-    input = wrapper.find('Checkbox').at(0).find('input');
-    input.node.checked = !input.node.checked;
-    input.simulate('change');
+      wrapper.find('TableRow').at(1).find('TableRowColumn').at(0).simulate('click');
 
-    assert.deepEqual(
-      wrapper.find('Checkbox').map((checkbox) => checkbox.props().checked),
-      [
-        true,
-        true,
-        true,
-        true,
-      ],
-      'should check all the checkboxes'
-    );
+      assert.deepEqual(getCheckboxStates(wrapper),
+        [false, true, false, false],
+        'should take the action into account'
+      );
 
-    input = wrapper.find('Checkbox').at(0).find('input');
-    input.node.checked = !input.node.checked;
-    input.simulate('change');
+      let input = wrapper.find('Checkbox').at(0).find('input');
+      input.node.checked = !input.node.checked;
+      input.simulate('change');
 
-    assert.deepEqual(
-      wrapper.find('Checkbox').map((checkbox) => checkbox.props().checked),
-      [
-        false,
-        false,
-        false,
-        false,
-      ],
-      'should uncheck all the checkboxes'
-    );
+      assert.deepEqual(getCheckboxStates(wrapper),
+        [true, true, true, true],
+        'should check all the checkboxes'
+      );
 
-    wrapper.update();
-    assert.deepEqual(
-      wrapper.find('Checkbox').map((checkbox) => checkbox.props().checked),
-      [
-        false,
-        false,
-        false,
-        false,
-      ],
-      'should be invariant to update'
-    );
+      input = wrapper.find('Checkbox').at(0).find('input');
+      input.node.checked = !input.node.checked;
+      input.simulate('change');
+
+      assert.deepEqual(getCheckboxStates(wrapper),
+        [false, false, false, false],
+        'should uncheck all the checkboxes'
+      );
+
+      wrapper.update();
+      assert.deepEqual(getCheckboxStates(wrapper),
+        [false, false, false, false],
+        'should be invariant to update'
+      );
+    });
+  });
+
+  describe('controlled', () => {
+    it('should allow the component to be controlled', () => {
+      const rows = [
+        'John Smith',
+        'Randal White',
+        'Christopher Nolan',
+      ];
+      const onRowSelection = spy();
+
+      const wrapper = mountWithContext(
+        <MultiSelectTable rows={rows} selected={[1]} onRowSelection={onRowSelection} />
+      );
+
+      assert.deepEqual(getCheckboxStates(wrapper), [false, false, true, false]);
+
+      wrapper.find('TableRow').at(1).find('TableRowColumn').at(0).simulate('click');
+      assert.deepEqual(getCheckboxStates(wrapper), [false, false, true, false]);
+
+      assert.deepEqual(onRowSelection.args[0][0], [0, 1]);
+
+      wrapper.setProps({
+        selected: [0, 1],
+      });
+      assert.deepEqual(getCheckboxStates(wrapper), [false, true, true, false]);
+    });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Closes #6006.
Closes #6295.

I some regards, this PR is introducing a breaking change by removing the ambiguity between default state and controlled state. Now, as soon as the `selected` property his used, the rows selection of the component are controlled. Hence fully implementing what's documented:

> This property can be used to programmatically select rows.
