### PR TITLE
[docs] Fix item 4 not showing as checked in Table controlled example a…

### DIFF
--- a/docs/src/app/components/pages/components/Table/ExampleControlled.js
+++ b/docs/src/app/components/pages/components/Table/ExampleControlled.js
@@ -49,8 +49,8 @@ export default class TableExampleControlled extends Component {
             <TableRowColumn>Stephanie Sanders</TableRowColumn>
             <TableRowColumn>Employed</TableRowColumn>
           </TableRow>
-          <TableRow>
-            <TableRowColumn selected={this.isSelected(3)}>4</TableRowColumn>
+          <TableRow selected={this.isSelected(3)}>
+            <TableRowColumn>4</TableRowColumn>
             <TableRowColumn>Steve Brown</TableRowColumn>
             <TableRowColumn>Employed</TableRowColumn>
           </TableRow>


### PR DESCRIPTION
…fter clicked it.

In the controlled example for the `Table` component it is not possible to make the last item no 4, change into the checked state.  
 
[Table component docs](http://www.material-ui.com/#/components/table)

