### PR TITLE
[List] Fix clicking "Toggle Nested Items" icon triggering left checkbox toggle.

### DIFF
--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -474,6 +474,9 @@ class ListItem extends Component {
   };
 
   handleNestedListToggle = (event) => {
+    if (this.props.leftCheckbox) {
+      event.preventDefault();
+    }
     event.stopPropagation();
 
     if (this.props.open === null) {

--- a/src/List/ListItem.spec.js
+++ b/src/List/ListItem.spec.js
@@ -104,10 +104,10 @@ describe('<ListItem />', () => {
 
       assert.strictEqual(wrapper.find(NestedList).props().open, false);
 
-      primaryTextButton.simulate('touchTap', {stopPropagation: () => {}});
+      primaryTextButton.simulate('touchTap', {preventDefault: () => {}, stopPropagation: () => {}});
       assert.strictEqual(wrapper.find(NestedList).props().open, true);
 
-      primaryTextButton.simulate('touchTap', {stopPropagation: () => {}});
+      primaryTextButton.simulate('touchTap', {preventDefault: () => {}, stopPropagation: () => {}});
       assert.strictEqual(wrapper.find(NestedList).props().open, false);
     });
 
@@ -169,7 +169,7 @@ describe('<ListItem />', () => {
       );
 
       const primaryTextButton = wrapper.find(EnhancedButton);
-      primaryTextButton.simulate('touchTap', {stopPropagation: () => {}});
+      primaryTextButton.simulate('touchTap', {preventDefault: () => {}, stopPropagation: () => {}});
       assert.strictEqual(wrapper.find(NestedList).props().open, true);
     });
 
@@ -185,7 +185,7 @@ describe('<ListItem />', () => {
       );
 
       const primaryTextButton = wrapper.find(EnhancedButton);
-      primaryTextButton.simulate('touchTap', {stopPropagation: () => {}});
+      primaryTextButton.simulate('touchTap', {preventDefault: () => {}, stopPropagation: () => {}});
       assert.strictEqual(wrapper.find(NestedList).props().open, false);
     });
   });


### PR DESCRIPTION
* IOS safari is affected (tested on iPad Mini 2i & iOS 10.3.2)
* Can't reproduce on Android/Windows mobile/desktop browsers

So the issue appears to be only under iOS safari.

The simple code snippet to reproduce:

```jsx
import React from 'react'
import ReactDOM from 'react-dom'
import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
import { List, ListItem } from 'material-ui/List'
import Checkbox from 'material-ui/Checkbox'
import injectTapEventPlugin from 'react-tap-event-plugin';

function onload() {
  injectTapEventPlugin();
  ReactDOM.render(
    (
      <MuiThemeProvider>
        <List>
          <ListItem primaryText="root" leftCheckbox={<Checkbox/>} nestedItems={
            [
              <ListItem primaryText="child1" />,
              <ListItem primaryText="child2" />
            ]
          } />
        </List>
      </MuiThemeProvider>
    ),
    document.body
  )
}

document.addEventListener('DOMContentLoaded', onload, false);
```

It might be `injectTapEventPlugin` or browser issue, but the result is that component doesn't work correctly and adding `preventDefault` seems to fix it.

Screenshots:
Win10/Chrome
![no-bug1](https://user-images.githubusercontent.com/4161883/27258611-66b36244-5407-11e7-882a-731597c09649.png)
![no-bug2](https://user-images.githubusercontent.com/4161883/27258612-68d03890-5407-11e7-8e26-6edf7ff744ec.jpg)

Android/Chrome
![no-bug3](https://user-images.githubusercontent.com/4161883/27258624-aa1bdec6-5407-11e7-96b6-93a38afec055.jpg)
![no-bug4](https://user-images.githubusercontent.com/4161883/27258630-b9b0b3c0-5407-11e7-8580-f57f18fa2d55.jpg)

iOS/Safari
![bug-1](https://user-images.githubusercontent.com/4161883/27258633-bf04c136-5407-11e7-96be-fbcd99428307.jpg)
![bug-2](https://user-images.githubusercontent.com/4161883/27258634-c15178d0-5407-11e7-9230-8c1ee692adbf.jpg)