### PR TITLE
[Dialog] disambiguation of types to match the spec

### DIFF
--- a/docs/src/pages/component-demos/dialogs/AlertDialog.js
+++ b/docs/src/pages/component-demos/dialogs/AlertDialog.js
@@ -2,7 +2,8 @@
 
 import React, { Component } from 'react';
 import Button from 'material-ui/Button';
-import Dialog, {
+import {
+  Alert,
   DialogActions,
   DialogContent,
   DialogContentText,
@@ -22,7 +23,7 @@ export default class AlertDialog extends Component {
         <Button onClick={() => this.setState({ open: true })}>
           Open alert dialog
         </Button>
-        <Dialog
+        <Alert
           open={this.state.open}
           onRequestClose={this.handleRequestClose}
         >
@@ -38,7 +39,7 @@ export default class AlertDialog extends Component {
             <Button onClick={this.handleRequestClose} primary>Disagree</Button>
             <Button onClick={this.handleRequestClose} primary>Agree</Button>
           </DialogActions>
-        </Dialog>
+        </Alert>
       </div>
     );
   }

--- a/docs/src/pages/component-demos/dialogs/AlertDialogSlide.js
+++ b/docs/src/pages/component-demos/dialogs/AlertDialogSlide.js
@@ -2,7 +2,8 @@
 
 import React, { Component } from 'react';
 import Button from 'material-ui/Button';
-import Dialog, {
+import {
+  Alert,
   DialogActions,
   DialogContent,
   DialogContentText,
@@ -23,7 +24,7 @@ export default class AlertDialogSlide extends Component {
         <Button onClick={() => this.setState({ open: true })}>
           Slide in alert dialog
         </Button>
-        <Dialog
+        <Alert
           open={this.state.open}
           transition={Slide}
           onRequestClose={this.handleRequestClose}
@@ -40,7 +41,7 @@ export default class AlertDialogSlide extends Component {
             <Button onClick={this.handleRequestClose} primary>Disagree</Button>
             <Button onClick={this.handleRequestClose} primary>Agree</Button>
           </DialogActions>
-        </Dialog>
+        </Alert>
       </div>
     );
   }

--- a/docs/src/pages/component-demos/dialogs/ConfirmationDialog.js
+++ b/docs/src/pages/component-demos/dialogs/ConfirmationDialog.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Button from 'material-ui/Button';
 import List, { ListItem, ListItemText } from 'material-ui/List';
-import Dialog, { DialogActions, DialogContent, DialogTitle } from 'material-ui/Dialog';
+import { Confirmation, DialogActions, DialogContent, DialogTitle } from 'material-ui/Dialog';
 import { LabelRadio as Radio, RadioGroup } from 'material-ui/Radio';
 
 const options = [
@@ -73,7 +73,7 @@ class ConfirmationDialog extends Component {
     } = this.props;
 
     return (
-      <Dialog onEntering={this.handleEntering} {...other}>
+      <Confirmation onEntering={this.handleEntering} {...other}>
         <DialogTitle>Phone Ringtone</DialogTitle>
         <DialogContent>
           <RadioGroup
@@ -96,7 +96,7 @@ class ConfirmationDialog extends Component {
           <Button onClick={this.handleCancel} primary>Cancel</Button>
           <Button onClick={this.handleOk} primary>Ok</Button>
         </DialogActions>
-      </Dialog>
+      </Confirmation>
     );
   }
 }

--- a/docs/src/pages/component-demos/dialogs/SimpleDialog.js
+++ b/docs/src/pages/component-demos/dialogs/SimpleDialog.js
@@ -1,0 +1,120 @@
+// @flow weak
+/* eslint-disable react/no-multi-comp */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { createStyleSheet, withStyles } from 'material-ui/styles';
+import Button from 'material-ui/Button';
+import Avatar from 'material-ui/Avatar';
+import List, { ListItem, ListItemAvatar, ListItemText } from 'material-ui/List';
+import Dialog, { DialogTitle } from 'material-ui/Dialog';
+import PersonIcon from 'material-ui-icons/Person';
+import AddIcon from 'material-ui-icons/Add';
+import Typography from 'material-ui/Typography';
+
+const emails = [
+  'username@gmail.com',
+  'user02@gmail.com',
+];
+
+class SimpleDialog extends Component {
+  static propTypes = {
+    onRequestClose: PropTypes.func,
+    selectedValue: PropTypes.string,
+  };
+
+  handleRequestClose = () => {
+    this.props.onRequestClose(this.props.selectedValue);
+  };
+
+  handleListItemClick = (value) => {
+    this.props.onRequestClose(value);
+  };
+
+  render() {
+    const {
+      onRequestClose, // eslint-disable-line no-unused-vars
+      selectedValue,  // eslint-disable-line no-unused-vars
+      ...other
+    } = this.props;
+
+    return (
+      <Dialog onRequestClose={this.handleRequestClose} {...other}>
+        <DialogTitle>Set backup account</DialogTitle>
+        <div>
+          <List>
+            {emails.map((email) => (
+              <ListItem
+                button
+                onClick={() => this.handleListItemClick(email)}
+                key={email}
+              >
+                <ListItemAvatar>
+                  <Avatar>
+                    <PersonIcon />
+                  </Avatar>
+                </ListItemAvatar>
+                <ListItemText primary={email} />
+              </ListItem>
+            ))}
+            <ListItem
+              button
+              onClick={() => this.handleListItemClick('addAccount')}
+            >
+              <ListItemAvatar>
+                <Avatar>
+                  <AddIcon />
+                </Avatar>
+              </ListItemAvatar>
+              <ListItemText primary="add account" />
+            </ListItem>
+          </List>
+        </div>
+      </Dialog>
+    );
+  }
+}
+
+const styleSheet = createStyleSheet('SimpleDialogDemo', () => ({
+  typography: {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    padding: 5,
+  },
+}));
+
+class SimpleDialogDemo extends Component {
+  state = {
+    open: false,
+    selectedValue: emails[1],
+  };
+
+  handleRequestClose = (value) => {
+    this.setState({ selectedValue: value, open: false });
+  };
+
+  render() {
+    return (
+      <div>
+        <Button onClick={() => this.setState({ open: true })}>
+          Open simple dialog
+        </Button>
+        <SimpleDialog
+          selectedValue={this.state.selectedValue}
+          open={this.state.open}
+          onRequestClose={this.handleRequestClose}
+        />
+        <Typography type="subheading" className={this.props.classes.typography}>
+          Selected: {this.state.selectedValue}
+        </Typography>
+      </div>
+    );
+  }
+}
+
+SimpleDialogDemo.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(SimpleDialogDemo);

--- a/docs/src/pages/component-demos/dialogs/dialogs.md
+++ b/docs/src/pages/component-demos/dialogs/dialogs.md
@@ -10,6 +10,16 @@ Dialogs contain text and UI controls.
 They retain focus until dismissed or a required action has been taken.
 Use dialogs sparingly because they are interruptive.
 
+## Simple Dialogs
+
+Simple dialogs can provide additional details or actions about a list item. For example, they can display avatars, icons, clarifying subtext, or orthogonal actions (such as adding an account).
+
+Touch mechanics:
+- Choosing an option immediately commits the option and closes the menu
+- Touching outside of the dialog, or pressing Back, cancels the action and closes the dialog
+
+{{demo='pages/component-demos/dialogs/SimpleDialog.js'}}
+
 ## Alerts
 
 Alerts are urgent interruptions, requiring acknowledgement, that inform the user about a situation.

--- a/src/Dialog/Alert.js
+++ b/src/Dialog/Alert.js
@@ -1,0 +1,15 @@
+// @flow
+
+import defaultProps from 'recompose/defaultProps';
+import Dialog from './Dialog';
+
+/**
+ * Alerts are urgent interruptions, requiring acknowledgement, that inform the user
+ * about a situation.
+ */
+const Alert = defaultProps({
+  ignoreBackdropClick: true,
+  ignoreEscapeKeyUp: true,
+})(Dialog);
+
+export default Alert;

--- a/src/Dialog/Confirmation.js
+++ b/src/Dialog/Confirmation.js
@@ -1,0 +1,15 @@
+// @flow
+
+import defaultProps from 'recompose/defaultProps';
+import Dialog from './Dialog';
+
+/**
+ * Confirmation dialogs require users to explicitly confirm their choice
+ * before an option is committed.
+ */
+const Confirmation = defaultProps({
+  ignoreBackdropClick: true,
+  ignoreEscapeKeyUp: true,
+})(Dialog);
+
+export default Confirmation;

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -20,7 +20,6 @@ export const styleSheet = createStyleSheet('MuiDialog', (theme) => {
       flexDirection: 'column',
       flex: '0 1 auto',
       position: 'relative',
-      width: '75%',
       maxHeight: '90vh',
       '&:focus': {
         outline: 'none',

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -1,5 +1,7 @@
 // @flow
 export { default } from './Dialog';
+export { default as Alert } from './Alert';
+export { default as Confirmation } from './Alert';
 export { default as DialogActions } from './DialogActions';
 export { default as DialogTitle } from './DialogTitle';
 export { default as DialogContent } from './DialogContent';


### PR DESCRIPTION
a.k.a  alert vs confirmation vs simple

This is an early look at what I'm thinking for more concrete types that match the [material ui spec dialogs](https://material.io/guidelines/components/dialogs.html#).  While you can use `Dialog` as-is with props, I think it makes sense to expose named components with behavior that matches the spec.

What do you think?

(Branched from and depends on #6898.  I didn't think about it but all those changes are currently showing too which makes the diff harder.  I'm guessing the diff will shrink with merge of #6898)

## Changes
- width specified in `Dialog` is too prescriptive for general use.  The `SimpleDialog` demo was rendering very wide
- Added `Alert` and `Confirmation`
- Updated demos
- Added "Simple Dialog" section and demo

## Todo/Problems/Questions
- Docs don't generate for `Alert` and `Confirmation`.  Is this style of declaration desirable or something else.  If desirable, I can look at fixing doc gen.
- Naming - as discussed on gitter - I'd like to do the dialog rename in this.  Do you or don't you support shorter names for ?

---
- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

