### PR TITLE
[DatePicker] #6926: Use pickerHeaderColor muiTheme property for DatePicker header customization

### DIFF
--- a/src/DatePicker/DateDisplay.js
+++ b/src/DatePicker/DateDisplay.js
@@ -15,7 +15,7 @@ function getStyles(props, context, state) {
       float: isLandscape ? 'left' : 'none',
       fontWeight: 700,
       display: 'inline-block',
-      backgroundColor: datePicker.selectColor,
+      backgroundColor: datePicker.headerColor,
       borderTopLeftRadius: 2,
       borderTopRightRadius: isLandscape ? 0 : 2,
       borderBottomLeftRadius: isLandscape ? 2 : 0,

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -100,6 +100,7 @@ export default function getMuiTheme(muiTheme, ...more) {
       selectColor: palette.primary2Color,
       selectTextColor: palette.alternateTextColor,
       calendarYearBackgroundColor: palette.canvasColor,
+      headerColor: palette.pickerHeaderColor || palette.primary1Color,
     },
     dialog: {
       titleFontSize: 22,


### PR DESCRIPTION
Provide possibility to override DatePicker header color via _pickerHeaderColor_ muiTheme property (similar to TimePicker).

See https://github.com/callemall/material-ui/issues/6926 for more details.


- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

