### PR TITLE
[Hidden] responsively hide content (js implementation)

### DIFF
--- a/docs/src/pages/component-api/Hidden/Hidden.md
+++ b/docs/src/pages/component-api/Hidden/Hidden.md
@@ -11,6 +11,7 @@ Props
 | children | Element |  | The content of the component. |
 | className | string |  | The CSS class name of the root element. |
 | component | union:&nbsp;string<br>&nbsp;Function<br> |  | The component used for the root node. Either a string to use a DOM element or a component. |
+| only | Breakpoints |  | Hide the given breakpoint. |
 | xsUp | boolean |  | If true, screens this size and up will be hidden. If false, screens this size and up will not be hidden. |
 | smUp | boolean |  | If true, screens this size and up will be hidden. If false, screens this size and up will not be hidden. |
 | mdUp | boolean |  | If true, screens this size and up will be hidden. If false, screens this size and up will not be hidden. |

--- a/docs/src/pages/component-api/Hidden/Hidden.md
+++ b/docs/src/pages/component-api/Hidden/Hidden.md
@@ -1,0 +1,26 @@
+Hidden
+======
+
+Responsively hides children based on the selected implementation.
+
+Props
+-----
+
+| Name | Type | Default | Description |
+|:-----|:-----|:--------|:------------|
+| children | Element |  | The content of the component. |
+| className | string |  | The CSS class name of the root element. |
+| component | union:&nbsp;string<br>&nbsp;Function<br> |  | The component used for the root node. Either a string to use a DOM element or a component. |
+| xsUp | boolean |  | If true, screens this size and up will be hidden. If false, screens this size and up will not be hidden. |
+| smUp | boolean |  | If true, screens this size and up will be hidden. If false, screens this size and up will not be hidden. |
+| mdUp | boolean |  | If true, screens this size and up will be hidden. If false, screens this size and up will not be hidden. |
+| lgUp | boolean |  | If true, screens this size and up will be hidden. If false, screens this size and up will not be hidden. |
+| xlUp | boolean |  | If true, screens this size and up will be hidden. If false, screens this size and up will not be hidden. |
+| xsDown | boolean |  | If true, screens this size and down will be hidden. If false, screens this size and down will not be hidden. |
+| smDown | boolean |  | If true, screens this size and down will be hidden. If false, screens this size and down will not be hidden. |
+| mdDown | boolean |  | If true, screens this size and down will be hidden. If false, screens this size and down will not be hidden. |
+| lgDown | boolean |  | If true, screens this size and down will be hidden. If false, screens this size and down will not be hidden. |
+| xlDown | boolean |  | If true, screens this size and down will be hidden. If false, screens this size and down will not be hidden. |
+| implementation | union:&nbsp;'js'<br>&nbsp;'css'<br> | 'js' | Specify which implementation to use.  'js' is the default, 'css' works better for server side rendering. |
+
+Any other properties supplied will be spread to the root element.

--- a/docs/src/pages/component-api/Layout/Layout.md
+++ b/docs/src/pages/component-api/Layout/Layout.md
@@ -8,13 +8,9 @@ Props
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| align | union:&nbsp;'flex-start'<br>&nbsp;'center'<br>&nbsp;'flex-end'<br>&nbsp;'stretch'<br> | 'stretch' | Defines the `align-items` style property. It's applied for all screen sizes. |
-| component | union:&nbsp;string<br>&nbsp;Function<br> | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
-| direction | union:&nbsp;'row'<br>&nbsp;'row-reverse'<br>&nbsp;'column'<br>&nbsp;'column-reverse'<br> | 'row' | Defines the `flex-direction` style property. It is applied for all screen sizes. |
-| justify | union:&nbsp;'flex-start', 'center', 'flex-end', 'space-between', 'space-around'<br> | 'flex-start' | Defines the `justify-content` style property. It is applied for all screen sizes. |
-| wrap | union:&nbsp;'nowrap'<br>&nbsp;'wrap'<br>&nbsp;'wrap-reverse'<br> | 'wrap' | Defines the `flex-wrap` style property. It's applied for all screen sizes. |
 | children | Element |  | The content of the component. |
 | className | string |  | The CSS class name of the root element. |
+| component | union:&nbsp;string<br>&nbsp;Function<br> | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
 | container | boolean | false | If `true`, the component will have the flex *container* behavior. You should be wrapping *items* with a *container*. |
 | item | boolean | false | It true, the component will have the flex *item* behavior. You should be wrapping *items* with a *container*. |
 | xs | union:&nbsp;boolean, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12<br> |  | Defines the number of grids the component is going to use. It's applied for all the screen sizes with the lowest priority. |
@@ -22,6 +18,10 @@ Props
 | md | union:&nbsp;boolean, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12<br> |  | Defines the number of grids the component is going to use. It's applied for the `md` breakpoint and wider screens if not overridden. |
 | lg | union:&nbsp;boolean, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12<br> |  | Defines the number of grids the component is going to use. It's applied for the `lg` breakpoint and wider screens if not overridden. |
 | xl | union:&nbsp;boolean, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12<br> |  | Defines the number of grids the component is going to use. It's applied for the `xl` breakpoint and wider screens. |
