### PR TITLE
[Switch] Add inputProps property link in the TextField

### DIFF
--- a/docs/src/pages/component-api/Checkbox/Checkbox.md
+++ b/docs/src/pages/component-api/Checkbox/Checkbox.md
@@ -12,6 +12,7 @@
 | disabled | bool |  | If `true`, the switch will be disabled. |
 | disabledClassName | string |  | The CSS class name of the root element when disabled. |
 | icon | node |  | The icon to display when the component is unchecked. If a string is provided, it will be used as a font ligature. |
+| inputProps | object |  | Properties applied to the `input` element. |
 | name | string |  |  |
 | onChange | function |  | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* `change` event<br>*checked:* The `checked` value of the switch |
 | ripple | bool |  | If `false`, the ripple effect will be disabled. |

--- a/docs/src/pages/component-api/Radio/Radio.md
+++ b/docs/src/pages/component-api/Radio/Radio.md
@@ -11,7 +11,8 @@
 | classes | object |  | Useful to extend the style applied to components. |
 | disabled | bool |  | If `true`, the component disabled. |
 | disabledClassName | string |  | The CSS class name of the root element when disabled. |
-| icon | node |  | The icon to display when the component is unselected. |
+| icon | node |  | The icon to display when the component is unselected. If a string is provided, it will be used as a font ligature. |
+| inputProps | object |  | Properties applied to the `input` element. |
 | name | string |  |  |
 | onChange | function |  | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* `change` event<br>*checked:* The `checked` value of the switch |
 | ripple | bool |  | If `false`, the ripple effect will be disabled. |

--- a/docs/src/pages/component-api/Switch/Switch.md
+++ b/docs/src/pages/component-api/Switch/Switch.md
@@ -11,7 +11,8 @@
 | classes | object |  | Useful to extend the style applied to components. |
 | disabled | bool |  | If `true`, the switch will be disabled. |
 | disabledClassName | string |  | The CSS class name of the root element when disabled. |
-| icon | node |  | The icon to display when the component is unchecked. |
+| icon | node |  | The icon to display when the component is unchecked. If a string is provided, it will be used as a font ligature. |
+| inputProps | object |  | Properties applied to the `input` element. |
 | name | string |  |  |
 | onChange | function |  | Callback fired when the  is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* `change` event<br>*checked:* The `checked` value of the switch |
 | ripple | bool |  | If `false`, the ripple effect will be disabled. |

--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -68,6 +68,10 @@ CheckboxDocs.propTypes = {
    * If a string is provided, it will be used as a font ligature.
    */
   icon: PropTypes.node,
+  /**
+   * Properties applied to the `input` element.
+   */
+  inputProps: PropTypes.object,
   /*
    * @ignore
    */

--- a/src/Radio/Radio.js
+++ b/src/Radio/Radio.js
@@ -72,8 +72,13 @@ RadioDocs.propTypes = {
   disabledClassName: PropTypes.string,
   /**
    * The icon to display when the component is unselected.
+   * If a string is provided, it will be used as a font ligature.
    */
   icon: PropTypes.node,
+  /**
+   * Properties applied to the `input` element.
+   */
+  inputProps: PropTypes.object,
   /*
    * @ignore
    */

--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -109,8 +109,13 @@ Switch.propTypes = {
   disabledClassName: PropTypes.string,
   /**
    * The icon to display when the component is unchecked.
+   * If a string is provided, it will be used as a font ligature.
    */
   icon: PropTypes.node,
+  /**
+   * Properties applied to the `input` element.
+   */
+  inputProps: PropTypes.object,
   /*
    * @ignore
    */

--- a/src/internal/SwitchBase.js
+++ b/src/internal/SwitchBase.js
@@ -93,6 +93,7 @@ export default function createSwitch(
         disabled,
         disabledClassName,
         icon: iconProp,
+        inputProps,
         name,
         onChange, // eslint-disable-line no-unused-vars
         tabIndex,
@@ -143,6 +144,7 @@ export default function createSwitch(
             disabled={disabled}
             tabIndex={tabIndex}
             value={value}
+            {...inputProps}
           />
         </IconButton>
       );
@@ -188,8 +190,13 @@ export default function createSwitch(
     disableRipple: PropTypes.bool,
     /**
      * The icon to display when the component is unchecked.
+     * If a string is provided, it will be used as a font ligature.
      */
     icon: PropTypes.node,
+    /**
+     * Properties applied to the `input` element.
+     */
+    inputProps: PropTypes.object,
     /*
      * @ignore
      */

--- a/src/internal/SwitchBase.spec.js
+++ b/src/internal/SwitchBase.spec.js
@@ -303,5 +303,12 @@ describe('<SwitchBase />', () => {
         assert.strictEqual(wrapper.state('checked'), !checkedMock);
       });
     });
+
+    describe('prop: inputProps', () => {
+      it('should be able to add aria', () => {
+        const wrapper2 = shallow(<SwitchBase inputProps={{ 'aria-label': 'foo' }} />);
+        assert.strictEqual(wrapper2.find('input').props()['aria-label'], 'foo');
+      });
+    });
   });
 });


### PR DESCRIPTION
Closes #6951 so people can add aria properties to the underlying input or whatever else.
This solution follows what we already have with the `TextField`/`Input` components.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

