### PR TITLE
[TextField] Fix enter behavior with multiline when controlled

### DIFF
--- a/src/TextField/EnhancedTextarea.js
+++ b/src/TextField/EnhancedTextarea.js
@@ -126,7 +126,9 @@ class EnhancedTextarea extends Component {
   }
 
   handleChange = (event) => {
-    this.syncHeightWithShadow(event.target.value);
+    if ( !this.props.hasOwnProperty('value') ) {
+      this.syncHeightWithShadow(event.target.value);
+    }
 
     if (this.props.hasOwnProperty('valueLink')) {
       this.props.valueLink.requestChange(event.target.value);

--- a/src/TextField/EnhancedTextarea.js
+++ b/src/TextField/EnhancedTextarea.js
@@ -126,7 +126,7 @@ class EnhancedTextarea extends Component {
   }
 
   handleChange = (event) => {
-    if ( !this.props.hasOwnProperty('value') ) {
+    if (!this.props.hasOwnProperty('value')) {
       this.syncHeightWithShadow(event.target.value);
     }
 

--- a/src/TextField/TextField.spec.js
+++ b/src/TextField/TextField.spec.js
@@ -44,24 +44,6 @@ describe('<TextField />', () => {
     assert.strictEqual(wrapper.find(TextFieldLabel).props().shrink, true, 'should shrink TextFieldLabel');
   });
 
-  it('does not change the height of text area', (done) => {
-    const wrapper = mountWithContext(
-      <TextField
-        onChange={() => {
-          const newHeight = textareaElement.props().style.height;
-          assert.strictEqual(newHeight, initialHeight, 'should not change the height of the text area');
-          done();
-        }}
-        value="some value"
-        id="unique"
-        multiLine={true}
-      />
-    );
-    const textareaElement = wrapper.find('textarea').at(1);
-    const initialHeight = textareaElement.props().style.height;
-    textareaElement.simulate('change', {target: {value: 'This is a really, really, really, really long string.'}});
-  });
-
   describe('prop: children', () => {
     it('should forward any property to the root', () => {
       const wrapper = shallowWithContext(

--- a/src/TextField/TextField.spec.js
+++ b/src/TextField/TextField.spec.js
@@ -6,6 +6,7 @@ import {assert} from 'chai';
 import TextField from './TextField';
 import TextFieldHint from './TextFieldHint';
 import TextFieldLabel from './TextFieldLabel';
+import EnhancedTextarea from './EnhancedTextarea';
 import getMuiTheme from '../styles/getMuiTheme';
 
 describe('<TextField />', () => {
@@ -42,6 +43,24 @@ describe('<TextField />', () => {
     assert.strictEqual(wrapper.find(TextFieldLabel).props().shrink, true, 'should shrink TextFieldLabel');
     wrapper.update();
     assert.strictEqual(wrapper.find(TextFieldLabel).props().shrink, true, 'should shrink TextFieldLabel');
+  });
+
+  it('does not change the height of text area', (done) => {
+    const wrapper = mountWithContext(
+      <TextField
+        onChange={() => {
+          const newHeight = textareaElement.props().style.height;
+          assert.strictEqual(newHeight, initialHeight, 'should not change the height of the text area');
+          done();
+        }}
+        value="some value"
+        id="unique"
+        multiLine={true}
+      />
+    );
+    const textareaElement = wrapper.find('textarea').at(1);
+    const initialHeight = textareaElement.props().style.height;
+    textareaElement.simulate('change', {target: {value: 'This is a really, really, really, really long string.'}});
   });
 
   describe('prop: children', () => {

--- a/src/TextField/TextField.spec.js
+++ b/src/TextField/TextField.spec.js
@@ -6,7 +6,6 @@ import {assert} from 'chai';
 import TextField from './TextField';
 import TextFieldHint from './TextFieldHint';
 import TextFieldLabel from './TextFieldLabel';
-import EnhancedTextarea from './EnhancedTextarea';
 import getMuiTheme from '../styles/getMuiTheme';
 
 describe('<TextField />', () => {


### PR DESCRIPTION
Fixes https://github.com/callemall/material-ui/issues/6990
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

