### PR TITLE
[Hidden] make down exclusive, remove unneeded props, cleanup docs

### DIFF
--- a/docs/src/pages/component-api/Hidden/Hidden.md
+++ b/docs/src/pages/component-api/Hidden/Hidden.md
@@ -12,16 +12,14 @@ Props
 | className | string |  | The CSS class name of the root element. |
 | component | union:&nbsp;string<br>&nbsp;Function<br> |  | The component used for the root node. Either a string to use a DOM element or a component. |
 | only | Breakpoints |  | Hide the given breakpoint. |
-| xsUp | boolean |  | If true, screens this size and up will be hidden. If false, screens this size and up will not be hidden. |
-| smUp | boolean |  | If true, screens this size and up will be hidden. If false, screens this size and up will not be hidden. |
-| mdUp | boolean |  | If true, screens this size and up will be hidden. If false, screens this size and up will not be hidden. |
-| lgUp | boolean |  | If true, screens this size and up will be hidden. If false, screens this size and up will not be hidden. |
-| xlUp | boolean |  | If true, screens this size and up will be hidden. If false, screens this size and up will not be hidden. |
-| xsDown | boolean |  | If true, screens this size and down will be hidden. If false, screens this size and down will not be hidden. |
-| smDown | boolean |  | If true, screens this size and down will be hidden. If false, screens this size and down will not be hidden. |
-| mdDown | boolean |  | If true, screens this size and down will be hidden. If false, screens this size and down will not be hidden. |
-| lgDown | boolean |  | If true, screens this size and down will be hidden. If false, screens this size and down will not be hidden. |
-| xlDown | boolean |  | If true, screens this size and down will be hidden. If false, screens this size and down will not be hidden. |
+| xsUp | boolean |  | If true, screens this size and up will be hidden. |
+| smUp | boolean |  | If true, screens this size and up will be hidden. |
+| mdUp | boolean |  | If true, screens this size and up will be hidden. |
+| lgUp | boolean |  | If true, screens this size and up will be hidden. |
+| smDown | boolean |  | If true, screens under this size will be hidden. |
+| mdDown | boolean |  | If true, screens under this size will be hidden. |
+| lgDown | boolean |  | If true, screens under this size will be hidden. |
+| xlDown | boolean |  | If true, screens under this size will be hidden. |
 | implementation | union:&nbsp;'js'<br>&nbsp;'css'<br> | 'js' | Specify which implementation to use.  'js' is the default, 'css' works better for server side rendering. |
 
 Any other properties supplied will be spread to the root element.

--- a/src/Hidden/Hidden.js
+++ b/src/Hidden/Hidden.js
@@ -27,52 +27,34 @@ export type HiddenProps = {
   only?: Breakpoints,
   /**
    * If true, screens this size and up will be hidden.
-   * If false, screens this size and up will not be hidden.
    */
   xsUp?: boolean, // eslint-disable-line react/sort-prop-types
   /**
    * If true, screens this size and up will be hidden.
-   * If false, screens this size and up will not be hidden.
    */
   smUp?: boolean, // eslint-disable-line react/sort-prop-types
   /**
    * If true, screens this size and up will be hidden.
-   * If false, screens this size and up will not be hidden.
    */
   mdUp?: boolean, // eslint-disable-line react/sort-prop-types
   /**
    * If true, screens this size and up will be hidden.
-   * If false, screens this size and up will not be hidden.
    */
   lgUp?: boolean, // eslint-disable-line react/sort-prop-types
   /**
-   * If true, screens this size and up will be hidden.
-   * If false, screens this size and up will not be hidden.
-   */
-  xlUp?: boolean, // eslint-disable-line react/sort-prop-types
-  /**
-   * If true, screens this size and down will be hidden.
-   * If false, screens this size and down will not be hidden.
-   */
-  xsDown?: boolean, // eslint-disable-line react/sort-prop-types
-  /**
-   * If true, screens this size and down will be hidden.
-   * If false, screens this size and down will not be hidden.
+   * If true, screens under this size will be hidden.
    */
   smDown?: boolean, // eslint-disable-line react/sort-prop-types
   /**
-   * If true, screens this size and down will be hidden.
-   * If false, screens this size and down will not be hidden.
+   * If true, screens under this size will be hidden.
    */
   mdDown?: boolean, // eslint-disable-line react/sort-prop-types
   /**
-   * If true, screens this size and down will be hidden.
-   * If false, screens this size and down will not be hidden.
+   * If true, screens under this size will be hidden.
    */
   lgDown?: boolean, // eslint-disable-line react/sort-prop-types
   /**
-   * If true, screens this size and down will be hidden.
-   * If false, screens this size and down will not be hidden.
+   * If true, screens under this size will be hidden.
    */
   xlDown?: boolean, // eslint-disable-line react/sort-prop-types
 };

