### PR TITLE
[Table] state.allRowsSelected was not updated if props.allRowsSelected changed

### DIFF
--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -149,6 +149,12 @@ class Table extends Component {
     }
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (this.props.allRowsSelected !== nextProps.allRowsSelected) {
+      this.setState({allRowsSelected: nextProps.allRowsSelected});
+    }
+  }
+
   isScrollbarVisible() {
     const tableDivHeight = this.refs.tableDiv.clientHeight;
     const tableBodyHeight = this.refs.tableBody.clientHeight;


### PR DESCRIPTION
`allRowsSelected` cannot be used as a controlled prop, because when the prop value changes the state does not get updated