### PR TITLE
[docs] Fix typo in class name

### DIFF
--- a/docs/src/pages/customization/OverridesClassNames.js
+++ b/docs/src/pages/customization/OverridesClassNames.js
@@ -7,7 +7,7 @@ import Button from 'material-ui/Button';
 
 // We can inject some CSS into the DOM.
 const styleSheet = createStyleSheet('OverridesClassNames', {
-  bouton: {
+  button: {
     background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
     borderRadius: 3,
     border: 0,
@@ -20,7 +20,7 @@ const styleSheet = createStyleSheet('OverridesClassNames', {
 
 function OverridesClassNames(props) {
   return (
-    <Button className={props.classes.bouton}>
+    <Button className={props.classes.button}>
       {props.children ? props.children : 'class names'}
     </Button>
   );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

I fixed typo in a class name.
`bouton` -> `button`

