### PR TITLE
[TextField] Fix disabled input color in Safari

### DIFF
--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -57,6 +57,7 @@ const getStyles = (props, context, state) => {
       color: props.disabled ? disabledTextColor : textColor,
       cursor: 'inherit',
       font: 'inherit',
+      WebkitTextFillColor: props.disabled ? disabledTextColor : textColor,
       WebkitTapHighlightColor: 'rgba(0,0,0,0)', // Remove mobile color flashing (deprecated style).
     },
     inputNative: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

When an input field is rendered disabled in Safari the input color sometimes is ignored. Apparently this happens only with some colors (e.g. `#666` leads to the bug, whereas `blue` doesn't). Tested with Safari 10.1.1.

See [this Stack Overflow question](https://stackoverflow.com/questions/262158/disabled-input-text-color) for context.

Here's a [JSFiddle](https://jsfiddle.net/1s43s015/2/) demonstrating the issue and solution.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

