### PR TITLE
[TextField] Replaced WebkitTextFillColor with WebkitOpacity

### DIFF
--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -57,7 +57,7 @@ const getStyles = (props, context, state) => {
       color: props.disabled ? disabledTextColor : textColor,
       cursor: 'inherit',
       font: 'inherit',
-      WebkitTextFillColor: props.disabled ? disabledTextColor : textColor,
+      WebkitOpacity: 1,
       WebkitTapHighlightColor: 'rgba(0,0,0,0)', // Remove mobile color flashing (deprecated style).
     },
     inputNative: {


### PR DESCRIPTION
WebkitTextFillColor overwrites any custom html css color rules

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

