### PR TITLE
[TextField] Fix Labels flicker in Chrome

### DIFF
--- a/src/Input/InputLabel.js
+++ b/src/Input/InputLabel.js
@@ -18,7 +18,7 @@ export const styleSheet = createStyleSheet('MuiInputLabel', theme => ({
     transform: `translate(0, ${theme.spacing.unit * 5}px) scale(1)`,
   },
   shrink: {
-    transform: `translate(0, ${theme.spacing.unit * 2 + 2}px) scale(0.75)`,
+    transform: `translate(0, ${theme.spacing.unit * 2 + 1.5}px) scale(0.75)`,
     transformOrigin: 'top left',
   },
   animated: {


### PR DESCRIPTION
I know this is ugly solution. But I can't stand that labels flicker 😡 
![recording- 1](https://cloud.githubusercontent.com/assets/4588778/26606044/11d96f06-4599-11e7-96ab-0855a7343837.gif)

Another hacky solution is to use `backface-visibility: hidden;` but it makes labels blurry.

Closes #6076