### PR TITLE
[Input] Improve support of the date/time fields

### DIFF
--- a/docs/src/pages/component-demos/text-fields/TextFields.js
+++ b/docs/src/pages/component-demos/text-fields/TextFields.js
@@ -12,6 +12,7 @@ const styleSheet = createStyleSheet('TextFields', theme => ({
   },
   input: {
     margin: theme.spacing.unit,
+    width: 200,
   },
 }));
 
@@ -67,6 +68,13 @@ class TextFields extends Component {
           multiline
           rows="4"
           defaultValue="Default Value"
+          className={classes.input}
+        />
+        <TextField
+          id="date"
+          label="From date"
+          type="date"
+          defaultValue="2017-05-24"
           className={classes.input}
         />
       </div>

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -54,6 +54,7 @@ export const styleSheet = createStyleSheet('MuiInput', theme => ({
     padding: '6px 0',
     border: 0,
     display: 'block',
+    boxSizing: 'content-box',
     verticalAlign: 'middle',
     whiteSpace: 'normal',
     background: 'none',
@@ -69,6 +70,7 @@ export const styleSheet = createStyleSheet('MuiInput', theme => ({
     },
   },
   singleline: {
+    height: '1em',
     appearance: 'textfield', // Improve type search style.
   },
   multiline: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Fixing #6879 has proven to be harder than expected. Only Chrome add some placeholder values.
We could change the `isDirty` in order to take that into account. But how do we reliably know that placeholder are going to be displayed? It's even harder to solve that problem with server side rendering consideration. So, I think that the best fix is, don't use empty values.
