### PR TITLE
[docs] Grid docs should refer to Hidden component/demo

### DIFF
--- a/docs/src/pages/component-api/Grid/Grid.md
+++ b/docs/src/pages/component-api/Grid/Grid.md
@@ -13,7 +13,7 @@
 | align | union:&nbsp;'flex-start'<br>&nbsp;'center'<br>&nbsp;'flex-end'<br>&nbsp;'stretch'<br> | 'stretch' | Defines the `align-items` style property. It's applied for all screen sizes. |
 | direction | union:&nbsp;'row'<br>&nbsp;'row-reverse'<br>&nbsp;'column'<br>&nbsp;'column-reverse'<br> | 'row' | Defines the `flex-direction` style property. It is applied for all screen sizes. |
 | gutter | union:&nbsp;0, 8, 16, 24, 40<br> | 16 | Defines the space between the type `item` component. It can only be used on a type `container` component. |
-| hidden | [HiddenProps](/layout/hidden) | undefined | If provided, will wrap with [Hidden](component-api/Hidden) component and given properties. |
+| hidden | [HiddenProps](/layout/hidden) | undefined | If provided, will wrap with [Hidden](/component-api/Hidden) component and given properties. |
 | justify | union:&nbsp;'flex-start', 'center', 'flex-end', 'space-between', 'space-around'<br> | 'flex-start' | Defines the `justify-content` style property. It is applied for all screen sizes. |
 | wrap | union:&nbsp;'nowrap'<br>&nbsp;'wrap'<br>&nbsp;'wrap-reverse'<br> | 'wrap' | Defines the `flex-wrap` style property. It's applied for all screen sizes. |
 | xs | union:&nbsp;boolean, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12<br> |  | Defines the number of grids the component is going to use. It's applied for all the screen sizes with the lowest priority. |

--- a/docs/src/pages/component-api/Grid/Grid.md
+++ b/docs/src/pages/component-api/Grid/Grid.md
@@ -13,7 +13,7 @@
 | align | union:&nbsp;'flex-start'<br>&nbsp;'center'<br>&nbsp;'flex-end'<br>&nbsp;'stretch'<br> | 'stretch' | Defines the `align-items` style property. It's applied for all screen sizes. |
 | direction | union:&nbsp;'row'<br>&nbsp;'row-reverse'<br>&nbsp;'column'<br>&nbsp;'column-reverse'<br> | 'row' | Defines the `flex-direction` style property. It is applied for all screen sizes. |
 | gutter | union:&nbsp;0, 8, 16, 24, 40<br> | 16 | Defines the space between the type `item` component. It can only be used on a type `container` component. |
-| hidden | HiddenProps | undefined | If provided, will wrap with Hidden component and given properties. |
+| hidden | [HiddenProps](/layout/hidden) | undefined | If provided, will wrap with [Hidden](component-api/Hidden) component and given properties. |
 | justify | union:&nbsp;'flex-start', 'center', 'flex-end', 'space-between', 'space-around'<br> | 'flex-start' | Defines the `justify-content` style property. It is applied for all screen sizes. |
 | wrap | union:&nbsp;'nowrap'<br>&nbsp;'wrap'<br>&nbsp;'wrap-reverse'<br> | 'wrap' | Defines the `flex-wrap` style property. It's applied for all screen sizes. |
 | xs | union:&nbsp;boolean, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12<br> |  | Defines the number of grids the component is going to use. It's applied for all the screen sizes with the lowest priority. |

--- a/docs/src/pages/component-api/Menu/MenuList.md
+++ b/docs/src/pages/component-api/Menu/MenuList.md
@@ -8,15 +8,4 @@
 | children | node |  | MenuList contents, normally `MenuItem`s. |
 
 Any other properties supplied will be spread to the root element.
-## Classes
 
