### PR TITLE
[Tab] SVG icon takes color from Icon's color props as well..

### DIFF
--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -120,7 +120,11 @@ class Tab extends Component {
       };
       // If it's svg icon set color via props
       if (icon.type.muiName !== 'FontIcon') {
-        iconProps.color = icon.props.style.color;
+        if (icon.props !== undefined && icon.props.style !== undefined && icon.props.style.color !== undefined) {
+          iconProps.color = icon.props.style.color;
+        } else {
+          iconProps.color = styles.root.color;
+        }
       }
       iconElement = React.cloneElement(icon, iconProps);
     }

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -120,7 +120,7 @@ class Tab extends Component {
       };
       // If it's svg icon set color via props
       if (icon.type.muiName !== 'FontIcon') {
-        iconProps.color = styles.root.color;
+        iconProps.color = icon.props.style.color;
       }
       iconElement = React.cloneElement(icon, iconProps);
     }

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -120,12 +120,18 @@ class Tab extends Component {
       };
       // If it's svg icon set color via props
       if (icon.type.muiName !== 'FontIcon') {
-        if (icon.props && icon.props.style && icon.props.style.color) {
-          iconProps.color = icon.props.style.color;
-        } else if (icon.props && icon.props.color) {
-          iconProps.color = icon.props.color;
-        } else {
-          iconProps.color = styles.root.color;
+        if (icon.props) {
+          if (icon.props.style && icon.props.style.color) {
+            iconProps.color = icon.props.style.color;
+          } else if (icon.props.color) {
+            iconProps.color = icon.props.color;
+          } else {
+            iconProps.color = styles.root.color;
+          }
+
+          if (icon.props.hoverColor) {
+            iconProps.hoverColor = icon.props.hoverColor;
+          }
         }
       }
       iconElement = React.cloneElement(icon, iconProps);

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -120,8 +120,10 @@ class Tab extends Component {
       };
       // If it's svg icon set color via props
       if (icon.type.muiName !== 'FontIcon') {
-        if (icon.props !== undefined && icon.props.style !== undefined && icon.props.style.color !== undefined) {
+        if (icon.props && icon.props.style && icon.props.style.color) {
           iconProps.color = icon.props.style.color;
+        } else if (icon.props && icon.props.color) {
+          iconProps.color = icon.props.color;
         } else {
           iconProps.color = styles.root.color;
         }


### PR DESCRIPTION
This is an improvement on the pull request [#7091](https://github.com/callemall/material-ui/pull/7091)..
The color can now be passed from the color prop also instead of just style.