### PR TITLE
[Dialog] Styling inner content container (component Paper)

### DIFF
--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -340,11 +340,7 @@ class DialogInline extends Component {
               className={contentClassName}
               style={styles.content}
             >
-              <Paper
-                className={paperClassName}
-                zDepth={4}
-                {...paperProps}
-              >
+              <Paper className={paperClassName} zDepth={4} {...paperProps}>
                 {titleElement}
                 <div
                   ref="dialogContent"
@@ -406,7 +402,7 @@ class Dialog extends Component {
      */
     children: PropTypes.node,
     /**
-     * The `className` to add to the root element.
+     * @ignore
      */
     className: PropTypes.string,
     /**
@@ -441,11 +437,11 @@ class Dialog extends Component {
      */
     overlayStyle: PropTypes.object,
     /**
-     * Properties applied to the `Paper` element.
+     * The CSS class name of the `Paper` element.
      */
     paperClassName: PropTypes.string,
     /**
-     * Props to be passed to paper.
+     * Properties applied to the `Paper` element.
      */
     paperProps: PropTypes.object,
     /**

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -161,7 +161,6 @@ class DialogInline extends Component {
     className: PropTypes.string,
     contentClassName: PropTypes.string,
     contentStyle: PropTypes.object,
-    innerContentStyle: PropTypes.object,
     modal: PropTypes.bool,
     onRequestClose: PropTypes.func,
     open: PropTypes.bool.isRequired,
@@ -343,6 +342,8 @@ class DialogInline extends Component {
           >
             <Paper
               className={paperClassName}
+              rounded={true}
+              zDepth={4}
               {...paperProps}
             >
               {titleElement}
@@ -418,7 +419,8 @@ class Dialog extends Component {
      */
     contentStyle: PropTypes.object,
     /**
-     * Overrides the inline-styles of the inner content container.
+     * Force the user to use one of the actions in the `Dialog`.Clicking outside the `Dialog`
+     * will not trigger the `onRequestClose`.
      */
     modal: PropTypes.bool,
     /**
@@ -478,10 +480,6 @@ class Dialog extends Component {
     autoScrollBodyContent: false,
     modal: false,
     repositionOnUpdate: true,
-    paperProps: {
-      rounded: true,
-      zDepth: 4,
-    },
   };
 
   renderLayer = () => {

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import EventListener from 'react-event-listener';
 import keycode from 'keycode';
-import propTypes from '../utils/propTypes';
 import transitions from '../styles/transitions';
 import Overlay from '../internal/Overlay';
 import RenderToLayer from '../internal/RenderToLayer';
@@ -162,20 +161,19 @@ class DialogInline extends Component {
     className: PropTypes.string,
     contentClassName: PropTypes.string,
     contentStyle: PropTypes.object,
-    innerContentClassName: PropTypes.string,
-    innerContentRounded: PropTypes.bool,
     innerContentStyle: PropTypes.object,
     modal: PropTypes.bool,
     onRequestClose: PropTypes.func,
     open: PropTypes.bool.isRequired,
     overlayClassName: PropTypes.string,
     overlayStyle: PropTypes.object,
+    paperClassName: PropTypes.string,
+    paperProps: PropTypes.object,
     repositionOnUpdate: PropTypes.bool,
     style: PropTypes.object,
     title: PropTypes.node,
     titleClassName: PropTypes.string,
     titleStyle: PropTypes.object,
-    zDepth: propTypes.zDepth,
   };
 
   static contextTypes = {
@@ -280,9 +278,7 @@ class DialogInline extends Component {
       className,
       contentClassName,
       contentStyle,
-      innerContentClassName,
-      innerContentStyle,
-      innerContentRounded,
+      paperClassName,
       overlayClassName,
       overlayStyle,
       open,
@@ -290,7 +286,7 @@ class DialogInline extends Component {
       titleStyle,
       title,
       style,
-      zDepth,
+      paperProps,
     } = this.props;
 
     const {prepareStyles} = this.context.muiTheme;
@@ -326,11 +322,11 @@ class DialogInline extends Component {
     return (
       <div className={className} style={prepareStyles(styles.root)}>
         {open &&
-          <EventListener
-            target="window"
-            onKeyUp={this.handleKeyUp}
-            onResize={this.handleResize}
-          />
+        <EventListener
+          target="window"
+          onKeyUp={this.handleKeyUp}
+          onResize={this.handleResize}
+        />
         }
         <ReactTransitionGroup
           component="div"
@@ -341,27 +337,25 @@ class DialogInline extends Component {
           transitionEnterTimeout={450}
         >
           {open &&
-            <TransitionItem
-              className={contentClassName}
-              style={styles.content}
+          <TransitionItem
+            className={contentClassName}
+            style={styles.content}
+          >
+            <Paper
+              className={paperClassName}
+              {...paperProps}
             >
-              <Paper
-                className={innerContentClassName}
-                rounded={innerContentRounded}
-                style={innerContentStyle}
-                zDepth={zDepth}
+              {titleElement}
+              <div
+                ref="dialogContent"
+                className={bodyClassName}
+                style={prepareStyles(styles.body)}
               >
-                {titleElement}
-                <div
-                  ref="dialogContent"
-                  className={bodyClassName}
-                  style={prepareStyles(styles.body)}
-                >
-                  {children}
-                </div>
-                {actionsContainer}
-              </Paper>
-            </TransitionItem>
+                {children}
+              </div>
+              {actionsContainer}
+            </Paper>
+          </TransitionItem>
           }
         </ReactTransitionGroup>
         <Overlay
@@ -424,21 +418,7 @@ class Dialog extends Component {
      */
     contentStyle: PropTypes.object,
     /**
-     * The `className` to add to the inner content container.
-     */
-    innerContentClassName: PropTypes.string,
-     /**
-     * By default, the inner content container will have a border radius.
-     * Set this to false to generate a container with sharp corners.
-     */
-    innerContentRounded: PropTypes.bool,
-    /**
      * Overrides the inline-styles of the inner content container.
-     */
-    innerContentStyle: PropTypes.object,
-    /**
-     * Force the user to use one of the actions in the `Dialog`.
-     * Clicking outside the `Dialog` will not trigger the `onRequestClose`.
      */
     modal: PropTypes.bool,
     /**
@@ -460,6 +440,14 @@ class Dialog extends Component {
      */
     overlayStyle: PropTypes.object,
     /**
+     * The `className` to add to the inner content container.
+     */
+    paperClassName: PropTypes.string,
+    /**
+     * Sets zDepth, rounded corners, css styles of `Paper` container. See more at component `Paper`.
+     */
+    paperProps: PropTypes.object,
+    /**
      * Determines whether the `Dialog` should be repositioned when it's contents are updated.
      */
     repositionOnUpdate: PropTypes.bool,
@@ -479,10 +467,6 @@ class Dialog extends Component {
      * Overrides the inline-styles of the title's root container element.
      */
     titleStyle: PropTypes.object,
-     /**
-     * This number represents the zDepth of the innner content container shadow.
-     */
-    zDepth: propTypes.zDepth,
   };
 
   static contextTypes = {
@@ -492,10 +476,12 @@ class Dialog extends Component {
   static defaultProps = {
     autoDetectWindowHeight: true,
     autoScrollBodyContent: false,
-    innerContentRounded: true,
     modal: false,
     repositionOnUpdate: true,
-    zDepth: 4,
+    paperProps: {
+      rounded: true,
+      zDepth: 4,
+    },
   };
 
   renderLayer = () => {

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import EventListener from 'react-event-listener';
 import keycode from 'keycode';
+import propTypes from '../utils/propTypes';
 import transitions from '../styles/transitions';
 import Overlay from '../internal/Overlay';
 import RenderToLayer from '../internal/RenderToLayer';
@@ -161,6 +162,9 @@ class DialogInline extends Component {
     className: PropTypes.string,
     contentClassName: PropTypes.string,
     contentStyle: PropTypes.object,
+    innerContentClassName: PropTypes.string,
+    innerContentRounded: PropTypes.bool,
+    innerContentStyle: PropTypes.object,
     modal: PropTypes.bool,
     onRequestClose: PropTypes.func,
     open: PropTypes.bool.isRequired,
@@ -171,6 +175,7 @@ class DialogInline extends Component {
     title: PropTypes.node,
     titleClassName: PropTypes.string,
     titleStyle: PropTypes.object,
+    zDepth: propTypes.zDepth,
   };
 
   static contextTypes = {
@@ -275,6 +280,9 @@ class DialogInline extends Component {
       className,
       contentClassName,
       contentStyle,
+      innerContentClassName,
+      innerContentStyle,
+      innerContentRounded,
       overlayClassName,
       overlayStyle,
       open,
@@ -282,6 +290,7 @@ class DialogInline extends Component {
       titleStyle,
       title,
       style,
+      zDepth,
     } = this.props;
 
     const {prepareStyles} = this.context.muiTheme;
@@ -336,7 +345,12 @@ class DialogInline extends Component {
               className={contentClassName}
               style={styles.content}
             >
-              <Paper zDepth={4}>
+              <Paper
+                className={innerContentClassName}
+                rounded={innerContentRounded}
+                style={innerContentStyle}
+                zDepth={zDepth}
+              >
                 {titleElement}
                 <div
                   ref="dialogContent"
@@ -398,7 +412,7 @@ class Dialog extends Component {
      */
     children: PropTypes.node,
     /**
-     * The css class name of the root element.
+     * The `className` to add to the root element.
      */
     className: PropTypes.string,
     /**
@@ -409,6 +423,19 @@ class Dialog extends Component {
      * Overrides the inline-styles of the content container.
      */
     contentStyle: PropTypes.object,
+    /**
+     * The `className` to add to the inner content container.
+     */
+    innerContentClassName: PropTypes.string,
+     /**
+     * By default, the inner content container will have a border radius.
+     * Set this to false to generate a container with sharp corners.
+     */
+    innerContentRounded: PropTypes.bool,
+    /**
+     * Overrides the inline-styles of the inner content container.
+     */
+    innerContentStyle: PropTypes.object,
     /**
      * Force the user to use one of the actions in the `Dialog`.
      * Clicking outside the `Dialog` will not trigger the `onRequestClose`.
@@ -452,6 +479,10 @@ class Dialog extends Component {
      * Overrides the inline-styles of the title's root container element.
      */
     titleStyle: PropTypes.object,
+     /**
+     * This number represents the zDepth of the innner content container shadow.
+     */
+    zDepth: propTypes.zDepth,
   };
 
   static contextTypes = {
@@ -461,8 +492,10 @@ class Dialog extends Component {
   static defaultProps = {
     autoDetectWindowHeight: true,
     autoScrollBodyContent: false,
+    innerContentRounded: true,
     modal: false,
     repositionOnUpdate: true,
+    zDepth: 4,
   };
 
   renderLayer = () => {

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -277,15 +277,15 @@ class DialogInline extends Component {
       className,
       contentClassName,
       contentStyle,
-      paperClassName,
       overlayClassName,
       overlayStyle,
       open,
+      paperClassName,
+      paperProps,
+      style,
       titleClassName,
       titleStyle,
       title,
-      style,
-      paperProps,
     } = this.props;
 
     const {prepareStyles} = this.context.muiTheme;
@@ -321,11 +321,11 @@ class DialogInline extends Component {
     return (
       <div className={className} style={prepareStyles(styles.root)}>
         {open &&
-        <EventListener
-          target="window"
-          onKeyUp={this.handleKeyUp}
-          onResize={this.handleResize}
-        />
+          <EventListener
+            target="window"
+            onKeyUp={this.handleKeyUp}
+            onResize={this.handleResize}
+          />
         }
         <ReactTransitionGroup
           component="div"
@@ -336,27 +336,26 @@ class DialogInline extends Component {
           transitionEnterTimeout={450}
         >
           {open &&
-          <TransitionItem
-            className={contentClassName}
-            style={styles.content}
-          >
-            <Paper
-              className={paperClassName}
-              rounded={true}
-              zDepth={4}
-              {...paperProps}
+            <TransitionItem
+              className={contentClassName}
+              style={styles.content}
             >
-              {titleElement}
-              <div
-                ref="dialogContent"
-                className={bodyClassName}
-                style={prepareStyles(styles.body)}
+              <Paper
+                className={paperClassName}
+                zDepth={4}
+                {...paperProps}
               >
-                {children}
-              </div>
-              {actionsContainer}
-            </Paper>
-          </TransitionItem>
+                {titleElement}
+                <div
+                  ref="dialogContent"
+                  className={bodyClassName}
+                  style={prepareStyles(styles.body)}
+                >
+                  {children}
+                </div>
+                {actionsContainer}
+              </Paper>
+            </TransitionItem>
           }
         </ReactTransitionGroup>
         <Overlay
@@ -419,8 +418,8 @@ class Dialog extends Component {
      */
     contentStyle: PropTypes.object,
     /**
-     * Force the user to use one of the actions in the `Dialog`.Clicking outside the `Dialog`
-     * will not trigger the `onRequestClose`.
+     * Force the user to use one of the actions in the `Dialog`.
+     * Clicking outside the `Dialog` will not trigger the `onRequestClose`.
      */
     modal: PropTypes.bool,
     /**
@@ -442,11 +441,11 @@ class Dialog extends Component {
      */
     overlayStyle: PropTypes.object,
     /**
-     * The `className` to add to the inner content container.
+     * Properties applied to the `Paper` element.
      */
     paperClassName: PropTypes.string,
     /**
-     * Sets zDepth, rounded corners, css styles of `Paper` container. See more at component `Paper`.
+     * Props to be passed to paper.
      */
     paperProps: PropTypes.object,
     /**

--- a/src/Dialog/Dialog.spec.js
+++ b/src/Dialog/Dialog.spec.js
@@ -51,13 +51,13 @@ describe('<Dialog />', () => {
   });
 
   it('should render a inner content container with sharp corners', () => {
-    const testClass = 'test-dialog-inner-content-rounded-class';
+    const testClass = 'test-dialog-paper-rounded-class';
 
     mountWithContext(
       <Dialog
         open={true}
-        innerContentClassName={testClass}
-        innerContentRounded={false}
+        paperClassName={testClass}
+        paperProps={{rounded: false}}
       />
     );
 
@@ -73,7 +73,7 @@ describe('<Dialog />', () => {
       overlay: 'test-dialog-overlay-class',
       body: 'test-dialog-body-class',
       content: 'test-dialog-content-class',
-      innerContent: 'test-dialog-inner-content-class',
+      innerContent: 'test-dialog-paper-class',
       titleContainer: 'test-dialog-title-container-class',
       actionsContainer: 'test-dialog-actions-container-class',
     };
@@ -86,7 +86,7 @@ describe('<Dialog />', () => {
         bodyClassName={testClasses.body}
         className={testClasses.root}
         contentClassName={testClasses.content}
-        innerContentClassName={testClasses.innerContent}
+        paperClassName={testClasses.innerContent}
         overlayClassName={testClasses.overlay}
         titleClassName={testClasses.titleContainer}
         actions={testAction}

--- a/src/Dialog/Dialog.spec.js
+++ b/src/Dialog/Dialog.spec.js
@@ -49,4 +49,58 @@ describe('<Dialog />', () => {
     TestUtils.Simulate.click(actionEl);
     assert.ok(clickSpy.called);
   });
+
+  it('should render a inner content container with sharp corners', () => {
+    const testClass = 'test-dialog-inner-content-rounded-class';
+
+    mountWithContext(
+      <Dialog
+        open={true}
+        innerContentClassName={testClass}
+        innerContentRounded={false}
+      />
+    );
+
+    const testEl = document.getElementsByClassName(testClass)[0];
+    assert.strictEqual(testEl.style.borderRadius, '0px');
+  });
+
+  describe('should render a custom className', () => {
+    const testTitle = 'test-dialog-title';
+    const testAction = <button>test</button>;
+    const testClasses = {
+      root: 'test-dialog-root-class',
+      overlay: 'test-dialog-overlay-class',
+      body: 'test-dialog-body-class',
+      content: 'test-dialog-content-class',
+      innerContent: 'test-dialog-inner-content-class',
+      titleContainer: 'test-dialog-title-container-class',
+      actionsContainer: 'test-dialog-actions-container-class',
+    };
+
+    mountWithContext(
+      <Dialog
+        open={true}
+        title={testTitle}
+        actionsContainerClassName={testClasses.actionsContainer}
+        bodyClassName={testClasses.body}
+        className={testClasses.root}
+        contentClassName={testClasses.content}
+        innerContentClassName={testClasses.innerContent}
+        overlayClassName={testClasses.overlay}
+        titleClassName={testClasses.titleContainer}
+        actions={testAction}
+      />
+    );
+
+    for (const key in testClasses) {
+      if (testClasses.hasOwnProperty(key)) {
+        const testClass = testClasses[key];
+
+        it(testClass, () => {
+          assert.ok(document.getElementsByClassName(testClass)[0]);
+        });
+      }
+    }
+  });
 });


### PR DESCRIPTION
PR is bring to solve [this issue](https://github.com/callemall/material-ui/issues/5775)
Now can to add custom className to inner content container (component Paper) and style it. 

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

