### PR TITLE
[createShallow] Remove cleanup

### DIFF
--- a/src/test-utils/createShallow.js
+++ b/src/test-utils/createShallow.js
@@ -25,9 +25,5 @@ export default function createShallow(
 
   shallowWithContext.context = context;
 
-  shallowWithContext.cleanUp = () => {
-    styleManager.reset();
-  };
-
   return shallowWithContext;
 }


### PR DESCRIPTION
`cleanUp()` on createShallow is not used even once in the project. Its dead code.