### PR TITLE
[core] Add missing flow import

### DIFF
--- a/src/internal/Backdrop.js
+++ b/src/internal/Backdrop.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React from 'react';
+import type { Element } from 'react';
 import classNames from 'classnames';
 import { createStyleSheet } from 'jss-theme-reactor';
 import withStyles from '../styles/withStyles';


### PR DESCRIPTION
> Uncaught ReferenceError: babelPluginFlowReactPropTypes_proptype_Element is not defined

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

