### PR TITLE
[BottomNavigation] fix type error when onChange is not defined

### DIFF
--- a/src/BottomNavigation/BottomNavigationButton.js
+++ b/src/BottomNavigation/BottomNavigationButton.js
@@ -54,7 +54,9 @@ class BottomNavigationButton extends Component {
   handleChange = event => {
     const { onChange, index, onClick } = this.props;
 
-    onChange(event, index);
+    if (onChange) {
+      onChange(event, index);
+    }
 
     if (onClick) {
       onClick(event);


### PR DESCRIPTION
Since `onChange` is not required it shouldn't throw an error if its missing

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

