### PR TITLE
fix type use of Element

### DIFF
--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -1,6 +1,7 @@
 // @flow
 
-import React, { Element, createElement, cloneElement } from 'react';
+import React, { createElement, cloneElement } from 'react';
+import type { Element } from 'react';
 import classNames from 'classnames';
 import { createStyleSheet } from 'jss-theme-reactor';
 import { capitalizeFirstLetter } from '../utils/helpers';

--- a/src/Grid/Grid.js
+++ b/src/Grid/Grid.js
@@ -12,7 +12,8 @@
  * - https://css-tricks.com/snippets/css/a-guide-to-flexbox/
  */
 
-import React, { Element } from 'react';
+import React from 'react';
+import type { Element } from 'react';
 import classNames from 'classnames';
 import { createStyleSheet } from 'jss-theme-reactor';
 import withStyles from '../styles/withStyles';

--- a/src/Hidden/Hidden.js
+++ b/src/Hidden/Hidden.js
@@ -1,6 +1,7 @@
 // @flow
 
-import React, { Element } from 'react';
+import React from 'react';
+import type { Element } from 'react';
 import HiddenJs from './HiddenJs';
 import type { Breakpoint } from '../styles/breakpoints';
 

--- a/src/Hidden/types.js
+++ b/src/Hidden/types.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { Element } from 'react';
+import type { Element } from 'react';
 import type { Breakpoint } from '../styles/breakpoints';
 
 export type HiddenProps = {

--- a/src/Typography/Typography.js
+++ b/src/Typography/Typography.js
@@ -1,6 +1,7 @@
 // @flow
 
-import React, { Element } from 'react';
+import React from 'react';
+import type { Element } from 'react';
 import classNames from 'classnames';
 import { createStyleSheet } from 'jss-theme-reactor';
 import { capitalizeFirstLetter } from '../utils/helpers';

--- a/src/internal/Modal.js
+++ b/src/internal/Modal.js
@@ -1,6 +1,7 @@
 // @flow
 
-import React, { Element, Component } from 'react';
+import React, { Component } from 'react';
+import type { Element } from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import { createStyleSheet } from 'jss-theme-reactor';

--- a/src/internal/Transition.js
+++ b/src/internal/Transition.js
@@ -1,6 +1,7 @@
 // @flow weak
 
-import React, { Component, Element as ReactElement } from 'react'; // DOM type `Element` used below
+import React, { Component } from 'react';
+import type { Element as ReactElement } from 'react'; // DOM type `Element` used below
 import ReactDOM from 'react-dom';
 import transitionInfo from 'dom-helpers/transition/properties';
 import addEventListener from 'dom-helpers/events/on';

--- a/src/test-utils/createRender.js
+++ b/src/test-utils/createRender.js
@@ -3,7 +3,8 @@
 import { create } from 'jss';
 import jssPreset from 'jss-preset-default';
 import { createStyleManager } from 'jss-theme-reactor';
-import React, { Element } from 'react';
+import React from 'react';
+import type { Element } from 'react';
 import { render as enzymeRender } from 'enzyme';
 import createMuiTheme from '../styles/theme';
 import MuiThemeProvider from '../styles/MuiThemeProvider';

--- a/src/transitions/Fade.js
+++ b/src/transitions/Fade.js
@@ -1,6 +1,7 @@
 // @flow weak
 
-import React, { Element, Component } from 'react';
+import React, { Component } from 'react';
+import type { Element } from 'react';
 import Transition from '../internal/Transition';
 import { duration } from '../styles/transitions';
 import customPropTypes from '../utils/customPropTypes';


### PR DESCRIPTION
Fix misuse of `Element` for flow.  Proper use should be `import type { Element } from 'react';`

Note - lint is failing on `prettier` prior to this PR.

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

