### PR TITLE
[Switch] Correctly change the cursor value

### DIFF
--- a/src/internal/withSwitchLabel.js
+++ b/src/internal/withSwitchLabel.js
@@ -15,6 +15,10 @@ export const styleSheet = createStyleSheet('MuiSwitchLabel', theme => ({
     cursor: 'pointer',
     WebkitTapHighlightColor: 'rgba(0,0,0,0)',
   },
+  disabled: {
+    color: theme.palette.text.disabled,
+    cursor: 'default',
+  },
   hasLabel: {
     marginLeft: -12,
     marginRight: theme.spacing.unit * 2, // used for row presentation of radio/checkbox
@@ -22,10 +26,6 @@ export const styleSheet = createStyleSheet('MuiSwitchLabel', theme => ({
   labelText: {
     fontFamily: theme.typography.fontFamily,
     userSelect: 'none',
-  },
-  disabled: {
-    color: theme.palette.text.disabled,
-    cursor: 'default',
   },
 }));
 
@@ -46,13 +46,10 @@ function withSwitchLabel(SwitchComponent) {
         classes.root,
         {
           [classes.hasLabel]: label && label.length,
+          [classes.disabled]: disabled,
         },
         labelClassNameProp,
       );
-
-      const labelTextClassName = classNames(classes.labelText, {
-        [classes.disabled]: disabled,
-      });
 
       const switchElement = (
         <SwitchComponent
@@ -71,7 +68,7 @@ function withSwitchLabel(SwitchComponent) {
       return (
         <label className={labelClassName}>
           {switchElement}
-          <span className={labelTextClassName}>
+          <span className={classes.labelText}>
             {label}
           </span>
         </label>

--- a/src/internal/withSwitchLabel.spec.js
+++ b/src/internal/withSwitchLabel.spec.js
@@ -83,7 +83,7 @@ describe('withSwitchLabel', () => {
         });
 
         assert.strictEqual(
-          wrapper.childAt(1).hasClass(classes.disabled),
+          wrapper.hasClass(classes.disabled),
           true,
           'should have the disabled class',
         );


### PR DESCRIPTION
Closes #7035.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

