### PR TITLE
[palette]: require color shape that matches defaults when specifying primary, accent, error

### DIFF
--- a/src/styles/palette.js
+++ b/src/styles/palette.js
@@ -1,5 +1,6 @@
 // @flow weak
-
+import difference from 'lodash/difference';
+import keys from 'lodash/keys';
 import { indigo, pink, grey, red, black, white } from './colors';
 import { getContrastRatio } from './colorManipulator';
 
@@ -64,6 +65,18 @@ export default function createPalette({
   error = red,
   type = 'light',
 } = {}) {
+  if (difference(keys(indigo), keys(primary)).length) {
+    throw new Error('Invalid primary color');
+  }
+
+  if (difference(keys(pink), keys(accent)).length) {
+    throw new Error('Invalid accent color');
+  }
+
+  if (difference(keys(red), keys(error)).length) {
+    throw new Error('Invalid error color');
+  }
+
   return {
     type,
     text: shades[type].text,

--- a/src/styles/palette.js
+++ b/src/styles/palette.js
@@ -59,22 +59,34 @@ export function getContrastText(color) {
   return light.text.primary;
 }
 
+class PaletteColorError extends Error {
+  constructor(themeColor) {
+    const palette = createPalette();
+    const message = [
+      `${themeColor} must have the following attributes: ${keys(palette[themeColor])}`,
+      'See the default colors, indigo, pink, or red, as exported from material-ui/style/colors.',
+    ];
+    super(message.join('\n'));
+  }
+}
+
 export default function createPalette({
   primary = indigo,
   accent = pink,
   error = red,
   type = 'light',
 } = {}) {
+
   if (difference(keys(indigo), keys(primary)).length) {
-    throw new Error('Invalid primary color');
+    throw new PaletteColorError('primary');
   }
 
   if (difference(keys(pink), keys(accent)).length) {
-    throw new Error('Invalid accent color');
+    throw new PaletteColorError('accent');
   }
 
   if (difference(keys(red), keys(error)).length) {
-    throw new Error('Invalid error color');
+    throw new PaletteColorError('error');
   }
 
   return {

--- a/src/styles/palette.js
+++ b/src/styles/palette.js
@@ -76,7 +76,6 @@ export default function createPalette({
   error = red,
   type = 'light',
 } = {}) {
-
   if (difference(keys(indigo), keys(primary)).length) {
     throw new PaletteColorError('primary');
   }

--- a/src/styles/theme.spec.js
+++ b/src/styles/theme.spec.js
@@ -8,6 +8,7 @@ import {
   pink,
   deepOrange,
   green,
+  fullBlack,
 } from './colors';
 
 describe('styles/theme', () => {
@@ -95,6 +96,33 @@ describe('styles/theme', () => {
         dark.text,
         'should use dark theme text',
       );
+    });
+
+    it('should throw an exception when a non-palette primary color is specified', () => {
+      try {
+        createPalette({ primary: fullBlack });
+        assert.fail(0, 1, 'primary color exception should have been thrown');
+      } catch (error) {
+        assert.strictEqual(error.message, 'Invalid primary color');
+      }
+    });
+
+    it('should throw an exception when a non-palette accent color is specified', () => {
+      try {
+        createPalette({ accent: fullBlack });
+        assert.fail(0, 1, 'accent color exception should have been thrown');
+      } catch (error) {
+        assert.strictEqual(error.message, 'Invalid accent color');
+      }
+    });
+
+    it('should throw an exception when a non-palette error color is specified', () => {
+      try {
+        createPalette({ error: fullBlack });
+        assert.fail(0, 1, 'error color exception should have been thrown');
+      } catch (error) {
+        assert.strictEqual(error.message, 'Invalid error color');
+      }
     });
   });
 });

--- a/src/styles/theme.spec.js
+++ b/src/styles/theme.spec.js
@@ -99,30 +99,15 @@ describe('styles/theme', () => {
     });
 
     it('should throw an exception when a non-palette primary color is specified', () => {
-      try {
-        createPalette({ primary: fullBlack });
-        assert.fail(0, 1, 'primary color exception should have been thrown');
-      } catch (error) {
-        assert.strictEqual(error.message, 'Invalid primary color');
-      }
+      assert.throws(() => createPalette({ primary: fullBlack }));
     });
 
     it('should throw an exception when a non-palette accent color is specified', () => {
-      try {
-        createPalette({ accent: fullBlack });
-        assert.fail(0, 1, 'accent color exception should have been thrown');
-      } catch (error) {
-        assert.strictEqual(error.message, 'Invalid accent color');
-      }
+      assert.throws(() => createPalette({ accent: fullBlack }));
     });
 
     it('should throw an exception when a non-palette error color is specified', () => {
-      try {
-        createPalette({ error: fullBlack });
-        assert.fail(0, 1, 'error color exception should have been thrown');
-      } catch (error) {
-        assert.strictEqual(error.message, 'Invalid error color');
-      }
+      assert.throws(() => createPalette({ error: fullBlack }));
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [X] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

If a color specified for primary, accent, or error does not have the expected shape, uncaught errors will occur when these colors are used within the theme.

For example, here is the stylesheet for Icon:

```jsx
export const styleSheet = createStyleSheet('MuiIcon', (theme) => {
  const { palette } = theme;
  return {
    root: {
      userSelect: 'none',
    },
    accent: {
      color: palette.accent.A200,
    },
    action: {
      color: palette.action.active,
    },
    contrast: {
      color: palette.getContrastText(palette.primary[500]),
    },
    disabled: {
      color: palette.action.disabled,
    },
    error: {
      color: palette.error[500],
    },
    primary: {
      color: palette.primary[500],
    },
  };
});
```

The palette's primary, accent, and error colors are expected to be objects that match the shape of a palette color exported from _styles/colors.js_ 

The approach taken in this PR is to compare the shape of the specified colors to the default values.  If they do not have the same attributes, an exception will be thrown.  This validation will be performed for primary, accent, and error.

PR in response to issue #6741
