### PR TITLE
[Card][CardTitle] Don't pass closeIcon to parent div

### DIFF
--- a/src/Card/CardTitle.js
+++ b/src/Card/CardTitle.js
@@ -36,6 +36,10 @@ class CardTitle extends Component {
      */
     children: PropTypes.node,
     /**
+     * Can be used to pass a closeIcon if you don't like the default expandable close Icon.
+     */
+    closeIcon: PropTypes.node,
+    /**
      * If true, this card component is expandable.
      */
     expandable: PropTypes.bool,
@@ -81,6 +85,7 @@ class CardTitle extends Component {
     const {
       actAsExpander, // eslint-disable-line no-unused-vars
       children,
+      closeIcon, // eslint-disable-line no-unused-vars
       expandable, // eslint-disable-line no-unused-vars
       showExpandableButton, // eslint-disable-line no-unused-vars
       style,


### PR DESCRIPTION
When using the `closeIcon` prop on `CardTitle`, the selected icon is displayed but a warning that the prop is passed to a div is displayed in the console. 

The closeIcon property is used by the parent `Card` element

Fixes #6812

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