-You can overrides all the class names injected by Material-UI thanks to the `classes` property.
-This property accepts the following keys:
-
-
-Have a look at [overriding with class names](/customization/overrides#overriding-with-class-names)
-section for more detail.
-
-If using the `overrides` key of the theme as documented
-[here](/customization/themes#customizing-all-instances-of-a-component-type),
-you need to use the following style sheet name: `null`.

--- a/docs/src/pages/component-api/TextField/TextField.md
+++ b/docs/src/pages/component-api/TextField/TextField.md
@@ -25,15 +25,4 @@
 | value | union:&nbsp;string<br>&nbsp;number<br> |  | The value of the `Input` element, required for a controlled component. |
 
 Any other properties supplied will be spread to the root element.
-## Classes
 
-You can overrides all the class names injected by Material-UI thanks to the `classes` property.
-This property accepts the following keys:
-
-
-Have a look at [overriding with class names](/customization/overrides#overriding-with-class-names)
-section for more detail.
-
-If using the `overrides` key of the theme as documented
-[here](/customization/themes#customizing-all-instances-of-a-component-type),
-you need to use the following style sheet name: `null`.

--- a/docs/src/pages/component-api/styles/MuiThemeProvider.md
+++ b/docs/src/pages/component-api/styles/MuiThemeProvider.md
@@ -10,15 +10,4 @@
 | theme | object |  |  |
 
 Any other properties supplied will be spread to the root element.
-## Classes
 
-You can overrides all the class names injected by Material-UI thanks to the `classes` property.
-This property accepts the following keys:
-
-
-Have a look at [overriding with class names](/customization/overrides#overriding-with-class-names)
-section for more detail.
-
-If using the `overrides` key of the theme as documented
-[here](/customization/themes#customizing-all-instances-of-a-component-type),
-you need to use the following style sheet name: `null`.

--- a/docs/src/pages/component-api/transitions/Fade.md
+++ b/docs/src/pages/component-api/transitions/Fade.md
@@ -17,15 +17,4 @@
 | onExited | Function |  | Callback fired when the component has exited. |
 
 Any other properties supplied will be spread to the root element.
-## Classes
 
-You can overrides all the class names injected by Material-UI thanks to the `classes` property.
-This property accepts the following keys:
-
-
-Have a look at [overriding with class names](/customization/overrides#overriding-with-class-names)
-section for more detail.
-
-If using the `overrides` key of the theme as documented
-[here](/customization/themes#customizing-all-instances-of-a-component-type),
-you need to use the following style sheet name: `null`.

--- a/docs/src/pages/component-api/transitions/Slide.md
+++ b/docs/src/pages/component-api/transitions/Slide.md
@@ -19,15 +19,4 @@
 | onExited | function |  | Callback fired when the component has exited. |
 
 Any other properties supplied will be spread to the root element.
-## Classes
 
-You can overrides all the class names injected by Material-UI thanks to the `classes` property.
-This property accepts the following keys:
-
-
-Have a look at [overriding with class names](/customization/overrides#overriding-with-class-names)
-section for more detail.
-
-If using the `overrides` key of the theme as documented
-[here](/customization/themes#customizing-all-instances-of-a-component-type),
-you need to use the following style sheet name: `null`.

--- a/scripts/generate-docs-markdown.js
+++ b/scripts/generate-docs-markdown.js
@@ -41,11 +41,11 @@ function generatePropDescription(required, description, type) {
 
   // two new lines result in a newline in the table. all other new lines
   // must be eliminated to prevent markdown mayhem.
-  let jsDocText = parsed.description.replace(/\n\n/g, '<br>').replace(/\n/g, ' ').replace(/\r/g, '')
+  let jsDocText = parsed.description.replace(/\n\n/g, '<br>').replace(/\n/g, ' ').replace(/\r/g, '');
 
   // convert bracketed component references into component API links
   // eg: [MenuItem component] will link to the component API for MenuItem
-  jsDocText = jsDocText.replace(/\[(\w+)\scomponent\]/g, `[$1](component-api/$1) component`);
+  jsDocText = jsDocText.replace(/\[(\w+)\scomponent\]/g, '[$1](component-api/$1) component');
 
   if (parsed.tags.some(tag => tag.title === 'ignore')) return null;
   let signature = '';

--- a/scripts/generate-docs-markdown.js
+++ b/scripts/generate-docs-markdown.js
@@ -41,11 +41,10 @@ function generatePropDescription(required, description, type) {
 
   // two new lines result in a newline in the table. all other new lines
   // must be eliminated to prevent markdown mayhem.
-  let jsDocText = parsed.description.replace(/\n\n/g, '<br>').replace(/\n/g, ' ').replace(/\r/g, '');
-
-  // convert bracketed component references into component API links
-  // eg: [MenuItem component] will link to the component API for MenuItem
-  jsDocText = jsDocText.replace(/\[(\w+)\scomponent\]/g, '[$1](component-api/$1) component');
+  const jsDocText = parsed.description
+    .replace(/\n\n/g, '<br>')
+    .replace(/\n/g, ' ')
+    .replace(/\r/g, '');
 
   if (parsed.tags.some(tag => tag.title === 'ignore')) return null;
   let signature = '';

--- a/scripts/generate-docs-markdown.js
+++ b/scripts/generate-docs-markdown.js
@@ -41,7 +41,11 @@ function generatePropDescription(required, description, type) {
 
   // two new lines result in a newline in the table. all other new lines
   // must be eliminated to prevent markdown mayhem.
-  const jsDocText = parsed.description.replace(/\n\n/g, '<br>').replace(/\n/g, ' ');
+  let jsDocText = parsed.description.replace(/\n\n/g, '<br>').replace(/\n/g, ' ').replace(/\r/g, '')
+
+  // convert bracketed component references into component API links
+  // eg: [MenuItem component] will link to the component API for MenuItem
+  jsDocText = jsDocText.replace(/\[(\w+)\scomponent\]/g, `[$1](component-api/$1) component`);
 
   if (parsed.tags.some(tag => tag.title === 'ignore')) return null;
   let signature = '';
@@ -114,7 +118,9 @@ function generatePropType(type) {
       }
       return `${type.name}:&nbsp;${values}<br>`;
     }
-
+    case 'HiddenProps': {
+      return `[${type.name}](/layout/hidden)`;
+    }
     default:
       return type.name;
   }
@@ -177,7 +183,7 @@ function generateProps(props) {
 }
 
 function generateClasses(styles) {
-  return `## Classes
+  return styles.classes.length ? `## Classes
 
 You can overrides all the class names injected by Material-UI thanks to the \`classes\` property.
 This property accepts the following keys:
@@ -188,7 +194,7 @@ section for more detail.
 
 If using the \`overrides\` key of the theme as documented
 [here](/customization/themes#customizing-all-instances-of-a-component-type),
-you need to use the following style sheet name: \`${styles.name}\`.`;
+you need to use the following style sheet name: \`${styles.name}\`.` : '';
 }
 
 export default function generateMarkdown(name, reactAPI) {

--- a/src/Grid/Grid.js
+++ b/src/Grid/Grid.js
@@ -190,7 +190,7 @@ type Props = {
    */
   gutter?: 0 | 8 | 16 | 24 | 40,
   /**
-   * If provided, will wrap with Hidden component and given properties.
+   * If provided, will wrap with [Hidden component] and given properties.
    */
   hidden?: HiddenProps,
   /**

--- a/src/Grid/Grid.js
+++ b/src/Grid/Grid.js
@@ -190,7 +190,7 @@ type Props = {
    */
   gutter?: 0 | 8 | 16 | 24 | 40,
   /**
-   * If provided, will wrap with [Hidden component] and given properties.
+   * If provided, will wrap with [Hidden](/component-api/Hidden) component and given properties.
    */
   hidden?: HiddenProps,
   /**


### PR DESCRIPTION
The Grid component API docs list a type of HiddenProps for the hidden prop, but this should really be a link to the Layout demo.  I've modified markdown generation to look for this type specifically and return a link.

~~Added the ability to link to components from proptype descriptions.  By including [Hidden component] in the description of Grid's hidden property, a link to the component API is generated when docs are built.~~ Grid's hidden property includes a markdown link to the Hidden component's api docs

I also made the following changes:

- Omit classes section for components that do not export a stylesheet (e.g. TextField)
- Strip carriage returns introduced from doc generation on windows (generating docs from Windows caused the markdown madness referred to in the comments)
