### PR TITLE
Improve accessibility in the component examples

### DIFF
--- a/docs/src/pages/component-demos/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/component-demos/app-bar/ButtonAppBar.js
@@ -30,7 +30,7 @@ function ButtonAppBar(props) {
     <div className={classes.root}>
       <AppBar className={classes.appBar}>
         <Toolbar>
-          <IconButton contrast>
+          <IconButton contrast aria-label="Menu">
             <MenuIcon />
           </IconButton>
           <Typography type="title" colorInherit className={classes.flex}>Title</Typography>

--- a/docs/src/pages/component-demos/buttons/IconButtons.js
+++ b/docs/src/pages/component-demos/buttons/IconButtons.js
@@ -18,16 +18,16 @@ function IconButtons(props) {
   const classes = props.classes;
   return (
     <div>
-      <IconButton className={classes.button}>
+      <IconButton className={classes.button} aria-label="Delete">
         <DeleteIcon />
       </IconButton>
-      <IconButton className={classes.button} disabled>
+      <IconButton className={classes.button} aria-label="Delete" disabled>
         <DeleteIcon />
       </IconButton>
-      <IconButton accent className={classes.button}>
+      <IconButton accent className={classes.button} aria-label="Add an alarm">
         <Icon>alarm</Icon>
       </IconButton>
-      <IconButton contrast className={classes.button}>
+      <IconButton contrast className={classes.button} aria-label="Add to shopping cart">
         <AddShoppingCartIcon />
       </IconButton>
     </div>

--- a/docs/src/pages/component-demos/cards/NowPlayingCard.js
+++ b/docs/src/pages/component-demos/cards/NowPlayingCard.js
@@ -52,13 +52,13 @@ function NowPlayingCard(props) {
             </Typography>
           </CardContent>
           <div className={classes.controls}>
-            <IconButton>
+            <IconButton aria-label="Previous">
               <SkipPreviousIcon />
             </IconButton>
-            <IconButton>
+            <IconButton aria-label="Play/pause">
               <PlayArrowIcon className={classes.playIcon} />
             </IconButton>
-            <IconButton>
+            <IconButton aria-label="Next">
               <SkipNextIcon />
             </IconButton>
           </div>

--- a/docs/src/pages/component-demos/cards/RecipeReviewCard.js
+++ b/docs/src/pages/component-demos/cards/RecipeReviewCard.js
@@ -59,10 +59,10 @@ class RecipeReviewCard extends Component {
             </Typography>
           </CardContent>
           <CardActions disableActionSpacing>
-            <IconButton>
+            <IconButton aria-label="Add to favorites">
               <FavoriteIcon />
             </IconButton>
-            <IconButton>
+            <IconButton aria-label="Share">
               <ShareIcon />
             </IconButton>
             <div className={classes.flexGrow} />
@@ -71,6 +71,8 @@ class RecipeReviewCard extends Component {
                 [classes.expandOpen]: this.state.expanded,
               })}
               onClick={this.handleExpandClick}
+              aria-expanded={this.state.expanded}
+              aria-label="Show more"
             >
               <ExpandMoreIcon />
             </IconButton>

--- a/docs/src/pages/component-demos/dialogs/FullScreenDialog.js
+++ b/docs/src/pages/component-demos/dialogs/FullScreenDialog.js
@@ -51,7 +51,11 @@ class FullScreenDialog extends Component {
         >
           <AppBar className={classes.appBar}>
             <Toolbar>
-              <IconButton contrast onClick={this.handleRequestClose}>
+              <IconButton
+                contrast
+                onClick={this.handleRequestClose}
+                aria-label="Close"
+              >
                 <CloseIcon />
               </IconButton>
               <Typography type="title" colorInherit className={classes.flex}>

--- a/docs/src/pages/component-demos/lists/CheckboxList.js
+++ b/docs/src/pages/component-demos/lists/CheckboxList.js
@@ -52,7 +52,7 @@ class CheckboxList extends Component {
               />
               <ListItemText primary={`Line item ${index + 1}`} />
               <ListItemSecondaryAction>
-                <IconButton>
+                <IconButton aria-label="Comments">
                   <CommentIcon />
                 </IconButton>
               </ListItemSecondaryAction>

--- a/docs/src/pages/component-demos/lists/InteractiveList.js
+++ b/docs/src/pages/component-demos/lists/InteractiveList.js
@@ -146,7 +146,7 @@ class InteractiveList extends Component {
                       secondary={secondary ? 'Secondary text' : null}
                     />
                     <ListItemSecondaryAction>
-                      <IconButton>
+                      <IconButton aria-label="Delete">
                         <DeleteIcon />
                       </IconButton>
                     </ListItemSecondaryAction>

--- a/docs/src/pages/component-demos/tables/EnhancedTable.js
+++ b/docs/src/pages/component-demos/tables/EnhancedTable.js
@@ -120,10 +120,10 @@ let EnhancedTableToolbar = props => {
       <div className={classes.spacer} />
       <div className={classes.actions}>
         {numSelected > 0
-          ? <IconButton>
+          ? <IconButton aria-label="Delete">
               <DeleteIcon />
             </IconButton>
-          : <IconButton>
+          : <IconButton aria-label="Filter list">
               <FilterListIcon />
             </IconButton>}
       </div>


### PR DESCRIPTION
* Added labels to the unlabeled IconButtons.
* Added aria-expanded to one of the Card example buttons to signify that the button in question expands the contents of the card.

The labels are intended to convey the meaning of the button rather than to describe the icons themselves. Please let me know if some of these labels seem incorrect.

Closes #6956.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted. (I got 67 linting errors in the unmodified next branch alone. Is this expected to be broken in next?)
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

