### PR TITLE
[AutoComplete] fixing a typo in docs - "reseted" -> "reset"

### DIFF
--- a/docs/src/app/components/pages/components/AutoComplete/ExampleControlled.js
+++ b/docs/src/app/components/pages/components/AutoComplete/ExampleControlled.js
@@ -15,7 +15,7 @@ const colors = [
 /**
  * `AutoComplete` search text can be implemented as a controlled value,
  * where `searchText` is handled by state in the parent component.
- * That value is reseted with the `onNewRequest` callback.
+ * That value is reset with the `onNewRequest` callback.
  */
 export default class AutoCompleteExampleControlled extends Component {
   state = {

--- a/docs/src/app/components/pages/components/AutoComplete/ExampleControlled.js
+++ b/docs/src/app/components/pages/components/AutoComplete/ExampleControlled.js
@@ -15,7 +15,7 @@ const colors = [
 /**
  * `AutoComplete` search text can be implemented as a controlled value,
  * where `searchText` is handled by state in the parent component.
- * That value is reset with the `onNewRequest` callback.
+ * This value is reset with the `onNewRequest` callback.
  */
 export default class AutoCompleteExampleControlled extends Component {
   state = {


### PR DESCRIPTION
[AutoComplete] - just a small PR to fix a typo in documentation.

