### PR TITLE
[Input] Fix incorrect type of autoFocus prop

### DIFF
--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -356,7 +356,7 @@ Input.propTypes = {
   /**
    * @ignore
    */
-  autoFocus: PropTypes.object,
+  autoFocus: PropTypes.bool,
   /**
    * Useful to extend the style applied to components.
    */


### PR DESCRIPTION
This was reported as [a comment](https://github.com/callemall/material-ui/issues/6398#issuecomment-309541516) on a related but different issue (#6398).