### PR TITLE
[breakpoints] up(‘xs’) should have a min-width of 0px

### DIFF
--- a/src/styles/breakpoints.js
+++ b/src/styles/breakpoints.js
@@ -19,12 +19,17 @@ export default function createBreakpoints(
     xl: 1920,
   },
   unit = 'px',
-  step = 1,
-) {
+  step = 1,) {
   const values = keys.map((n) => breakpoints[n]);
 
   function up(name) {
-    const value = breakpoints[name] || name;
+    let value;
+    // min-width of xs starts at 0
+    if (name === 'xs') {
+      value = 0;
+    } else {
+      value = breakpoints[name] || name;
+    }
     return `@media (min-width:${value}${unit})`;
   }
 
@@ -37,7 +42,7 @@ export default function createBreakpoints(
     const startIndex = keys.indexOf(start);
     const endIndex = keys.indexOf(end);
     return `@media (min-width:${values[startIndex]}${unit}) and (max-width:${
-      values[endIndex + 1] - (step / 100)}${unit})`;
+    values[endIndex + 1] - (step / 100)}${unit})`;
   }
 
   function only(name) {

--- a/src/styles/breakpoints.js
+++ b/src/styles/breakpoints.js
@@ -19,7 +19,8 @@ export default function createBreakpoints(
     xl: 1920,
   },
   unit = 'px',
-  step = 1,) {
+  step = 1,
+) {
   const values = keys.map((n) => breakpoints[n]);
 
   function up(name) {

--- a/src/styles/breakpoints.spec.js
+++ b/src/styles/breakpoints.spec.js
@@ -11,7 +11,11 @@ describe('createBreakpoints', () => {
   });
 
   describe('up', () => {
-    it('should work', () => {
+    it('should work for xs', () => {
+      assert.strictEqual(breakpoints.up('xs'), '@media (min-width:0px)');
+    });
+
+    it('should work for md', () => {
       assert.strictEqual(breakpoints.up('md'), '@media (min-width:960px)');
     });
   });


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

This matches behavior of `withWidth`.  Since `xs` is the smallest size, anything using `up('xs')` should be displayed.