### PR TITLE
[AppBar] Rendering Children of AppBar before the right icon

### DIFF
--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -320,8 +320,8 @@ class AppBar extends Component {
       >
         {menuElementLeft}
         {titleElement}
-        {menuElementRight}
         {children}
+        {menuElementRight}
       </Paper>
     );
   }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

Currently no tests for the children other than that they render, but happy to add tests for render order if you guys see this as a change that you want to merge?
Description: see #6866 

Happy also to rebase so that the commit messages are according to the projects standards (AFAIK: `[AppBar] changed order of children output`

