### PR TITLE
[TableBody] When Pre-scan is disabled, selection no longer worked

### DIFF
--- a/docs/src/app/components/pages/components/Table/ExampleControlled.js
+++ b/docs/src/app/components/pages/components/Table/ExampleControlled.js
@@ -33,7 +33,7 @@ export default class TableExampleControlled extends Component {
             <TableHeaderColumn>Status</TableHeaderColumn>
           </TableRow>
         </TableHeader>
-        <TableBody>
+        <TableBody preScanRows={false}>
           <TableRow selected={this.isSelected(0)}>
             <TableRowColumn>1</TableRowColumn>
             <TableRowColumn>John Smith</TableRowColumn>

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -141,9 +141,11 @@ class TableBody extends Component {
       }
     }
 
-    this.setState({
-      selectedRows: this.getSelectedRows(nextProps),
-    });
+    if (nextProps.preScanRows) {
+      this.setState({
+        selectedRows: this.getSelectedRows(nextProps),
+      });
+    }
   }
 
   isControlled = false


### PR DESCRIPTION
Since the selected attribute on the rows has no effect on actual selected rows, when it changes the render is never actually updated. With this surfaced the developer can supply the array of indexes that we are already checking index in for each separate row, and it will automatically update the table the way you would expect.
