### PR TITLE
[ListItemText] Add disableTypography property

### DIFF
--- a/docs/src/pages/component-api/List/ListItemText.md
+++ b/docs/src/pages/component-api/List/ListItemText.md
@@ -6,6 +6,7 @@
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | classes | object |  | Useful to extend the style applied to components. |
+| disableTypography | bool | false | If `true`, the children won't be wrapped by a typography component. For instance, that can be usefull to can render an h4 instead of a |
 | inset | bool | false | If `true`, the children will be indented. This should be used if there is no left avatar or left icon. |
 | primary | node | false |  |
 | secondary | node | false |  |

--- a/src/List/ListItemText.js
+++ b/src/List/ListItemText.js
@@ -29,7 +29,15 @@ export const styleSheet = createStyleSheet('MuiListItemText', theme => ({
 }));
 
 function ListItemText(props, context) {
-  const { classes, className: classNameProp, primary, secondary, inset, ...other } = props;
+  const {
+    classes,
+    className: classNameProp,
+    disableTypography,
+    primary,
+    secondary,
+    inset,
+    ...other
+  } = props;
   const { dense } = context;
   const className = classNames(
     classes.root,
@@ -43,17 +51,17 @@ function ListItemText(props, context) {
   return (
     <div className={className} {...other}>
       {primary &&
-        (typeof primary === 'string'
-          ? <Typography type="subheading" className={classNames({ [classes.text]: dense })}>
+        (disableTypography
+          ? primary
+          : <Typography type="subheading" className={classNames({ [classes.text]: dense })}>
               {primary}
-            </Typography>
-          : primary)}
+            </Typography>)}
       {secondary &&
-        (typeof secondary === 'string'
-          ? <Typography secondary type="body1" className={classNames({ [classes.text]: dense })}>
+        (disableTypography
+          ? secondary
+          : <Typography secondary type="body1" className={classNames({ [classes.text]: dense })}>
               {secondary}
-            </Typography>
-          : secondary)}
+            </Typography>)}
     </div>
   );
 }
@@ -68,6 +76,11 @@ ListItemText.propTypes = {
    */
   className: PropTypes.string,
   /**
+   * If `true`, the children won't be wrapped by a typography component.
+   * For instance, that can be usefull to can render an h4 instead of a
+   */
+  disableTypography: PropTypes.bool,
+  /**
    * If `true`, the children will be indented.
    * This should be used if there is no left avatar or left icon.
    */
@@ -77,6 +90,7 @@ ListItemText.propTypes = {
 };
 
 ListItemText.defaultProps = {
+  disableTypography: false,
   primary: false,
   secondary: false,
   inset: false,

--- a/src/List/ListItemText.spec.js
+++ b/src/List/ListItemText.spec.js
@@ -82,6 +82,42 @@ describe('<ListItemText />', () => {
     });
   });
 
+  describe('prop: disableTypography', () => {
+    it('should wrap children in `<Typography/>` by default', () => {
+      const wrapper = shallow(
+        <ListItemText primary="This is the primary text" secondary="This is the secondary text" />,
+      );
+
+      assert.strictEqual(wrapper.children().length, 2, 'should have 2 children');
+      assert.strictEqual(wrapper.childAt(0).name(), 'withStyles(Typography)');
+      assert.strictEqual(wrapper.childAt(0).props().type, 'subheading');
+      assert.strictEqual(
+        wrapper.childAt(0).children().equals('This is the primary text'),
+        true,
+        'should have the primary text',
+      );
+
+      assert.strictEqual(wrapper.childAt(1).name(), 'withStyles(Typography)');
+      assert.strictEqual(wrapper.childAt(1).props().type, 'body1');
+      assert.strictEqual(wrapper.childAt(1).props().secondary, true);
+      assert.strictEqual(
+        wrapper.childAt(1).children().equals('This is the secondary text'),
+        true,
+        'should have the secondary text',
+      );
+    });
+
+    it('should render JSX children', () => {
+      const primaryChild = <p className="test">This is the primary text</p>;
+      const secondaryChild = <p className="test">This is the secondary text</p>;
+      const wrapper = shallow(
+        <ListItemText primary={primaryChild} secondary={secondaryChild} disableTypography />,
+      );
+      assert.strictEqual(wrapper.childAt(0).equals(primaryChild), true);
+      assert.strictEqual(wrapper.childAt(1).equals(secondaryChild), true);
+    });
+  });
+
   it('should render primary and secondary text', () => {
     const wrapper = shallow(
       <ListItemText primary="This is the primary text" secondary="This is the secondary text" />,


### PR DESCRIPTION
Closes #7067 

### Description

`ListItemText` previously always wrapped the `props.children` with a `Typography` component. This PR adds functionality to make the wrapper component conditional.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

