### PR TITLE
[Docs] Fix Typo in AutoComplete Example

### DIFF
--- a/docs/src/app/components/pages/components/AutoComplete/ExampleDataSources.js
+++ b/docs/src/app/components/pages/components/AutoComplete/ExampleDataSources.js
@@ -4,8 +4,8 @@ import MenuItem from 'material-ui/MenuItem';
 
 const dataSource1 = [
   {
-    text: 'text-value1',
-    value: (
+    value: 'text-value1',
+    text: (
       <MenuItem
         primaryText="text-value1"
         secondaryText="&#9786;"
@@ -13,8 +13,8 @@ const dataSource1 = [
     ),
   },
   {
-    text: 'text-value2',
-    value: (
+    value: 'text-value2',
+    text: (
       <MenuItem
         primaryText="text-value2"
         secondaryText="&#9786;"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

in this example, `text` and `value` are mistaken in their places.
`text` is for displaying, and `value` is for matching the searching keyword.

