### PR TITLE
Updated default button type

### DIFF
--- a/src/internal/EnhancedButton.js
+++ b/src/internal/EnhancedButton.js
@@ -75,7 +75,7 @@ class EnhancedButton extends Component {
     onKeyboardFocus: () => {},
     onTouchTap: () => {},
     tabIndex: 0,
-    type: 'button',
+    type: 'submit',
   };
 
   static contextTypes = {


### PR DESCRIPTION
Updated default button type from `button` to `submit` as the default for a button is always submit. That'll conflict if someone uses it like that.
Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

