### PR TITLE
[TextField] Fix cursor behaviour with multiline when controlled (#4430)

### DIFF
--- a/src/TextField/EnhancedTextarea.js
+++ b/src/TextField/EnhancedTextarea.js
@@ -115,8 +115,12 @@ class EnhancedTextarea extends Component {
     newHeight = Math.max(newHeight, rowsHeight);
 
     if (this.state.height !== newHeight) {
+      const input = this.refs.input;
+      const cursorPosition = input.selectionStart;
       this.setState({
         height: newHeight,
+      }, () => {
+        input.setSelectionRange(cursorPosition, cursorPosition);
       });
 
       if (props.onHeightChange) {


### PR DESCRIPTION
cursor jumps to the end in a multiLine TextField on line break, only when the input is controlled and within a Dialog.

Multi-line TextField within Dialog (cursor jumps to the end):
![](https://cloud.githubusercontent.com/assets/893649/21484231/620d5778-cb76-11e6-8411-2e539bffeaa8.gif)

Multi-line TextField (works fine):
![](https://cloud.githubusercontent.com/assets/893649/21484244/8ece9966-cb76-11e6-88fb-c7a51b2e11ed.gif)

* Update EnhancedTextarea.js
Closes #4430 

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