--- a/src/Hidden/HiddenJs.js
+++ b/src/Hidden/HiddenJs.js
@@ -25,8 +25,6 @@ function HiddenJs(props: Props): ?Element<any> {
     smUp, // eslint-disable-line no-unused-vars
     mdUp, // eslint-disable-line no-unused-vars
     lgUp, // eslint-disable-line no-unused-vars
-    xlUp, // eslint-disable-line no-unused-vars
-    xsDown, // eslint-disable-line no-unused-vars
     smDown, // eslint-disable-line no-unused-vars
     mdDown, // eslint-disable-line no-unused-vars
     lgDown, // eslint-disable-line no-unused-vars
@@ -50,7 +48,7 @@ function HiddenJs(props: Props): ?Element<any> {
       const breakpointDown = props[`${breakpoint}Down`];
       if (
         (breakpointUp && isWidthUp(width, breakpoint)) ||
-        (breakpointDown && (isWidthDown(width, breakpoint, true)))
+        (breakpointDown && isWidthDown(width, breakpoint))
       ) {
         visible = false;
         break;

--- a/src/Hidden/HiddenJs.spec.js
+++ b/src/Hidden/HiddenJs.spec.js
@@ -71,8 +71,7 @@ describe('<HiddenJs />', () => {
     });
 
     describe('down', () => {
-      shouldNotRender('xs', 'Down', ['xs']);
-      shouldRender('xs', 'Down', ['sm', 'md', 'lg']);
+      shouldRender('xs', 'Down', ['xs', 'sm', 'md', 'lg']);
     });
 
     describe('only', () => {
@@ -88,8 +87,8 @@ describe('<HiddenJs />', () => {
     });
 
     describe('down', () => {
-      shouldNotRender('sm', 'Down', ['xs', 'sm']);
-      shouldRender('sm', 'Down', ['md', 'lg', 'xl']);
+      shouldNotRender('sm', 'Down', ['xs']);
+      shouldRender('sm', 'Down', ['sm', 'md', 'lg', 'xl']);
     });
 
     describe('only', () => {
@@ -105,8 +104,8 @@ describe('<HiddenJs />', () => {
     });
 
     describe('down', () => {
-      shouldNotRender('md', 'Down', ['xs', 'sm', 'md']);
-      shouldRender('md', 'Down', ['lg', 'xl']);
+      shouldNotRender('md', 'Down', ['xs', 'sm']);
+      shouldRender('md', 'Down', ['md', 'lg', 'xl']);
     });
 
     describe('only', () => {
@@ -122,8 +121,8 @@ describe('<HiddenJs />', () => {
     });
 
     describe('down', () => {
-      shouldNotRender('lg', 'Down', ['xs', 'sm', 'md', 'lg']);
-      shouldRender('lg', 'Down', ['xl']);
+      shouldNotRender('lg', 'Down', ['xs', 'sm', 'md']);
+      shouldRender('lg', 'Down', ['lg', 'xl']);
     });
 
     describe('only', () => {
@@ -139,7 +138,8 @@ describe('<HiddenJs />', () => {
     });
 
     describe('down', () => {
-      shouldNotRender('xl', 'Down', ['xs', 'sm', 'md', 'lg', 'xl']);
+      shouldRender('xl', 'Down', ['xl']);
+      shouldNotRender('xl', 'Down', ['xs', 'sm', 'md', 'lg']);
     });
 
     describe('only', () => {


### PR DESCRIPTION
`isWidthDown` was used as `exclusive` by default, but in my initial implementation of `Hidden`, I thought it made sense to implement the `down` props as `inclusive`.  Once I used it with `Layout`, it made sense why it was defaulted as `exclusive`.

For example, I want an `item` that lays out on md and higher only:

This felt awkward:
`<Layout item md hidden={{ smDown: true }}>`

With this PR, it will now be:
`<Layout item md hidden={{ mdDown: true }}>`

Also:
- removed superfluous docs on props
- remove useless props `xsDown` and `xlUp`

---

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

