### PR TITLE
[Dialog] Remove css width as it is too prescriptive for simple dialogs

### DIFF
--- a/docs/src/pages/component-api/Dialog/Dialog.md
+++ b/docs/src/pages/component-api/Dialog/Dialog.md
@@ -23,7 +23,6 @@ Dialogs are overlaid modal paper based components with a backdrop.
 | onExited | Function |  | Callback fired when the dialog has exited. |
 | onRequestClose | Function |  | Callback fired when the dialog requests to be closed. |
 | open | boolean | false | If `true`, the Dialog is open. |
-| paperClassName | string |  | The CSS class name of the paper inner element. |
 | transition | union:&nbsp;Function<br>&nbsp;Element<*><br> | Fade | Transition component. |
 
 Any other properties supplied will be spread to the root element.
@@ -33,10 +32,10 @@ Any other properties supplied will be spread to the root element.
 You can overrides all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 - `root`
-- `dialog`
-- `dialogWidthXs`
-- `dialogWidthSm`
-- `dialogWidthMd`
+- `paper`
+- `paperWidthXs`
+- `paperWidthSm`
+- `paperWidthMd`
 - `fullScreen`
 
 Have a look at [overriding with class names](/customization/overrides#overriding-with-class-names)

--- a/docs/src/pages/component-demos/dialogs/AlertDialog.js
+++ b/docs/src/pages/component-demos/dialogs/AlertDialog.js
@@ -14,7 +14,9 @@ export default class AlertDialog extends Component {
     open: false,
   };
 
-  handleRequestClose = () => this.setState({ open: false });
+  handleRequestClose = () => {
+    this.setState({ open: false });
+  };
 
   render() {
     return (

--- a/docs/src/pages/component-demos/dialogs/AlertDialogSlide.js
+++ b/docs/src/pages/component-demos/dialogs/AlertDialogSlide.js
@@ -15,7 +15,9 @@ export default class AlertDialogSlide extends Component {
     open: false,
   };
 
-  handleRequestClose = () => this.setState({ open: false });
+  handleRequestClose = () => {
+    this.setState({ open: false });
+  };
 
   render() {
     return (

--- a/docs/src/pages/component-demos/dialogs/ConfirmationDialog.js
+++ b/docs/src/pages/component-demos/dialogs/ConfirmationDialog.js
@@ -61,10 +61,16 @@ class ConfirmationDialog extends Component {
   };
 
   render() {
-    const { onRequestClose, selectedValue, ...other } = this.props;
+    const { selectedValue, ...other } = this.props;
 
     return (
-      <Dialog onEntering={this.handleEntering} {...other}>
+      <Dialog
+        ignoreBackdropClick
+        ignoreEscapeKeyUp
+        maxWidth="xs"
+        onEntering={this.handleEntering}
+        {...other}
+      >
         <DialogTitle>Phone Ringtone</DialogTitle>
         <DialogContent>
           <RadioGroup
@@ -144,8 +150,9 @@ class ConfirmationDialogDemo extends Component {
             <ListItemText primary="Default notification ringtone" secondary="Tethys" />
           </ListItem>
           <ConfirmationDialog
-            maxWidth="xs"
-            paperClassName={classes.dialog}
+            classes={{
+              paper: classes.dialog,
+            }}
             open={this.state.open}
             onRequestClose={this.handleRequestClose}
             selectedValue={this.state.selectedValue}

--- a/docs/src/pages/component-demos/dialogs/SimpleDialog.js
+++ b/docs/src/pages/component-demos/dialogs/SimpleDialog.js
@@ -1,0 +1,105 @@
+// @flow weak
+/* eslint-disable react/no-multi-comp */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { createStyleSheet, withStyles } from 'material-ui/styles';
+import Button from 'material-ui/Button';
+import Avatar from 'material-ui/Avatar';
+import List, { ListItem, ListItemAvatar, ListItemText } from 'material-ui/List';
+import Dialog, { DialogTitle } from 'material-ui/Dialog';
+import PersonIcon from 'material-ui-icons/Person';
+import AddIcon from 'material-ui-icons/Add';
+import Typography from 'material-ui/Typography';
+import { blue } from 'material-ui/styles/colors';
+
+const emails = ['username@gmail.com', 'user02@gmail.com'];
+
+const styleSheet = createStyleSheet('SimpleDialog', () => ({
+  avatar: {
+    background: blue[100],
+    color: blue[600],
+  },
+}));
+
+class SimpleDialog extends Component {
+  handleRequestClose = () => {
+    this.props.onRequestClose(this.props.selectedValue);
+  };
+
+  handleListItemClick = value => {
+    this.props.onRequestClose(value);
+  };
+
+  render() {
+    const { classes, onRequestClose, selectedValue, ...other } = this.props;
+
+    return (
+      <Dialog onRequestClose={this.handleRequestClose} {...other}>
+        <DialogTitle>Set backup account</DialogTitle>
+        <div>
+          <List>
+            {emails.map(email =>
+              <ListItem button onClick={() => this.handleListItemClick(email)} key={email}>
+                <ListItemAvatar>
+                  <Avatar className={classes.avatar}>
+                    <PersonIcon />
+                  </Avatar>
+                </ListItemAvatar>
+                <ListItemText primary={email} />
+              </ListItem>,
+            )}
+            <ListItem button onClick={() => this.handleListItemClick('addAccount')}>
+              <ListItemAvatar>
+                <Avatar>
+                  <AddIcon />
+                </Avatar>
+              </ListItemAvatar>
+              <ListItemText primary="add account" />
+            </ListItem>
+          </List>
+        </div>
+      </Dialog>
+    );
+  }
+}
+
+SimpleDialog.propTypes = {
+  classes: PropTypes.object.isRequired,
+  onRequestClose: PropTypes.func,
+  selectedValue: PropTypes.string,
+};
+
+const SimpleDialogWrapped = withStyles(styleSheet)(SimpleDialog);
+
+class SimpleDialogDemo extends Component {
+  state = {
+    open: false,
+    selectedValue: emails[1],
+  };
+
+  handleRequestClose = value => {
+    this.setState({ selectedValue: value, open: false });
+  };
+
+  render() {
+    return (
+      <div>
+        <Typography type="subheading">
+          Selected: {this.state.selectedValue}
+        </Typography>
+        <br />
+        <Button onClick={() => this.setState({ open: true })}>
+          Open simple dialog
+        </Button>
+        <SimpleDialogWrapped
+          selectedValue={this.state.selectedValue}
+          open={this.state.open}
+          onRequestClose={this.handleRequestClose}
+        />
+      </div>
+    );
+  }
+}
+
+export default SimpleDialogDemo;

--- a/docs/src/pages/component-demos/dialogs/dialogs.md
+++ b/docs/src/pages/component-demos/dialogs/dialogs.md
@@ -10,6 +10,17 @@ Dialogs contain text and UI controls.
 They retain focus until dismissed or a required action has been taken.
 Use dialogs sparingly because they are interruptive.
 
+## Simple Dialogs
+
+Simple dialogs can provide additional details or actions about a list item.
+For example, they can display avatars, icons, clarifying subtext, or orthogonal actions (such as adding an account).
+
+Touch mechanics:
+- Choosing an option immediately commits the option and closes the menu
+- Touching outside of the dialog, or pressing Back, cancels the action and closes the dialog
+
+{{demo='pages/component-demos/dialogs/SimpleDialog.js'}}
+
 ## Alerts
 
 Alerts are urgent interruptions, requiring acknowledgement, that inform the user about a situation.
@@ -35,7 +46,8 @@ You can also swap out the transition, the next example uses `Slide`.
 
 ## Confirmation dialogs
 
-Confirmation dialogs require users to explicitly confirm their choice before an option is committed. For example, users can listen to multiple ringtones but only make a final selection upon touching “OK.”
+Confirmation dialogs require users to explicitly confirm their choice before an option is committed.
+For example, users can listen to multiple ringtones but only make a final selection upon touching “OK.”
 
 Touching “Cancel” in a confirmation dialog, or pressing Back, cancels the action, discards any changes, and closes the dialog.
 

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -16,24 +16,23 @@ export const styleSheet = createStyleSheet('MuiDialog', theme => ({
     justifyContent: 'center',
     alignItems: 'center',
   },
-  dialog: {
+  paper: {
     display: 'flex',
     flexDirection: 'column',
     flex: '0 1 auto',
     position: 'relative',
-    width: '75%',
     maxHeight: '90vh',
     '&:focus': {
       outline: 'none',
     },
   },
-  dialogWidthXs: {
+  paperWidthXs: {
     maxWidth: theme.breakpoints.getWidth('xs'),
   },
-  dialogWidthSm: {
+  paperWidthSm: {
     maxWidth: theme.breakpoints.getWidth('sm'),
   },
-  dialogWidthMd: {
+  paperWidthMd: {
     maxWidth: theme.breakpoints.getWidth('md'),
   },
   fullScreen: {
@@ -126,10 +125,6 @@ type Props = {
    */
   open?: boolean,
   /**
-   * The CSS class name of the paper inner element.
-   */
-  paperClassName?: string,
-  /**
    * Transition component.
    */
   transition?: Function | Element<*>,
@@ -159,7 +154,6 @@ function Dialog(props: Props) {
     onExiting,
     onExited,
     onRequestClose,
-    paperClassName,
     transition,
     ...other
   } = props;
@@ -199,9 +193,8 @@ function Dialog(props: Props) {
           data-mui-test="Dialog"
           elevation={24}
           className={classNames(
-            classes.dialog,
-            classes[`dialogWidth${capitalizeFirstLetter(maxWidth)}`],
-            paperClassName,
+            classes.paper,
+            classes[`paperWidth${capitalizeFirstLetter(maxWidth)}`],
             { [classes.fullScreen]: fullScreen },
           )}
         >

--- a/src/Dialog/Dialog.spec.js
+++ b/src/Dialog/Dialog.spec.js
@@ -78,7 +78,7 @@ describe('<Dialog />', () => {
     const paper = fade.childAt(0);
     assert.strictEqual(paper.length === 1 && paper.name(), 'withStyles(Paper)');
 
-    assert.strictEqual(paper.hasClass(classes.dialog), true, 'should have the dialog class');
+    assert.strictEqual(paper.hasClass(classes.paper), true, 'should have the dialog class');
   });
 
   it('should not be open by default', () => {
@@ -102,10 +102,10 @@ describe('<Dialog />', () => {
     );
   });
 
-  describe('prop: paperClassName', () => {
+  describe('prop: classes', () => {
     it('should add the class on the Paper element', () => {
       const className = 'foo';
-      const wrapper = shallow(<Dialog paperClassName={className} />);
+      const wrapper = shallow(<Dialog classes={{ paper: className }} />);
       assert.strictEqual(wrapper.find(Paper).hasClass(className), true);
     });
   });
@@ -113,7 +113,7 @@ describe('<Dialog />', () => {
   describe('prop: maxWidth', () => {
     it('should use the right className', () => {
       const wrapper = shallow(<Dialog maxWidth="xs" />);
-      assert.strictEqual(wrapper.find(Paper).hasClass(classes.dialogWidthXs), true);
+      assert.strictEqual(wrapper.find(Paper).hasClass(classes.paperWidthXs), true);
     });
   });
 


### PR DESCRIPTION
After looking at how bootstrap is handling [the backdrop and escape thing](https://v4-alpha.getbootstrap.com/components/modal/), I do no longer think that we should be exposing any more API than what we currently have. It's making things less opinionated. 

Following #6903.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

