### PR TITLE
[Modal] Add a keepMounted property

### DIFF
--- a/docs/src/components/AppDrawer.js
+++ b/docs/src/components/AppDrawer.js
@@ -83,6 +83,7 @@ function AppDrawer(props) {
       open={props.open}
       onRequestClose={props.onRequestClose}
       docked={props.docked}
+      keepMounted
     >
       <div className={classes.nav}>
         <Toolbar className={classes.toolbar}>

--- a/src/internal/Modal.spec.js
+++ b/src/internal/Modal.spec.js
@@ -36,11 +36,8 @@ describe('<Modal />', () => {
       wrapper = shallow(<Modal show data-my-prop="woof"><p>Hello World</p></Modal>);
     });
 
-    it('should render a portal when shown', () => {
-      assert.strictEqual(wrapper.name(), 'Portal');
-    });
-
     it('should render the modal div inside the portal', () => {
+      assert.strictEqual(wrapper.name(), 'Portal', 'should render a portal when shown');
       const modal = wrapper.childAt(0);
       assert.strictEqual(modal.is('div'), true, 'should be a div');
       assert.strictEqual(modal.hasClass(classes.root), true, 'should have the root class');
@@ -190,7 +187,10 @@ describe('<Modal />', () => {
           </Modal>,
         );
       });
-      after(() => wrapper.unmount());
+
+      after(() => {
+        wrapper.unmount();
+      });
 
       it('should not render the content', () => {
         assert.strictEqual(
@@ -257,7 +257,10 @@ describe('<Modal />', () => {
           </Modal>,
         );
       });
-      after(() => wrapper.unmount());
+
+      after(() => {
+        wrapper.unmount();
+      });
 
       it('should render a backdrop component into the portal before the modal content', () => {
         const modal = document.getElementById('modal');
@@ -292,7 +295,10 @@ describe('<Modal />', () => {
           </Modal>,
         );
       });
-      after(() => wrapper.unmount());
+
+      after(() => {
+        wrapper.unmount();
+      });
 
       it('should not render a backdrop component into the portal before the modal content', () => {
         const modal = document.getElementById('modal');
@@ -409,6 +415,20 @@ describe('<Modal />', () => {
         assert.strictEqual(onEscapeKeyUpStub.calledWith(event), true);
         assert.strictEqual(onRequestCloseStub.callCount, 0);
       });
+    });
+  });
+
+  describe('prop: keepMounted', () => {
+    it('should keep the children in the DOM', () => {
+      const children = <p>Hello World</p>;
+      const wrapper = shallow(<Modal keepMounted show={false}><div>{children}</div></Modal>);
+      assert.strictEqual(wrapper.contains(children), true);
+    });
+
+    it('should not keep the children in the DOM', () => {
+      const children = <p>Hello World</p>;
+      const wrapper = shallow(<Modal show={false}><div>{children}</div></Modal>);
+      assert.strictEqual(wrapper.contains(children), false);
     });
   });
 });

--- a/src/internal/Portal.js
+++ b/src/internal/Portal.js
@@ -74,9 +74,12 @@ class Portal extends Component {
 
 Portal.propTypes = {
   /**
-   * The content of the component.
+   * The content to portal in order to escape the parent DOM node.
    */
   children: PropTypes.node,
+  /**
+   * If `true` the children will be mounted into the DOM.
+   */
   open: PropTypes.bool,
 };
 

--- a/src/transitions/Slide.js
+++ b/src/transitions/Slide.js
@@ -7,6 +7,11 @@ import Transition from '../internal/Transition';
 import customPropTypes from '../utils/customPropTypes';
 import { duration } from '../styles/transitions';
 
+const GUTTER = 24;
+
+// Translate the element so he can't be seen in the screen.
+// Later, we gonna translate back the element to his original location
+// with `translate3d(0, 0, 0)`.`
 function getTranslateValue(props, element) {
   const { direction } = props;
   const rect = element.getBoundingClientRect();
@@ -14,7 +19,7 @@ function getTranslateValue(props, element) {
   if (direction === 'left') {
     return `translate3d(calc(100vw - ${rect.left}px), 0, 0)`;
   } else if (direction === 'right') {
-    return `translate3d(${0 - (rect.left + rect.width)}px, 0, 0)`;
+    return `translate3d(${0 - (rect.left + rect.width + GUTTER)}px, 0, 0)`;
   } else if (direction === 'up') {
     return `translate3d(0, calc(100vh - ${rect.top}px), 0)`;
   }
@@ -32,11 +37,8 @@ class Slide extends Component {
 
   componentDidMount() {
     if (!this.props.in) {
-      /* We need to set initial translate values of transition element
-       * otherwise component will be shown when in=false.
-       * transitions are handled by direct access to element,
-       * so we need to access that same element too here.
-       */
+      // We need to set initial translate values of transition element
+      // otherwise component will be shown when in=false.
       const element = ReactDOM.findDOMNode(this.transition);
       // $FlowFixMe
       element.style.transform = getTranslateValue(this.props, element);
@@ -46,6 +48,11 @@ class Slide extends Component {
   transition = null;
 
   handleEnter = element => {
+    // Reset the transformation when needed.
+    // That's triggering a reflow.
+    if (element.style.transform) {
+      element.style.transform = 'translate3d(0, 0, 0)';
+    }
     element.style.transform = getTranslateValue(this.props, element);
     if (this.props.onEnter) {
       this.props.onEnter(element);

--- a/src/transitions/Slide.spec.js
+++ b/src/transitions/Slide.spec.js
@@ -95,7 +95,7 @@ describe('<Slide />', () => {
     describe('handleEnter()', () => {
       let element;
 
-      before(() => {
+      beforeEach(() => {
         element = {
           getBoundingClientRect: () => ({
             width: 500,
@@ -115,13 +115,20 @@ describe('<Slide />', () => {
         assert.strictEqual(element.style.transform, 'translate3d(calc(100vw - 300px), 0, 0)');
         wrapper.setProps({ direction: 'right' });
         instance.handleEnter(element);
-        assert.strictEqual(element.style.transform, 'translate3d(-800px, 0, 0)');
+        assert.strictEqual(element.style.transform, 'translate3d(-824px, 0, 0)');
         wrapper.setProps({ direction: 'up' });
         instance.handleEnter(element);
         assert.strictEqual(element.style.transform, 'translate3d(0, calc(100vh - 200px), 0)');
         wrapper.setProps({ direction: 'down' });
         instance.handleEnter(element);
         assert.strictEqual(element.style.transform, 'translate3d(0, -500px, 0)');
+      });
+
+      it('should reset the previous transition if needed', () => {
+        element.style.transform = 'translate3d(-824px, 0, 0)';
+        wrapper.setProps({ direction: 'right' });
+        instance.handleEnter(element);
+        assert.strictEqual(element.style.transform, 'translate3d(-824px, 0, 0)');
       });
     });
 
@@ -161,7 +168,7 @@ describe('<Slide />', () => {
         assert.strictEqual(element.style.transform, 'translate3d(calc(100vw - 300px), 0, 0)');
         wrapper.setProps({ direction: 'right' });
         instance.handleEnter(element);
-        assert.strictEqual(element.style.transform, 'translate3d(-800px, 0, 0)');
+        assert.strictEqual(element.style.transform, 'translate3d(-824px, 0, 0)');
         wrapper.setProps({ direction: 'up' });
         instance.handleEnter(element);
         assert.strictEqual(element.style.transform, 'translate3d(0, calc(100vh - 200px), 0)');


### PR DESCRIPTION
1. So we have the **top level** information in the index of the search provided by Algolia:
That should result in a much better search experience.

**Expected**

![unnamed 1](https://user-images.githubusercontent.com/3165635/26898469-67d2a7f4-4bcc-11e7-9ed0-d0770ffe4925.png)
**Actual**

![unnamed](https://user-images.githubusercontent.com/3165635/26898464-64af19cc-4bcc-11e7-977d-efa97b1387eb.png)

2. So we maximise the responsiveness of the Drawer in the documentation. We save around 100ms by using the `keepMounted` option on a high-end device. That should definitely be perceivable by any user. @nathanmarks That's something we have been discussing a long time ago :).

**Before**
![capture d ecran 2017-06-07 a 21 34 14](https://user-images.githubusercontent.com/3165635/26898624-e85dfe50-4bcc-11e7-87c9-b57a4c24c9b5.png)

**After**
![capture d ecran 2017-06-07 a 21 35 36](https://user-images.githubusercontent.com/3165635/26898616-df9dbb8e-4bcc-11e7-84e9-cd748ef36920.png)


- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

