### PR TITLE
[flow] Fix small issues

### DIFF
--- a/docs/src/pages/component-api/Hidden/Hidden.md
+++ b/docs/src/pages/component-api/Hidden/Hidden.md
@@ -10,18 +10,17 @@ Props
 |:-----|:-----|:--------|:------------|
 | children | Element |  | The content of the component. |
 | className | string |  | The CSS class name of the root element. |
-| component | union:&nbsp;string<br>&nbsp;Function<br>&nbsp;Element<*><br> |  | If string or Function, component is used as the root node and all other props are passed including children. If an Element, it will be rendered as-is and no other props are propagated. |
-| only | union:&nbsp;Breakpoints<br>&nbsp;Array<Breakpoints><br> |  | Hide the given breakpoint(s). |
-| xsUp | boolean |  | If true, screens this size and up will be hidden. |
-| smUp | boolean |  | If true, screens this size and up will be hidden. |
-| mdUp | boolean |  | If true, screens this size and up will be hidden. |
-| lgUp | boolean |  | If true, screens this size and up will be hidden. |
-| xlUp | boolean |  | If true, screens this size and up will be hidden. |
-| xsDown | boolean |  | If true, screens this size and down will be hidden. |
-| smDown | boolean |  | If true, screens this size and down will be hidden. |
-| mdDown | boolean |  | If true, screens this size and down will be hidden. |
-| lgDown | boolean |  | If true, screens this size and down will be hidden. |
-| xlDown | boolean |  | If true, screens this size and down will be hidden. |
+| only | union:&nbsp;Breakpoint<br>&nbsp;Array<Breakpoint><br> |  | Hide the given breakpoint(s). |
+| xsUp | boolean | false | If true, screens this size and up will be hidden. |
+| smUp | boolean | false | If true, screens this size and up will be hidden. |
+| mdUp | boolean | false | If true, screens this size and up will be hidden. |
+| lgUp | boolean | false | If true, screens this size and up will be hidden. |
+| xlUp | boolean | false | If true, screens this size and up will be hidden. |
+| xsDown | boolean | false | If true, screens this size and down will be hidden. |
+| smDown | boolean | false | If true, screens this size and down will be hidden. |
+| mdDown | boolean | false | If true, screens this size and down will be hidden. |
+| lgDown | boolean | false | If true, screens this size and down will be hidden. |
+| xlDown | boolean | false | If true, screens this size and down will be hidden. |
 | implementation | union:&nbsp;'js'<br>&nbsp;'css'<br> | 'js' | Specify which implementation to use.  'js' is the default, 'css' works better for server side rendering. |
 
 Any other properties supplied will be spread to the root element.

--- a/src/Grid/Grid.js
+++ b/src/Grid/Grid.js
@@ -140,12 +140,7 @@ export const styleSheet = createStyleSheet('MuiGrid', (theme) => {
   };
 });
 
