### PR TITLE
[AutoComplete] Fix ghost clicks on new requests

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -266,6 +266,9 @@ class AutoComplete extends Component {
   };
 
   handleItemTouchTap = (event, child) => {
+    // Prevent ghost clicks
+    event.preventDefault();
+
     const dataSource = this.props.dataSource;
     const index = parseInt(child.key, 10);
     const chosenRequest = dataSource[index];


### PR DESCRIPTION
Fixes ghost clicks happening when touch tapping `AutoComplete`'s menu items on iOS touch devices.

The ghost clicks could lead to unexpected navigation with items underneath the `AutoComplete`'s menu items

