### PR TITLE
[package]: fix incompatible "recompose" version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "prop-types": "^15.5.7",
     "react-transition-group": "^1.1.2",
     "react-event-listener": "^0.4.5",
-    "recompose": "^0.23.0",
+    "recompose": "0.23.0",
     "simple-assign": "^0.1.0",
     "warning": "^3.0.0"
   },


### PR DESCRIPTION
recompose 0.23.2 or greater is not compatible with material-ui. The`^0.23.0` spec in package.json will cause `0.23.3` to be installed and break builds 

Closes #6848