### PR TITLE
[Table] Handle 0 or 1 rows within the header

### DIFF
--- a/src/Table/TableHeader.js
+++ b/src/Table/TableHeader.js
@@ -105,8 +105,14 @@ class TableHeader extends Component {
   }
 
   createBaseHeaderRow() {
-    const numChildren = React.Children.count(this.props.children);
-    const child = (numChildren === 1) ? this.props.children : this.props.children[numChildren - 1];
+    const childrenArray = React.Children.toArray(this.props.children);
+    const numChildren = childrenArray.length;
+    if (numChildren < 1) {
+      return null;
+    }
+
+    const child = childrenArray[numChildren - 1];
+
     const props = {
       key: `h${numChildren}`,
       rowNumber: numChildren,

--- a/test/integration/Table/ArrayHeaderTable.js
+++ b/test/integration/Table/ArrayHeaderTable.js
@@ -1,0 +1,33 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import {
+  Table,
+  TableBody,
+  TableHeader,
+  TableHeaderColumn,
+  TableRow,
+} from 'src/Table';
+
+class ArrayHeaderTable extends Component {
+  render() {
+    return (
+      <Table>
+        <TableHeader displaySelectAll={false} adjustForCheckbox={false}>
+          {this.props.headers.map((header, index) => (<TableRow key={index}>
+            {header.columns.map((column, columnIndex) => (
+              <TableHeaderColumn key={columnIndex}>{column}</TableHeaderColumn>)
+            )}
+          </TableRow>))}
+        </TableHeader>
+        <TableBody displayRowCheckbox={false} />
+      </Table>
+    );
+  }
+}
+
+
+ArrayHeaderTable.propTypes = {
+  headers: PropTypes.array.isRequired,
+};
+
+export default ArrayHeaderTable;

--- a/test/integration/Table/ArrayHeaderTable.spec.js
+++ b/test/integration/Table/ArrayHeaderTable.spec.js
@@ -1,0 +1,76 @@
+/* eslint-env mocha */
+import React from 'react';
+import PropTypes from 'prop-types';
+import {mount} from 'enzyme';
+import {assert} from 'chai';
+import getMuiTheme from 'src/styles/getMuiTheme';
+import ArrayHeaderTable from './ArrayHeaderTable';
+
+function getHeaderContent(wrapper) {
+  const headers = wrapper.find('TableHeader');
+  if (headers.length !== 1) {
+    return undefined;
+  }
+
+  const mapHeaderColumn = (headerColumn) => headerColumn.props().children;
+  const mapHeaderRow = (headerRow) => headerRow.find('TableHeaderColumn').map(mapHeaderColumn).join();
+
+  const rows = headers.at(0).find('TableRow');
+  const mappedRows = rows.map(mapHeaderRow);
+
+  return mappedRows.join('\n');
+}
+
+describe('<ArrayHeaderTable />', () => {
+  let muiTheme;
+  let mountWithContext;
+
+  before(() => {
+    window.getSelection = () => ({
+      removeAllRanges: () => { },
+    });
+    muiTheme = getMuiTheme();
+    mountWithContext = (node) => mount(node, {
+      context: {muiTheme},
+      childContextTypes: {muiTheme: PropTypes.object},
+    });
+  });
+
+  describe('uncontrolled', () => {
+    it('should render empty header', () => {
+      const headers = [];
+      const wrapper = mountWithContext(
+        <ArrayHeaderTable headers={headers} />
+      );
+
+      assert.deepEqual(getHeaderContent(wrapper),
+        '',
+        'should be the header content'
+      );
+    });
+
+    it('should render single header row', () => {
+      const headers = [{columns: ['One', 'Two']}];
+      const wrapper = mountWithContext(
+        <ArrayHeaderTable headers={headers} />
+      );
+
+      assert.deepEqual(getHeaderContent(wrapper),
+        'One,Two',
+        'should be the header content'
+      );
+    });
+
+    it('should render both header rows', () => {
+      const headers = [{columns: ['One', 'Two']}, {columns: ['Three', 'Four']}];
+      const wrapper = mountWithContext(
+        <ArrayHeaderTable headers={headers} />
+      );
+
+      assert.deepEqual(getHeaderContent(wrapper),
+        'One,Two\nThree,Four',
+        'should be the header content'
+      );
+    });
+  });
+});


### PR DESCRIPTION
If passing an array of header rows to the table-header. The table header
will not be rendered if the array is either empty or does contain just
a single item.

Fixes #5322

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [X] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

