### PR TITLE
[TimePicker] Add getTime()

### DIFF
--- a/src/TimePicker/TimePicker.js
+++ b/src/TimePicker/TimePicker.js
@@ -128,6 +128,10 @@ class TimePicker extends Component {
     }
   }
 
+  getTime() {
+    return this.state.time;
+  }
+
   /**
    * Alias for `openDialog()` for an api consistent with TextField.
    */


### PR DESCRIPTION
`DatePicker.prototype.getDate()` is available,
but `TimePicker.prototype.getTime()` is not.

We should fix the inconsistency.