### PR TITLE
[Switch] Fix focus style for RadioButton Checkbox Toggle

### DIFF
--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -73,6 +73,7 @@ function getStyles(props, context, state) {
       borderRadius,
       transition: transitions.easeOut(),
       backgroundColor: backgroundColor,
+      overflow: 'hidden',
       // That's the default value for a button but not a link
       textAlign: 'center',
     },

--- a/src/internal/ScaleIn.js
+++ b/src/internal/ScaleIn.js
@@ -39,7 +39,6 @@ class ScaleIn extends Component {
 
     const mergedRootStyles = Object.assign({}, {
       position: 'relative',
-      overflow: 'hidden',
       height: '100%',
     }, style);
 


### PR DESCRIPTION
Remove  overflow: 'hidden' from ScaleIn.js