### PR TITLE
[Tab] SVG Icons will take the color from the style props of the icon elemen…

### DIFF
--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -120,7 +120,11 @@ class Tab extends Component {
       };
       // If it's svg icon set color via props
       if (icon.type.muiName !== 'FontIcon') {
-        iconProps.color = icon.props.style.color;
+        if (icon.props !== undefined && icon.props.style !== undefined && icon.props.style.color !== undefined) {
+          iconProps.color = icon.props.style.color;
+        } else {
+          iconProps.color = styles.root.color;
+        }
       }
       iconElement = React.cloneElement(icon, iconProps);
     }

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -120,7 +120,7 @@ class Tab extends Component {
       };
       // If it's svg icon set color via props
       if (icon.type.muiName !== 'FontIcon') {
-        iconProps.color = styles.root.color;
+        iconProps.color = icon.props.style.color;
       }
       iconElement = React.cloneElement(icon, iconProps);
     }


### PR DESCRIPTION
The SVG icons color style is not being used in the tab even though the comment before the line says it takes the color style if it's SVG icon.