### PR TITLE
[MenuItem] Add targetOrigin prop

### DIFF
--- a/src/MenuItem/MenuItem.js
+++ b/src/MenuItem/MenuItem.js
@@ -63,6 +63,9 @@ class MenuItem extends Component {
     /**
      * Location of the anchor for the popover of nested `MenuItem`
      * elements.
+     * Options:
+     * horizontal: [left, middle, right]
+     * vertical: [top, center, bottom].
      */
     anchorOrigin: propTypes.origin,
     /**
@@ -136,6 +139,14 @@ class MenuItem extends Component {
      */
     style: PropTypes.object,
     /**
+     * Location on the popover of nested `MenuItem` elements that will attach
+     * to the anchor's origin.
+     * Options:
+     * horizontal: [left, middle, right]
+     * vertical: [top, center, bottom].
+     */
+    targetOrigin: propTypes.origin,
+    /**
      * The value of the menu item.
      */
     value: PropTypes.any,
@@ -148,6 +159,7 @@ class MenuItem extends Component {
     disabled: false,
     focusState: 'none',
     insetChildren: false,
+    targetOrigin: {horizontal: 'left', vertical: 'top'},
   };
 
   static contextTypes = {
@@ -242,6 +254,7 @@ class MenuItem extends Component {
       style,
       animation,
       anchorOrigin,
+      targetOrigin,
       value, // eslint-disable-line no-unused-vars
       ...other
     } = this.props;
@@ -286,6 +299,7 @@ class MenuItem extends Component {
           anchorOrigin={anchorOrigin}
           anchorEl={this.state.anchorEl}
           open={this.state.open}
+          targetOrigin={targetOrigin}
           useLayerForClickAway={false}
           onRequestClose={this.handleRequestClose}
         >

--- a/src/MenuItem/MenuItem.spec.js
+++ b/src/MenuItem/MenuItem.spec.js
@@ -6,6 +6,7 @@ import {shallow} from 'enzyme';
 import getMuiTheme from 'src/styles/getMuiTheme';
 import MenuItem from './MenuItem';
 import ListItem from '../List/ListItem';
+import Popover from '../Popover/Popover';
 
 describe('<MenuItem />', () => {
   const muiTheme = getMuiTheme();
@@ -23,5 +24,25 @@ describe('<MenuItem />', () => {
 
     const wrapper = shallowWithHoverColor(<MenuItem />);
     assert.strictEqual(wrapper.find(ListItem).prop('hoverColor'), testColor);
+  });
+
+  it('should pass anchorOrigin to the <Popover />', () => {
+    const menuItems = [<MenuItem />, <MenuItem />];
+    const anchorOrigin = {horizontal: 'middle', vertical: 'bottom'};
+    const wrapper = shallowWithContext(
+      <MenuItem menuItems={menuItems} anchorOrigin={anchorOrigin} />
+    );
+    const popoverWrapper = wrapper.find(ListItem).find(Popover);
+    assert.strictEqual(popoverWrapper.prop('anchorOrigin'), anchorOrigin);
+  });
+
+  it('should pass targetOrigin to the <Popover />', () => {
+    const menuItems = [<MenuItem />, <MenuItem />];
+    const targetOrigin = {horizontal: 'middle', vertical: 'bottom'};
+    const wrapper = shallowWithContext(
+      <MenuItem menuItems={menuItems} targetOrigin={targetOrigin} />
+    );
+    const popoverWrapper = wrapper.find(ListItem).find(Popover);
+    assert.strictEqual(popoverWrapper.prop('targetOrigin'), targetOrigin);
   });
 });


### PR DESCRIPTION
Fixes #6831 

This PR adds the `targetOrigin` prop to the `MenuItem` component, and adds the valid values for the it and the `anchorOrigin` prop on its documentation page.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

