### PR TITLE
[ListItem] Exposing onTouchTap API in order to address Issue #6938

### DIFF
--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -250,7 +250,11 @@ class ListItem extends Component {
     onTouchEnd: PropTypes.func,
     /** @ignore */
     onTouchStart: PropTypes.func,
-    /** @ignore */
+    /**
+     * Callback function fired when the list item is touch-tapped.
+     *
+     * @param {object} event TouchTap event targeting the list item.
+     */
     onTouchTap: PropTypes.func,
     /**
      * Control toggle state of nested list.
@@ -459,6 +463,16 @@ class ListItem extends Component {
     this.props.onMouseLeave(event);
   };
 
+  handleTouchTap = (event) => {
+    if (this.props.onTouchTap) {
+      this.props.onTouchTap(event);
+    }
+
+    if (this.props.primaryTogglesNestedList) {
+      this.handleNestedListToggle(event);
+    }
+  };
+
   handleNestedListToggle = (event) => {
     event.stopPropagation();
 
@@ -563,7 +577,6 @@ class ListItem extends Component {
       onMouseLeave, // eslint-disable-line no-unused-vars
       onNestedListToggle, // eslint-disable-line no-unused-vars
       onTouchStart, // eslint-disable-line no-unused-vars
-      onTouchTap,
       rightAvatar,
       rightIcon,
       rightIconButton,
@@ -708,7 +721,7 @@ class ListItem extends Component {
               onMouseEnter={this.handleMouseEnter}
               onTouchStart={this.handleTouchStart}
               onTouchEnd={this.handleTouchEnd}
-              onTouchTap={primaryTogglesNestedList ? this.handleNestedListToggle : onTouchTap}
+              onTouchTap={this.handleTouchTap}
               ref={(node) => this.button = node}
               style={Object.assign({}, styles.root, style)}
             >

--- a/src/List/ListItem.spec.js
+++ b/src/List/ListItem.spec.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import {assert} from 'chai';
+import {spy} from 'sinon';
 import ListItem from './ListItem';
 import EnhancedButton from '../internal/EnhancedButton';
 import getMuiTheme from '../styles/getMuiTheme';
@@ -74,6 +75,19 @@ describe('<ListItem />', () => {
     );
     assert.ok(wrapper.find('.test-checkbox').length);
     assert.strictEqual(wrapper.find(`.${testClass}`).length, 1, 'should have a div with the test class');
+  });
+
+  it('should trigger onTouchTap handler when appropriate.', () => {
+    const onTouchTap = spy();
+    const wrapper = shallowWithContext(
+      <ListItem
+        onTouchTap={onTouchTap}
+      />
+    );
+    const primaryTextButton = wrapper.find(EnhancedButton);
+
+    primaryTextButton.simulate('touchTap', {stopPropagation: () => {}});
+    assert.strictEqual(onTouchTap.callCount, 1);
   });
 
   describe('prop: primaryTogglesNestedList', () => {


### PR DESCRIPTION
Allows for the fixing of https://github.com/callemall/material-ui/issues/6938

From the conversation on https://github.com/callemall/material-ui/pull/6907 it was suggested that instead of just calling an `event.preventDefault` within the listItem, the `onTouchTap` API be exposed to the user. That way it can be handled as appropriate.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

