### PR TITLE
[Documentation] Fix link to material-ui-icons

### DIFF
--- a/docs/src/pages/getting-started/installation.md
+++ b/docs/src/pages/getting-started/installation.md
@@ -25,7 +25,7 @@ on how to do so.
 ## SVG Icons
 
 In order to use prebuilt SVG Material icons, such as those found in the [component demos](/component-demos)
-you must first install the [material-ui-icons](https://www.npmjs.org/package/material-ui) package:
+you must first install the [material-ui-icons](https://www.npmjs.org/package/material-ui-icons) package:
 
 ```
 npm install -S material-ui-icons


### PR DESCRIPTION
The link was previously pointing to the material-ui package

<!-- Thanks so much for your PR, your contribution is appreciated! -->

None of the below are done, but the contents of the edited line speak for themselves. Just a typo-fix in documentation.

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

