### PR TITLE
[Modal] Fixes cannot revert back to original overflow when have multiple modals

### DIFF
--- a/src/internal/modalManager.js
+++ b/src/internal/modalManager.js
@@ -49,21 +49,23 @@ export function createModalManager({
       hideSiblings(container, modal.mountNode);
     }
 
-    const containerStyle = {
-      overflow: 'hidden',
-      paddingRight: undefined,
-    };
+    if (modals.length === 1) {
+      const containerStyle = {
+        overflow: 'hidden',
+        paddingRight: undefined,
+      };
 
-    // Save our current overflow so we can revert
-    // back to it when all modals are closed!
-    prevOverflow = container.style.overflow;
+      // Save our current overflow so we can revert
+      // back to it when all modals are closed!
+      prevOverflow = container.style.overflow;
 
-    if (bodyIsOverflowing((container))) {
-      prevPadding = container.style.paddingRight;
-      containerStyle.paddingRight = `${parseInt(prevPadding || 0, 10) + getScrollbarSize()}px`;
+      if (bodyIsOverflowing((container))) {
+        prevPadding = container.style.paddingRight;
+        containerStyle.paddingRight = `${parseInt(prevPadding || 0, 10) + getScrollbarSize()}px`;
+      }
+
+      css(container, containerStyle);
     }
-
-    css(container, containerStyle);
 
     return modalIdx;
   }


### PR DESCRIPTION
When we have multiple modals opened, eg a popup menu open a dialog box, the container does not restore back to the original overflow after all the modals are closed. This is due to it always overwrite previous saved overflow when new modals are added. This fix is just save the overflow only when first modal is added.