### PR TITLE
[TextField] Fix a warning of 'Failed prop type'.

### DIFF
--- a/src/TextField/EnhancedTextarea.js
+++ b/src/TextField/EnhancedTextarea.js
@@ -34,7 +34,7 @@ class EnhancedTextarea extends Component {
   static propTypes = {
     defaultValue: PropTypes.any,
     disabled: PropTypes.bool,
-    hintText: PropTypes.string,
+    hintText: PropTypes.node,
     onChange: PropTypes.func,
     onHeightChange: PropTypes.func,
     rows: PropTypes.number,


### PR DESCRIPTION
`TextField` passes prop `hintText` to `EnhancedTextArea`. The former defines its type as `PropTypes.node` while the later expects `PropTypes.string`, resulting in the warning.

Fix #6747.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

