### PR TITLE
React 16 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "lodash.throttle": "^4.1.1",
     "prop-types": "^15.5.7",
     "react-addons-create-fragment": "^15.4.0",
-    "react-addons-transition-group": "^15.4.0",
+    "react-transition-group": "^1.1.2",
     "react-event-listener": "^0.4.5",
     "recompose": "^0.23.0",
     "simple-assign": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "lodash.merge": "^4.6.0",
     "lodash.throttle": "^4.1.1",
     "prop-types": "^15.5.7",
-    "react-addons-create-fragment": "^15.4.0",
     "react-transition-group": "^1.1.2",
     "react-event-listener": "^0.4.5",
     "recompose": "^0.23.0",

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -8,7 +8,7 @@ import Overlay from '../internal/Overlay';
 import RenderToLayer from '../internal/RenderToLayer';
 import Paper from '../Paper';
 
-import ReactTransitionGroup from 'react-addons-transition-group';
+import ReactTransitionGroup from 'react-transition-group/TransitionGroup';
 
 class TransitionItem extends Component {
   static propTypes = {

--- a/src/ReactFragment/ReactFragment.js
+++ b/src/ReactFragment/ReactFragment.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+/**
+ * Copied from react/lib/ReactFragment in React 15.5.4
+ * because this file does not exist anymore in React 16.
+ * Modified to match code style.
+ */
+
+import _prodInvariant from 'react/lib/reactProdInvariant';
+
+import ReactChildren from 'react/lib/ReactChildren';
+import ReactElement from 'react/lib/ReactElement';
+
+import emptyFunction from 'fbjs/lib/emptyFunction';
+import invariant from 'fbjs/lib/invariant';
+import warning from 'fbjs/lib/warning';
+
+/**
+ * We used to allow keyed objects to serve as a collection of ReactElements,
+ * or nested sets. This allowed us a way to explicitly key a set or fragment of
+ * components. This is now being replaced with an opaque data structure.
+ * The upgrade path is to call React.addons.createFragment({ key: value }) to
+ * create a keyed fragment. The resulting data structure is an array.
+ */
+
+const numericPropertyRegex = /^\d+$/;
+
+let warnedAboutNumeric = false;
+
+const ReactFragment = {
+  /**
+   * Wrap a keyed object in an opaque proxy that warns you if you access any
+   * of its properties.
+   * See https://facebook.github.io/react/docs/create-fragment.html
+   */
+  create: function(object) {
+    if (typeof object !== 'object' || !object || Array.isArray(object)) {
+      if (process.env.NODE_ENV !== 'production') {
+        warning(false, 'React.addons.createFragment only accepts a single object. Got: %s', object);
+      }
+
+      return object;
+    }
+    if (ReactElement.isValidElement(object)) {
+      if (process.env.NODE_ENV !== 'production') {
+        warning(false, 'React.addons.createFragment does not accept a ReactElement ' + 'without a wrapper object.');
+      }
+      return object;
+    }
+
+    if (!(object.nodeType !== 1)) {
+      if (process.env.NODE_ENV !== 'production') {
+        invariant(false, 'React.addons.createFragment(...): Encountered an invalid child; ' +
+          'DOM elements are not valid children of React components.');
+      } else {
+        _prodInvariant('0');
+      }
+    }
+
+    const result = [];
+
+    for (const key in object) {
+      if (process.env.NODE_ENV !== 'production') {
+        if (!warnedAboutNumeric && numericPropertyRegex.test(key)) {
+          warning(false, 'React.addons.createFragment(...): ' +
+            'Child objects should have ' +
+            'non-numeric keys so ordering is preserved.');
+          warnedAboutNumeric = true;
+        }
+      }
+      ReactChildren.mapIntoWithKeyPrefixInternal(object[key], result, key, emptyFunction.thatReturnsArgument);
+    }
+
+    return result;
+  },
+};
+
+export default ReactFragment.create;

--- a/src/internal/ExpandTransition.js
+++ b/src/internal/ExpandTransition.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import ReactTransitionGroup from 'react-addons-transition-group';
+import ReactTransitionGroup from 'react-transition-group/TransitionGroup';
 import ExpandTransitionChild from './ExpandTransitionChild';
 
 class ExpandTransition extends Component {

--- a/src/internal/ScaleIn.js
+++ b/src/internal/ScaleIn.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import ReactTransitionGroup from 'react-addons-transition-group';
+import ReactTransitionGroup from 'react-transition-group/TransitionGroup';
 import ScaleInChild from './ScaleInChild';
 
 class ScaleIn extends Component {

--- a/src/internal/SlideIn.js
+++ b/src/internal/SlideIn.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import ReactTransitionGroup from 'react-addons-transition-group';
+import ReactTransitionGroup from 'react-transition-group/TransitionGroup';
 import SlideInChild from './SlideInChild';
 
 class SlideIn extends Component {

--- a/src/internal/TouchRipple.js
+++ b/src/internal/TouchRipple.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import ReactTransitionGroup from 'react-addons-transition-group';
+import ReactTransitionGroup from 'react-transition-group/TransitionGroup';
 import Dom from '../utils/dom';
 import CircleRipple from './CircleRipple';
 

--- a/src/utils/childUtils.js
+++ b/src/utils/childUtils.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import createFragment from 'react-addons-create-fragment';
+import createFragment from '../ReactFragment/ReactFragment';
 
 export function createChildFragment(fragments) {
   const newFragments = {};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Closes #6704 
These packages are not compatible with React 16 because their corresponding react/lib module does not exist anymore:
- react-addons-transition-group (react/lib/ReactTransitionGroup)
fix: use `react-transition-group/TransitionGroup` [[ref](https://www.npmjs.com/package/react-addons-transition-group)]
- react-addons-create-fragment (react/lib/ReactFragment)
fix: copy react/lib/ReactFragment from React 15.5.4. I don't think this is the best solution, need suggestion...