### PR TITLE
[docs] Fix MobileStepper API

### DIFF
--- a/docs/src/pages/component-api/MobileStepper/MobileStepper.md
+++ b/docs/src/pages/component-api/MobileStepper/MobileStepper.md
@@ -13,7 +13,7 @@
 | nextButtonText | node | 'Next' | Set the text that appears for the next button. |
 | <span style="color: #31a148">onBack *</span> | function |  | Passed into the onClick prop of the Back button. |
 | <span style="color: #31a148">onNext *</span> | function |  | Passed into the onClick prop of the Next button. |
-| position | enum:&nbsp;'bottom'<br>&nbsp;'top'<br>&nbsp;'static'<br> | 'bottom' | Set the text that appears for the next button. |
+| position | enum:&nbsp;'bottom'<br>&nbsp;'top'<br>&nbsp;'static'<br> | 'bottom' | Set the positioning type. |
 | <span style="color: #31a148">steps *</span> | number |  | The total steps. |
 | type | enum:&nbsp;'text'<br>&nbsp;'dots'<br>&nbsp;'progress'<br> | 'dots' | The type of mobile stepper to use. |
 

--- a/src/MobileStepper/MobileStepper.js
+++ b/src/MobileStepper/MobileStepper.js
@@ -149,7 +149,7 @@ MobileStepper.propTypes = {
    */
   onNext: PropTypes.func.isRequired,
   /**
-   * Set the text that appears for the next button.
+   * Set the positioning type.
    */
   position: PropTypes.oneOf(['bottom', 'top', 'static']),
   /**


### PR DESCRIPTION
Wrong `position` property description, duplicated with `nextButtonText `

