### PR TITLE
[Tabs] Cancel throttled event callbacks

### DIFF
--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -147,6 +147,11 @@ class Tabs extends Component {
     this.updatePositionStates(nextProps);
   }
 
+  componentWillUnmount() {
+    this.handleResize.cancel();
+    this.handleTabsScroll.cancel();
+  }
+
   tabs = undefined;
 
   handleResize = throttle(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
This PR addresses the "Cannot read property 'scrollLeft' of null'" error reported in #6713.  By cancelling the throttled events, the event callback is no longer firing after the component has unmounted and the null issue is addressed.

- [x] ~~PR has tests / docs demo~~, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, ~~and auto-closes the related issue(s)~~ (http://tr.im/vFqem).

