### PR TITLE
[TextField] Accessibility fix for horizontal rules

### DIFF
--- a/src/TextField/TextFieldUnderline.js
+++ b/src/TextField/TextFieldUnderline.js
@@ -112,8 +112,8 @@ const TextFieldUnderline = (props) => {
 
   return (
     <div>
-      <hr style={prepareStyles(underline)} />
-      <hr style={prepareStyles(focusedUnderline)} />
+      <hr aria-hidden="true" style={prepareStyles(underline)} />
+      <hr aria-hidden="true" style={prepareStyles(focusedUnderline)} />
     </div>
   );
 };


### PR DESCRIPTION
This should resolve #6763, which uses horizontal rules for display purposes under TextFields and shouldn't be read to screen readers.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

