### PR TITLE
[TimePicker] Support for inline container

### DIFF
--- a/docs/src/app/components/pages/components/TimePicker/ExampleInline.js
+++ b/docs/src/app/components/pages/components/TimePicker/ExampleInline.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import TimePicker from 'material-ui/TimePicker';
+
+/**
+ * Inline Date Pickers are displayed below the input, rather than as a modal dialog.
+ */
+const TimePickerExampleInline = () => (
+  <div>
+    <TimePicker
+      hintText="Inline Dialog"
+      container="inline"
+    />
+    <TimePicker
+      autoOk={true}
+      hintText="Inline Dialog with auto ok"
+      container="inline"
+    />
+  </div>
+);
+
+export default TimePickerExampleInline;

--- a/docs/src/app/components/pages/components/TimePicker/Page.js
+++ b/docs/src/app/components/pages/components/TimePicker/Page.js
@@ -10,6 +10,8 @@ import TimePickerExampleSimple from './ExampleSimple';
 import timePickerExampleSimpleCode from '!raw!./ExampleSimple';
 import TimePickerExampleComplex from './ExampleComplex';
 import timePickerExampleComplexCode from '!raw!./ExampleComplex';
+import TimePickerInline from './ExampleInline';
+import timePickerInlineCode from '!raw!./ExampleInline';
 import TimePickerExampleInternational from './ExampleInternational';
 import timePickerExampleInternationalCode from '!raw!./ExampleInternational';
 import TimePickerExampleStep from './ExampleStep';