-export type Align = 'flex-start' | 'center' | 'flex-end' | 'stretch'
-export type Direction = 'row' | 'row-reverse' | 'column' | 'column-reverse'
-export type Gutters = 0 | 8 | 16 | 24 | 40
-export type GridSizes = boolean | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12
-export type Justify = 'flex-start' | 'center' | 'flex-end' | 'space-between' | 'space-around'
-export type Wrap = 'nowrap' | 'wrap' | 'wrap-reverse'
+type GridSizes = boolean | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12
 
 type Props = {
   /**
@@ -175,31 +170,31 @@ type Props = {
    * Defines the `align-items` style property.
    * It's applied for all screen sizes.
    */
-  align?: Align, // eslint-disable-line react/sort-prop-types
+  align?: 'flex-start' | 'center' | 'flex-end' | 'stretch',
   /**
    * Defines the `flex-direction` style property.
    * It is applied for all screen sizes.
    */
-  direction?: Direction, // eslint-disable-line react/sort-prop-types
+  direction?: 'row' | 'row-reverse' | 'column' | 'column-reverse',
   /**
    * Defines the space between the type `item` component.
    * It can only be used on a type `container` component.
    */
-  gutter?: Gutters, // eslint-disable-line react/sort-prop-types
+  gutter?: 0 | 8 | 16 | 24 | 40,
   /**
    * If provided, will wrap with Hidden component and given properties.
    */
-  hidden?: HiddenProps, // eslint-disable-line react/sort-prop-types
+  hidden?: HiddenProps,
   /**
    * Defines the `justify-content` style property.
    * It is applied for all screen sizes.
    */
-  justify?: Justify, // eslint-disable-line react/sort-prop-types
+  justify?: 'flex-start' | 'center' | 'flex-end' | 'space-between' | 'space-around',
   /**
    * Defines the `flex-wrap` style property.
    * It's applied for all screen sizes.
    */
-  wrap?: Wrap, // eslint-disable-line react/sort-prop-types
+  wrap?: 'nowrap' | 'wrap' | 'wrap-reverse',
   /**
    * Defines the number of grids the component is going to use.
    * It's applied for all the screen sizes with the lowest priority.
@@ -209,22 +204,22 @@ type Props = {
    * Defines the number of grids the component is going to use.
    * It's applied for the `sm` breakpoint and wider screens if not overridden.
    */
-  sm?: GridSizes, // eslint-disable-line react/sort-prop-types
+  sm?: GridSizes,
   /**
    * Defines the number of grids the component is going to use.
    * It's applied for the `md` breakpoint and wider screens if not overridden.
    */
-  md?: GridSizes, // eslint-disable-line react/sort-prop-types
+  md?: GridSizes,
   /**
    * Defines the number of grids the component is going to use.
    * It's applied for the `lg` breakpoint and wider screens if not overridden.
    */
-  lg?: GridSizes, // eslint-disable-line react/sort-prop-types
+  lg?: GridSizes,
   /**
    * Defines the number of grids the component is going to use.
    * It's applied for the `xl` breakpoint and wider screens.
    */
-  xl?: GridSizes, // eslint-disable-line react/sort-prop-types
+  xl?: GridSizes,
 };
 
 function Grid(props: Props, context: any) {

--- a/src/Hidden/types.js
+++ b/src/Hidden/types.js
@@ -19,41 +19,41 @@ export type HiddenProps = {
   /**
    * If true, screens this size and up will be hidden.
    */
-  xsUp?: boolean, // eslint-disable-line react/sort-prop-types
+  xsUp?: boolean,
   /**
    * If true, screens this size and up will be hidden.
    */
-  smUp?: boolean, // eslint-disable-line react/sort-prop-types
+  smUp?: boolean,
   /**
    * If true, screens this size and up will be hidden.
    */
-  mdUp?: boolean, // eslint-disable-line react/sort-prop-types
+  mdUp?: boolean,
   /**
    * If true, screens this size and up will be hidden.
    */
-  lgUp?: boolean, // eslint-disable-line react/sort-prop-types
+  lgUp?: boolean,
   /**
    * If true, screens this size and up will be hidden.
    */
-  xlUp?: boolean, // eslint-disable-line react/sort-prop-types
+  xlUp?: boolean,
   /**
    * If true, screens this size and down will be hidden.
    */
-  xsDown?: boolean, // eslint-disable-line react/sort-prop-types
+  xsDown?: boolean,
   /**
    * If true, screens this size and down will be hidden.
    */
-  smDown?: boolean, // eslint-disable-line react/sort-prop-types
+  smDown?: boolean,
   /**
    * If true, screens this size and down will be hidden.
    */
-  mdDown?: boolean, // eslint-disable-line react/sort-prop-types
+  mdDown?: boolean,
   /**
    * If true, screens this size and down will be hidden.
    */
-  lgDown?: boolean, // eslint-disable-line react/sort-prop-types
+  lgDown?: boolean,
   /**
    * If true, screens this size and down will be hidden.
    */
-  xlDown?: boolean, // eslint-disable-line react/sort-prop-types
+  xlDown?: boolean,
 };


### PR DESCRIPTION
- Remove ` // eslint-disable-line react/sort-prop-types` comments are no longer enforced
- Remove export of internal type that is also fixing the `PropTypes.any` issue