### PR TITLE
[docs] Hide the context implementation details

### DIFF
--- a/docs/src/components/ApiMenuComponents.js
+++ b/docs/src/components/ApiMenuComponents.js
@@ -8,11 +8,7 @@ import Menu, { MenuItem } from 'material-ui/Menu';
 import MoreVertIcon from 'material-ui-icons/MoreVert';
 import { kebabCase } from 'docs/src/utils/helpers';
 
-export default class ApiMenuComponents extends Component {
-  static propTypes = {
-    components: PropTypes.array.isRequired,
-  };
-
+class ApiMenuComponents extends Component {
   state = {
     anchorEl: undefined,
     open: false,
@@ -64,3 +60,9 @@ export default class ApiMenuComponents extends Component {
     );
   }
 }
+
+ApiMenuComponents.propTypes = {
+  components: PropTypes.array.isRequired,
+};
+
+export default ApiMenuComponents;

--- a/docs/src/components/AppContent.js
+++ b/docs/src/components/AppContent.js
@@ -3,11 +3,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import MarkdownElement from 'docs/src/components/MarkdownElement';
 
-export const styleSheet = createStyleSheet('AppContent', (theme) => {
+const styleSheet = createStyleSheet('AppContent', (theme) => {
   return {
     content: theme.mixins.gutters({
       paddingTop: 80,
@@ -23,14 +22,14 @@ export const styleSheet = createStyleSheet('AppContent', (theme) => {
   };
 });
 
-export default function AppContent(props, context) {
+function AppContent(props) {
   const {
     className,
+    classes,
     children: childrenProp,
     route,
   } = props;
 
-  const classes = context.styleManager.render(styleSheet);
   let children = childrenProp;
 
   if (!children) {
@@ -51,10 +50,9 @@ ${route.childRoutes.map((childRoute) => (`- [${childRoute.title}](${childRoute.p
 
 AppContent.propTypes = {
   children: PropTypes.node,
+  classes: PropTypes.object.isRequired,
   className: PropTypes.string,
   route: PropTypes.object.isRequired,
 };
 
-AppContent.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
-};
+export default withStyles(styleSheet)(AppContent);

--- a/docs/src/components/AppDrawer.js
+++ b/docs/src/components/AppDrawer.js
@@ -2,14 +2,13 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { createStyleSheet } from 'jss-theme-reactor';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import shallowEqual from 'recompose/shallowEqual';
 import List from 'material-ui/List';
 import Toolbar from 'material-ui/Toolbar';
 import Drawer from 'material-ui/Drawer';
 import Typography from 'material-ui/Typography';
 import Divider from 'material-ui/Divider';
-import customPropTypes from 'material-ui/utils/customPropTypes';
 import AppDrawerNavItem from 'docs/src/components/AppDrawerNavItem';
 import Link from 'docs/src/components/Link';
 
@@ -77,20 +76,7 @@ function reduceChildRoutes(props, items, childRoute, index) {
   return items;
 }
 
-export default class AppDrawer extends Component {
-  static propTypes = {
-    className: PropTypes.string,
-    docked: PropTypes.bool.isRequired,
-    onRequestClose: PropTypes.func.isRequired,
-    open: PropTypes.bool.isRequired,
-    routes: PropTypes.array.isRequired,
-  };
-
-  static contextTypes = {
-    theme: customPropTypes.muiRequired,
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class AppDrawer extends Component {
   shouldComponentUpdate(nextProps, nextState, nextContext) {
     return (
       !shallowEqual(this.props, nextProps) ||
@@ -100,7 +86,7 @@ export default class AppDrawer extends Component {
   }
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
     const GITHUB_RELEASE_BASE_URL = 'https://github.com/callemall/material-ui/releases/tag/';
 
     return (
@@ -134,3 +120,19 @@ export default class AppDrawer extends Component {
     );
   }
 }
+
+AppDrawer.propTypes = {
+  classes: PropTypes.object.isRequired,
+  className: PropTypes.string,
+  docked: PropTypes.bool.isRequired,
+  onRequestClose: PropTypes.func.isRequired,
+  open: PropTypes.bool.isRequired,
+  routes: PropTypes.array.isRequired,
+};
+
+AppDrawer.contextTypes = {
+  theme: PropTypes.object.isRequired,
+  styleManager: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(AppDrawer);

--- a/docs/src/components/AppDrawerNavItem.js
+++ b/docs/src/components/AppDrawerNavItem.js
@@ -4,13 +4,12 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import classNames from 'classnames';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { ListItem } from 'material-ui/List';
 import Button from 'material-ui/Button';
 import Collapse from 'material-ui/transitions/Collapse';
 
-export const styleSheet = createStyleSheet('AppDrawerNavItem', (theme) => {
+const styleSheet = createStyleSheet('AppDrawerNavItem', (theme) => {
   return {
     button: theme.mixins.gutters({
       borderRadius: 0,
@@ -44,21 +43,9 @@ export const styleSheet = createStyleSheet('AppDrawerNavItem', (theme) => {
   };
 });
 
-export default class AppDrawerNavItem extends Component {
-  static propTypes = {
-    children: PropTypes.node,
-    onClick: PropTypes.func,
-    openImmediately: PropTypes.bool,
-    title: PropTypes.string.isRequired,
-    to: PropTypes.string,
-  };
-
+class AppDrawerNavItem extends Component {
   static defaultProps = {
     openImmediately: false,
-  };
-
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
   };
 
   state = {
@@ -76,8 +63,7 @@ export default class AppDrawerNavItem extends Component {
   };
 
   render() {
-    const { children, title, to } = this.props;
-    const classes = this.context.styleManager.render(styleSheet);
+    const { children, classes, title, to } = this.props;
 
     if (to) {
       return (
@@ -111,3 +97,14 @@ export default class AppDrawerNavItem extends Component {
     );
   }
 }
+
+AppDrawerNavItem.propTypes = {
+  children: PropTypes.node,
+  classes: PropTypes.object.isRequired,
+  onClick: PropTypes.func,
+  openImmediately: PropTypes.bool,
+  title: PropTypes.string.isRequired,
+  to: PropTypes.string,
+};
+
+export default withStyles(styleSheet)(AppDrawerNavItem);

--- a/docs/src/components/AppFrame.js
+++ b/docs/src/components/AppFrame.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
-import { createStyleSheet } from 'jss-theme-reactor';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Typography from 'material-ui/Typography';
 import AppBar from 'material-ui/AppBar';
 import Toolbar from 'material-ui/Toolbar';
@@ -12,7 +12,6 @@ import IconButton from 'material-ui/IconButton';
 import withWidth, { isWidthUp } from 'material-ui/utils/withWidth';
 import MenuIcon from 'material-ui-icons/Menu';
 import LightbulbOutlineIcon from 'material-ui-icons/LightbulbOutline';
-import customPropTypes from 'material-ui/utils/customPropTypes';
 import AppDrawer from 'docs/src/components/AppDrawer';
 import DemoButton from 'docs/src/components/DemoButton';
 import AppSearch from 'docs/src/components/AppSearch';
@@ -112,7 +111,7 @@ class AppFrame extends Component {
       width,
     } = this.props;
 
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
     const title = getTitle(routes);
 
     let drawerDocked = isWidthUp('lg', width);
@@ -168,16 +167,14 @@ class AppFrame extends Component {
 
 AppFrame.propTypes = {
   children: PropTypes.node.isRequired,
+  classes: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired,
   routes: PropTypes.array.isRequired,
   width: PropTypes.string.isRequired,
 };
 
-AppFrame.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
-};
-
 export default compose(
+  withStyles(styleSheet),
   withWidth(),
   connect(),
 )(AppFrame);

--- a/docs/src/components/Demo.js
+++ b/docs/src/components/Demo.js
@@ -2,9 +2,8 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { createStyleSheet } from 'jss-theme-reactor';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import shallowEqual from 'recompose/shallowEqual';
-import customPropTypes from 'material-ui/utils/customPropTypes';
 import IconButton from 'material-ui/IconButton';
 import Collapse from 'material-ui/transitions/Collapse';
 import CodeIcon from 'material-ui-icons/Code';
@@ -62,14 +61,10 @@ const styleSheet = createStyleSheet('Demo', (theme) => {
   };
 });
 
-export default class Demo extends Component {
-  static propTypes = {
-    demo: PropTypes.string.isRequired,
-  };
-
+class Demo extends Component {
   static contextTypes = {
-    theme: customPropTypes.muiRequired,
-    styleManager: customPropTypes.muiRequired,
+    theme: PropTypes.object.isRequired,
+    styleManager: PropTypes.object.isRequired,
   };
 
   state = {
@@ -78,8 +73,8 @@ export default class Demo extends Component {
 
   shouldComponentUpdate(nextProps, nextState, nextContext) {
     return (
-      nextProps.demo !== this.props.demo ||
-      nextState.codeOpen !== this.state.codeOpen ||
+      !shallowEqual(this.props, nextProps) ||
+      !shallowEqual(this.state, nextState) ||
       !shallowEqual(this.context, nextContext)
     );
   }
@@ -93,7 +88,7 @@ export default class Demo extends Component {
   render() {
     const DemoComponent = requireDemos(`./${this.props.demo}`).default;
     const demoSource = requireDemoSource(`./${this.props.demo}`);
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
     const code = `\`\`\`js\n${demoSource}\n\`\`\``;
 
     return (
@@ -114,3 +109,10 @@ export default class Demo extends Component {
     );
   }
 }
+
+Demo.propTypes = {
+  classes: PropTypes.object.isRequired,
+  demo: PropTypes.string.isRequired,
+};
+
+export default withStyles(styleSheet)(Demo);

--- a/docs/src/components/MarkdownDocs.js
+++ b/docs/src/components/MarkdownDocs.js
@@ -2,8 +2,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Button from 'material-ui/Button';
 import MarkdownElement from 'docs/src/components/MarkdownElement';
 import Demo from 'docs/src/components/Demo';
@@ -27,9 +26,9 @@ const emptyRegexp = /^\s*$/;
 
 const SOURCE_CODE_ROOT_URL = 'https://github.com/callemall/material-ui/tree/next';
 
-export default function MarkdownDocs(props, context) {
-  const classes = context.styleManager.render(styleSheet);
-  const contents = props.route.content
+function MarkdownDocs(props) {
+  const { classes, route } = props;
+  const contents = route.content
     .replace(headerRegexp, '') // Remove header informations
     .split(/^{{|}}$/gm) // Split markdown into an array, separating demos
     .filter((content) => !emptyRegexp.test(content)); // Remove empty lines
@@ -37,14 +36,14 @@ export default function MarkdownDocs(props, context) {
   let markdownUrl = SOURCE_CODE_ROOT_URL;
 
   // Map back to the source code
-  if (props.route.componentAPI) {
+  if (route.componentAPI) {
     markdownUrl += `/src${
-      props.route.componentAPI.path.replace('./component-api/', '/').replace('.md', '.js')
+      route.componentAPI.path.replace('./component-api/', '/').replace('.md', '.js')
     }`;
-  } else if (props.route.demo) {
-    markdownUrl += `/docs/src/pages/component-demos${props.route.demo.path.replace('./', '/')}`;
+  } else if (route.demo) {
+    markdownUrl += `/docs/src/pages/component-demos${route.demo.path.replace('./', '/')}`;
   } else {
-    markdownUrl += `/docs/src/pages${props.route.path}.md`;
+    markdownUrl += `/docs/src/pages${route.path}.md`;
   }
 
   return (
@@ -66,6 +65,7 @@ export default function MarkdownDocs(props, context) {
 }
 
 MarkdownDocs.propTypes = {
+  classes: PropTypes.object.isRequired,
   route: PropTypes.shape({
     content: PropTypes.string.isRequired,
     path: PropTypes.string.isRequired,
@@ -74,6 +74,4 @@ MarkdownDocs.propTypes = {
   }).isRequired,
 };
 
-MarkdownDocs.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
-};
+export default withStyles(styleSheet)(MarkdownDocs);

--- a/docs/src/components/MarkdownElement.js
+++ b/docs/src/components/MarkdownElement.js
@@ -3,9 +3,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { createStyleSheet } from 'jss-theme-reactor';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import marked from 'marked';
-import customPropTypes from 'material-ui/utils/customPropTypes';
 import prism from 'docs/src/utils/prism';
 
 const renderer = new marked.Renderer();
@@ -167,13 +166,12 @@ const styleSheet = createStyleSheet('MarkdownElement', (theme) => ({
   },
 }));
 
-function MarkdownElement(props, context) {
+function MarkdownElement(props) {
   const {
+    classes,
     className,
     text,
   } = props;
-
-  const classes = context.styleManager.render(styleSheet);
 
   /* eslint-disable react/no-danger */
   return (
@@ -186,12 +184,9 @@ function MarkdownElement(props, context) {
 }
 
 MarkdownElement.propTypes = {
+  classes: PropTypes.object.isRequired,
   className: PropTypes.string,
   text: PropTypes.string.isRequired,
 };
 
-MarkdownElement.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
-};
-
-export default MarkdownElement;
+export default withStyles(styleSheet)(MarkdownElement);

--- a/docs/src/pages/Home.js
+++ b/docs/src/pages/Home.js
@@ -1,14 +1,14 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Link from 'react-router/lib/Link';
-import customPropTypes from 'material-ui/utils/customPropTypes';
 import Typography from 'material-ui/Typography';
 import Button from 'material-ui/Button';
 import muiLogo from 'docs/src/assets/images/material-ui-logo.svg';
 
-export const styleSheet = createStyleSheet('Home', (theme) => {
+const styleSheet = createStyleSheet('Home', (theme) => {
   const { palette, breakpoints } = theme;
 
   return {
@@ -43,8 +43,8 @@ export const styleSheet = createStyleSheet('Home', (theme) => {
   };
 });
 
-function Home(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function Home(props) {
+  const classes = props.classes;
 
   return (
     <div className={classes.root}>
@@ -71,8 +71,8 @@ function Home(props, context) {
   );
 }
 
-Home.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+Home.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
 
-export default Home;
+export default withStyles(styleSheet)(Home);

--- a/docs/src/pages/component-demos/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/component-demos/app-bar/ButtonAppBar.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import AppBar from 'material-ui/AppBar';
 import Toolbar from 'material-ui/Toolbar';
 import Typography from 'material-ui/Typography';
@@ -24,8 +24,8 @@ const styleSheet = createStyleSheet('ButtonAppBar', () => ({
   },
 }));
 
-export default function ButtonAppBar(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function ButtonAppBar(props) {
+  const classes = props.classes;
   return (
     <div className={classes.root}>
       <AppBar className={classes.appBar}>
@@ -41,6 +41,8 @@ export default function ButtonAppBar(props, context) {
   );
 }
 
-ButtonAppBar.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+ButtonAppBar.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(ButtonAppBar);

--- a/docs/src/pages/component-demos/app-bar/SimpleAppBar.js
+++ b/docs/src/pages/component-demos/app-bar/SimpleAppBar.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import AppBar from 'material-ui/AppBar';
 import Toolbar from 'material-ui/Toolbar';
 import Typography from 'material-ui/Typography';
@@ -18,8 +18,8 @@ const styleSheet = createStyleSheet('SimpleAppBar', () => ({
   },
 }));
 
-export default function SimpleAppBar(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function SimpleAppBar(props) {
+  const classes = props.classes;
   return (
     <div className={classes.root}>
       <AppBar className={classes.appBar}>
@@ -31,6 +31,8 @@ export default function SimpleAppBar(props, context) {
   );
 }
 
-SimpleAppBar.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+SimpleAppBar.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(SimpleAppBar);

--- a/docs/src/pages/component-demos/avatars/IconAvatars.js
+++ b/docs/src/pages/component-demos/avatars/IconAvatars.js
@@ -1,10 +1,10 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import Avatar from 'material-ui/Avatar';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { pink, green } from 'material-ui/styles/colors';
+import Avatar from 'material-ui/Avatar';
 import FolderIcon from 'material-ui-icons/Folder';
 import PageviewIcon from 'material-ui-icons/Pageview';
 import AssignmentIcon from 'material-ui-icons/Assignment';
@@ -29,8 +29,8 @@ const styleSheet = createStyleSheet('IconAvatars', () => ({
   },
 }));
 
-export default function IconAvatars(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function IconAvatars(props) {
+  const classes = props.classes;
   return (
     <div className={classes.row}>
       <Avatar className={classes.avatar}>
@@ -46,6 +46,8 @@ export default function IconAvatars(props, context) {
   );
 }
 
-IconAvatars.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+IconAvatars.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(IconAvatars);

--- a/docs/src/pages/component-demos/avatars/ImageAvatars.js
+++ b/docs/src/pages/component-demos/avatars/ImageAvatars.js
@@ -1,9 +1,9 @@
 // @flow weak
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Avatar from 'material-ui/Avatar';
 import remyImage from 'docs/src/assets/images/remy.jpg';
 import uxecoImage from 'docs/src/assets/images/uxceo-128.jpg';
@@ -22,8 +22,8 @@ const styleSheet = createStyleSheet('ImageAvatars', () => ({
   },
 }));
 
-export default function ImageAvatars(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function ImageAvatars(props) {
+  const classes = props.classes;
   return (
     <div className={classes.row}>
       <Avatar
@@ -40,6 +40,8 @@ export default function ImageAvatars(props, context) {
   );
 }
 
-ImageAvatars.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+ImageAvatars.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(ImageAvatars);

--- a/docs/src/pages/component-demos/avatars/LetterAvatars.js
+++ b/docs/src/pages/component-demos/avatars/LetterAvatars.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Avatar from 'material-ui/Avatar';
 import { deepOrange, deepPurple } from 'material-ui/styles/colors';
 
@@ -26,8 +26,8 @@ const styleSheet = createStyleSheet('LetterAvatars', () => ({
   },
 }));
 
-export default function LetterAvatars(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function LetterAvatars(props) {
+  const classes = props.classes;
   return (
     <div className={classes.row}>
       <Avatar className={classes.avatar}>H</Avatar>
@@ -37,6 +37,8 @@ export default function LetterAvatars(props, context) {
   );
 }
 
-LetterAvatars.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+LetterAvatars.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(LetterAvatars);

--- a/docs/src/pages/component-demos/badges/SimpleBadge.js
+++ b/docs/src/pages/component-demos/badges/SimpleBadge.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Badge from 'material-ui/Badge';
 import MailIcon from 'material-ui-icons/Mail';
 import FolderIcon from 'material-ui-icons/Folder';
@@ -13,8 +13,8 @@ const styleSheet = createStyleSheet('SimpleBadge', (theme) => ({
   },
 }));
 
-export default function SimpleBadge(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function SimpleBadge(props) {
+  const classes = props.classes;
   return (
     <div>
       <Badge
@@ -35,6 +35,8 @@ export default function SimpleBadge(props, context) {
   );
 }
 
-SimpleBadge.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+SimpleBadge.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(SimpleBadge);

--- a/docs/src/pages/component-demos/bottom-navigation/LabelBottomNavigation.js
+++ b/docs/src/pages/component-demos/bottom-navigation/LabelBottomNavigation.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React, { Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import BottomNavigation, { BottomNavigationButton } from 'material-ui/BottomNavigation';
 import RestoreIcon from 'material-ui-icons/Restore';
 import FavoriteIcon from 'material-ui-icons/Favorite';
@@ -15,7 +15,7 @@ const styleSheet = createStyleSheet('LabelBottomNavigation', () => ({
   },
 }));
 
-export default class LabelBottomNavigation extends Component {
+class LabelBottomNavigation extends Component {
   state = {
     index: 0,
   };
@@ -25,7 +25,7 @@ export default class LabelBottomNavigation extends Component {
   };
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
     const { index } = this.state;
 
     return (
@@ -56,6 +56,8 @@ export default class LabelBottomNavigation extends Component {
   }
 }
 
-LabelBottomNavigation.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+LabelBottomNavigation.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(LabelBottomNavigation);

--- a/docs/src/pages/component-demos/bottom-navigation/SimpleBottomNavigation.js
+++ b/docs/src/pages/component-demos/bottom-navigation/SimpleBottomNavigation.js
@@ -1,20 +1,20 @@
 // @flow weak
 
 import React, { Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import BottomNavigation, { BottomNavigationButton } from 'material-ui/BottomNavigation';
 import RestoreIcon from 'material-ui-icons/Restore';
 import FavoriteIcon from 'material-ui-icons/Favorite';
 import LocationOnIcon from 'material-ui-icons/LocationOn';
 
-const styleSheet = createStyleSheet('BottomNavigation', () => ({
+const styleSheet = createStyleSheet('SimpleBottomNavigation', () => ({
   root: {
     width: 500,
   },
 }));
 
-export default class SimpleBottomNavigation extends Component {
+class SimpleBottomNavigation extends Component {
   state = {
     index: 0,
   };
@@ -24,7 +24,7 @@ export default class SimpleBottomNavigation extends Component {
   };
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
     const { index } = this.state;
 
     return (
@@ -52,6 +52,8 @@ export default class SimpleBottomNavigation extends Component {
   }
 }
 
-SimpleBottomNavigation.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+SimpleBottomNavigation.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(SimpleBottomNavigation);

--- a/docs/src/pages/component-demos/buttons/FlatButtons.js
+++ b/docs/src/pages/component-demos/buttons/FlatButtons.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Button from 'material-ui/Button';
 
 const styleSheet = createStyleSheet('FlatButtons', (theme) => ({
@@ -11,8 +11,8 @@ const styleSheet = createStyleSheet('FlatButtons', (theme) => ({
   },
 }));
 
-export default function FlatButtons(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function FlatButtons(props) {
+  const classes = props.classes;
   return (
     <div>
       <Button className={classes.button}>Default</Button>
@@ -24,6 +24,8 @@ export default function FlatButtons(props, context) {
   );
 }
 
-FlatButtons.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+FlatButtons.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(FlatButtons);

--- a/docs/src/pages/component-demos/buttons/FloatingActionButtons.js
+++ b/docs/src/pages/component-demos/buttons/FloatingActionButtons.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Button from 'material-ui/Button';
 import AddIcon from 'material-ui-icons/Add';
 import ModeEditIcon from 'material-ui-icons/ModeEdit';
@@ -13,8 +13,8 @@ const styleSheet = createStyleSheet('FloatingActionButtons', (theme) => ({
   },
 }));
 
-export default function FloatingActionButtons(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function FloatingActionButtons(props) {
+  const classes = props.classes;
   return (
     <div>
       <Button fab primary className={classes.button}>
@@ -27,6 +27,8 @@ export default function FloatingActionButtons(props, context) {
   );
 }
 
-FloatingActionButtons.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+FloatingActionButtons.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(FloatingActionButtons);

--- a/docs/src/pages/component-demos/buttons/IconButtons.js
+++ b/docs/src/pages/component-demos/buttons/IconButtons.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import IconButton from 'material-ui/IconButton';
 import DeleteIcon from 'material-ui-icons/Delete';
 import AlarmIcon from 'material-ui-icons/Alarm';
@@ -14,8 +14,8 @@ const styleSheet = createStyleSheet('IconButtons', (theme) => ({
   },
 }));
 
-export default function IconButtons(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function IconButtons(props) {
+  const classes = props.classes;
   return (
     <div>
       <IconButton className={classes.button}>
@@ -34,6 +34,8 @@ export default function IconButtons(props, context) {
   );
 }
 
-IconButtons.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+IconButtons.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(IconButtons);

--- a/docs/src/pages/component-demos/buttons/RaisedButtons.js
+++ b/docs/src/pages/component-demos/buttons/RaisedButtons.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Button from 'material-ui/Button';
 
 const styleSheet = createStyleSheet('RaisedButtons', (theme) => ({
@@ -11,8 +11,8 @@ const styleSheet = createStyleSheet('RaisedButtons', (theme) => ({
   },
 }));
 
-export default function RaisedButtons(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function RaisedButtons(props) {
+  const classes = props.classes;
   return (
     <div>
       <Button raised className={classes.button}>Default</Button>
@@ -31,6 +31,8 @@ export default function RaisedButtons(props, context) {
   );
 }
 
-RaisedButtons.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+RaisedButtons.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(RaisedButtons);

--- a/docs/src/pages/component-demos/cards/NowPlayingCard.js
+++ b/docs/src/pages/component-demos/cards/NowPlayingCard.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Card, { CardContent } from 'material-ui/Card';
 import IconButton from 'material-ui/IconButton';
 import Typography from 'material-ui/Typography';
@@ -38,8 +38,8 @@ const styleSheet = createStyleSheet('NowPlayingCard', () => ({
   },
 }));
 
-export default function NowPlayingCard(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function NowPlayingCard(props) {
+  const classes = props.classes;
 
   return (
     <div>
@@ -71,6 +71,8 @@ export default function NowPlayingCard(props, context) {
   );
 }
 
-NowPlayingCard.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+NowPlayingCard.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(NowPlayingCard);

--- a/docs/src/pages/component-demos/cards/RecipeReviewCard.js
+++ b/docs/src/pages/component-demos/cards/RecipeReviewCard.js
@@ -1,9 +1,9 @@
 // @flow weak
 
 import React, { Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import classnames from 'classnames';
-import customPropTypes from 'material-ui/utils/customPropTypes';
 import Card, {
   CardHeader,
   CardMedia,
@@ -35,17 +35,15 @@ const styleSheet = createStyleSheet('RecipeReviewCard', (theme) => ({
   flexGrow: { flex: '1 1 auto' },
 }));
 
-export default class RecipeReviewCard extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class RecipeReviewCard extends Component {
   state = { expanded: false };
 
-  handleExpandClick = () => this.setState({ expanded: !this.state.expanded });
+  handleExpandClick = () => {
+    this.setState({ expanded: !this.state.expanded });
+  };
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
 
     return (
       <div>
@@ -119,3 +117,9 @@ export default class RecipeReviewCard extends Component {
     );
   }
 }
+
+RecipeReviewCard.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(RecipeReviewCard);

--- a/docs/src/pages/component-demos/cards/SimpleCard.js
+++ b/docs/src/pages/component-demos/cards/SimpleCard.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Card, { CardActions, CardContent } from 'material-ui/Card';
 import Button from 'material-ui/Button';
 import Typography from 'material-ui/Typography';
@@ -27,8 +27,8 @@ const styleSheet = createStyleSheet('SimpleCard', (theme) => ({
   },
 }));
 
-export default function SimpleCard(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function SimpleCard(props) {
+  const classes = props.classes;
   const bull = <span className={classes.bullet}>&bull;</span>;
 
   return (
@@ -53,6 +53,9 @@ export default function SimpleCard(props, context) {
   );
 }
 
-SimpleCard.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+SimpleCard.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(SimpleCard);
+

--- a/docs/src/pages/component-demos/cards/SimpleMediaCard.js
+++ b/docs/src/pages/component-demos/cards/SimpleMediaCard.js
@@ -1,19 +1,21 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Card, { CardActions, CardContent, CardMedia } from 'material-ui/Card';
 import Button from 'material-ui/Button';
 import Typography from 'material-ui/Typography';
 import reptileImage from 'docs/src/assets/images/contemplative-reptile.jpg';
 
 const styleSheet = createStyleSheet('SimpleMediaCard', () => ({
-  card: { maxWidth: 345 },
+  card: {
+    maxWidth: 345,
+  },
 }));
 
-export default function SimpleMediaCard(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function SimpleMediaCard(props) {
+  const classes = props.classes;
   return (
     <div>
       <Card className={classes.card}>
@@ -38,6 +40,8 @@ export default function SimpleMediaCard(props, context) {
   );
 }
 
-SimpleMediaCard.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+SimpleMediaCard.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(SimpleMediaCard);

--- a/docs/src/pages/component-demos/chips/Chips.js
+++ b/docs/src/pages/component-demos/chips/Chips.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Avatar from 'material-ui/Avatar';
 import Chip from 'material-ui/Chip';
 import FaceIcon from 'material-ui-icons/Face';
@@ -31,8 +31,8 @@ function handleClick() {
   alert('You clicked the Chip.'); // eslint-disable-line no-alert
 }
 
-export default function Chips(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function Chips(props) {
+  const classes = props.classes;
   return (
     <div className={classes.row}>
       <Chip
@@ -62,6 +62,8 @@ export default function Chips(props, context) {
   );
 }
 
-Chips.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+Chips.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(Chips);

--- a/docs/src/pages/component-demos/chips/ChipsArray.js
+++ b/docs/src/pages/component-demos/chips/ChipsArray.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React, { Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Chip from 'material-ui/Chip';
 
 const styleSheet = createStyleSheet('ChipsArray', (theme) => ({
@@ -16,11 +16,7 @@ const styleSheet = createStyleSheet('ChipsArray', (theme) => ({
   },
 }));
 
-export default class ChipsArray extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class ChipsArray extends Component {
   state = { chipData: [
     { key: 0, label: 'Angular' },
     { key: 1, label: 'JQuery' },
@@ -39,7 +35,7 @@ export default class ChipsArray extends Component {
     },
   };
 
-  handleRequestDelete = (key) => {
+  handleRequestDelete = (key) => () => {
     if (key === 3) {
       alert('Why would you want to delete React?! :)'); // eslint-disable-line no-alert
       return;
@@ -52,14 +48,14 @@ export default class ChipsArray extends Component {
   };
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
 
     const renderChip = (data) => {
       return (
         <Chip
           label={data.label}
           key={data.key}
-          onRequestDelete={() => this.handleRequestDelete(data.key)}
+          onRequestDelete={this.handleRequestDelete(data.key)}
           className={classes.chip}
         />
       );
@@ -72,3 +68,9 @@ export default class ChipsArray extends Component {
     );
   }
 }
+
+ChipsArray.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(ChipsArray);

--- a/docs/src/pages/component-demos/dialogs/ConfirmationDialog.js
+++ b/docs/src/pages/component-demos/dialogs/ConfirmationDialog.js
@@ -3,8 +3,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Button from 'material-ui/Button';
 import List, { ListItem, ListItemText } from 'material-ui/List';
 import Dialog, { DialogActions, DialogContent, DialogTitle } from 'material-ui/Dialog';
@@ -113,11 +112,7 @@ const styleSheet = createStyleSheet('ConfirmationDialogDemo', (theme) => ({
   },
 }));
 
-export default class ConfirmationDialogDemo extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class ConfirmationDialogDemo extends Component {
   state = {
     anchorEl: undefined,
     open: false,
@@ -126,12 +121,16 @@ export default class ConfirmationDialogDemo extends Component {
 
   button = undefined;
 
-  handleClickListItem = (event) => this.setState({ open: true, anchorEl: event.currentTarget });
+  handleClickListItem = (event) => {
+    this.setState({ open: true, anchorEl: event.currentTarget });
+  };
 
-  handleRequestClose = (value) => this.setState({ selectedValue: value, open: false });
+  handleRequestClose = (value) => {
+    this.setState({ selectedValue: value, open: false });
+  };
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
     return (
       <div className={classes.root}>
         <List>
@@ -170,3 +169,8 @@ export default class ConfirmationDialogDemo extends Component {
   }
 }
 
+ConfirmationDialogDemo.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(ConfirmationDialogDemo);

--- a/docs/src/pages/component-demos/dialogs/FullScreenDialog.js
+++ b/docs/src/pages/component-demos/dialogs/FullScreenDialog.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React, { Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Button from 'material-ui/Button';
 import Dialog from 'material-ui/Dialog';
 import List, { ListItem, ListItemText } from 'material-ui/List';
@@ -23,16 +23,21 @@ const styleSheet = createStyleSheet('FullScreenDialog', () => ({
   },
 }));
 
-export default class FullScreenDialog extends Component {
+class FullScreenDialog extends Component {
   state = {
     open: false,
   };
 
-  handleRequestClose = () => this.setState({ open: false });
-  handleOpen = () => this.setState({ open: true });
+  handleRequestClose = () => {
+    this.setState({ open: false });
+  };
+
+  handleOpen = () => {
+    this.setState({ open: true });
+  };
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
     return (
       <div>
         <Button onClick={this.handleOpen}>
@@ -70,6 +75,8 @@ export default class FullScreenDialog extends Component {
   }
 }
 
-FullScreenDialog.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+FullScreenDialog.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(FullScreenDialog);

--- a/docs/src/pages/component-demos/dividers/InsetDividers.js
+++ b/docs/src/pages/component-demos/dividers/InsetDividers.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import List, { ListItem, ListItemText } from 'material-ui/List';
 import Avatar from 'material-ui/Avatar';
 import Divider from 'material-ui/Divider';
@@ -17,8 +17,8 @@ const styleSheet = createStyleSheet('InsetDividers', (theme) => ({
   },
 }));
 
-export default function InsetDividers(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function InsetDividers(props) {
+  const classes = props.classes;
   return (
     <List className={classes.root}>
       <ListItem button>
@@ -38,6 +38,8 @@ export default function InsetDividers(props, context) {
   );
 }
 
-InsetDividers.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+InsetDividers.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(InsetDividers);

--- a/docs/src/pages/component-demos/dividers/ListDividers.js
+++ b/docs/src/pages/component-demos/dividers/ListDividers.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import List, { ListItem, ListItemText } from 'material-ui/List';
 import Divider from 'material-ui/Divider';
 
@@ -14,8 +14,8 @@ const styleSheet = createStyleSheet('ListDividers', (theme) => ({
   },
 }));
 
-export default function ListDividers(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function ListDividers(props) {
+  const classes = props.classes;
   return (
     <List className={classes.root}>
       <ListItem button>
@@ -33,6 +33,8 @@ export default function ListDividers(props, context) {
   );
 }
 
-ListDividers.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+ListDividers.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(ListDividers);

--- a/docs/src/pages/component-demos/drawers/UndockedDrawer.js
+++ b/docs/src/pages/component-demos/drawers/UndockedDrawer.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React, { Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Drawer from 'material-ui/Drawer';
 import Button from 'material-ui/Button';
 import List, { ListItem, ListItemIcon, ListItemText } from 'material-ui/List';
@@ -26,7 +26,7 @@ const styleSheet = createStyleSheet('UndockedDrawer', () => ({
   },
 }));
 
-export default class UndockedDrawer extends Component {
+class UndockedDrawer extends Component {
   state = {
     open: {
       top: false,
@@ -52,7 +52,7 @@ export default class UndockedDrawer extends Component {
   handleRightClose = () => this.toggleDrawer('right', false);
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
 
     const mailFolderListItems = (
       <div>
@@ -172,6 +172,8 @@ export default class UndockedDrawer extends Component {
   }
 }
 
-UndockedDrawer.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+UndockedDrawer.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(UndockedDrawer);

--- a/docs/src/pages/component-demos/lists/CheckboxList.js
+++ b/docs/src/pages/component-demos/lists/CheckboxList.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React, { Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import List, { ListItem, ListItemSecondaryAction, ListItemText } from 'material-ui/List';
 import Checkbox from 'material-ui/Checkbox';
 import IconButton from 'material-ui/IconButton';
@@ -16,11 +16,7 @@ const styleSheet = createStyleSheet('CheckboxList', (theme) => ({
   },
 }));
 
-export default class CheckboxList extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class CheckboxList extends Component {
   state = {
     checked: [0],
   };
@@ -42,7 +38,7 @@ export default class CheckboxList extends Component {
   };
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
 
     return (
       <div className={classes.root}>
@@ -73,3 +69,8 @@ export default class CheckboxList extends Component {
   }
 }
 
+CheckboxList.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(CheckboxList);

--- a/docs/src/pages/component-demos/lists/CheckboxListSecondary.js
+++ b/docs/src/pages/component-demos/lists/CheckboxListSecondary.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React, { Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import List, { ListItem, ListItemSecondaryAction, ListItemText } from 'material-ui/List';
 import Checkbox from 'material-ui/Checkbox';
 import Avatar from 'material-ui/Avatar';
@@ -16,11 +16,7 @@ const styleSheet = createStyleSheet('CheckboxListSecondary', (theme) => ({
   },
 }));
 
-export default class CheckboxListSecondary extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class CheckboxListSecondary extends Component {
   state = {
     checked: [1],
   };
@@ -42,7 +38,7 @@ export default class CheckboxListSecondary extends Component {
   };
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
 
     return (
       <div className={classes.root}>
@@ -65,3 +61,8 @@ export default class CheckboxListSecondary extends Component {
   }
 }
 
+CheckboxListSecondary.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(CheckboxListSecondary);

--- a/docs/src/pages/component-demos/lists/FolderList.js
+++ b/docs/src/pages/component-demos/lists/FolderList.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import List, { ListItem, ListItemText } from 'material-ui/List';
 import Avatar from 'material-ui/Avatar';
 import FolderIcon from 'material-ui-icons/Folder';
@@ -15,8 +15,8 @@ const styleSheet = createStyleSheet('FolderList', (theme) => ({
   },
 }));
 
-function FolderList(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function FolderList(props) {
+  const classes = props.classes;
   return (
     <div className={classes.root}>
       <List>
@@ -33,8 +33,8 @@ function FolderList(props, context) {
   );
 }
 
-FolderList.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+FolderList.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
 
-export default FolderList;
+export default withStyles(styleSheet)(FolderList);

--- a/docs/src/pages/component-demos/lists/InsetList.js
+++ b/docs/src/pages/component-demos/lists/InsetList.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import List, { ListItem, ListItemIcon, ListItemText } from 'material-ui/List';
 import StarIcon from 'material-ui-icons/Star';
 
@@ -14,8 +14,8 @@ const styleSheet = createStyleSheet('InsetList', (theme) => ({
   },
 }));
 
-function InsetList(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function InsetList(props) {
+  const classes = props.classes;
   return (
     <List className={classes.root}>
       <ListItem button>
@@ -31,8 +31,8 @@ function InsetList(props, context) {
   );
 }
 
-InsetList.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+InsetList.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
 
-export default InsetList;
+export default withStyles(styleSheet)(InsetList);

--- a/docs/src/pages/component-demos/lists/InteractiveList.js
+++ b/docs/src/pages/component-demos/lists/InteractiveList.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React, { cloneElement, Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import List, {
   ListItem,
   ListItemAvatar,
@@ -41,17 +41,13 @@ function generate(element) {
 }
 
 class InteractiveList extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
   state = {
     dense: false,
     secondary: false,
   };
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
     const { dense, secondary } = this.state;
 
     return (
@@ -165,4 +161,8 @@ class InteractiveList extends Component {
   }
 }
 
-export default InteractiveList;
+InteractiveList.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(InteractiveList);

--- a/docs/src/pages/component-demos/lists/SimpleList.js
+++ b/docs/src/pages/component-demos/lists/SimpleList.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import List, { ListItem, ListItemIcon, ListItemText } from 'material-ui/List';
 import Divider from 'material-ui/Divider';
 import InboxIcon from 'material-ui-icons/Inbox';
@@ -16,8 +16,8 @@ const styleSheet = createStyleSheet('SimpleList', (theme) => ({
   },
 }));
 
-function SimpleList(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function SimpleList(props) {
+  const classes = props.classes;
   return (
     <div className={classes.root}>
       <List>
@@ -47,8 +47,8 @@ function SimpleList(props, context) {
   );
 }
 
-SimpleList.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+SimpleList.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
 
-export default SimpleList;
+export default withStyles(styleSheet)(SimpleList);

--- a/docs/src/pages/component-demos/lists/SwitchListSecondary.js
+++ b/docs/src/pages/component-demos/lists/SwitchListSecondary.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React, { Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import List, {
   ListItem,
   ListItemIcon,
@@ -22,11 +22,7 @@ const styleSheet = createStyleSheet('SwitchListSecondary', (theme) => ({
   },
 }));
 
-export default class SwitchListSecondary extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class SwitchListSecondary extends Component {
   state = {
     checked: ['wifi'],
   };
@@ -48,7 +44,7 @@ export default class SwitchListSecondary extends Component {
   };
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
 
     return (
       <div className={classes.root}>
@@ -82,3 +78,9 @@ export default class SwitchListSecondary extends Component {
     );
   }
 }
+
+SwitchListSecondary.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(SwitchListSecondary);

--- a/docs/src/pages/component-demos/menus/SimpleListMenu.js
+++ b/docs/src/pages/component-demos/menus/SimpleListMenu.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React, { Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import List, { ListItem, ListItemText } from 'material-ui/List';
 import Menu, { MenuItem } from 'material-ui/Menu';
 
@@ -20,11 +20,7 @@ const options = [
   'Hide all notification content',
 ];
 
-export default class SimpleListMenu extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class SimpleListMenu extends Component {
   state = {
     anchorEl: undefined,
     open: false,
@@ -33,14 +29,20 @@ export default class SimpleListMenu extends Component {
 
   button = undefined;
 
-  handleClickListItem = (event) => this.setState({ open: true, anchorEl: event.currentTarget });
+  handleClickListItem = (event) => {
+    this.setState({ open: true, anchorEl: event.currentTarget });
+  };
 
-  handleMenuItemClick = (event, index) => this.setState({ selectedIndex: index, open: false });
+  handleMenuItemClick = (event, index) => {
+    this.setState({ selectedIndex: index, open: false });
+  };
 
-  handleRequestClose = () => this.setState({ open: false });
+  handleRequestClose = () => {
+    this.setState({ open: false });
+  };
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
     return (
       <div className={classes.root}>
         <List>
@@ -81,3 +83,8 @@ export default class SimpleListMenu extends Component {
   }
 }
 
+SimpleListMenu.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(SimpleListMenu);

--- a/docs/src/pages/component-demos/menus/SimpleMenu.js
+++ b/docs/src/pages/component-demos/menus/SimpleMenu.js
@@ -1,23 +1,10 @@
 // @flow weak
 
 import React, { Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
 import Button from 'material-ui/Button';
 import Menu, { MenuItem } from 'material-ui/Menu';
 
-const styleSheet = createStyleSheet('SimpleMenu', () => ({
-  menu: {},
-  content: {
-    margin: 0,
-  },
-}));
-
-export default class SimpleMenu extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class SimpleMenu extends Component {
   state = {
     anchorEl: undefined,
     open: false,
@@ -25,12 +12,15 @@ export default class SimpleMenu extends Component {
 
   button = undefined;
 
-  handleClick = (event) => this.setState({ open: true, anchorEl: event.currentTarget });
+  handleClick = (event) => {
+    this.setState({ open: true, anchorEl: event.currentTarget });
+  };
 
-  handleRequestClose = () => this.setState({ open: false });
+  handleRequestClose = () => {
+    this.setState({ open: false });
+  };
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
     return (
       <div>
         <Button
@@ -43,7 +33,6 @@ export default class SimpleMenu extends Component {
         <Menu
           id="simple-menu"
           anchorEl={this.state.anchorEl}
-          className={classes.menu}
           open={this.state.open}
           onRequestClose={this.handleRequestClose}
         >
@@ -56,3 +45,4 @@ export default class SimpleMenu extends Component {
   }
 }
 
+export default SimpleMenu;

--- a/docs/src/pages/component-demos/paper/PaperSheet.js
+++ b/docs/src/pages/component-demos/paper/PaperSheet.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Typography from 'material-ui/Typography';
 
@@ -13,8 +13,8 @@ const styleSheet = createStyleSheet('PaperSheet', (theme) => ({
   }),
 }));
 
-export default function PaperSheet(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function PaperSheet(props) {
+  const classes = props.classes;
   return (
     <div>
       <Paper className={classes.root} elevation={4}>
@@ -29,6 +29,8 @@ export default function PaperSheet(props, context) {
   );
 }
 
-PaperSheet.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+PaperSheet.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(PaperSheet);

--- a/docs/src/pages/component-demos/progress/Circular.js
+++ b/docs/src/pages/component-demos/progress/Circular.js
@@ -1,18 +1,18 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { CircularProgress } from 'material-ui/Progress';
 
-const styleSheet = createStyleSheet('Circular', () => ({
+const styleSheet = createStyleSheet('Circular', (theme) => ({
   progress: {
-    margin: '0 10px',
+    margin: `0 ${theme.spacing.unit * 2}px`,
   },
 }));
 
-export default function Circular(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function Circular(props) {
+  const classes = props.classes;
   return (
     <div>
       <CircularProgress className={classes.progress} />
@@ -21,6 +21,8 @@ export default function Circular(props, context) {
   );
 }
 
-Circular.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+Circular.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(Circular);

--- a/docs/src/pages/component-demos/progress/CircularFab.js
+++ b/docs/src/pages/component-demos/progress/CircularFab.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React, { Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { CircularProgress } from 'material-ui/Progress';
 import { green } from 'material-ui/styles/colors';
 import Button from 'material-ui/Button';
@@ -27,15 +27,15 @@ const styleSheet = createStyleSheet('CircularFab', () => ({
   },
 }));
 
-export default class CircularFab extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class CircularFab extends Component {
   state = {
     loading: false,
     success: false,
   };
+
+  componentWillUnmount() {
+    clearTimeout(this.timer);
+  }
 
   handleButtonClick = () => {
     if (!this.state.loading) {
@@ -43,19 +43,21 @@ export default class CircularFab extends Component {
         success: false,
         loading: true,
       }, () => {
-        setTimeout(() => {
+        this.timer = setTimeout(() => {
           this.setState({
             loading: false,
             success: true,
           });
-        }, 2000);
+        }, 2e3);
       });
     }
   };
 
+  timer = undefined;
+
   render() {
     const { loading, success } = this.state;
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
     let buttonClass = '';
 
     if (success) {
@@ -77,3 +79,9 @@ export default class CircularFab extends Component {
     );
   }
 }
+
+CircularFab.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(CircularFab);

--- a/docs/src/pages/component-demos/progress/LinearBuffer.js
+++ b/docs/src/pages/component-demos/progress/LinearBuffer.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React, { Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { LinearProgress } from 'material-ui/Progress';
 
 const styleSheet = createStyleSheet('LinearBuffer', () => ({
@@ -12,7 +12,7 @@ const styleSheet = createStyleSheet('LinearBuffer', () => ({
   },
 }));
 
-export default class LinearBuffer extends Component {
+class LinearBuffer extends Component {
   state = {
     completed: 0,
     buffer: 10,
@@ -40,7 +40,7 @@ export default class LinearBuffer extends Component {
   }
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
     const { completed, buffer } = this.state;
     return (
       <div className={classes.root}>
@@ -50,6 +50,8 @@ export default class LinearBuffer extends Component {
   }
 }
 
-LinearBuffer.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+LinearBuffer.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(LinearBuffer);

--- a/docs/src/pages/component-demos/progress/LinearDeterminate.js
+++ b/docs/src/pages/component-demos/progress/LinearDeterminate.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React, { Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { LinearProgress } from 'material-ui/Progress';
 
 const styleSheet = createStyleSheet('LinearDeterminate', () => ({
@@ -12,7 +12,7 @@ const styleSheet = createStyleSheet('LinearDeterminate', () => ({
   },
 }));
 
-export default class LinearDeterminate extends Component {
+class LinearDeterminate extends Component {
   state = {
     completed: 0,
   }
@@ -38,7 +38,7 @@ export default class LinearDeterminate extends Component {
   }
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
     return (
       <div className={classes.root}>
         <LinearProgress mode="determinate" value={this.state.completed} />
@@ -47,6 +47,8 @@ export default class LinearDeterminate extends Component {
   }
 }
 
-LinearDeterminate.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+LinearDeterminate.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(LinearDeterminate);

--- a/docs/src/pages/component-demos/progress/LinearIndeterminate.js
+++ b/docs/src/pages/component-demos/progress/LinearIndeterminate.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { LinearProgress } from 'material-ui/Progress';
 
 const styleSheet = createStyleSheet('LinearIndeterminate', () => ({
@@ -12,8 +12,8 @@ const styleSheet = createStyleSheet('LinearIndeterminate', () => ({
   },
 }));
 
-export default function LinearIndeterminate(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function LinearIndeterminate(props) {
+  const classes = props.classes;
   return (
     <div className={classes.root}>
       <LinearProgress />
@@ -21,6 +21,8 @@ export default function LinearIndeterminate(props, context) {
   );
 }
 
-LinearIndeterminate.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+LinearIndeterminate.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(LinearIndeterminate);

--- a/docs/src/pages/component-demos/progress/LinearQuery.js
+++ b/docs/src/pages/component-demos/progress/LinearQuery.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { LinearProgress } from 'material-ui/Progress';
 
 const styleSheet = createStyleSheet('LinearQuery', () => ({
@@ -12,8 +12,8 @@ const styleSheet = createStyleSheet('LinearQuery', () => ({
   },
 }));
 
-export default function LinearQuery(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function LinearQuery(props) {
+  const classes = props.classes;
   return (
     <div className={classes.root}>
       <LinearProgress mode="query" />
@@ -21,6 +21,8 @@ export default function LinearQuery(props, context) {
   );
 }
 
-LinearQuery.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+LinearQuery.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(LinearQuery);

--- a/docs/src/pages/component-demos/selection-controls/RadioButtonsGroup.js
+++ b/docs/src/pages/component-demos/selection-controls/RadioButtonsGroup.js
@@ -1,22 +1,18 @@
 // @flow weak
 
 import React, { Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { LabelRadio, RadioGroup } from 'material-ui/Radio';
 import { FormLabel, FormControl } from 'material-ui/Form';
 
-const styleSheet = createStyleSheet('RadioButtonsGroup', () => ({
+const styleSheet = createStyleSheet('RadioButtonsGroup', (theme) => ({
   group: {
-    margin: '8px 0',
+    margin: `${theme.spacing.unit}px 0`,
   },
 }));
 
-export default class RadioButtonsGroup extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class RadioButtonsGroup extends Component {
   state = {
     selectedValue: undefined,
   };
@@ -26,7 +22,7 @@ export default class RadioButtonsGroup extends Component {
   };
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
 
     return (
       <FormControl required>
@@ -48,3 +44,8 @@ export default class RadioButtonsGroup extends Component {
   }
 }
 
+RadioButtonsGroup.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(RadioButtonsGroup);

--- a/docs/src/pages/component-demos/tables/BasicTable.js
+++ b/docs/src/pages/component-demos/tables/BasicTable.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Table, { TableBody, TableCell, TableHead, TableRow } from 'material-ui/Table';
 import Paper from 'material-ui/Paper';
 
@@ -28,8 +28,8 @@ const data = [
   createData('Gingerbread', 356, 16.0, 49, 3.9),
 ];
 
-export default function BasicTable(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function BasicTable(props) {
+  const classes = props.classes;
 
   return (
     <Paper className={classes.paper}>
@@ -61,6 +61,8 @@ export default function BasicTable(props, context) {
   );
 }
 
-BasicTable.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+BasicTable.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(BasicTable);

--- a/docs/src/pages/component-demos/tables/EnhancedTable.js
+++ b/docs/src/pages/component-demos/tables/EnhancedTable.js
@@ -2,10 +2,10 @@
 /* eslint-disable react/no-multi-comp */
 
 import React, { Component } from 'react';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import { createStyleSheet } from 'jss-theme-reactor';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import keycode from 'keycode';
-import customPropTypes from 'material-ui/utils/customPropTypes';
 import Table, {
   TableBody,
   TableCell,
@@ -20,14 +20,6 @@ import Checkbox from 'material-ui/Checkbox';
 import IconButton from 'material-ui/IconButton';
 import DeleteIcon from 'material-ui-icons/Delete';
 import FilterListIcon from 'material-ui-icons/FilterList';
-
-const styleSheet = createStyleSheet('EnhancedTable', () => ({
-  paper: {
-    width: '100%',
-    marginTop: 30,
-    overflowX: 'auto',
-  },
-}));
 
 let counter = 0;
 function createData(name, calories, fat, carbs, protein) {
@@ -51,9 +43,9 @@ class EnhancedTableHead extends Component {
     orderBy: PropTypes.string.isRequired,
   };
 
-  createSortHandler = (property) => {
-    return (event) => this.props.onRequestSort(event, property);
-  };
+  createSortHandler = (property) => (event) => {
+    this.props.onRequestSort(event, property);
+  }
 
   render() {
     const { order, orderBy } = this.props;
@@ -90,7 +82,9 @@ class EnhancedTableHead extends Component {
 
 const toolbarStyleSheet = createStyleSheet('EnhancedTableToolbar', (theme) => {
   return {
-    root: { paddingRight: 2 },
+    root: {
+      paddingRight: 2,
+    },
     highlight: (
       theme.palette.type === 'light' ? {
         color: theme.palette.accent[800],
@@ -106,17 +100,15 @@ const toolbarStyleSheet = createStyleSheet('EnhancedTableToolbar', (theme) => {
   };
 });
 
-function EnhancedTableToolbar(props, context) {
-  const { numSelected } = props;
-  const classes = context.styleManager.render(toolbarStyleSheet);
-  let classNames = classes.root;
-
-  if (numSelected > 0) {
-    classNames += ` ${classes.highlight}`;
-  }
+let EnhancedTableToolbar = (props) => {
+  const { numSelected, classes } = props;
 
   return (
-    <Toolbar className={classNames}>
+    <Toolbar
+      className={classNames(classes.root, {
+        [classes.highlight]: numSelected > 0,
+      })}
+    >
       <div className={classes.title}>
         {numSelected > 0 ? (
           <Typography type="subheading">{numSelected} selected</Typography>
@@ -138,21 +130,24 @@ function EnhancedTableToolbar(props, context) {
       </div>
     </Toolbar>
   );
-}
+};
 
 EnhancedTableToolbar.propTypes = {
+  classes: PropTypes.object.isRequired,
   numSelected: PropTypes.number.isRequired,
 };
 
-EnhancedTableToolbar.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
-};
+EnhancedTableToolbar = withStyles(toolbarStyleSheet)(EnhancedTableToolbar);
 
-export default class EnhancedTable extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
+const styleSheet = createStyleSheet('EnhancedTable', () => ({
+  paper: {
+    width: '100%',
+    marginTop: 30,
+    overflowX: 'auto',
+  },
+}));
 
+class EnhancedTable extends Component {
   state = {
     order: 'asc',
     orderBy: 'calories',
@@ -185,9 +180,9 @@ export default class EnhancedTable extends Component {
 
   handleSelectAllClick = (event, checked) => {
     if (checked) {
-      return this.setState({ selected: this.state.data.map((n) => n.id) });
+      this.setState({ selected: this.state.data.map((n) => n.id) });
     }
-    return this.setState({ selected: [] });
+    this.setState({ selected: [] });
   };
 
   handleKeyDown = (event, id) => {
@@ -217,12 +212,10 @@ export default class EnhancedTable extends Component {
     this.setState({ selected: newSelected });
   };
 
-  isSelected = (id) => {
-    return this.state.selected.indexOf(id) !== -1;
-  };
+  isSelected = (id) => this.state.selected.indexOf(id) !== -1;
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
     const { data, order, orderBy, selected } = this.state;
 
     return (
@@ -266,3 +259,9 @@ export default class EnhancedTable extends Component {
     );
   }
 }
+
+EnhancedTable.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(EnhancedTable);

--- a/docs/src/pages/component-demos/tabs/BasicTabs.js
+++ b/docs/src/pages/component-demos/tabs/BasicTabs.js
@@ -3,8 +3,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Tabs, { Tab } from 'material-ui/Tabs';
 
@@ -29,11 +28,7 @@ const styleSheet = createStyleSheet('BasicTabs', (theme) => ({
   },
 }));
 
-export default class BasicTabs extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class BasicTabs extends Component {
   state = {
     index: 0,
   };
@@ -43,7 +38,7 @@ export default class BasicTabs extends Component {
   }
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
 
     return (
       <Paper className={classes.root}>
@@ -61,3 +56,9 @@ export default class BasicTabs extends Component {
     );
   }
 }
+
+BasicTabs.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(BasicTabs);

--- a/docs/src/pages/component-demos/tabs/BasicTabsWrappedLabel.js
+++ b/docs/src/pages/component-demos/tabs/BasicTabsWrappedLabel.js
@@ -3,8 +3,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Tabs, { Tab } from 'material-ui/Tabs';
 
@@ -29,11 +28,7 @@ const styleSheet = createStyleSheet('BasicTabsWrappedLabel', (theme) => ({
   },
 }));
 
-export default class BasicTabsWrappedLabel extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class BasicTabsWrappedLabel extends Component {
   state = {
     index: 0,
   };
@@ -43,7 +38,7 @@ export default class BasicTabsWrappedLabel extends Component {
   }
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
 
     return (
       <Paper className={classes.root}>
@@ -61,3 +56,9 @@ export default class BasicTabsWrappedLabel extends Component {
     );
   }
 }
+
+BasicTabsWrappedLabel.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(BasicTabsWrappedLabel);

--- a/docs/src/pages/component-demos/tabs/CenteredTabs.js
+++ b/docs/src/pages/component-demos/tabs/CenteredTabs.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React, { Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Tabs, { Tab } from 'material-ui/Tabs';
 
@@ -13,11 +13,7 @@ const styleSheet = createStyleSheet('CenteredTabs', () => ({
   },
 }));
 
-export default class CenteredTabs extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class CenteredTabs extends Component {
   state = {
     index: 0,
   };
@@ -27,7 +23,7 @@ export default class CenteredTabs extends Component {
   };
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
 
     return (
       <Paper className={classes.root}>
@@ -45,3 +41,9 @@ export default class CenteredTabs extends Component {
     );
   }
 }
+
+CenteredTabs.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(CenteredTabs);

--- a/docs/src/pages/component-demos/tabs/DisabledTabs.js
+++ b/docs/src/pages/component-demos/tabs/DisabledTabs.js
@@ -2,15 +2,10 @@
 /* eslint-disable react/no-multi-comp */
 
 import React, { Component } from 'react';
-import customPropTypes from 'material-ui/utils/customPropTypes';
 import Paper from 'material-ui/Paper';
 import Tabs, { Tab } from 'material-ui/Tabs';
 
-export default class DisabledTabs extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class DisabledTabs extends Component {
   state = {
     index: 0,
   };
@@ -31,3 +26,5 @@ export default class DisabledTabs extends Component {
     );
   }
 }
+
+export default DisabledTabs;

--- a/docs/src/pages/component-demos/tabs/FullWidthTabs.js
+++ b/docs/src/pages/component-demos/tabs/FullWidthTabs.js
@@ -3,9 +3,8 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { createStyleSheet } from 'jss-theme-reactor';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import SwipeableViews from 'react-swipeable-views';
-import customPropTypes from 'material-ui/utils/customPropTypes';
 import Paper from 'material-ui/Paper';
 import Tabs, { Tab } from 'material-ui/Tabs';
 
@@ -29,11 +28,7 @@ const styleSheet = createStyleSheet('FullWidthTabs', (theme) => ({
   },
 }));
 
-export default class FullWidthTabs extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class FullWidthTabs extends Component {
   state = {
     index: 0,
   };
@@ -47,7 +42,7 @@ export default class FullWidthTabs extends Component {
   };
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
 
     return (
       <Paper style={{ width: 500 }}>
@@ -72,3 +67,9 @@ export default class FullWidthTabs extends Component {
     );
   }
 }
+
+FullWidthTabs.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(FullWidthTabs);

--- a/docs/src/pages/component-demos/tabs/ScrollableTabsButtonAuto.js
+++ b/docs/src/pages/component-demos/tabs/ScrollableTabsButtonAuto.js
@@ -3,8 +3,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Tabs, { Tab } from 'material-ui/Tabs';
 
@@ -29,11 +28,7 @@ const styleSheet = createStyleSheet('ScrollableTabsButtonAuto', (theme) => ({
   },
 }));
 
-export default class ScrollableTabsButtonAuto extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class ScrollableTabsButtonAuto extends Component {
   state = {
     index: 0,
   };
@@ -43,7 +38,7 @@ export default class ScrollableTabsButtonAuto extends Component {
   }
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
 
     return (
       <Paper className={classes.root}>
@@ -74,3 +69,9 @@ export default class ScrollableTabsButtonAuto extends Component {
     );
   }
 }
+
+ScrollableTabsButtonAuto.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(ScrollableTabsButtonAuto);

--- a/docs/src/pages/component-demos/tabs/ScrollableTabsButtonForce.js
+++ b/docs/src/pages/component-demos/tabs/ScrollableTabsButtonForce.js
@@ -3,8 +3,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Tabs, { Tab } from 'material-ui/Tabs';
 import PhoneIcon from 'material-ui-icons/Phone';
@@ -35,11 +34,7 @@ const styleSheet = createStyleSheet('ScrollableTabsButtonForce', (theme) => ({
   },
 }));
 
-export default class ScrollableTabsButtonForce extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class ScrollableTabsButtonForce extends Component {
   state = {
     index: 0,
   };
@@ -49,7 +44,7 @@ export default class ScrollableTabsButtonForce extends Component {
   }
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
 
     return (
       <Paper className={classes.root}>
@@ -81,3 +76,9 @@ export default class ScrollableTabsButtonForce extends Component {
     );
   }
 }
+
+ScrollableTabsButtonForce.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(ScrollableTabsButtonForce);

--- a/docs/src/pages/component-demos/tabs/ScrollableTabsButtonPrevent.js
+++ b/docs/src/pages/component-demos/tabs/ScrollableTabsButtonPrevent.js
@@ -3,8 +3,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Tabs, { Tab } from 'material-ui/Tabs';
 import PhoneIcon from 'material-ui-icons/Phone';
@@ -36,11 +35,7 @@ const styleSheet = createStyleSheet('ScrollableTabsButtonPrevent', (theme) => ({
   },
 }));
 
-export default class ScrollableTabsButtonPrevent extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class ScrollableTabsButtonPrevent extends Component {
   state = {
     index: 0,
   };
@@ -50,7 +45,7 @@ export default class ScrollableTabsButtonPrevent extends Component {
   }
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
 
     return (
       <Paper className={classes.root}>
@@ -81,3 +76,9 @@ export default class ScrollableTabsButtonPrevent extends Component {
     );
   }
 }
+
+ScrollableTabsButtonPrevent.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(ScrollableTabsButtonPrevent);

--- a/docs/src/pages/component-demos/text-fields/ComposedTextField.js
+++ b/docs/src/pages/component-demos/text-fields/ComposedTextField.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React, { Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Input from 'material-ui/Input';
 import InputLabel from 'material-ui/Input/InputLabel';
 import FormControl from 'material-ui/Form/FormControl';
@@ -17,17 +17,17 @@ const styleSheet = createStyleSheet('ComposedTextField', () => ({
   },
 }));
 
-export default class ComposedTextField extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class ComposedTextField extends Component {
   state = {
     name: 'Composed TextField',
   };
 
+  handleChange = (event) => {
+    this.setState({ name: event.target.value });
+  };
+
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
 
     return (
       <div className={classes.container}>
@@ -38,7 +38,7 @@ export default class ComposedTextField extends Component {
           <Input
             id="name"
             value={this.state.name}
-            onChange={(event) => this.setState({ name: event.target.value })}
+            onChange={this.handleChange}
           />
         </FormControl>
       </div>
@@ -46,3 +46,8 @@ export default class ComposedTextField extends Component {
   }
 }
 
+ComposedTextField.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(ComposedTextField);

--- a/docs/src/pages/component-demos/text-fields/TextFields.js
+++ b/docs/src/pages/component-demos/text-fields/TextFields.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React, { Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import TextField from 'material-ui/TextField';
 
 const styleSheet = createStyleSheet('TextFields', () => ({
@@ -15,17 +15,13 @@ const styleSheet = createStyleSheet('TextFields', () => ({
   },
 }));
 
-export default class TextFields extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  };
-
+class TextFields extends Component {
   state = {
     name: 'Cat in the Hat',
   };
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
 
     return (
       <div className={classes.container}>
@@ -66,3 +62,9 @@ export default class TextFields extends Component {
     );
   }
 }
+
+TextFields.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(TextFields);

--- a/docs/src/pages/component-demos/text-fields/TextInputs.js
+++ b/docs/src/pages/component-demos/text-fields/TextInputs.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Input from 'material-ui/Input/Input';
 
 const styleSheet = createStyleSheet('TextInputs', () => ({
@@ -15,8 +15,8 @@ const styleSheet = createStyleSheet('TextInputs', () => ({
   },
 }));
 
-export default function TextInputs(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function TextInputs(props) {
+  const classes = props.classes;
   return (
     <div className={classes.container}>
       <Input
@@ -41,6 +41,8 @@ export default function TextInputs(props, context) {
   );
 }
 
-TextInputs.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+TextInputs.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(TextInputs);

--- a/docs/src/pages/layout/grid/AutoGrid.js
+++ b/docs/src/pages/layout/grid/AutoGrid.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Grid from 'material-ui/Grid';
 
@@ -18,8 +18,8 @@ const styleSheet = createStyleSheet('AutoGrid', (theme) => ({
   },
 }));
 
-export default function AutoGrid(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function AutoGrid(props) {
+  const classes = props.classes;
 
   return (
     <div className={classes.root}>
@@ -61,6 +61,8 @@ export default function AutoGrid(props, context) {
   );
 }
 
-AutoGrid.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+AutoGrid.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(AutoGrid);

--- a/docs/src/pages/layout/grid/CenteredGrid.js
+++ b/docs/src/pages/layout/grid/CenteredGrid.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Grid from 'material-ui/Grid';
 
@@ -18,8 +18,8 @@ const styleSheet = createStyleSheet('CenteredGrid', (theme) => ({
   },
 }));
 
-export default function CenteredGrid(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function CenteredGrid(props) {
+  const classes = props.classes;
 
   return (
     <div className={classes.root}>
@@ -64,6 +64,8 @@ export default function CenteredGrid(props, context) {
   );
 }
 
-CenteredGrid.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+CenteredGrid.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(CenteredGrid);

--- a/docs/src/pages/layout/grid/FullWidthGrid.js
+++ b/docs/src/pages/layout/grid/FullWidthGrid.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Grid from 'material-ui/Grid';
 
@@ -18,8 +18,8 @@ const styleSheet = createStyleSheet('FullWidthGrid', (theme) => ({
   },
 }));
 
-export default function FullWidthGrid(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function FullWidthGrid(props) {
+  const classes = props.classes;
 
   return (
     <div className={classes.root}>
@@ -64,6 +64,8 @@ export default function FullWidthGrid(props, context) {
   );
 }
 
-FullWidthGrid.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+FullWidthGrid.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(FullWidthGrid);

--- a/docs/src/pages/layout/grid/GuttersGrid.js
+++ b/docs/src/pages/layout/grid/GuttersGrid.js
@@ -1,8 +1,8 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 
 import React, { Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Grid from 'material-ui/Grid';
 import { LabelRadio, RadioGroup } from 'material-ui/Radio';
 import Paper from 'material-ui/Paper';
@@ -23,11 +23,7 @@ const styleSheet = createStyleSheet('GuttersGrid', () => {
   };
 });
 
-export default class GuttersGrid extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  }
-
+class GuttersGrid extends Component {
   state = {
     gutter: '16',
   }
@@ -39,7 +35,7 @@ export default class GuttersGrid extends Component {
   }
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
     const {
       gutter,
     } = this.state;
@@ -85,3 +81,9 @@ export default class GuttersGrid extends Component {
     );
   }
 }
+
+GuttersGrid.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(GuttersGrid);

--- a/docs/src/pages/layout/grid/InteractiveGrid.js
+++ b/docs/src/pages/layout/grid/InteractiveGrid.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React, { Component } from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Grid from 'material-ui/Grid';
 import { LabelRadio, RadioGroup } from 'material-ui/Radio';
 import Paper from 'material-ui/Paper';
@@ -26,11 +26,7 @@ const styleSheet = createStyleSheet('InteractiveGrid', () => {
   };
 });
 
-export default class InteractiveGrid extends Component {
-  static contextTypes = {
-    styleManager: customPropTypes.muiRequired,
-  }
-
+class InteractiveGrid extends Component {
   state = {
     direction: 'row',
     justify: 'center',
@@ -45,7 +41,7 @@ export default class InteractiveGrid extends Component {
   }
 
   render() {
-    const classes = this.context.styleManager.render(styleSheet);
+    const classes = this.props.classes;
     const {
       align,
       direction,
@@ -121,3 +117,9 @@ export default class InteractiveGrid extends Component {
     );
   }
 }
+
+InteractiveGrid.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(InteractiveGrid);

--- a/docs/src/pages/layout/hidden/BreakpointDown.js
+++ b/docs/src/pages/layout/hidden/BreakpointDown.js
@@ -1,8 +1,8 @@
 // @flow weak
 import React from 'react';
 import PropTypes from 'prop-types';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import compose from 'recompose/compose';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Hidden from 'material-ui/Hidden';
 import withWidth from 'material-ui/utils/withWidth';
@@ -34,8 +34,8 @@ const styleSheet = createStyleSheet('BreakpointDown', (theme) => ({
   },
 }));
 
-function BreakpointDown(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function BreakpointDown(props) {
+  const classes = props.classes;
 
   return (
     <div className={classes.container}>
@@ -67,11 +67,11 @@ function BreakpointDown(props, context) {
 }
 
 BreakpointDown.propTypes = {
+  classes: PropTypes.object.isRequired,
   width: PropTypes.string,
 };
 
-BreakpointDown.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
-};
-
-export default withWidth()(BreakpointDown);
+export default compose(
+  withStyles(styleSheet),
+  withWidth(),
+)(BreakpointDown);

--- a/docs/src/pages/layout/hidden/BreakpointOnly.js
+++ b/docs/src/pages/layout/hidden/BreakpointOnly.js
@@ -1,8 +1,8 @@
 // @flow weak
 import React from 'react';
 import PropTypes from 'prop-types';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import compose from 'recompose/compose';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Hidden from 'material-ui/Hidden';
 import withWidth from 'material-ui/utils/withWidth';
@@ -34,8 +34,8 @@ const styleSheet = createStyleSheet('BreakpointOnly', (theme) => ({
   },
 }));
 
-function BreakpointOnly(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function BreakpointOnly(props) {
+  const classes = props.classes;
 
   return (
     <div className={classes.container}>
@@ -59,11 +59,11 @@ function BreakpointOnly(props, context) {
 }
 
 BreakpointOnly.propTypes = {
+  classes: PropTypes.object.isRequired,
   width: PropTypes.string,
 };
 
-BreakpointOnly.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
-};
-
-export default withWidth()(BreakpointOnly);
+export default compose(
+  withStyles(styleSheet),
+  withWidth(),
+)(BreakpointOnly);

--- a/docs/src/pages/layout/hidden/BreakpointUp.js
+++ b/docs/src/pages/layout/hidden/BreakpointUp.js
@@ -1,8 +1,8 @@
 // @flow weak
 import React from 'react';
 import PropTypes from 'prop-types';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import compose from 'recompose/compose';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Hidden from 'material-ui/Hidden';
 import withWidth from 'material-ui/utils/withWidth';
@@ -34,8 +34,8 @@ const styleSheet = createStyleSheet('BreakpointUp', (theme) => ({
   },
 }));
 
-function BreakpointUp(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function BreakpointUp(props) {
+  const classes = props.classes;
 
   return (
     <div className={classes.container}>
@@ -67,11 +67,11 @@ function BreakpointUp(props, context) {
 }
 
 BreakpointUp.propTypes = {
+  classes: PropTypes.object.isRequired,
   width: PropTypes.string,
 };
 
-BreakpointUp.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
-};
-
-export default withWidth()(BreakpointUp);
+export default compose(
+  withStyles(styleSheet),
+  withWidth(),
+)(BreakpointUp);

--- a/docs/src/pages/layout/hidden/GridIntegration.js
+++ b/docs/src/pages/layout/hidden/GridIntegration.js
@@ -1,8 +1,8 @@
 // @flow weak
 import React from 'react';
 import PropTypes from 'prop-types';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import compose from 'recompose/compose';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Grid from 'material-ui/Grid';
 import withWidth from 'material-ui/utils/withWidth';
@@ -28,8 +28,8 @@ const styleSheet = createStyleSheet('GridIntegration', (theme) => ({
   },
 }));
 
-function GridIntegration(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function GridIntegration(props) {
+  const classes = props.classes;
 
   return (
     <div className={classes.root}>
@@ -58,11 +58,11 @@ function GridIntegration(props, context) {
 }
 
 GridIntegration.propTypes = {
+  classes: PropTypes.object.isRequired,
   width: PropTypes.string,
 };
 
-GridIntegration.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
-};
-
-export default withWidth()(GridIntegration);
+export default compose(
+  withStyles(styleSheet),
+  withWidth(),
+)(GridIntegration);

--- a/docs/src/pages/style/Color.js
+++ b/docs/src/pages/style/Color.js
@@ -1,9 +1,9 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import * as colors from 'material-ui/styles/colors';
-import customPropTypes from 'material-ui/utils/customPropTypes';
 import { getContrastRatio } from 'material-ui/styles/colorManipulator';
 
 const mainColors = [
@@ -115,8 +115,8 @@ function getColorBlock(classes, colorName, colorValue, colorTitle) {
   );
 }
 
-export default function Color(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function Color(props) {
+  const classes = props.classes;
 
   return (
     <div className={classes.root}>
@@ -134,6 +134,8 @@ export default function Color(props, context) {
   );
 }
 
-Color.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+Color.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(Color);

--- a/docs/src/pages/style/Icons.js
+++ b/docs/src/pages/style/Icons.js
@@ -1,8 +1,8 @@
 // @flow weak
 
 import React from 'react';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Icon from 'material-ui/Icon';
 
 const styleSheet = createStyleSheet('Icons', () => ({
@@ -14,8 +14,8 @@ const styleSheet = createStyleSheet('Icons', () => ({
   },
 }));
 
-export default function Icons(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function Icons(props) {
+  const classes = props.classes;
   return (
     <div className={classes.icons}>
       <Icon>add_circle</Icon>
@@ -29,6 +29,8 @@ export default function Icons(props, context) {
   );
 }
 
-Icons.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+Icons.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(Icons);

--- a/docs/src/pages/style/SvgIcons.js
+++ b/docs/src/pages/style/SvgIcons.js
@@ -2,8 +2,8 @@
 
 import React from 'react';
 import classNames from 'classnames';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { blue, red, green } from 'material-ui/styles/colors';
 import SvgIcon from 'material-ui/SvgIcon';
 
@@ -28,8 +28,8 @@ const HomeIcon = (props) => (
   </SvgIcon>
 );
 
-export default function SvgIcons(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function SvgIcons(props) {
+  const classes = props.classes;
   return (
     <div>
       <HomeIcon className={classes.icon} />
@@ -39,6 +39,8 @@ export default function SvgIcons(props, context) {
   );
 }
 
-SvgIcons.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+SvgIcons.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(SvgIcons);

--- a/docs/src/pages/style/SvgMaterialIcons.js
+++ b/docs/src/pages/style/SvgMaterialIcons.js
@@ -1,10 +1,10 @@
 // @flow weak
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import AccessAlarmIcon from 'material-ui-icons/AccessAlarm';
 import ThreeDRotation from 'material-ui-icons/ThreeDRotation';
-import { createStyleSheet } from 'jss-theme-reactor';
-import customPropTypes from 'material-ui/utils/customPropTypes';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
 
 const styleSheet = createStyleSheet('SvgMaterialIcons', (theme) => ({
   icon: {
@@ -12,8 +12,8 @@ const styleSheet = createStyleSheet('SvgMaterialIcons', (theme) => ({
   },
 }));
 
-export default function SvgMaterialIcons(props, context) {
-  const classes = context.styleManager.render(styleSheet);
+function SvgMaterialIcons(props) {
+  const classes = props.classes;
   return (
     <div>
       <AccessAlarmIcon className={classes.icon} />
@@ -22,6 +22,8 @@ export default function SvgMaterialIcons(props, context) {
   );
 }
 
-SvgMaterialIcons.contextTypes = {
-  styleManager: customPropTypes.muiRequired,
+SvgMaterialIcons.propTypes = {
+  classes: PropTypes.object.isRequired,
 };
+
+export default withStyles(styleSheet)(SvgMaterialIcons);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

First, the React core team is advising against directly exposing the context API to end users. Also, they are planning some changes on it. Finally, using a Higher-order Component should make our life simpler if we move to an event base theme update system.

cc @nathanmarks.