### PR TITLE
[eslint] Loosen no-unused-vars eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,6 @@ module.exports = {
     'no-prototype-builtins': 'off', // airbnb use error
     'object-curly-spacing': 'off', // use babel plugin rule
     'no-restricted-properties': 'off', // To remove once react-docgen support ** operator.
-    'no-unused-vars': ['error', { vars: 'all', args: 'after-used', ignoreRestSiblings: false }], // airbnb use ignoreRestSiblings
 
     'babel/object-curly-spacing': ['error', 'always'],
 

--- a/docs/src/pages/component-demos/dialogs/ConfirmationDialog.js
+++ b/docs/src/pages/component-demos/dialogs/ConfirmationDialog.js
@@ -66,11 +66,7 @@ class ConfirmationDialog extends Component {
   };
 
   render() {
-    const {
-      onRequestClose, // eslint-disable-line no-unused-vars
-      selectedValue, // eslint-disable-line no-unused-vars
-      ...other
-    } = this.props;
+    const { onRequestClose, selectedValue, ...other } = this.props;
 
     return (
       <Dialog onEntering={this.handleEntering} {...other}>

--- a/docs/src/pages/customization/ThemeDefault.js
+++ b/docs/src/pages/customization/ThemeDefault.js
@@ -12,12 +12,7 @@ const style = {
 };
 
 function ThemeDefault(props) {
-  const {
-    theme: {
-      id, // eslint-disable-line no-unused-vars
-      ...theme
-    },
-  } = props;
+  const { theme: { id, ...theme } } = props;
 
   const text = `
 \`\`\`js

--- a/src/BottomNavigation/BottomNavigationButton.js
+++ b/src/BottomNavigation/BottomNavigationButton.js
@@ -69,8 +69,8 @@ class BottomNavigationButton extends Component {
       classes,
       className: classNameProp,
       showLabel: showLabelProp,
-      onChange, // eslint-disable-line no-unused-vars
-      index, // eslint-disable-line no-unused-vars
+      onChange,
+      index,
       ...other
     } = this.props;
 

--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -93,14 +93,7 @@ class FormControl extends Component {
   };
 
   render() {
-    const {
-      children,
-      classes,
-      className,
-      disabled, // eslint-disable-line no-unused-vars
-      error, // eslint-disable-line no-unused-vars
-      ...other
-    } = this.props;
+    const { children, classes, className, disabled, error, ...other } = this.props;
 
     return (
       <div

--- a/src/Hidden/HiddenJs.js
+++ b/src/Hidden/HiddenJs.js
@@ -20,16 +20,16 @@ function HiddenJs(props: Props) {
   const {
     children,
     only,
-    xsUp, // eslint-disable-line no-unused-vars
-    smUp, // eslint-disable-line no-unused-vars
-    mdUp, // eslint-disable-line no-unused-vars
-    lgUp, // eslint-disable-line no-unused-vars
-    xlUp, // eslint-disable-line no-unused-vars
-    xsDown, // eslint-disable-line no-unused-vars
-    smDown, // eslint-disable-line no-unused-vars
-    mdDown, // eslint-disable-line no-unused-vars
-    lgDown, // eslint-disable-line no-unused-vars
-    xlDown, // eslint-disable-line no-unused-vars
+    xsUp,
+    smUp,
+    mdUp,
+    lgUp,
+    xlUp,
+    xsDown,
+    smDown,
+    mdDown,
+    lgDown,
+    xlDown,
     width,
     ...other
   } = props;

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -257,13 +257,13 @@ class Input extends Component {
       id,
       inputClassName: inputClassNameProp,
       inputProps: inputPropsProp,
-      inputRef, // eslint-disable-line no-unused-vars
+      inputRef,
       multiline,
-      onBlur, // eslint-disable-line no-unused-vars
-      onFocus, // eslint-disable-line no-unused-vars
-      onChange, // eslint-disable-line no-unused-vars
-      onClean, // eslint-disable-line no-unused-vars
-      onDirty, // eslint-disable-line no-unused-vars
+      onBlur,
+      onFocus,
+      onChange,
+      onClean,
+      onDirty,
       onKeyDown,
       onKeyUp,
       placeholder,

--- a/src/Input/Textarea.js
+++ b/src/Input/Textarea.js
@@ -150,13 +150,13 @@ class Textarea extends Component {
       classes,
       className,
       defaultValue,
-      disabled, // eslint-disable-line no-unused-vars
-      hintText, // eslint-disable-line no-unused-vars
-      onChange, // eslint-disable-line no-unused-vars
-      onHeightChange, // eslint-disable-line no-unused-vars
+      disabled,
+      hintText,
+      onChange,
+      onHeightChange,
       rows,
-      rowsMax, // eslint-disable-line no-unused-vars
-      textareaRef, // eslint-disable-line no-unused-vars
+      rowsMax,
+      textareaRef,
       value,
       ...other
     } = this.props;

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -75,7 +75,7 @@ class Menu extends Component {
       className,
       open,
       MenuListProps,
-      onEnter, // eslint-disable-line no-unused-vars
+      onEnter,
       onEntering,
       onEntered,
       onExit,

--- a/src/Menu/MenuList.js
+++ b/src/Menu/MenuList.js
@@ -128,13 +128,7 @@ class MenuList extends Component {
   }
 
   render() {
-    const {
-      children,
-      className,
-      onBlur, // eslint-disable-line no-unused-vars
-      onKeyDown, // eslint-disable-line no-unused-vars
-      ...other
-    } = this.props;
+    const { children, className, onBlur, onKeyDown, ...other } = this.props;
 
     return (
       <List

--- a/src/Radio/RadioGroup.js
+++ b/src/Radio/RadioGroup.js
@@ -53,7 +53,7 @@ class RadioGroup extends Component {
       className: classNameProp,
       name,
       selectedValue,
-      onChange, // eslint-disable-line no-unused-vars
+      onChange,
       ...other
     } = this.props;
 

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -125,10 +125,10 @@ class Tab extends Component {
       className: classNameProp,
       fullWidth,
       icon: iconProp,
-      index, // eslint-disable-line no-unused-vars
+      index,
       label: labelProp,
       labelClassName,
-      onChange, // eslint-disable-line no-unused-vars
+      onChange,
       selected,
       style: styleProp,
       textColor,

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -218,7 +218,7 @@ class Tabs extends Component {
 
   render() {
     const {
-      buttonClassName, // eslint-disable-line no-unused-vars
+      buttonClassName,
       centered,
       classes,
       children: childrenProp,
@@ -229,9 +229,9 @@ class Tabs extends Component {
       indicatorColor,
       onChange,
       scrollable,
-      scrollButtons, // eslint-disable-line no-unused-vars
+      scrollButtons,
       textColor,
-      width, // eslint-disable-line no-unused-vars
+      width,
       ...other
     } = this.props;
 

--- a/src/internal/ButtonBase.js
+++ b/src/internal/ButtonBase.js
@@ -176,18 +176,18 @@ class ButtonBase extends Component {
       className: classNameProp,
       component,
       disabled,
-      focusRipple, // eslint-disable-line no-unused-vars
+      focusRipple,
       keyboardFocusedClassName,
-      onBlur, // eslint-disable-line no-unused-vars
-      onFocus, // eslint-disable-line no-unused-vars
-      onKeyboardFocus, // eslint-disable-line no-unused-vars
-      onKeyDown, // eslint-disable-line no-unused-vars
-      onKeyUp, // eslint-disable-line no-unused-vars
-      onMouseDown, // eslint-disable-line no-unused-vars
-      onMouseLeave, // eslint-disable-line no-unused-vars
-      onMouseUp, // eslint-disable-line no-unused-vars
-      onTouchEnd, // eslint-disable-line no-unused-vars
-      onTouchStart, // eslint-disable-line no-unused-vars
+      onBlur,
+      onFocus,
+      onKeyboardFocus,
+      onKeyDown,
+      onKeyUp,
+      onMouseDown,
+      onMouseLeave,
+      onMouseUp,
+      onTouchEnd,
+      onTouchStart,
       ripple,
       tabIndex,
       type,

--- a/src/internal/Modal.js
+++ b/src/internal/Modal.js
@@ -336,25 +336,25 @@ class Modal extends Component<DefaultProps, Props, State> {
   render() {
     const {
       disableBackdrop,
-      backdropComponent, // eslint-disable-line no-unused-vars
-      backdropClassName, // eslint-disable-line no-unused-vars
-      backdropTransitionDuration, // eslint-disable-line no-unused-vars
+      backdropComponent,
+      backdropClassName,
+      backdropTransitionDuration,
       backdropInvisible,
-      ignoreBackdropClick, // eslint-disable-line no-unused-vars
-      ignoreEscapeKeyUp, // eslint-disable-line no-unused-vars
+      ignoreBackdropClick,
+      ignoreEscapeKeyUp,
       children,
       classes,
       className,
-      modalManager: modalManagerProp, // eslint-disable-line no-unused-vars
-      onBackdropClick, // eslint-disable-line no-unused-vars
-      onEscapeKeyUp, // eslint-disable-line no-unused-vars
-      onRequestClose, // eslint-disable-line no-unused-vars
+      modalManager: modalManagerProp,
+      onBackdropClick,
+      onEscapeKeyUp,
+      onRequestClose,
       onEnter,
       onEntering,
       onEntered,
       onExit,
       onExiting,
-      onExited, // eslint-disable-line no-unused-vars
+      onExited,
       show,
       ...other
     } = this.props;

--- a/src/internal/Popover.js
+++ b/src/internal/Popover.js
@@ -262,23 +262,23 @@ class Popover extends Component {
       children,
       classes,
       className,
-      modal, // eslint-disable-line no-unused-vars
+      modal,
       onRequestClose,
       open,
-      getContentAnchorEl, // eslint-disable-line no-unused-vars
-      anchorEl, // eslint-disable-line no-unused-vars
-      anchorOrigin, // eslint-disable-line no-unused-vars
-      role, // eslint-disable-line no-unused-vars
-      transformOrigin, // eslint-disable-line no-unused-vars
-      transitionDuration, // eslint-disable-line no-unused-vars
+      getContentAnchorEl,
+      anchorEl,
+      anchorOrigin,
+      role,
+      transformOrigin,
+      transitionDuration,
       enteredClassName,
       enteringClassName,
       exitedClassName,
       exitingClassName,
-      onEnter, // eslint-disable-line no-unused-vars
-      onEntering, // eslint-disable-line no-unused-vars
+      onEnter,
+      onEntering,
       onEntered,
-      onExit, // eslint-disable-line no-unused-vars
+      onExit,
       onExiting,
       onExited,
       elevation,

--- a/src/internal/SwitchBase.js
+++ b/src/internal/SwitchBase.js
@@ -95,7 +95,7 @@ export default function createSwitch(
         icon: iconProp,
         inputProps,
         name,
-        onChange, // eslint-disable-line no-unused-vars
+        onChange,
         tabIndex,
         value,
         ...other

--- a/src/internal/TouchRipple.js
+++ b/src/internal/TouchRipple.js
@@ -155,11 +155,7 @@ class TouchRipple extends Component {
   };
 
   render() {
-    const {
-      center, // eslint-disable-line no-unused-vars
-      className,
-      ...other
-    } = this.props;
+    const { center, className, ...other } = this.props;
     const classes = this.context.styleManager.render(styleSheet);
 
     return (

--- a/src/internal/Transition.js
+++ b/src/internal/Transition.js
@@ -336,21 +336,21 @@ class Transition extends Component<DefaultProps, Props, State> {
     const {
       children,
       className,
-      in: inProp, // eslint-disable-line no-unused-vars
-      enteredClassName, // eslint-disable-line no-unused-vars
-      enteringClassName, // eslint-disable-line no-unused-vars
-      exitedClassName, // eslint-disable-line no-unused-vars
-      exitingClassName, // eslint-disable-line no-unused-vars
-      onEnter, // eslint-disable-line no-unused-vars
-      onEntering, // eslint-disable-line no-unused-vars
-      onEntered, // eslint-disable-line no-unused-vars
-      onExit, // eslint-disable-line no-unused-vars
-      onExiting, // eslint-disable-line no-unused-vars
-      onExited, // eslint-disable-line no-unused-vars
-      onRequestTimeout, // eslint-disable-line no-unused-vars
-      timeout, // eslint-disable-line no-unused-vars
-      transitionAppear, // eslint-disable-line no-unused-vars
-      unmountOnExit, // eslint-disable-line no-unused-vars
+      in: inProp,
+      enteredClassName,
+      enteringClassName,
+      exitedClassName,
+      exitingClassName,
+      onEnter,
+      onEntering,
+      onEntered,
+      onExit,
+      onExiting,
+      onExited,
+      onRequestTimeout,
+      timeout,
+      transitionAppear,
+      unmountOnExit,
       ...other
     } = this.props;
 

--- a/src/internal/Transition.spec.js
+++ b/src/internal/Transition.spec.js
@@ -255,7 +255,7 @@ describe('<Transition />', () => {
 
       render() {
         const {
-          initialIn, // eslint-disable-line no-unused-vars, react/prop-types
+          initialIn, // eslint-disable-line react/prop-types
           ...other
         } = this.props;
 

--- a/src/transitions/Collapse.js
+++ b/src/transitions/Collapse.js
@@ -100,11 +100,11 @@ class Collapse extends Component {
       children,
       classes,
       containerClassName,
-      onEnter, // eslint-disable-line no-unused-vars
-      onEntering, // eslint-disable-line no-unused-vars
-      onExit, // eslint-disable-line no-unused-vars
-      onExiting, // eslint-disable-line no-unused-vars
-      transitionDuration, // eslint-disable-line no-unused-vars
+      onEnter,
+      onEntering,
+      onExit,
+      onExiting,
+      transitionDuration,
       ...other
     } = this.props;
 

--- a/src/transitions/Fade.js
+++ b/src/transitions/Fade.js
@@ -92,11 +92,11 @@ class Fade extends Component<DefaultProps, Props, void> {
   render() {
     const {
       children,
-      enterTransitionDuration, // eslint-disable-line no-unused-vars
-      leaveTransitionDuration, // eslint-disable-line no-unused-vars
-      onEnter, // eslint-disable-line no-unused-vars
-      onEntering, // eslint-disable-line no-unused-vars
-      onExit, // eslint-disable-line no-unused-vars
+      enterTransitionDuration,
+      leaveTransitionDuration,
+      onEnter,
+      onEntering,
+      onExit,
       ...other
     } = this.props;
 

--- a/src/transitions/Slide.js
+++ b/src/transitions/Slide.js
@@ -79,12 +79,12 @@ class Slide extends Component {
   render() {
     const {
       children,
-      offset, // eslint-disable-line no-unused-vars
-      onEnter, // eslint-disable-line no-unused-vars
-      onEntering, // eslint-disable-line no-unused-vars
-      onExiting, // eslint-disable-line no-unused-vars
-      enterTransitionDuration, // eslint-disable-line no-unused-vars
-      leaveTransitionDuration, // eslint-disable-line no-unused-vars
+      offset,
+      onEnter,
+      onEntering,
+      onExiting,
+      enterTransitionDuration,
+      leaveTransitionDuration,
       ...other
     } = this.props;
 


### PR DESCRIPTION
This PR fixes #7052 by removing altogether the overridden `no-unused-vars` Eslint rule and therefore using the Airbnb configuration.

Also removes occurrences of `eslint-disable-line no-unused-vars` pragmas from the source code.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

