### PR TITLE
[Menu] Fix RegExp error on keydown

### DIFF
--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -373,7 +373,7 @@ class Menu extends Component {
         return;
       }
       const {primaryText} = child.props;
-      if (typeof primaryText === 'string' && new RegExp(`^${keys}`, 'i').test(primaryText)) {
+      if (typeof primaryText === 'string' && primaryText.substr(0, keys.length).toLowerCase() === keys.toLowerCase()) {
         foundIndex = index;
       }
     });

--- a/src/Menu/Menu.spec.js
+++ b/src/Menu/Menu.spec.js
@@ -137,6 +137,9 @@ describe('<Menu />', () => {
         '"b00!" does not change the focus index, which is probably a bug');
       onMenuItemFocusChangeSpy.reset();
 
+      // Test RegExp-breaking key. If implementation is testing with RegExp, a syntax error will throw.
+      wrapper.simulate('keydown', keycodeEvent('\\'));
+
       wrapper.unmount(); // Otherwise the timer in FocusRipple keeps Node from exiting
     });
   });


### PR DESCRIPTION
Menu throws SyntaxError from onKeyDown handler.

To reproduce, go to http://www.material-ui.com/#/components/dropdown-menu, open a menu, hit "\\" character on keyboard, see SyntaxError in console.

Caused by constructing a RegExp to find matching menu items. Characters are not filtered at all, allowing invalid RegExp.

This PR uses simple string functions instead of RegExp and adds a test case for this particular key (\\).

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

