### PR TITLE
[Popover] Fix user can't tap on text input to change cursor location

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -392,6 +392,10 @@ class AutoComplete extends Component {
     this.refs.searchTextField.focus();
   }
 
+  shouldTriggerClickAway = (event) => {
+    return event.target !== this.refs.searchTextField.getInputNode();
+  }
+
   render() {
     const {
       anchorOrigin,
@@ -537,6 +541,7 @@ class AutoComplete extends Component {
           onChange={this.handleChange}
         />
         <Popover
+          shouldTriggerClickAway={this.shouldTriggerClickAway}
           style={Object.assign({}, styles.popover, popoverStyle)}
           canAutoPosition={false}
           anchorOrigin={anchorOrigin}

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -243,11 +243,13 @@ class Popover extends Component {
   }
 
   componentClickAway = (event) => {
+    if (event.type === 'click') {
+      return event.preventDefault();
+    }
     if (this.props.shouldTriggerClickAway && !this.props.shouldTriggerClickAway(event)) {
       return;
     }
 
-    event.preventDefault();
     this.requestClose('clickAway');
   };
 

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -69,6 +69,13 @@ class Popover extends Component {
      */
     open: PropTypes.bool,
     /**
+     * A function that should determine whether the `clickAway` event should be
+     * triggered according to superior logic than what Popover knows.
+     * For e.g, if Popover is used adjacent to some other component, like TextBox,
+     * then clicking on the textbox should not trigger `clickAway`.
+     */
+    shouldTriggerClickAway: PropTypes.func,
+    /**
      * Override the inline-styles of the root element.
      */
     style: PropTypes.object,
@@ -236,10 +243,12 @@ class Popover extends Component {
   }
 
   componentClickAway = (event) => {
-    if (this.props.useLayerForClickAway !== false) {
-      event.preventDefault();
-      this.requestClose('clickAway');
+    if (this.props.shouldTriggerClickAway && !this.props.shouldTriggerClickAway(event)) {
+      return;
     }
+
+    event.preventDefault();
+    this.requestClose('clickAway');
   };
 
   getAnchorPosition(el) {

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -236,8 +236,10 @@ class Popover extends Component {
   }
 
   componentClickAway = (event) => {
-    event.preventDefault();
-    this.requestClose('clickAway');
+    if (this.props.useLayerForClickAway !== false) {
+      event.preventDefault();
+      this.requestClose('clickAway');
+    }
   };
 
   getAnchorPosition(el) {


### PR DESCRIPTION
should not call clickAway if useLayerForClickAway is false

fixes #6888 

see issue for more details

- [x] PR has tests / docs demo, and is linted. - no tests
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

