### PR TITLE
[eslint] enable flow's built-in types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -95,11 +95,13 @@ module.exports = {
     'mocha/no-pending-tests': 'error',
     'mocha/no-skipped-tests': 'error',
 
+    'flowtype/define-flow-type': 'error',
     'flowtype/require-valid-file-annotation': ['error', 'always'],
     'flowtype/require-parameter-type': 'off',
     'flowtype/require-return-type': 'off',
     'flowtype/space-after-type-colon': 'off',
     'flowtype/space-before-type-colon': 'off',
     'flowtype/type-id-match': 'off',
+    'flowtype/use-flow-type': 'error',
   },
 };

--- a/src/internal/Modal.js
+++ b/src/internal/Modal.js
@@ -246,8 +246,8 @@ class Modal extends Component<DefaultProps, Props, State> {
 
   handleHide() {
     this.props.modalManager.remove(this);
-    this.onDocumentKeyUpListener && this.onDocumentKeyUpListener.remove();
-    this.onFocusListener && this.onFocusListener.remove();
+    if (this.onDocumentKeyUpListener) this.onDocumentKeyUpListener.remove();
+    if (this.onFocusListener) this.onFocusListener.remove();
     this.restoreLastFocus();
   }
 

--- a/src/internal/Modal.js
+++ b/src/internal/Modal.js
@@ -1,4 +1,4 @@
-// @flow weak
+// @flow
 
 import React, { Element, Component } from 'react';
 import ReactDOM from 'react-dom';
@@ -246,8 +246,8 @@ class Modal extends Component<DefaultProps, Props, State> {
 
   handleHide() {
     this.props.modalManager.remove(this);
-    this.onDocumentKeyUpListener.remove();
-    this.onFocusListener.remove();
+    this.onDocumentKeyUpListener && this.onDocumentKeyUpListener.remove();
+    this.onFocusListener && this.onFocusListener.remove();
     this.restoreLastFocus();
   }
 
@@ -264,7 +264,7 @@ class Modal extends Component<DefaultProps, Props, State> {
     }
   };
 
-  handleDocumentKeyUp = event => {
+  handleDocumentKeyUp = (event: Event) => {
     if (!this.mounted || !this.props.modalManager.isTopModal(this)) {
       return;
     }
@@ -282,7 +282,7 @@ class Modal extends Component<DefaultProps, Props, State> {
     }
   };
 
-  handleBackdropClick = event => {
+  handleBackdropClick = (event: Event) => {
     if (event.target !== event.currentTarget) {
       return;
     }

--- a/src/utils/addEventListener.js
+++ b/src/utils/addEventListener.js
@@ -1,13 +1,13 @@
-// @flow weak
+// @flow
 
 import addEventListener from 'dom-helpers/events/on';
 import removeEventListener from 'dom-helpers/events/off';
 
-export default function(node, event, handler, options) {
-  addEventListener(node, event, handler, options);
+export default function(node: Node, event: string, handler: EventHandler, capture?: boolean) {
+  addEventListener(node, event, handler, capture);
   return {
     remove() {
-      removeEventListener(node, event, handler, options);
+      removeEventListener(node, event, handler, capture);
     },
   };
 }


### PR DESCRIPTION
I was having a problem with eslint failing to see Flow's built-in types, which prevented further typing efforts.  This fixes the problem and adds a few more types.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

