### PR TITLE
[DatePicker] Arrow direction in RTL 

### DIFF
--- a/src/DatePicker/Calendar.js
+++ b/src/DatePicker/Calendar.js
@@ -182,6 +182,8 @@ class Calendar extends Component {
 
   handleWindowKeyDown = (event) => {
     if (this.props.open) {
+      const nextArrow = this.context.muiTheme.isRtl ? 'left' : 'right';
+      const prevArrow = this.context.muiTheme.isRtl ? 'right' : 'left';
       switch (keycode(event)) {
         case 'up':
           if (event.altKey && event.shiftKey) {
@@ -203,7 +205,7 @@ class Calendar extends Component {
           }
           break;
 
-        case 'right':
+        case nextArrow:
           if (event.altKey && event.shiftKey) {
             this.addSelectedYears(1);
           } else if (event.shiftKey) {
@@ -213,7 +215,7 @@ class Calendar extends Component {
           }
           break;
 
-        case 'left':
+        case prevArrow:
           if (event.altKey && event.shiftKey) {
             this.addSelectedYears(-1);
           } else if (event.shiftKey) {

--- a/src/DatePicker/Calendar.js
+++ b/src/DatePicker/Calendar.js
@@ -113,7 +113,9 @@ class Calendar extends Component {
 
   setDisplayDate(date, newSelectedDate) {
     const newDisplayDate = this.props.utils.getFirstDayOfMonth(date);
-    const direction = newDisplayDate > this.state.displayDate ? 'left' : 'right';
+    const nextDirection = this.context.muiTheme.isRtl ? 'right' : 'left';
+    const prevDirection = this.context.muiTheme.isRtl ? 'left' : 'right';
+    const direction = newDisplayDate > this.state.displayDate ? nextDirection : prevDirection;
 
     if (newDisplayDate !== this.state.displayDate) {
       this.setState({
@@ -150,8 +152,11 @@ class Calendar extends Component {
   };
 
   handleMonthChange = (months) => {
+    const nextDirection = this.context.muiTheme.isRtl ? 'right' : 'left';
+    const prevDirection = this.context.muiTheme.isRtl ? 'left' : 'right';
+    const direction = months >= 0 ? nextDirection : prevDirection;
     this.setState({
-      transitionDirection: months >= 0 ? 'left' : 'right',
+      transitionDirection: direction,
       displayDate: this.props.utils.addMonths(this.state.displayDate, months),
     });
   };

--- a/src/DatePicker/Calendar.js
+++ b/src/DatePicker/Calendar.js
@@ -113,11 +113,11 @@ class Calendar extends Component {
 
   setDisplayDate(date, newSelectedDate) {
     const newDisplayDate = this.props.utils.getFirstDayOfMonth(date);
-    const nextDirection = this.context.muiTheme.isRtl ? 'right' : 'left';
-    const prevDirection = this.context.muiTheme.isRtl ? 'left' : 'right';
-    const direction = newDisplayDate > this.state.displayDate ? nextDirection : prevDirection;
 
     if (newDisplayDate !== this.state.displayDate) {
+      const nextDirection = this.context.muiTheme.isRtl ? 'right' : 'left';
+      const prevDirection = this.context.muiTheme.isRtl ? 'left' : 'right';
+      const direction = newDisplayDate > this.state.displayDate ? nextDirection : prevDirection;
       this.setState({
         displayDate: newDisplayDate,
         transitionDirection: direction,

--- a/src/DatePicker/CalendarToolbar.js
+++ b/src/DatePicker/CalendarToolbar.js
@@ -40,7 +40,7 @@ class CalendarToolbar extends Component {
   };
 
   static contextTypes = {
-     muiTheme: PropTypes.object.isRequired,
+    muiTheme: PropTypes.object.isRequired,
   };
 
   state = {

--- a/src/DatePicker/CalendarToolbar.js
+++ b/src/DatePicker/CalendarToolbar.js
@@ -49,8 +49,8 @@ class CalendarToolbar extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.displayDate !== this.props.displayDate) {
-      const nextDirection = this.context.muiTheme.isRtl ? "right" : "left";
-      const prevDirection = this.context.muiTheme.isRtl ? "left" : "right";
+      const nextDirection = this.context.muiTheme.isRtl ? 'right' : 'left';
+      const prevDirection = this.context.muiTheme.isRtl ? 'left' : 'right';
       const direction = nextProps.displayDate > this.props.displayDate ? nextDirection : prevDirection;
       this.setState({
         transitionDirection: direction,

--- a/src/DatePicker/CalendarToolbar.js
+++ b/src/DatePicker/CalendarToolbar.js
@@ -39,6 +39,10 @@ class CalendarToolbar extends Component {
     prevMonth: true,
   };
 
+  static contextTypes = {
+     muiTheme: PropTypes.object.isRequired,
+  };
+
   state = {
     transitionDirection: 'up',
   };
@@ -72,13 +76,17 @@ class CalendarToolbar extends Component {
       year: 'numeric',
     }).format(displayDate);
 
+    const nextButtonIcon = this.context.muiTheme.isRtl ? <NavigationChevronLeft /> : <NavigationChevronRight />;
+    const prevButtonIcon = this.context.muiTheme.isRtl ? <NavigationChevronRight /> : <NavigationChevronLeft />;
+
+
     return (
       <div style={styles.root}>
         <IconButton
           disabled={!this.props.prevMonth}
           onTouchTap={this.handleTouchTapPrevMonth}
         >
-          <NavigationChevronLeft />
+          {prevButtonIcon}
         </IconButton>
         <SlideInTransitionGroup
           direction={this.state.transitionDirection}
@@ -92,7 +100,7 @@ class CalendarToolbar extends Component {
           disabled={!this.props.nextMonth}
           onTouchTap={this.handleTouchTapNextMonth}
         >
-          <NavigationChevronRight />
+          {nextButtonIcon}
         </IconButton>
       </div>
     );

--- a/src/DatePicker/CalendarToolbar.js
+++ b/src/DatePicker/CalendarToolbar.js
@@ -49,7 +49,9 @@ class CalendarToolbar extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.displayDate !== this.props.displayDate) {
-      const direction = nextProps.displayDate > this.props.displayDate ? 'left' : 'right';
+      const nextDirection = this.context.muiTheme.isRtl ? "right" : "left";
+      const prevDirection = this.context.muiTheme.isRtl ? "left" : "right";
+      const direction = nextProps.displayDate > this.props.displayDate ? nextDirection : prevDirection;
       this.setState({
         transitionDirection: direction,
       });


### PR DESCRIPTION
(Re)fixed arrow direction (the left and right chevrons) in DatePicker so that right-is-left and left-is-right if isRtl == true.

[the code used to be like this but was changed at some point, probably by mistake]