### PR TITLE
[Snackbar] update flow, convert Snackbar, remove unused customPropTypes.origin

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "eslint-plugin-prettier": "^2.1.2",
     "eslint-plugin-react": "^7.1.0",
     "eventsource-polyfill": "^0.9.6",
-    "flow-bin": "^0.48.0",
+    "flow-bin": "^0.49.1",
     "flow-copy-source": "^1.2.0",
     "flow-typed": "^2.1.2",
     "fs-extra": "^3.0.1",

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -1,12 +1,11 @@
-// @flow weak
+// @flow
 
 import React, { Component, createElement, cloneElement } from 'react';
-import PropTypes from 'prop-types';
+import type { Element } from 'react';
 import classNames from 'classnames';
 import { createStyleSheet } from 'jss-theme-reactor';
 import withStyles from '../styles/withStyles';
 import { duration } from '../styles/transitions';
-import customPropTypes from '../utils/customPropTypes';
 import ClickAwayListener from '../internal/ClickAwayListener';
 import { capitalizeFirstLetter } from '../utils/helpers';
 import Slide from '../transitions/Slide';
@@ -67,15 +66,106 @@ export const styleSheet = createStyleSheet('MuiSnackbar', theme => {
   };
 });
 
-class Snackbar extends Component {
-  static defaultProps = {
+type Origin = {
+  horizontal: 'left' | 'center' | 'right' | number,
+  vertical: 'top' | 'center' | 'bottom' | number,
+};
+
+type DefaultProps = {
+  anchorOrigin: Origin,
+  autoHideDuration: ?number,
+  enterTransitionDuration: number,
+  leaveTransitionDuration: number,
+};
+
+type Props = DefaultProps & {
+  /**
+   * The action to display.
+   */
+  action?: Element<*>,
+  /**
+   * The anchor of the `Snackbar`.
+   */
+  anchorOrigin?: Origin,
+  /**
+   * The number of milliseconds to wait before automatically dismissing.
+   * This behavior is disabled by default with the `null` value.
+   */
+  autoHideDuration?: number,
+  /**
+   * If you wish the take control over the children of the component you can use that property.
+   * When using it, no `SnackbarContent` component will be rendered.
+   */
+  children?: Element<*>,
+  /**
+   * Useful to extend the style applied to components.
+   */
+  classes: Object,
+  /**
+   * @ignore
+   */
+  className?: string,
+  /**
+   * Customizes duration of enter animation (ms)
+   */
+  enterTransitionDuration?: number,
+  /**
+   * Customizes duration of leave animation (ms)
+   */
+  leaveTransitionDuration?: number,
+  /**
+   * The message to display.
+   */
+  message?: Element<*>,
+  /**
+   * @ignore
+   */
+  onMouseEnter?: Function,
+  /**
+   * @ignore
+   */
+  onMouseLeave?: Function,
+  /**
+   * Callback fired when the component requests to be closed.
+   *
+   * Typically `onRequestClose` is used to set state in the parent component,
+   * which is used to control the `Snackbar` `open` prop.
+   *
+   * The `reason` parameter can optionally be used to control the response to `onRequestClose`,
+   * for example ignoring `clickaway`.
+   *
+   * @param {event} event The event that triggered the close request
+   * @param {string} reason Can be:`"timeout"` (`autoHideDuration` expired) or: `"clickaway"`
+   */
+  onRequestClose?: (event: ?SyntheticUIEvent, reason: string) => void,
+  /**
+   * If true, `Snackbar` is open.
+   */
+  open: boolean,
+  /**
+   * Properties applied to the `SnackbarContent` element.
+   */
+  SnackbarContentProps?: Object,
+  /**
+   * Object with Transition component, props & create Fn.
+   */
+  transition?: Function | Element<*>,
+};
+
+type State = {
+  exited: boolean,
+};
+
+class Snackbar extends Component<DefaultProps, Props, State> {
+  props: Props;
+  static defaultProps: DefaultProps = {
     anchorOrigin: { vertical: 'bottom', horizontal: 'center' },
     autoHideDuration: null,
     enterTransitionDuration: duration.enteringScreen,
     leaveTransitionDuration: duration.leavingScreen,
   };
 
-  state = {
+  state: State = {
     // Used to only render active snackbars.
     exited: false,
   };
@@ -168,7 +258,8 @@ class Snackbar extends Component {
       onRequestClose,
       open,
       SnackbarContentProps,
-      transition: transitionProps,
+      // $FlowFixMe - invalid error? Property cannot be accessed on any member of intersection type
+      transition: transitionProp,
       ...other
     } = this.props;
 
@@ -176,8 +267,8 @@ class Snackbar extends Component {
       return null;
     }
 
-    const createTransitionFn = typeof transitionProps === 'function' ? createElement : cloneElement;
-    const transition = transitionProps || <Slide direction={vertical === 'top' ? 'down' : 'up'} />;
+    const createTransitionFn = typeof transitionProp === 'function' ? createElement : cloneElement;
+    const transition = transitionProp || <Slide direction={vertical === 'top' ? 'down' : 'up'} />;
 
     return (
       <ClickAwayListener onClickAway={this.handleClickAway}>
@@ -208,79 +299,5 @@ class Snackbar extends Component {
     );
   }
 }
-
-Snackbar.propTypes = {
-  /**
-   * The action to display.
-   */
-  action: PropTypes.node,
-  /**
-   * The anchor of the `Snackbar`.
-   */
-  anchorOrigin: customPropTypes.origin,
-  /**
-   * The number of milliseconds to wait before automatically dismissing.
-   * This behavior is disabled by default with the `null` value.
-   */
-  autoHideDuration: PropTypes.number,
-  /**
-   * If you wish the take control over the children of the component you can use that property.
-   * When using it, no `SnackbarContent` component will be rendered.
-   */
-  children: PropTypes.node,
-  /**
-   * Useful to extend the style applied to components.
-   */
-  classes: PropTypes.object.isRequired,
-  /**
-   * @ignore
-   */
-  className: PropTypes.string,
-  /**
-   * Customizes duration of enter animation (ms)
-   */
-  enterTransitionDuration: PropTypes.number,
-  /**
-   * Customizes duration of leave animation (ms)
-   */
-  leaveTransitionDuration: PropTypes.number,
-  /**
-   * The message to display.
-   */
-  message: PropTypes.node,
-  /**
-   * @ignore
-   */
-  onMouseEnter: PropTypes.func,
-  /**
-   * @ignore
-   */
-  onMouseLeave: PropTypes.func,
-  /**
-   * Callback fired when the component requests to be closed.
-   *
-   * Typically `onRequestClose` is used to set state in the parent component,
-   * which is used to control the `Snackbar` `open` prop.
-   *
-   * The `reason` parameter can optionally be used to control the response to `onRequestClose`,
-   * for example ignoring `clickaway`.
-   *
-   * @param {event} event The event that triggered the close request
-   * @param {string} reason Can be:`"timeout"` (`autoHideDuration` expired) or: `"clickaway"`
-   */
-  onRequestClose: PropTypes.func,
-  /**
-   * If true, `Snackbar` is open.
-   */
-  open: PropTypes.bool.isRequired,
-  /**
-   * Properties applied to the `SnackbarContent` element.
-   */
-  SnackbarContentProps: PropTypes.object,
-  /**
-   * Object with Transition component, props & create Fn.
-   */
-  transition: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
-};
 
 export default withStyles(styleSheet)(Snackbar);

--- a/src/Snackbar/Snackbar.spec.js
+++ b/src/Snackbar/Snackbar.spec.js
@@ -57,7 +57,7 @@ describe('<Snackbar />', () => {
       clock.restore();
     });
 
-    it('should be call onRequestClose when the timer is done', () => {
+    it('should call onRequestClose when the timer is done', () => {
       const handleRequestClose = spy();
       const autoHideDuration = 2e3;
       const wrapper = mount(

--- a/src/Snackbar/SnackbarContent.js
+++ b/src/Snackbar/SnackbarContent.js
@@ -1,7 +1,7 @@
-// @flow weak
+// @flow
 
 import React from 'react';
-import PropTypes from 'prop-types';
+import type { Element } from 'react';
 import classNames from 'classnames';
 import { createStyleSheet } from 'jss-theme-reactor';
 import withStyles from '../styles/withStyles';
@@ -43,7 +43,26 @@ export const styleSheet = createStyleSheet('MuiSnackbarContent', theme => {
   };
 });
 
-function SnackbarContent(props) {
+type Props = {
+  /**
+   * The action to display.
+   */
+  action?: Element<*>,
+  /**
+   * Useful to extend the style applied to components.
+   */
+  classes: Object,
+  /**
+   * @ignore
+   */
+  className?: string,
+  /**
+   * The message to display.
+   */
+  message: Element<*>,
+};
+
+function SnackbarContent(props: Props) {
   const { action, classes, className, message, ...other } = props;
 
   return (
@@ -69,24 +88,5 @@ function SnackbarContent(props) {
     </Paper>
   );
 }
-
-SnackbarContent.propTypes = {
-  /**
-   * The action to display.
-   */
-  action: PropTypes.node,
-  /**
-   * Useful to extend the style applied to components.
-   */
-  classes: PropTypes.object.isRequired,
-  /**
-   * @ignore
-   */
-  className: PropTypes.string,
-  /**
-   * The message to display.
-   */
-  message: PropTypes.node.isRequired,
-};
 
 export default withStyles(styleSheet)(SnackbarContent);

--- a/src/utils/customPropTypes.js
+++ b/src/utils/customPropTypes.js
@@ -3,28 +3,7 @@
 
 import PropTypes from 'prop-types';
 
-let customPropTypes = {};
-
-if (process.env.NODE_ENV !== 'production') {
-  const horizontal = PropTypes.oneOfType([
-    PropTypes.oneOf(['left', 'center', 'right']),
-    PropTypes.number,
-  ]);
-
-  const vertical = PropTypes.oneOfType([
-    PropTypes.oneOf(['top', 'center', 'bottom']),
-    PropTypes.number,
-  ]);
-
-  customPropTypes = {
-    horizontal,
-    vertical,
-    origin: PropTypes.shape({
-      horizontal,
-      vertical,
-    }),
-  };
-}
+const customPropTypes = {};
 
 customPropTypes.muiRequired = (props, propName, componentName, location, propFullName, ...args) => {
   if (process.env.NODE_ENV === 'production') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2683,9 +2683,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.48.0:
-  version "0.48.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.48.0.tgz#72d075143524358db8901525e3c784dc13a7c7ee"
+flow-bin@^0.49.1:
+  version "0.49.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.49.1.tgz#c9e456b3173a7535a4ffaf28956352c63bb8e3e9"
 
 flow-copy-source@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
I ran into my own misuse of `onRequestClose` signature so figured it was time to convert this one :)

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

