### PR TITLE
[Drawer] Fix behavior on RTL layouts

### DIFF
--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -246,9 +246,9 @@ class Drawer extends Component {
   onBodyTouchStart = (event) => {
     const swipeAreaWidth = this.props.swipeAreaWidth;
 
-    const touchStartX = !this.context.muiTheme.isRtl ?
-      event.touches[0].pageX :
-      (document.body.offsetWidth - event.touches[0].pageX);
+    const touchStartX = this.context.muiTheme.isRtl ?
+      (document.body.offsetWidth - event.touches[0].pageX) :
+      event.touches[0].pageX;
     const touchStartY = event.touches[0].pageY;
 
     // Open only if swiping from far left (or right) while closed
@@ -279,7 +279,7 @@ class Drawer extends Component {
   };
 
   setPosition(translateX) {
-    const rtlTranslateMultiplier = !this.context.muiTheme.isRtl ? 1 : -1;
+    const rtlTranslateMultiplier = this.context.muiTheme.isRtl ? -1 : 1;
     const drawer = ReactDOM.findDOMNode(this.refs.clickAwayableElement);
     const transformCSS = `translate(${(this.getTranslateMultiplier() * rtlTranslateMultiplier * translateX)}px, 0)`;
     this.refs.overlay.setOpacity(1 - translateX / this.getMaxTranslateX());
@@ -299,9 +299,9 @@ class Drawer extends Component {
   }
 
   onBodyTouchMove = (event) => {
-    const currentX = !this.context.muiTheme.isRtl ?
-      event.touches[0].pageX :
-      (document.body.offsetWidth - event.touches[0].pageX);
+    const currentX = this.context.muiTheme.isRtl ?
+      (document.body.offsetWidth - event.touches[0].pageX) :
+      event.touches[0].pageX;
     const currentY = event.touches[0].pageY;
 
     if (this.state.swiping) {
@@ -329,9 +329,9 @@ class Drawer extends Component {
 
   onBodyTouchEnd = (event) => {
     if (this.state.swiping) {
-      const currentX = !this.context.muiTheme.isRtl ?
-        event.changedTouches[0].pageX :
-        (document.body.offsetWidth - event.changedTouches[0].pageX);
+      const currentX = this.context.muiTheme.isRtl ?
+        (document.body.offsetWidth - event.changedTouches[0].pageX) :
+        event.changedTouches[0].pageX;
       const translateRatio = this.getTranslateX(currentX) / this.getMaxTranslateX();
 
       this.maybeSwiping = false;

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -246,7 +246,9 @@ class Drawer extends Component {
   onBodyTouchStart = (event) => {
     const swipeAreaWidth = this.props.swipeAreaWidth;
 
-    const touchStartX = event.touches[0].pageX;
+    const touchStartX = !this.context.muiTheme.isRtl ?
+      event.touches[0].pageX :
+      (document.body.offsetWidth - event.touches[0].pageX);
     const touchStartY = event.touches[0].pageY;
 
     // Open only if swiping from far left (or right) while closed
@@ -277,8 +279,9 @@ class Drawer extends Component {
   };
 
   setPosition(translateX) {
+    const rtlTranslateMultiplier = !this.context.muiTheme.isRtl ? 1 : -1;
     const drawer = ReactDOM.findDOMNode(this.refs.clickAwayableElement);
-    const transformCSS = `translate(${(this.getTranslateMultiplier() * translateX)}px, 0)`;
+    const transformCSS = `translate(${(this.getTranslateMultiplier() * rtlTranslateMultiplier * translateX)}px, 0)`;
     this.refs.overlay.setOpacity(1 - translateX / this.getMaxTranslateX());
     autoPrefix.set(drawer.style, 'transform', transformCSS);
   }
@@ -296,7 +299,9 @@ class Drawer extends Component {
   }
 
   onBodyTouchMove = (event) => {
-    const currentX = event.touches[0].pageX;
+    const currentX = !this.context.muiTheme.isRtl ?
+      event.touches[0].pageX :
+      (document.body.offsetWidth - event.touches[0].pageX);
     const currentY = event.touches[0].pageY;
 
     if (this.state.swiping) {
@@ -324,7 +329,9 @@ class Drawer extends Component {
 
   onBodyTouchEnd = (event) => {
     if (this.state.swiping) {
-      const currentX = event.changedTouches[0].pageX;
+      const currentX = !this.context.muiTheme.isRtl ?
+        event.changedTouches[0].pageX :
+        (document.body.offsetWidth - event.changedTouches[0].pageX);
       const translateRatio = this.getTranslateX(currentX) / this.getMaxTranslateX();
 
       this.maybeSwiping = false;


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

As reported in #5603, If you set `isRtl: true`, Drawer component swipe to open and close does not work as expected. In fact, a sidebar that located on the right of the screen opens by swiping from the left while it should get opened by swiping from the right. Also, an open drawer can get closed by swiping to the left, while it should get closed by swiping to the right.

This pull request applies some minor changes to detect `isRtl` and change swipe behavior based on that.

Please let me know if any changes required.