### PR TITLE
[Textfield] add an autoFocus property

### DIFF
--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -246,6 +246,7 @@ class Input extends Component {
 
   render() {
     const {
+      autoFocus,
       classes,
       className: classNameProp,
       component,
@@ -319,6 +320,13 @@ class Input extends Component {
       ...inputPropsProp,
     };
 
+    if (autoFocus) {
+      inputProps = {
+        autoFocus,
+        ...inputProps,
+      };
+    }
+
     if (component) {
       inputProps = {
         rowsMax,
@@ -368,6 +376,10 @@ class Input extends Component {
 }
 
 Input.propTypes = {
+  /**
+   * If `true`, the input element will have the `autoFocus` CSS property.
+   */
+  autoFocus: PropTypes.bool,
   /**
    * Useful to extend the style applied to components.
    */

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -8,6 +8,7 @@ import FormHelperText from '../Form/FormHelperText';
 
 function TextField(props) {
   const {
+    autoFocus,
     className,
     defaultValue,
     disabled,
@@ -50,6 +51,7 @@ function TextField(props) {
           {label}
         </InputLabel>}
       <Input
+        autoFocus={autoFocus}
         className={InputClassName}
         defaultValue={defaultValue}
         disabled={disabled}
@@ -73,6 +75,10 @@ function TextField(props) {
 }
 
 TextField.propTypes = {
+  /**
+   * If `true`, the `Input` element will have the `autoFocus` CSS property.
+   */
+  autoFocus: PropTypes.bool,
   /**
    * @ignore
    */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

@oliviertassinari tasked me to do a PR after I complained so here i am.

This PR add an autoFocus property to the Textfield component. It seems to work locally in a modified documentation site. It reacted weirdly in my own app but it's probably a problem in my app because the workaround suggested by @oliviertassinari reacted the same way.

So, is it how it's supposed to be done ?