+| align | union:&nbsp;'flex-start'<br>&nbsp;'center'<br>&nbsp;'flex-end'<br>&nbsp;'stretch'<br> | 'stretch' | Defines the `align-items` style property. It's applied for all screen sizes. |
+| direction | union:&nbsp;'row'<br>&nbsp;'row-reverse'<br>&nbsp;'column'<br>&nbsp;'column-reverse'<br> | 'row' | Defines the `flex-direction` style property. It is applied for all screen sizes. |
 | gutter | union:&nbsp;0, 8, 16, 24, 40<br> | 16 | Defines the space between the type `item` component. It can only be used on a type `container` component. |
+| justify | union:&nbsp;'flex-start', 'center', 'flex-end', 'space-between', 'space-around'<br> | 'flex-start' | Defines the `justify-content` style property. It is applied for all screen sizes. |
+| wrap | union:&nbsp;'nowrap'<br>&nbsp;'wrap'<br>&nbsp;'wrap-reverse'<br> | 'wrap' | Defines the `flex-wrap` style property. It's applied for all screen sizes. |
 
 Any other properties supplied will be spread to the root element.

--- a/scripts/build-api-docs.js
+++ b/scripts/build-api-docs.js
@@ -6,6 +6,10 @@ import path from 'path';
 import * as reactDocgen from 'react-docgen';
 import generateMarkdown from './generate-docs-markdown';
 
+const ignoredItems = [
+  'internal',
+  'HiddenJs.js'
+]
 const componentRegex = /^([A-Z][a-z]+)+\.js/;
 const docsDir = path.resolve(__dirname, '../docs/src/pages/component-api');
 const srcDir = path.resolve(__dirname, '../src');
