### PR TITLE
[Input] Fix the color used

### DIFF
--- a/docs/src/pages/component-demos/tables/EnhancedTable.js
+++ b/docs/src/pages/component-demos/tables/EnhancedTable.js
@@ -85,11 +85,11 @@ const toolbarStyleSheet = createStyleSheet('EnhancedTableToolbar', (theme) => ({
   },
   highlight: (
     theme.palette.type === 'light' ? {
-      color: theme.palette.accent[800],
-      backgroundColor: theme.palette.accent[50],
+      color: theme.palette.accent.A700,
+      backgroundColor: theme.palette.accent.A100,
     } : {
-      color: theme.palette.accent[50],
-      backgroundColor: theme.palette.accent[800],
+      color: theme.palette.accent.A100,
+      backgroundColor: theme.palette.accent.A700,
     }
   ),
   spacer: {

--- a/src/Form/FormLabel.js
+++ b/src/Form/FormLabel.js
@@ -8,7 +8,7 @@ import { createStyleSheet } from 'jss-theme-reactor';
 import withStyles from '../styles/withStyles';
 
 export const styleSheet = createStyleSheet('MuiFormLabel', (theme) => {
-  const focusColor = theme.palette.primary.A200;
+  const focusColor = theme.palette.primary[500];
   return {
     root: {
       fontFamily: theme.typography.fontFamily,

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -24,7 +24,7 @@ export const styleSheet = createStyleSheet('MuiInput', (theme) => ({
   },
   inkbar: {
     '&:after': {
-      backgroundColor: theme.palette.primary.A200,
+      backgroundColor: theme.palette.primary[500],
       left: 0,
       bottom: -2,
       // Doing the other way around crash on IE11 "''" https://github.com/cssinjs/jss/issues/242

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -110,40 +110,6 @@ class Tabs extends Component {
     this.updateScrollButtonState();
   }, 100);
 
-  getClassGroups = () => {
-    const {
-      centered,
-      classes,
-      className: classNameProp,
-      scrollable,
-    } = this.props;
-    const classGroups = {};
-
-    classGroups.flexContainer = classNames(
-      classes.flexContainer,
-    );
-
-    classGroups.root = classNames(
-      classes.root,
-      classNameProp,
-    );
-
-    classGroups.scroller = classNames(
-      classes.scrollingContainer,
-      {
-        [classes.fixed]: !scrollable,
-        [classes.scrollable]: scrollable,
-      },
-    );
-
-    classGroups.tabItemContainer = classNames(
-      classes.flexContainer,
-      { [classes.centered]: centered && !scrollable },
-    );
-
-    return classGroups;
-  }
-
   getConditionalElements = () => {
     const {
       buttonClassName,
@@ -251,23 +217,34 @@ class Tabs extends Component {
   render() {
     const {
       buttonClassName, // eslint-disable-line no-unused-vars
-      centered, // eslint-disable-line no-unused-vars
-      classes, // eslint-disable-line no-unused-vars
+      centered,
+      classes,
       children: childrenProp,
-      className: classNameProp, // eslint-disable-line no-unused-vars
+      className: classNameProp,
       fullWidth,
       index,
       indicatorClassName,
       indicatorColor,
       onChange,
-      scrollable, // eslint-disable-line no-unused-vars
+      scrollable,
       scrollButtons, // eslint-disable-line no-unused-vars
       textColor,
       width, // eslint-disable-line no-unused-vars
       ...other
     } = this.props;
 
-    const classGroups = this.getClassGroups();
+    const className = classNames(classes.root, classNameProp);
+    const scrollerClassName = classNames(
+      classes.scrollingContainer,
+      {
+        [classes.fixed]: !scrollable,
+        [classes.scrollable]: scrollable,
+      },
+    );
+    const tabItemContainerClassName = classNames(
+      classes.flexContainer,
+      { [classes.centered]: centered && !scrollable },
+    );
 
     const children = Children.map(childrenProp, (tab, childIndex) => {
       return cloneElement(tab, {
@@ -282,19 +259,19 @@ class Tabs extends Component {
     const conditionalElements = this.getConditionalElements();
 
     return (
-      <div className={classGroups.root} {...other}>
+      <div className={className} {...other}>
         <EventListener target="window" onResize={this.handleResize} />
         {conditionalElements.scrollbarSizeListener}
-        <div className={classGroups.flexContainer}>
+        <div className={classes.flexContainer}>
           {conditionalElements.scrollButtonLeft}
           <div
-            className={classGroups.scroller}
+            className={scrollerClassName}
             style={this.state.scrollerStyle}
             ref={(node) => { this.tabs = node; }}
             role="tablist"
             onScroll={this.handleTabsScroll}
           >
-            <div className={classGroups.tabItemContainer}>
+            <div className={tabItemContainerClassName}>
               {children}
             </div>
             <TabIndicator


### PR DESCRIPTION
Following the Theme section of the documentation, the `A` colors are only supposed
to be used with the `accent` color, not the `primary` one.

This is a continuation of #6532. You can have a look at Argos to see the diff.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

