### PR TITLE
[withStyles] Provide context for withStyles classes error

### DIFF
--- a/src/styles/withStyles.js
+++ b/src/styles/withStyles.js
@@ -6,6 +6,7 @@ import warning from 'warning';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import wrapDisplayName from 'recompose/wrapDisplayName';
 import createEagerFactory from 'recompose/createEagerFactory';
+import getDisplayName from 'recompose/getDisplayName';
 import customPropTypes from '../utils/customPropTypes';
 
 // Link a style sheet with a component.
@@ -13,6 +14,7 @@ import customPropTypes from '../utils/customPropTypes';
 // instead, it returns a new, with a `classes` property.
 const withStyles = styleSheet => BaseComponent => {
   const factory = createEagerFactory(BaseComponent);
+  const componentName = getDisplayName(BaseComponent);
 
   class Style extends Component {
     // Exposed for test purposes.
@@ -31,7 +33,8 @@ const withStyles = styleSheet => BaseComponent => {
             warning(
               renderedClasses[key],
               `Material-UI: the key \`${key}\` ` +
-                'provided to the classes property object is not implemented.',
+                'provided to the classes property object is not implemented ' +
+                `in ${componentName}.`,
             );
 
             acc[key] = `${renderedClasses[key]} ${classesProp[key]}`;


### PR DESCRIPTION
The error message from `withStyles` was:

```
Warning: Material-UI: the key `vertical` provided to the classes property object is not implemented
```

Now it is:

```
Warning: Material-UI: the key `vertical` provided to the classes property object is not implemented in MyComponent
```

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

