### PR TITLE
[Popover] Only prevent default click interactions

### DIFF
--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -235,8 +235,7 @@ class Popover extends Component {
     }
   }
 
-  componentClickAway = (event) => {
-    event.preventDefault();
+  componentClickAway = () => {
     this.requestClose('clickAway');
   };
 


### PR DESCRIPTION
Revert 8dac6267b0dec19605901a2c22323ee388a9190a as I don't think that it's relevant to prevent default here. I would rather see it on specific elements.

Closes #6888
Closes #6891

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

