### PR TITLE
[Snackbar] Close and re-open when onActionTouchTap or onRequestClose changes

### DIFF
--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -119,8 +119,15 @@ class Snackbar extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.open && nextProps.open &&
-        (nextProps.message !== this.props.message || nextProps.action !== this.props.action)) {
+    if (
+        this.props.open && nextProps.open &&
+        (
+            nextProps.message !== this.props.message ||
+            nextProps.action !== this.props.action ||
+            nextProps.onActionTouchTap !== this.props.onActionTouchTap ||
+            nextProps.onRequestClose !== this.props.onRequestClose
+        )
+    ) {
       this.setState({
         open: false,
       });


### PR DESCRIPTION
Hello,

Imagine the following situation: you have a mailbox with a list of messages. There is a button next to each message to delete it. When you click on one of these buttons, a Snackbar appears "Message deleted", with the action "Undo".
If you click on several buttons to delete several messages, the same message exactly is displayed in the Snackbar (however, `onActionTouchTap` is different).

For the user, it would be better to see the previous Snackbar disappear and appear again when he/she deletes a new message, even if it displays exactly the same message.

In short, this PR closes and opens the Snackbar when `onActionTouchTap` or `onRequestClose` changes (and not only when `message` or `action` changes).