### PR TITLE
[Drawer] Remove event listeners on unmount

### DIFF
--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -140,6 +140,7 @@ class Drawer extends Component {
 
   componentWillUnmount() {
     this.disableSwipeHandling();
+    this.removeBodyTouchListeners();
   }
 
   getStyles() {
@@ -278,6 +279,12 @@ class Drawer extends Component {
     document.body.addEventListener('touchcancel', this.onBodyTouchEnd);
   };
 
+  removeBodyTouchListeners() {
+    document.body.removeEventListener('touchmove', this.onBodyTouchMove);
+    document.body.removeEventListener('touchend', this.onBodyTouchEnd);
+    document.body.removeEventListener('touchcancel', this.onBodyTouchEnd);
+  }
+
   setPosition(translateX) {
     const rtlTranslateMultiplier = this.context.muiTheme.isRtl ? -1 : 1;
     const drawer = ReactDOM.findDOMNode(this.refs.clickAwayableElement);
@@ -359,9 +366,7 @@ class Drawer extends Component {
       this.maybeSwiping = false;
     }
 
-    document.body.removeEventListener('touchmove', this.onBodyTouchMove);
-    document.body.removeEventListener('touchend', this.onBodyTouchEnd);
-    document.body.removeEventListener('touchcancel', this.onBodyTouchEnd);
+    this.removeBodyTouchListeners();
   };
 
   render() {

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -1,13 +1,21 @@
 /* eslint-env mocha */
 import React from 'react';
-import {shallow} from 'enzyme';
-import {expect} from 'chai';
+import {shallow, mount} from 'enzyme';
+import {assert} from 'chai';
 import Drawer from './Drawer';
 import getMuiTheme from '../styles/getMuiTheme';
+import merge from 'lodash.merge';
 
 describe('<Drawer />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+  const mountWithContext = (node) => mount(node, {context: {muiTheme}});
+  const fireBodyMouseEvent = (name, properties) => {
+    const event = document.createEvent('MouseEvents');
+    event.initEvent(name, true, true);
+    merge(event, properties);
+    document.body.dispatchEvent(event);
+  };
 
   describe('propTypes', () => {
     it('accepts number in the width props', () => {
@@ -23,9 +31,38 @@ describe('<Drawer />', () => {
     });
 
     it('throws an error on wrong percentage format', () => {
-      expect(() => shallowWithContext(
+      assert.throws(() => shallowWithContext(
         <Drawer width="80" />
-      )).to.throw(Error, 'Not a valid percentage format.');
+      ), Error, 'Not a valid percentage format.');
+    });
+  });
+
+  describe('touch', () => {
+    it('opens and closes', () => {
+      const wrapper = mountWithContext(<Drawer width={200} docked={false} />);
+      assert.strictEqual(wrapper.state().open, false, 'should start closed');
+      fireBodyMouseEvent('touchstart', {touches: [{pageX: 0, pageY: 0}]});
+      assert.strictEqual(wrapper.instance().maybeSwiping, true, 'should be listening for swipe');
+      fireBodyMouseEvent('touchmove', {touches: [{pageX: 20, pageY: 0}]});
+      assert.strictEqual(wrapper.state().swiping, 'opening', 'should be opening');
+      fireBodyMouseEvent('touchend', {changedTouches: [{pageX: 180, pageY: 0}]});
+      assert.strictEqual(wrapper.state().open, true, 'should be open');
+      fireBodyMouseEvent('touchstart', {touches: [{pageX: 200, pageY: 0}]});
+      assert.strictEqual(wrapper.instance().maybeSwiping, true, 'should be listening for swipe');
+      fireBodyMouseEvent('touchmove', {touches: [{pageX: 180, pageY: 0}]});
+      assert.strictEqual(wrapper.state().swiping, 'closing', 'should be closing');
+      fireBodyMouseEvent('touchend', {changedTouches: [{pageX: 20, pageY: 0}]});
+      assert.strictEqual(wrapper.state().open, false, 'should be closed');
+      wrapper.unmount();
+    });
+
+    it('removes event listeners on unmount', () => {
+      const wrapper = mountWithContext(<Drawer width={200} docked={false} />);
+      // Trigger listeners.
+      fireBodyMouseEvent('touchstart', {touches: [{pageX: 0, pageY: 0}]});
+      wrapper.unmount();
+      // Should trigger setState warning if listeners aren't cleaned.
+      fireBodyMouseEvent('touchmove', {touches: [{pageX: 20, pageY: 0}]});
     });
   });
 });


### PR DESCRIPTION
Should fix error `TypeError: undefined is not an object (evaluating 'this.refs.overlay.setOpacity') ` that can happen if the Drawer is unmounted in the middle of a touch interaction.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