@@ -19,6 +21,7 @@ import timePickerCode from '!raw!material-ui/TimePicker/TimePicker';
 const descriptions = {
   simple: 'Time Picker supports 12 hour and 24 hour formats. In 12 hour format the AM and PM indicators toggle the ' +
   'selected time period. You can also disable the Dialog passing true to the disabled property.',
+  inline: 'Inline Time Pickers are displayed below the input, rather than as a modal dialog.',
   controlled: '`TimePicker` can be used as a controlled component.',
   localised: 'The buttons can be localised using the `cancelLabel` and `okLabel` properties.',
   step: 'The number of minutes on each step can be configured using the `minutesStep` property.',
@@ -34,6 +37,13 @@ const TimePickersPage = () => (
       code={timePickerExampleSimpleCode}
     >
       <TimePickerExampleSimple />
+    </CodeExample>
+    <CodeExample
+      title="Inline examples"
+      description={descriptions.inline}
+      code={timePickerInlineCode}
+    >
+      <TimePickerInline />
     </CodeExample>
     <CodeExample
       title="Controlled examples"

--- a/src/TimePicker/TimePicker.js
+++ b/src/TimePicker/TimePicker.js
@@ -21,6 +21,12 @@ class TimePicker extends Component {
      */
     cancelLabel: PropTypes.node,
     /**
+     * Used to control how the Time Picker will be displayed when the input field is focused.
+     * `dialog` (default) displays the TimePicker as a dialog with a modal.
+     * `inline` displays the TimePicker below the input field (similar to auto complete).
+     */
+    container: PropTypes.oneOf(['dialog', 'inline']),
+    /**
      * The initial time value of the TimePicker.
      */
     defaultTime: PropTypes.object,
@@ -95,6 +101,7 @@ class TimePicker extends Component {
   static defaultProps = {
     autoOk: false,
     cancelLabel: 'Cancel',
+    container: 'dialog',
     defaultTime: null,
     disabled: false,
     format: 'ampm',
@@ -184,6 +191,7 @@ class TimePicker extends Component {
     const {
       autoOk,
       cancelLabel,
+      container,
       defaultTime, // eslint-disable-line no-unused-vars
       dialogBodyStyle,
       dialogStyle,
@@ -216,6 +224,7 @@ class TimePicker extends Component {
         <TimePickerDialog
           ref="dialogWindow"
           bodyStyle={dialogBodyStyle}
+          container={container}
           initialTime={this.state.dialogTime}
           onAccept={this.handleAcceptDialog}
           onShow={onShow}

--- a/src/TimePicker/TimePickerDialog.js
+++ b/src/TimePicker/TimePickerDialog.js
@@ -5,12 +5,16 @@ import keycode from 'keycode';
 import Clock from './Clock';
 import Dialog from '../Dialog';
 import FlatButton from '../FlatButton';
+import Popover from '../Popover/Popover';
+import PopoverAnimationVertical from '../Popover/PopoverAnimationVertical';
 
 class TimePickerDialog extends Component {
   static propTypes = {
+    animation: PropTypes.func,
     autoOk: PropTypes.bool,
     bodyStyle: PropTypes.object,
     cancelLabel: PropTypes.node,
+    container: PropTypes.oneOf(['dialog', 'inline']),
     format: PropTypes.oneOf(['ampm', '24hr']),
     initialTime: PropTypes.object,
     minutesStep: PropTypes.number,
@@ -24,6 +28,7 @@ class TimePickerDialog extends Component {
   static defaultProps = {
     okLabel: 'OK',
     cancelLabel: 'Cancel',
+    container: 'dialog',
   };
 
   static contextTypes = {
@@ -78,12 +83,16 @@ class TimePickerDialog extends Component {
       bodyStyle,
       initialTime,
       onAccept, // eslint-disable-line no-unused-vars
+      onDismiss, // eslint-disable-line no-unused-vars
+      onShow, // eslint-disable-line no-unused-vars
       format,
       autoOk,
       okLabel,
       cancelLabel,
       style,
       minutesStep,
+      container,
+      animation,
       ...other
     } = this.props;
 
@@ -91,12 +100,21 @@ class TimePickerDialog extends Component {
       root: {
         fontSize: 14,
         color: this.context.muiTheme.timePicker.clockColor,
+        minWidth: 280,
       },
       dialogContent: {
         width: 280,
       },
       body: {
         padding: 0,
+      },
+      actions: {
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'flex-end',
+        margin: 0,
+        maxHeight: 48,
+        padding: 8,
       },
     };
 
@@ -118,30 +136,37 @@ class TimePickerDialog extends Component {
     const onClockChangeMinutes = autoOk === true ? this.handleTouchTapOK : undefined;
     const open = this.state.open;
 
+    const Container = (container === 'inline' ? Popover : Dialog);
+
     return (
-      <Dialog
-        {...other}
-        style={Object.assign(styles.root, style)}
-        bodyStyle={Object.assign(styles.body, bodyStyle)}
-        actions={actions}
-        contentStyle={styles.dialogContent}
-        repositionOnUpdate={false}
-        open={open}
-        onRequestClose={this.handleRequestClose}
-      >
-        {open &&
-          <EventListener target="window" onKeyUp={this.handleKeyUp} />
-        }
-        {open &&
-          <Clock
-            ref="clock"
-            format={format}
-            initialTime={initialTime}
-            onChangeMinutes={onClockChangeMinutes}
-            minutesStep={minutesStep}
-          />
-        }
-      </Dialog>
+      <div {...other} ref="root">
+        <Container
+          anchorEl={this.refs.root} // For Popover
+          animation={animation || PopoverAnimationVertical} // For Popover
+          style={Object.assign(styles.root, style)}
+          bodyStyle={Object.assign(styles.body, bodyStyle)}
+          contentStyle={styles.dialogContent}
+          repositionOnUpdate={false}
+          open={open}
+          onRequestClose={this.handleRequestClose}
+        >
+          {open &&
+            <EventListener target="window" onKeyUp={this.handleKeyUp} />
+          }
+          {open &&
+            <Clock
+              ref="clock"
+              format={format}
+              initialTime={initialTime}
+              onChangeMinutes={onClockChangeMinutes}
+              minutesStep={minutesStep}
+            />
+          }
+          <div style={styles.actions}>
+            {actions}
+          </div>
+        </Container>
+      </div>
     );
   }
 }


### PR DESCRIPTION
Gives TimePicker the same `container` prop as DatePicker, to allow for inline dialogs.

- [ ] PR has tests
- [x] docs demo
- [x] is linted.

