### PR TITLE
[TextField] Fix unfocused state when disabled

### DIFF
--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -290,10 +290,10 @@ class TextField extends Component {
   componentWillReceiveProps(nextProps) {
     if (nextProps.disabled && !this.props.disabled) {
       this.setState({
-        isFocused: false
+        isFocused: false,
       });
     }
-    
+
     if (nextProps.errorText !== this.props.errorText) {
       this.setState({
         errorText: nextProps.errorText,

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -288,6 +288,10 @@ class TextField extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
+    if (nextProps.disabled) {
+      this.setState({isFocused: false});
+    }
+    
     if (nextProps.errorText !== this.props.errorText) {
       this.setState({
         errorText: nextProps.errorText,

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -288,7 +288,7 @@ class TextField extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.disabled) {
+    if (nextProps.disabled && !this.props.disabled) {
       this.setState({isFocused: false});
     }
     

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -289,7 +289,9 @@ class TextField extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.disabled && !this.props.disabled) {
-      this.setState({isFocused: false});
+      this.setState({
+        isFocused: false
+      });
     }
     
     if (nextProps.errorText !== this.props.errorText) {


### PR DESCRIPTION
Basically I found out that if the component is currently focused and then becomes disabled while it is then it will be stuck in focused state until it becomes enabled again.
Even then, since the blur event does not get emitted for some reason (yet it becomes blurred), then once it becomes enabled again you have to manually focus and unfocus it again for it to get the unfocused state.

This PR fixes this by making sure the focused state is set to false when disabled is set to true.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

