### PR TITLE
[Tabs] Improve component lifecycle

### DIFF
--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -150,8 +150,15 @@ export default class Tab extends Component {
     this.checkTextWrap();
   }
 
-  componentDidUpdate() {
-    this.checkTextWrap();
+  componentDidUpdate(prevProps, prevState) {
+    if (this.state.wrappedText === prevState.wrappedText) {
+      /**
+       * At certain text and tab lengths, a larger font size may wrap to two lines while the smaller
+       * font size still only requires one line.  This check will prevent an infinite render loop
+       * fron occurring in that scenario.
+       */
+      this.checkTextWrap();
+    }
   }
 
   handleChange = (event) => {

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -5,7 +5,8 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { createStyleSheet } from 'jss-theme-reactor';
 import EventListener from 'react-event-listener';
-import throttle from 'lodash/throttle';
+import debounce from 'lodash/debounce';
+import isEqual from 'lodash/isEqual';
 import ScrollbarSize from 'react-scrollbar-size';
 import scroll from 'scroll';
 import customPropTypes from '../utils/customPropTypes';
@@ -140,11 +141,23 @@ class Tabs extends Component {
   };
 
   componentDidMount() {
-    this.updatePositionStates(this.props);
+    this.updateIndicatorState(this.props);
+    this.updateScrollButtonState();
   }
 
   componentWillReceiveProps(nextProps) {
-    this.updatePositionStates(nextProps);
+    if (this.props.index !== nextProps.index) {
+      this.updateIndicatorState(nextProps);
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (
+      this.props.width !== prevProps.width ||
+      !isEqual(this.state.indicatorStyle, prevState.indicatorStyle)
+    ) {
+      this.scrollSelectedIntoView();
+    }
   }
 
   componentWillUnmount() {
@@ -154,7 +167,8 @@ class Tabs extends Component {
 
   tabs = undefined;
 
-  handleResize = throttle(() => {
+  handleResize = debounce(() => {
+    this.updateIndicatorState(this.props);
     this.updateScrollButtonState();
   }, 100);
 
@@ -174,7 +188,7 @@ class Tabs extends Component {
     });
   }
 
-  handleTabsScroll = throttle(() => {
+  handleTabsScroll = debounce(() => {
     this.updateScrollButtonState();
   }, 100);
 
@@ -234,15 +248,6 @@ class Tabs extends Component {
       (scrollButtons === 'on')
     );
 
-    conditionalElements.windowResizeListener = (
-      showScrollButtons ? (
-        <EventListener
-          target="window"
-          onResize={this.handleResize}
-        />
-      ) : null
-    );
-
     conditionalElements.scrollButtonLeft = (
       showScrollButtons ? (
         <TabScrollButton
@@ -268,32 +273,35 @@ class Tabs extends Component {
     return conditionalElements;
   }
 
+  getTabsMeta = (index) => {
+    const tabsMeta = this.tabs.getBoundingClientRect();
+    tabsMeta.scrollLeft = this.tabs.scrollLeft;
+    const tabMeta = this.tabs.children[0].children[index].getBoundingClientRect();
+    return { tabsMeta, tabMeta };
+  }
+
   moveTabsScroll = (delta) => {
     const nextScrollLeft = this.tabs.scrollLeft + delta;
     scroll.left(this.tabs, nextScrollLeft);
   }
 
-  updatePositionStates(props) {
+  updateIndicatorState(props) {
     if (this.tabs) {
-      const tabsMeta = this.tabs.getBoundingClientRect();
-      tabsMeta.scrollLeft = this.tabs.scrollLeft;
+      const { tabsMeta, tabMeta } = this.getTabsMeta(props.index);
 
-      const tabMeta = this.tabs.children[0].children[props.index].getBoundingClientRect();
+      const indicatorStyle = {
+        left: tabMeta.left + (tabsMeta.scrollLeft - tabsMeta.left),
+        width: tabMeta.width, // May be wrong until the font is loaded.
+      };
 
-      this.setState({
-        indicatorStyle: {
-          left: tabMeta.left + (tabsMeta.scrollLeft - tabsMeta.left),
-          width: tabMeta.width, // May be wrong until the font is loaded.
-        },
-      });
-
-      this.scrollSelectedIntoView(tabsMeta, tabMeta);
-
-      this.updateScrollButtonState(); // determine if scroll buttons should be shown
+      if (!isEqual(indicatorStyle, this.state.indicatorStyle)) {
+        this.setState({ indicatorStyle });
+      }
     }
   }
 
-  scrollSelectedIntoView = (tabsMeta, tabMeta) => {
+  scrollSelectedIntoView = () => {
+    const { tabsMeta, tabMeta } = this.getTabsMeta(this.props.index);
     if (tabMeta.left < tabsMeta.left) {
       // left side of button is out of view
       const nextScrollLeft = tabsMeta.scrollLeft + (tabMeta.left - tabsMeta.left);
@@ -306,17 +314,19 @@ class Tabs extends Component {
   }
 
   updateScrollButtonState = () => {
-    const showLeftScroll = this.tabs.scrollLeft > 0;
-    const showRightScroll = this.tabs.scrollWidth > (this.tabs.clientWidth + this.tabs.scrollLeft);
+    const { scrollable, scrollButtons } = this.props;
 
-    if (
-      showLeftScroll !== this.state.showLeftScroll ||
-      showRightScroll !== this.state.showRightScroll
-    ) {
-      this.setState({
-        showLeftScroll,
-        showRightScroll,
-      });
+    if (scrollable && scrollButtons !== 'off') {
+      const { scrollLeft, scrollWidth, clientWidth } = this.tabs;
+      const showLeftScroll = scrollLeft > 0;
+      const showRightScroll = scrollWidth > (clientWidth + scrollLeft);
+
+      if (
+        showLeftScroll !== this.state.showLeftScroll ||
+        showRightScroll !== this.state.showRightScroll
+      ) {
+        this.setState({ showLeftScroll, showRightScroll });
+      }
     }
   };
 
@@ -354,7 +364,7 @@ class Tabs extends Component {
 
     return (
       <div className={classGroups.root} {...other}>
-        {conditionalElements.windowResizeListener}
+        <EventListener target="window" onResize={this.handleResize} />
         {conditionalElements.scrollbarSizeListener}
         <div className={classGroups.flexContainer}>
           {conditionalElements.scrollButtonLeft}

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -154,7 +154,7 @@ class Tabs extends Component {
   componentDidUpdate(prevProps, prevState) {
     if (
       this.props.width !== prevProps.width ||
-      !isEqual(this.state.indicatorStyle, prevState.indicatorStyle)
+      this.state.indicatorStyle !== prevState.indicatorStyle
     ) {
       this.scrollSelectedIntoView();
     }


### PR DESCRIPTION
This PR resolves #6713.  The main focus of the PR is to improve the lifecycling handling of the Tabs component to avoid unnecessary re-renders, state changes, and forcible scrolling.  Additionally, while testing, a few other issues were uncovered that were not part of the issue and have been resolved.  The full description of changes is below:

- Use debounce instead of throttle to match behavior of withWidth
- Limit setting of state to scenarios where it's needed
- Fix issue with fullWidth and centered tabs indicator not resizing when window size changes
- Limit situations where scrolling selected tab into view occurs (e.g. no longer scroll into view just because component was  rendered again)
- Fix issue with wrapped label tabs potentially entering infinite render loop
- Improve test structure and update for new code layout

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests ~~/ docs demo~~, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

