### PR TITLE
[FormHelperText] Add a min-height

### DIFF
--- a/src/Form/FormHelperText.js
+++ b/src/Form/FormHelperText.js
@@ -12,6 +12,7 @@ export const styleSheet = createStyleSheet('MuiFormHelperText', theme => ({
     fontFamily: theme.typography.fontFamily,
     fontSize: 12,
     lineHeight: 1.4,
+    minHeight: 16,
     margin: 0,
   },
   error: {


### PR DESCRIPTION
Add a min-height as the flexbox layout with wrap mode might not be enough.
One might want to do the following the get his text-fields with a **consistent height** even when one field has **an helper text**:
```jsx
<TextField
  id="name"
  label="Name"
  value={this.state.name}
  onChange={event => this.setState({ name: event.target.value })}
  helperText="helperText"
/>
<TextField
  id="uncontrolled"
  label="Uncontrolled"
  defaultValue="foo"
  className={classes.input}
  helperText={<span />}
/>
```

![capture d ecran 2017-06-08 a 20 07 23](https://user-images.githubusercontent.com/3165635/26943524-23fc75b8-4c86-11e7-9ac1-bd4910e97d3d.png)


Closes #7068

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).
