### PR TITLE
[TableBody] Fixed columnId passed to onCellClick when displayRowCheckbox is false

### DIFF
--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -421,12 +421,7 @@ class TableBody extends Component {
   };
 
   getColumnId(columnNumber) {
-    let columnId = columnNumber;
-    if (this.props.displayRowCheckbox) {
-      columnId--;
-    }
-
-    return columnId;
+    return columnNumber - 1;
   }
 
   render() {


### PR DESCRIPTION
When `displayRowCheckbox` is false, the first child of TableRow is `null`. This means that when TableRow.render() is called, the first actual column gets a `columnNumber` equal to 1, just like when `displayRowCheckbox` is true.

For this reason, `TableBody.getColumnId(columnNumber)` has to subtract 1 from `columnNumber` in both cases.

Without this patch, when `displayRowCheckbox` is false and the first column is clicked, `onCellClick` is called with `columnId` equal to 1.