@@ -60,7 +64,7 @@ function buildDocs(componentPath) {
 function findComponents(dir) {
   fs.readdir(dir, (err, items) => {
     items.forEach((item) => {
-      if (item === 'internal') {
+      if (ignoredItems.includes(item)) {
         return;
       }
 

--- a/scripts/build-api-docs.js
+++ b/scripts/build-api-docs.js
@@ -8,8 +8,8 @@ import generateMarkdown from './generate-docs-markdown';
 
 const ignoredItems = [
   'internal',
-  'HiddenJs.js'
-]
+  'HiddenJs.js',
+];
 const componentRegex = /^([A-Z][a-z]+)+\.js/;
 const docsDir = path.resolve(__dirname, '../docs/src/pages/component-api');
 const srcDir = path.resolve(__dirname, '../src');

--- a/src/Hidden/Hidden.js
+++ b/src/Hidden/Hidden.js
@@ -9,7 +9,7 @@ export type DefaultProps = {
   component: string | Function,
 }
 
-export type Props = DefaultProps & {
+export type Props = {
   /**
    * The content of the component.
    */

--- a/src/Hidden/Hidden.js
+++ b/src/Hidden/Hidden.js
@@ -1,0 +1,109 @@
+// @flow
+/**
+ * Responsively hides children based on the selected implementation.
+ */
+import React, { Element } from 'react';
+import HiddenJs from './Hidden';
+
+export type DefaultProps = {
+  component: string | Function,
+}
+
+export type Props = DefaultProps & {
+  /**
+   * The content of the component.
+   */
+  children?: Element<any>,
+  /**
+   * The CSS class name of the root element.
+   */
+  className?: string,
+  /**
+   * The component used for the root node.
+   * Either a string to use a DOM element or a component.
+   */
+  component?: string | Function,
+  /**
+   * If true, screens this size and up will be hidden.
+   * If false, screens this size and up will not be hidden.
+   */
+  xsUp?: boolean, // eslint-disable-line react/sort-prop-types
+  /**
+   * If true, screens this size and up will be hidden.
+   * If false, screens this size and up will not be hidden.
+   */
+  smUp?: boolean, // eslint-disable-line react/sort-prop-types
+  /**
+   * If true, screens this size and up will be hidden.
+   * If false, screens this size and up will not be hidden.
+   */
+  mdUp?: boolean, // eslint-disable-line react/sort-prop-types
+  /**
+   * If true, screens this size and up will be hidden.
+   * If false, screens this size and up will not be hidden.
+   */
+  lgUp?: boolean, // eslint-disable-line react/sort-prop-types
+  /**
+   * If true, screens this size and up will be hidden.
+   * If false, screens this size and up will not be hidden.
+   */
+  xlUp?: boolean, // eslint-disable-line react/sort-prop-types
+  /**
+   * If true, screens this size and down will be hidden.
+   * If false, screens this size and down will not be hidden.
+   */
+  xsDown?: boolean, // eslint-disable-line react/sort-prop-types
+  /**
+   * If true, screens this size and down will be hidden.
+   * If false, screens this size and down will not be hidden.
+   */
+  smDown?: boolean, // eslint-disable-line react/sort-prop-types
+  /**
+   * If true, screens this size and down will be hidden.
+   * If false, screens this size and down will not be hidden.
+   */
+  mdDown?: boolean, // eslint-disable-line react/sort-prop-types
+  /**
+   * If true, screens this size and down will be hidden.
+   * If false, screens this size and down will not be hidden.
+   */
+  lgDown?: boolean, // eslint-disable-line react/sort-prop-types
+  /**
+   * If true, screens this size and down will be hidden.
+   * If false, screens this size and down will not be hidden.
+   */
+  xlDown?: boolean, // eslint-disable-line react/sort-prop-types
+};
+
+export const defaultProps: DefaultProps = {
+  component: 'div',
+  xsUp: false,
+  smUp: false,
+  mdUp: false,
+  lgUp: false,
+  xlUp: false,
+  xsDown: false,
+  smDown: false,
+  mdDown: false,
+  lgDown: false,
+  xlDown: false,
+};
+
+function Hidden(props: Props & { implementation?: 'js' | 'css' }) {
+  const {
+    implementation,
+    ...other
+  } = props;
+
+  if (implementation === 'js') {
+    return <HiddenJs {...other} />;
+  }
+
+  throw new Error('<HiddenJs implementation="css" /> is not yet implemented');
+}
+
+Hidden.defaultProps = {
+  implementation: 'js',
+};
+
+export default Hidden;

--- a/src/Hidden/Hidden.js
+++ b/src/Hidden/Hidden.js
@@ -1,7 +1,4 @@
 // @flow
-/**
- * Responsively hides children based on the selected implementation.
- */
 import React, { Element } from 'react';
 import HiddenJs from './Hidden';
 
@@ -9,7 +6,7 @@ export type DefaultProps = {
   component: string | Function,
 }
 
-export type Props = {
+export type HiddenProps = {
   /**
    * The content of the component.
    */
@@ -89,7 +86,18 @@ export const defaultProps: DefaultProps = {
   xlDown: false,
 };
 
-function Hidden(props: Props & { implementation?: 'js' | 'css' }) {
+type Props = HiddenProps & {
+  /**
+   * Specify which implementation to use.  'js' is the default, 'css' works better for server
+   * side rendering.
+   */
+  implementation?: 'js' | 'css'
+}
+
+/**
+ * Responsively hides children based on the selected implementation.
+ */
+function Hidden(props: Props) {
   const {
     implementation,
     ...other
@@ -99,7 +107,7 @@ function Hidden(props: Props & { implementation?: 'js' | 'css' }) {
     return <HiddenJs {...other} />;
   }
 
-  throw new Error('<HiddenJs implementation="css" /> is not yet implemented');
+  throw new Error('<Hidden implementation="css" /> is not yet implemented');
 }
 
 Hidden.defaultProps = {

--- a/src/Hidden/Hidden.js
+++ b/src/Hidden/Hidden.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Element } from 'react';
 import HiddenJs from './Hidden';
+import type { Breakpoints } from '../styles/breakpoints';
 
 export type DefaultProps = {
   component: string | Function,
@@ -20,6 +21,10 @@ export type HiddenProps = {
    * Either a string to use a DOM element or a component.
    */
   component?: string | Function,
+  /**
+   * Hide the given breakpoint.
+   */
+  only?: Breakpoints,
   /**
    * If true, screens this size and up will be hidden.
    * If false, screens this size and up will not be hidden.

--- a/src/Hidden/HiddenJs.js
+++ b/src/Hidden/HiddenJs.js
@@ -2,10 +2,10 @@
 /**
  * Responsively hides children by omission.
  */
-import React, { Element, PureComponent } from 'react';
+import React, { Element } from 'react';
 import { keys as breakpoints } from '../styles/breakpoints';
 import withWidth, { isWidthDown, isWidthUp } from '../utils/withWidth';
-import type { DefaultProps, Props } from './Hidden';
+import type { Props } from './Hidden';
 import { defaultProps } from './Hidden';
 
 type JsProps = Props & {
@@ -16,56 +16,54 @@ type JsProps = Props & {
     width: string,
 };
 
-class HiddenJs extends PureComponent<DefaultProps, JsProps, void> {
-  static defaultProps: DefaultProps = defaultProps;
-  props: JsProps;
+function HiddenJs(props: JsProps): ?Element<any> {
+  const {
+    children,
+    component,
+    xsUp, // eslint-disable-line no-unused-vars
+    smUp, // eslint-disable-line no-unused-vars
+    mdUp, // eslint-disable-line no-unused-vars
+    lgUp, // eslint-disable-line no-unused-vars
+    xlUp, // eslint-disable-line no-unused-vars
+    xsDown, // eslint-disable-line no-unused-vars
+    smDown, // eslint-disable-line no-unused-vars
+    mdDown, // eslint-disable-line no-unused-vars
+    lgDown, // eslint-disable-line no-unused-vars
+    xlDown, // eslint-disable-line no-unused-vars
+    width,
+    ...other
+  } = props;
 
-  render(): ?Element<any> {
-    const {
-      children,
-      component: ComponentProp,
-      xsUp, // eslint-disable-line no-unused-vars
-      smUp, // eslint-disable-line no-unused-vars
-      mdUp, // eslint-disable-line no-unused-vars
-      lgUp, // eslint-disable-line no-unused-vars
-      xlUp, // eslint-disable-line no-unused-vars
-      xsDown, // eslint-disable-line no-unused-vars
-      smDown, // eslint-disable-line no-unused-vars
-      mdDown, // eslint-disable-line no-unused-vars
-      lgDown, // eslint-disable-line no-unused-vars
-      xlDown, // eslint-disable-line no-unused-vars
-      width,
-      ...other
-    } = this.props;
+  // workaround: see https://github.com/facebook/flow/issues/1660#issuecomment-297775427
+  const ComponentProp = component || defaultProps.component;
+  let visible = true;
 
-    let visible = true;
-
-    // determine visibility based on the smallest size up
-    for (let i = 0; i < breakpoints.length; i += 1) {
-      const breakpoint = breakpoints[i];
-      const breakpointUp = this.props[`${breakpoint}Up`];
-      const breakpointDown = this.props[`${breakpoint}Down`];
-      if (
-        (breakpointUp && isWidthUp(width, breakpoint)) ||
-        (breakpointDown && (isWidthDown(width, breakpoint, true)))
-      ) {
-        visible = false;
-        break;
-      }
+  // determine visibility based on the smallest size up
+  for (let i = 0; i < breakpoints.length; i += 1) {
+    const breakpoint = breakpoints[i];
+    const breakpointUp = props[`${breakpoint}Up`];
+    const breakpointDown = props[`${breakpoint}Down`];
+    if (
+      (breakpointUp && isWidthUp(width, breakpoint)) ||
+      (breakpointDown && (isWidthDown(width, breakpoint, true)))
+    ) {
+      visible = false;
+      break;
     }
-
-    if (!visible) {
-      return null;
-    }
-
-    return (
-      <ComponentProp {...other}>
-        {children}
-      </ComponentProp>
-    );
   }
-}
-// for testing purposes
-export { HiddenJs };
 
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <ComponentProp {...other}>
+      {children}
+    </ComponentProp>
+  );
+}
+
+HiddenJs.defaultProps = defaultProps;
+
+export { HiddenJs }; // for testing
 export default withWidth(HiddenJs);

--- a/src/Hidden/HiddenJs.js
+++ b/src/Hidden/HiddenJs.js
@@ -5,10 +5,10 @@
 import React, { Element } from 'react';
 import { keys as breakpoints } from '../styles/breakpoints';
 import withWidth, { isWidthDown, isWidthUp } from '../utils/withWidth';
-import type { Props } from './Hidden';
+import type { HiddenProps } from './Hidden';
 import { defaultProps } from './Hidden';
 
-type JsProps = Props & {
+type Props = HiddenProps & {
   /**
    * @ignore
    * width prop provided by withWidth decorator
@@ -16,7 +16,7 @@ type JsProps = Props & {
     width: string,
 };
 
-function HiddenJs(props: JsProps): ?Element<any> {
+function HiddenJs(props: Props): ?Element<any> {
   const {
     children,
     component,

--- a/src/Hidden/HiddenJs.js
+++ b/src/Hidden/HiddenJs.js
@@ -1,0 +1,71 @@
+// @flow
+/**
+ * Responsively hides children by omission.
+ */
+import React, { Element, PureComponent } from 'react';
+import { keys as breakpoints } from '../styles/breakpoints';
+import withWidth, { isWidthDown, isWidthUp } from '../utils/withWidth';
+import type { DefaultProps, Props } from './Hidden';
+import { defaultProps } from './Hidden';
+
+type JsProps = Props & {
+  /**
+   * @ignore
+   * width prop provided by withWidth decorator
+   */
+    width: string,
+};
+
+class HiddenJs extends PureComponent<DefaultProps, JsProps, void> {
+  static defaultProps: DefaultProps = defaultProps;
+  props: JsProps;
+
+  render(): ?Element<any> {
+    const {
+      children,
+      component: ComponentProp,
+      xsUp, // eslint-disable-line no-unused-vars
+      smUp, // eslint-disable-line no-unused-vars
+      mdUp, // eslint-disable-line no-unused-vars
+      lgUp, // eslint-disable-line no-unused-vars
+      xlUp, // eslint-disable-line no-unused-vars
+      xsDown, // eslint-disable-line no-unused-vars
+      smDown, // eslint-disable-line no-unused-vars
+      mdDown, // eslint-disable-line no-unused-vars
+      lgDown, // eslint-disable-line no-unused-vars
+      xlDown, // eslint-disable-line no-unused-vars
+      width,
+      ...other
+    } = this.props;
+
+    let visible = true;
+
+    // determine visibility based on the smallest size up
+    for (let i = 0; i < breakpoints.length; i += 1) {
+      const breakpoint = breakpoints[i];
+      const breakpointUp = this.props[`${breakpoint}Up`];
+      const breakpointDown = this.props[`${breakpoint}Down`];
+      if (
+        (breakpointUp && isWidthUp(width, breakpoint)) ||
+        (breakpointDown && (isWidthDown(width, breakpoint, true)))
+      ) {
+        visible = false;
+        break;
+      }
+    }
+
+    if (!visible) {
+      return null;
+    }
+
+    return (
+      <ComponentProp {...other}>
+        {children}
+      </ComponentProp>
+    );
+  }
+}
+// for testing purposes
+export { HiddenJs };
+
+export default withWidth(HiddenJs);

--- a/src/Hidden/HiddenJs.js
+++ b/src/Hidden/HiddenJs.js
@@ -65,5 +65,4 @@ function HiddenJs(props: Props): ?Element<any> {
 
 HiddenJs.defaultProps = defaultProps;
 
-export { HiddenJs }; // for testing
-export default withWidth(HiddenJs);
+export default withWidth()(HiddenJs);

--- a/src/Hidden/HiddenJs.js
+++ b/src/Hidden/HiddenJs.js
@@ -20,6 +20,7 @@ function HiddenJs(props: Props): ?Element<any> {
   const {
     children,
     component,
+    only,
     xsUp, // eslint-disable-line no-unused-vars
     smUp, // eslint-disable-line no-unused-vars
     mdUp, // eslint-disable-line no-unused-vars
@@ -38,17 +39,22 @@ function HiddenJs(props: Props): ?Element<any> {
   const ComponentProp = component || defaultProps.component;
   let visible = true;
 
-  // determine visibility based on the smallest size up
-  for (let i = 0; i < breakpoints.length; i += 1) {
-    const breakpoint = breakpoints[i];
-    const breakpointUp = props[`${breakpoint}Up`];
-    const breakpointDown = props[`${breakpoint}Down`];
-    if (
-      (breakpointUp && isWidthUp(width, breakpoint)) ||
-      (breakpointDown && (isWidthDown(width, breakpoint, true)))
-    ) {
-      visible = false;
-      break;
+  // `only` takes priority.
+  if (only && width === only) {
+    visible = false;
+  } else {
+    // determine visibility based on the smallest size up
+    for (let i = 0; i < breakpoints.length; i += 1) {
+      const breakpoint = breakpoints[i];
+      const breakpointUp = props[`${breakpoint}Up`];
+      const breakpointDown = props[`${breakpoint}Down`];
+      if (
+        (breakpointUp && isWidthUp(width, breakpoint)) ||
+        (breakpointDown && (isWidthDown(width, breakpoint, true)))
+      ) {
+        visible = false;
+        break;
+      }
     }
   }
 

--- a/src/Hidden/HiddenJs.spec.js
+++ b/src/Hidden/HiddenJs.spec.js
@@ -111,7 +111,7 @@ describe('<HiddenJs />', () => {
 
     describe('only', () => {
       shouldNotRender('md', 'only', ['md']);
-      shouldRender('wd', 'only', ['xs', 'sm', 'lg', 'xl']);
+      shouldRender('md', 'only', ['xs', 'sm', 'lg', 'xl']);
     });
   });
 

--- a/src/Hidden/HiddenJs.spec.js
+++ b/src/Hidden/HiddenJs.spec.js
@@ -14,12 +14,29 @@ describe('<HiddenJs />', () => {
     shallowWithWidth = (node, options = {}) => shallow(node, options).dive().dive();
   });
 
+  function resolveProp(upDownOnly, breakpoint) {
+    if (upDownOnly === 'only') {
+      return { only: breakpoint };
+    }
+
+    return { [`${breakpoint}${upDownOnly}`]: true };
+  }
+
   function shouldNotRender(
-    width: Breakpoints, upOrDown: 'Up' | 'Down', smallerBreakpoints: Array<Breakpoints>) {
+    width: Breakpoints,
+    upDownOnly: 'Up' | 'Down' | 'only',
+    smallerBreakpoints: Array<Breakpoints>,
+  ) {
+    const descriptions = {
+      Up: '(smaller)',
+      Down: '(same or smaller)',
+      only: '(exact match)',
+    };
     smallerBreakpoints.forEach((breakpoint) => {
-      const up = upOrDown === 'Up';
-      it(`should not render ${breakpoint} ${up ? '(smaller)' : '(same or smaller)'}`, () => {
-        const props = { width, [`${breakpoint}${upOrDown}`]: true };
+      const prop = resolveProp(upDownOnly, breakpoint);
+
+      it(`should not render ${breakpoint} ${descriptions[upDownOnly]}`, () => {
+        const props = { width, ...prop };
         const wrapper = shallowWithWidth(<HiddenJs {...props}>foo</HiddenJs>);
         assert.strictEqual(wrapper.type(), null, 'should render nothing');
       });
@@ -27,11 +44,19 @@ describe('<HiddenJs />', () => {
   }
 
   function shouldRender(
-    width: Breakpoints, upOrDown: 'Up' | 'Down', sameOrLargerBreakpoints: Array<Breakpoints>) {
+    width: Breakpoints,
+    upDownOnly: 'Up' | 'Down' | 'only',
+    sameOrLargerBreakpoints: Array<Breakpoints>,
+  ) {
+    const descriptions = {
+      Up: '(same or larger)',
+      Down: '(larger)',
+      only: '(not exact match)',
+    };
     sameOrLargerBreakpoints.forEach((breakpoint) => {
-      const up = upOrDown === 'Up';
-      it(`should render ${breakpoint} ${up ? '(same or larger)' : '(larger)'}`, () => {
-        const props = { width, [`${breakpoint}${upOrDown}`]: true };
+      const prop = resolveProp(upDownOnly, breakpoint);
+      it(`should render ${breakpoint} ${descriptions[upDownOnly]}`, () => {
+        const props = { width, ...prop };
         const wrapper = shallowWithWidth(<HiddenJs {...props}>foo</HiddenJs>);
         assert.isNotNull(wrapper.type(), 'should render children');
         assert.strictEqual(wrapper.name(), 'div');
@@ -49,6 +74,11 @@ describe('<HiddenJs />', () => {
       shouldNotRender('xs', 'Down', ['xs']);
       shouldRender('xs', 'Down', ['sm', 'md', 'lg']);
     });
+
+    describe('only', () => {
+      shouldNotRender('xs', 'only', ['xs']);
+      shouldRender('xs', 'only', ['sm', 'md', 'lg', 'xl']);
+    });
   });
 
   describe('screen width: sm', () => {
@@ -60,6 +90,11 @@ describe('<HiddenJs />', () => {
     describe('down', () => {
       shouldNotRender('sm', 'Down', ['xs', 'sm']);
       shouldRender('sm', 'Down', ['md', 'lg', 'xl']);
+    });
+
+    describe('only', () => {
+      shouldNotRender('sm', 'only', ['sm']);
+      shouldRender('sm', 'only', ['xs', 'md', 'lg', 'xl']);
     });
   });
 
@@ -73,6 +108,11 @@ describe('<HiddenJs />', () => {
       shouldNotRender('md', 'Down', ['xs', 'sm', 'md']);
       shouldRender('md', 'Down', ['lg', 'xl']);
     });
+
+    describe('only', () => {
+      shouldNotRender('md', 'only', ['md']);
+      shouldRender('wd', 'only', ['xs', 'sm', 'lg', 'xl']);
+    });
   });
 
   describe('screen width: lg', () => {
@@ -85,6 +125,11 @@ describe('<HiddenJs />', () => {
       shouldNotRender('lg', 'Down', ['xs', 'sm', 'md', 'lg']);
       shouldRender('lg', 'Down', ['xl']);
     });
+
+    describe('only', () => {
+      shouldNotRender('lg', 'only', ['lg']);
+      shouldRender('lg', 'only', ['xs', 'sm', 'md', 'xl']);
+    });
   });
 
   describe('screen width: xl', () => {
@@ -95,6 +140,11 @@ describe('<HiddenJs />', () => {
 
     describe('down', () => {
       shouldNotRender('xl', 'Down', ['xs', 'sm', 'md', 'lg', 'xl']);
+    });
+
+    describe('only', () => {
+      shouldNotRender('xl', 'only', ['xl']);
+      shouldRender('xl', 'only', ['xs', 'sm', 'md', 'lg']);
     });
   });
 });

--- a/src/Hidden/HiddenJs.spec.js
+++ b/src/Hidden/HiddenJs.spec.js
@@ -1,0 +1,101 @@
+// @flow weak
+/* eslint-disable no-loop-func */
+import React from 'react';
+import { assert } from 'chai';
+import { createShallow } from 'src/test-utils/index';
+import { HiddenJs } from './HiddenJs';
+import type { Breakpoints } from '../styles/breakpoints';
+
+describe('<HiddenJs />', () => {
+  let shallow;
+
+  before(() => {
+    shallow = createShallow();
+  });
+
+  function shouldNotRender(
+    width: Breakpoints, upOrDown: 'Up' | 'Down', smallerBreakpoints: Array<Breakpoints>) {
+    for (let i = 0; i < smallerBreakpoints.length; i += 1) {
+      const breakpoint = smallerBreakpoints[i];
+      const up = upOrDown === 'Up';
+      it(`should not render ${breakpoint} ${up ? '(smaller)' : '(same or smaller)'}`, () => {
+        const props = { width, [`${breakpoint}${upOrDown}`]: true };
+        const wrapper = shallow(<HiddenJs {...props}>foo</HiddenJs>);
+        assert.strictEqual(wrapper.type(), null, 'should render nothing');
+      });
+    }
+  }
+
+  function shouldRender(
+    width: Breakpoints, upOrDown: 'Up' | 'Down', sameOrLargerBreakpoints: Array<Breakpoints>) {
+    for (let i = 0; i < sameOrLargerBreakpoints.length; i += 1) {
+      const breakpoint = sameOrLargerBreakpoints[i];
+      const up = upOrDown === 'Up';
+      it(`should render ${breakpoint} ${up ? '(same or larger)' : '(larger)'}`, () => {
+        const props = { width, [`${breakpoint}${upOrDown}`]: true };
+        const wrapper = shallow(<HiddenJs {...props}>foo</HiddenJs>);
+        assert.isNotNull(wrapper.type(), 'should render children');
+        assert.strictEqual(wrapper.name(), 'div');
+        assert.strictEqual(wrapper.first().text(), 'foo', 'should render children');
+      });
+    }
+  }
+
+  describe('screen width: xs', () => {
+    describe('up', () => {
+      shouldNotRender('xs', 'Up', ['xs', 'sm', 'md', 'lg', 'xl']);
+    });
+
+    describe('down', () => {
+      shouldNotRender('xs', 'Down', ['xs']);
+      shouldRender('xs', 'Down', ['sm', 'md', 'lg']);
+    });
+  });
+
+  describe('screen width: sm', () => {
+    describe('up', () => {
+      shouldRender('sm', 'Up', ['xs']);
+      shouldNotRender('sm', 'Up', ['sm', 'md', 'lg', 'xl']);
+    });
+
+    describe('down', () => {
+      shouldNotRender('sm', 'Down', ['xs', 'sm']);
+      shouldRender('sm', 'Down', ['md', 'lg', 'xl']);
+    });
+  });
+
+  describe('screen width: md', () => {
+    describe('up', () => {
+      shouldRender('md', 'Up', ['xs', 'sm']);
+      shouldNotRender('md', 'Up', ['md', 'lg', 'xl']);
+    });
+
+    describe('down', () => {
+      shouldNotRender('md', 'Down', ['xs', 'sm', 'md']);
+      shouldRender('md', 'Down', ['lg', 'xl']);
+    });
+  });
+
+  describe('screen width: lg', () => {
+    describe('up', () => {
+      shouldRender('lg', 'Up', ['xs', 'sm', 'md']);
+      shouldNotRender('lg', 'Up', ['lg', 'xl']);
+    });
+
+    describe('down', () => {
+      shouldNotRender('lg', 'Down', ['xs', 'sm', 'md', 'lg']);
+      shouldRender('lg', 'Down', ['xl']);
+    });
+  });
+
+  describe('screen width: xl', () => {
+    describe('up', () => {
+      shouldRender('xl', 'Up', ['xs', 'sm', 'md', 'lg']);
+      shouldNotRender('xl', 'Up', ['xl']);
+    });
+
+    describe('down', () => {
+      shouldNotRender('xl', 'Down', ['xs', 'sm', 'md', 'lg', 'xl']);
+    });
+  });
+});

--- a/src/Hidden/HiddenJs.spec.js
+++ b/src/Hidden/HiddenJs.spec.js
@@ -2,15 +2,16 @@
 /* eslint-disable no-loop-func */
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils/index';
-import { HiddenJs } from './HiddenJs';
+import { createShallow } from 'src/test-utils';
+import HiddenJs from './HiddenJs';
 import type { Breakpoints } from '../styles/breakpoints';
 
 describe('<HiddenJs />', () => {
-  let shallow;
+  let shallowWithWidth;
 
   before(() => {
-    shallow = createShallow();
+    const shallow = createShallow();
+    shallowWithWidth = (node, options = {}) => shallow(node, options).dive().dive();
   });
 
   function shouldNotRender(
@@ -19,7 +20,7 @@ describe('<HiddenJs />', () => {
       const up = upOrDown === 'Up';
       it(`should not render ${breakpoint} ${up ? '(smaller)' : '(same or smaller)'}`, () => {
         const props = { width, [`${breakpoint}${upOrDown}`]: true };
-        const wrapper = shallow(<HiddenJs {...props}>foo</HiddenJs>);
+        const wrapper = shallowWithWidth(<HiddenJs {...props}>foo</HiddenJs>);
         assert.strictEqual(wrapper.type(), null, 'should render nothing');
       });
     });
@@ -31,7 +32,7 @@ describe('<HiddenJs />', () => {
       const up = upOrDown === 'Up';
       it(`should render ${breakpoint} ${up ? '(same or larger)' : '(larger)'}`, () => {
         const props = { width, [`${breakpoint}${upOrDown}`]: true };
-        const wrapper = shallow(<HiddenJs {...props}>foo</HiddenJs>);
+        const wrapper = shallowWithWidth(<HiddenJs {...props}>foo</HiddenJs>);
         assert.isNotNull(wrapper.type(), 'should render children');
         assert.strictEqual(wrapper.name(), 'div');
         assert.strictEqual(wrapper.first().text(), 'foo', 'should render children');

--- a/src/Hidden/HiddenJs.spec.js
+++ b/src/Hidden/HiddenJs.spec.js
@@ -15,21 +15,19 @@ describe('<HiddenJs />', () => {
 
   function shouldNotRender(
     width: Breakpoints, upOrDown: 'Up' | 'Down', smallerBreakpoints: Array<Breakpoints>) {
-    for (let i = 0; i < smallerBreakpoints.length; i += 1) {
-      const breakpoint = smallerBreakpoints[i];
+    smallerBreakpoints.forEach((breakpoint) => {
       const up = upOrDown === 'Up';
       it(`should not render ${breakpoint} ${up ? '(smaller)' : '(same or smaller)'}`, () => {
         const props = { width, [`${breakpoint}${upOrDown}`]: true };
         const wrapper = shallow(<HiddenJs {...props}>foo</HiddenJs>);
         assert.strictEqual(wrapper.type(), null, 'should render nothing');
       });
-    }
+    });
   }
 
   function shouldRender(
     width: Breakpoints, upOrDown: 'Up' | 'Down', sameOrLargerBreakpoints: Array<Breakpoints>) {
-    for (let i = 0; i < sameOrLargerBreakpoints.length; i += 1) {
-      const breakpoint = sameOrLargerBreakpoints[i];
+    sameOrLargerBreakpoints.forEach((breakpoint) => {
       const up = upOrDown === 'Up';
       it(`should render ${breakpoint} ${up ? '(same or larger)' : '(larger)'}`, () => {
         const props = { width, [`${breakpoint}${upOrDown}`]: true };
@@ -38,7 +36,7 @@ describe('<HiddenJs />', () => {
         assert.strictEqual(wrapper.name(), 'div');
         assert.strictEqual(wrapper.first().text(), 'foo', 'should render children');
       });
-    }
+    });
   }
 
   describe('screen width: xs', () => {

--- a/src/Hidden/index.js
+++ b/src/Hidden/index.js
@@ -1,0 +1,8 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+import Hidden from './Hidden';
+import HiddenJs from './HiddenJs';
+
+export default Hidden;
+export {
+  HiddenJs,
+};

--- a/src/styles/breakpoints.js
+++ b/src/styles/breakpoints.js
@@ -1,4 +1,5 @@
 // @flow weak
+export type Breakpoints = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 // Sorted ASC by size. That's important.
 export const keys = [

--- a/src/utils/withWidth.js
+++ b/src/utils/withWidth.js
@@ -29,7 +29,6 @@ export const isWidthUp = (screenWidth, breakpoint, inclusive = true) => {
 export const isWidthDown = (screenWidth, breakpoint, inclusive = false) => {
   if (inclusive) {
     return keys.indexOf(screenWidth) >= keys.indexOf(breakpoint);
-
   }
   return keys.indexOf(screenWidth) > keys.indexOf(breakpoint);
 };

--- a/src/utils/withWidth.js
+++ b/src/utils/withWidth.js
@@ -7,13 +7,32 @@ import createEagerFactory from 'recompose/createEagerFactory';
 import customPropTypes from '../utils/customPropTypes';
 import { keys } from '../styles/breakpoints';
 
-export const isWidthUp = (baseWidth, width) => (
-  keys.indexOf(baseWidth) <= keys.indexOf(width)
-);
+/**
+ * By default, returns true if screen width is the same or greater than the given breakpoint.
+ * @param screenWidth
+ * @param breakpoint
+ * @param inclusive - defaults to true
+ */
+export const isWidthUp = (screenWidth, breakpoint, inclusive = true) => {
+  if (inclusive) {
+    return keys.indexOf(screenWidth) <= keys.indexOf(breakpoint);
+  }
+  return keys.indexOf(screenWidth) < keys.indexOf(breakpoint);
+};
 
-export const isWidthDown = (baseWidth, width) => (
-  keys.indexOf(baseWidth) > keys.indexOf(width)
-);
+/**
+ * By default, returns true if screen less than the given breakpoint.
+ * @param screenWidth
+ * @param breakpoint
+ * @param inclusive - defaults to false
+ */
+export const isWidthDown = (screenWidth, breakpoint, inclusive = false) => {
+  if (inclusive) {
+    return keys.indexOf(screenWidth) >= keys.indexOf(breakpoint);
+
+  }
+  return keys.indexOf(screenWidth) > keys.indexOf(breakpoint);
+};
 
 function withWidth(options = {}) {
   const {

--- a/src/utils/withWidth.spec.js
+++ b/src/utils/withWidth.spec.js
@@ -46,18 +46,28 @@ describe('withWidth', () => {
   });
 
   describe('isWidthUp', () => {
-    it('should work as expected', () => {
+    it('should work as default inclusive', () => {
       assert.strictEqual(isWidthUp('md', 'lg'), true, 'should accept larger size');
       assert.strictEqual(isWidthUp('md', 'md'), true, 'should be inclusive');
       assert.strictEqual(isWidthUp('md', 'sm'), false, 'should reject smaller size');
     });
+    it('should work as exclusive', () => {
+      assert.strictEqual(isWidthUp('md', 'lg', false), true, 'should accept larger size');
+      assert.strictEqual(isWidthUp('md', 'md', false), false, 'should be exclusive');
+      assert.strictEqual(isWidthUp('md', 'sm', false), false, 'should reject smaller size');
+    });
   });
 
   describe('isWidthDown', () => {
-    it('should work as expected', () => {
+    it('should work as default exclusive', () => {
       assert.strictEqual(isWidthDown('md', 'lg'), false, 'should reject larger size');
       assert.strictEqual(isWidthDown('md', 'md'), false, 'should be exclusive');
       assert.strictEqual(isWidthDown('md', 'sm'), true, 'should accept smaller size');
+    });
+    it('should work as inclusive', () => {
+      assert.strictEqual(isWidthDown('md', 'lg', true), false, 'should reject larger size');
+      assert.strictEqual(isWidthDown('md', 'md', true), true, 'should be inclusive');
+      assert.strictEqual(isWidthDown('md', 'sm', true), true, 'should accept smaller size');
     });
   });
 


### PR DESCRIPTION
@see https://github.com/callemall/material-ui/issues/6726#issuecomment-298162706

This component will responsively hide content (return null) based on the given breakpoint.  Once accepted, this will also be integrated into the `Layout` API for brevity.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

