### PR TITLE
[FormControl] Fix onFocus and onBlur events override

### DIFF
--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -53,11 +53,17 @@ class FormControl extends Component {
     if (!this.state.focused) {
       this.setState({ focused: true });
     }
+    if (this.props.onFocus) {
+      this.props.onFocus();
+    }
   };
 
   handleBlur = () => {
     if (this.state.focused) {
       this.setState({ focused: false });
+    }
+    if (this.props.onBlur) {
+      this.props.onBlur();
     }
   };
 
@@ -84,10 +90,10 @@ class FormControl extends Component {
 
     return (
       <div
-        onFocus={this.handleFocus}
-        onBlur={this.handleBlur}
         className={classNames(classes.root, className)}
         {...other}
+        onFocus={this.handleFocus}
+        onBlur={this.handleBlur}
       >
         {children}
       </div>
@@ -112,6 +118,14 @@ FormControl.propTypes = {
    * If `true`, the label should be displayed in an error state.
    */
   error: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  onBlur: PropTypes.func,
+  /**
+   * @ignore
+   */
+  onFocus: PropTypes.func,
   /**
    * If `true`, the label will indicate that the input is required.
    */

--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -50,20 +50,20 @@ class FormControl extends Component {
   }
 
   handleFocus = () => {
-    if (!this.state.focused) {
-      this.setState({ focused: true });
-    }
     if (this.props.onFocus) {
       this.props.onFocus();
+    }
+    if (!this.state.focused) {
+      this.setState({ focused: true });
     }
   };
 
   handleBlur = () => {
-    if (this.state.focused) {
-      this.setState({ focused: false });
-    }
     if (this.props.onBlur) {
       this.props.onBlur();
+    }
+    if (this.state.focused) {
+      this.setState({ focused: false });
     }
   };
 


### PR DESCRIPTION
handleFocus and handleBlur will always executed (and so set correctly the focused-state), calls custom onFocus or onBlur, if they exists in props.

fixes #6940

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

