### PR TITLE
[ListItem] Use the .shortest duration

### DIFF
--- a/docs/src/components/AppDrawerNavItem.js
+++ b/docs/src/components/AppDrawerNavItem.js
@@ -15,6 +15,9 @@ const styleSheet = createStyleSheet('AppDrawerNavItem', theme => ({
     justifyContent: 'flex-start',
     textTransform: 'none',
     width: '100%',
+    transition: theme.transitions.create('background-color', {
+      duration: theme.transitions.duration.shortest,
+    }),
     '&:hover': {
       textDecoration: 'none',
     },

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -40,7 +40,7 @@ export const styleSheet = createStyleSheet('MuiListItem', theme => ({
   },
   button: {
     transition: theme.transitions.create('background-color', {
-      duration: theme.transitions.duration.short,
+      duration: theme.transitions.duration.shortest,
     }),
     '&:hover': {
       textDecoration: 'none',

--- a/src/Menu/MenuItem.js
+++ b/src/Menu/MenuItem.js
@@ -13,9 +13,6 @@ export const styleSheet = createStyleSheet('MuiMenuItem', theme => ({
     height: 48,
     boxSizing: 'border-box',
     background: 'none',
-    transition: theme.transitions.create('background-color', {
-      duration: theme.transitions.duration.short,
-    }),
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',


### PR DESCRIPTION
I have noticed that firebase is using a similar transition:
Them (100ms):
![capture d ecran 2017-06-25 a 17 50 29](https://user-images.githubusercontent.com/3165635/27517550-d3104cdc-59ce-11e7-830b-777c0cca7051.png)
Us (150ms instead of 250ms):
![capture d ecran 2017-06-25 a 18 02 10](https://user-images.githubusercontent.com/3165635/27517782-566f791a-59d2-11e7-95dc-fa75dd0cdc89.png)

Closes #6317

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

