### PR TITLE
fixing #6444 focus index on multiselect

### DIFF
--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -176,7 +176,7 @@ class Menu extends Component {
   constructor(props, context) {
     super(props, context);
     const filteredChildren = this.getFilteredChildren(props.children);
-    const selectedIndex = this.getSelectedIndex(props, filteredChildren);
+    const selectedIndex = this.getLastSelectedIndex(props, filteredChildren);
 
     const newFocusIndex = props.disableAutoFocus ? -1 : selectedIndex >= 0 ? selectedIndex : 0;
     if (newFocusIndex !== -1 && props.onMenuItemFocusChange) {
@@ -199,8 +199,14 @@ class Menu extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
+    let selectedIndex;
     const filteredChildren = this.getFilteredChildren(nextProps.children);
-    const selectedIndex = this.getSelectedIndex(nextProps, filteredChildren);
+
+    if (this.props.multiple !== true) {
+      selectedIndex = this.getLastSelectedIndex(nextProps, filteredChildren);
+    } else {
+      selectedIndex = this.state.focusIndex;
+    }
 
     const newFocusIndex = nextProps.disableAutoFocus ? -1 : selectedIndex >= 0 ? selectedIndex : 0;
     if (newFocusIndex !== this.state.focusIndex && this.props.onMenuItemFocusChange) {
@@ -312,7 +318,7 @@ class Menu extends Component {
     return menuItemCount;
   }
 
-  getSelectedIndex(props, filteredChildren) {
+  getLastSelectedIndex(props, filteredChildren) {
     let selectedIndex = -1;
     let menuItemIndex = 0;
 


### PR DESCRIPTION
trying to solve #6444 after https://github.com/callemall/material-ui/pull/6460 has failed 

* getSelectedIndex changed to getLastSelectedIndex
* if multiple select is used, don't use getLastSelectedIndex and keep current focus