### PR TITLE
[core] Remove usage of 'not-allowed'

### DIFF
--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -79,7 +79,6 @@ export const styleSheet = createStyleSheet('MuiInput', (theme) => ({
   },
   disabled: {
     color: theme.palette.text.disabled,
-    cursor: 'not-allowed',
   },
   underline: {
     borderBottom: `1px solid ${theme.palette.text.divider}`,

--- a/src/internal/ButtonBase.js
+++ b/src/internal/ButtonBase.js
@@ -22,7 +22,7 @@ export const styleSheet = createStyleSheet('MuiButtonBase', {
     textDecoration: 'none',
   },
   disabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
 });
 

--- a/src/internal/withSwitchLabel.js
+++ b/src/internal/withSwitchLabel.js
@@ -24,7 +24,7 @@ export const styleSheet = createStyleSheet('MuiSwitchLabel', (theme) => ({
   },
   disabled: {
     color: theme.palette.text.disabled,
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
 }));
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Continue #6700 PR of @demigor. As [raised by](https://github.com/twbs/bootstrap/issues/22222) the Bootstrap maintainers, button nor input have the disabled cursor [natively](https://www.w3schools.com/tags/att_button_disabled.asp). This change is making Material-UI less opinionated.