### PR TITLE
[Snackbar] documentation - key property

### DIFF
--- a/docs/src/pages/component-api/Input/Input.md
+++ b/docs/src/pages/component-api/Input/Input.md
@@ -10,7 +10,6 @@
 | component | union:&nbsp;string<br>&nbsp;func<br> |  | The component used for the root node. Either a string to use a DOM element or a component. It's an `input` by default. |
 | defaultValue | union:&nbsp;string<br>&nbsp;number<br> |  | The default input value, useful when not controlling the component. |
 | disableUnderline | bool | false | If `true`, the input will not have an underline. |
-| disabled | bool |  | If `true`, the input will be disabled. |
 | error | bool |  | If `true`, the input will indicate an error. |
 | id | string |  |  |
 | inputProps | object |  | Properties applied to the `input` element. |

--- a/docs/src/pages/component-api/Input/Textarea.md
+++ b/docs/src/pages/component-api/Input/Textarea.md
@@ -5,17 +5,10 @@
 ## Props
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| className | string |  |  |
 | classes | object |  | Useful to extend the style applied to components. |
-| defaultValue | any |  |  |
-| disabled | bool |  |  |
-| hintText | string |  |  |
-| onChange | function |  |  |
-| onHeightChange | function |  |  |
 | rows | union:&nbsp;string<br>&nbsp;number<br> | 1 | Number of rows to display when multiline option is set to true. |
 | rowsMax | union:&nbsp;string<br>&nbsp;number<br> |  | Maxium number of rows to display when multiline option is set to true. |
 | textareaRef | function |  | Use that property to pass a ref callback to the native textarea component. |
-| value | string |  |  |
 
 Any other properties supplied will be spread to the root element.
 

--- a/docs/src/pages/component-api/Snackbar/Snackbar.md
+++ b/docs/src/pages/component-api/Snackbar/Snackbar.md
@@ -12,7 +12,7 @@
 | children | Element |  | If you wish the take control over the children of the component you can use that property. When using it, no `SnackbarContent` component will be rendered. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | enterTransitionDuration | number | duration.enteringScreen | Customizes duration of enter animation (ms) |
-| <span style="color: #31a148">key *</span> | any |  | When displaying multiple consecutive Snackbars from a parent renedering a single <Snackbar/>, add the key property to ensure independent treatment of each message. e.g. <Snackbar key={message} />, otherwise, the message may update-in-place and features such as autoHideDuration may be canceled. |
+| key | any |  | When displaying multiple consecutive Snackbars from a parent renedering a single <Snackbar/>, add the key property to ensure independent treatment of each message. e.g. <Snackbar key={message} />, otherwise, the message may update-in-place and features such as autoHideDuration may be canceled. |
 | leaveTransitionDuration | number | duration.leavingScreen | Customizes duration of leave animation (ms) |
 | message | Element |  | The message to display. |
 | onRequestClose | signature |  | Callback fired when the component requests to be closed.<br>Typically `onRequestClose` is used to set state in the parent component, which is used to control the `Snackbar` `open` prop.<br>The `reason` parameter can optionally be used to control the response to `onRequestClose`, for example ignoring `clickaway`. |

--- a/docs/src/pages/component-api/Snackbar/Snackbar.md
+++ b/docs/src/pages/component-api/Snackbar/Snackbar.md
@@ -5,18 +5,19 @@
 ## Props
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| SnackbarContentProps | object |  | Properties applied to the `SnackbarContent` element. |
-| action | node |  | The action to display. |
-| anchorOrigin | customPropTypes.origin | { vertical: 'bottom', horizontal: 'center' } | The anchor of the `Snackbar`. |
+| SnackbarContentProps | Object |  | Properties applied to the `SnackbarContent` element. |
+| action | Element |  | The action to display. |
+| anchorOrigin | signature | { vertical: 'bottom', horizontal: 'center' } | The anchor of the `Snackbar`. |
 | autoHideDuration | number | null | The number of milliseconds to wait before automatically dismissing. This behavior is disabled by default with the `null` value. |
-| children | node |  | If you wish the take control over the children of the component you can use that property. When using it, no `SnackbarContent` component will be rendered. |
-| classes | object |  | Useful to extend the style applied to components. |
+| children | Element |  | If you wish the take control over the children of the component you can use that property. When using it, no `SnackbarContent` component will be rendered. |
+| classes | Object |  | Useful to extend the style applied to components. |
 | enterTransitionDuration | number | duration.enteringScreen | Customizes duration of enter animation (ms) |
+| <span style="color: #31a148">key *</span> | any |  | When displaying multiple consecutive Snackbars from a parent renedering a single <Snackbar/>, add the key property to ensure independent treatment of each message. e.g. <Snackbar key={message} />, otherwise, the message may update-in-place and features such as autoHideDuration may be canceled. |
 | leaveTransitionDuration | number | duration.leavingScreen | Customizes duration of leave animation (ms) |
-| message | node |  | The message to display. |
-| onRequestClose | function |  | Callback fired when the component requests to be closed.<br>Typically `onRequestClose` is used to set state in the parent component, which is used to control the `Snackbar` `open` prop.<br>The `reason` parameter can optionally be used to control the response to `onRequestClose`, for example ignoring `clickaway`.<br><br>**Signature:**<br>`function(event: event, reason: string) => void`<br>*event:* The event that triggered the close request<br>*reason:* Can be:`"timeout"` (`autoHideDuration` expired) or: `"clickaway"` |
-| <span style="color: #31a148">open *</span> | bool |  | If true, `Snackbar` is open. |
-| transition | union:&nbsp;func<br>&nbsp;element<br> |  | Object with Transition component, props & create Fn. |
+| message | Element |  | The message to display. |
+| onRequestClose | signature |  | Callback fired when the component requests to be closed.<br>Typically `onRequestClose` is used to set state in the parent component, which is used to control the `Snackbar` `open` prop.<br>The `reason` parameter can optionally be used to control the response to `onRequestClose`, for example ignoring `clickaway`. |
+| <span style="color: #31a148">open *</span> | boolean |  | If true, `Snackbar` is open. |
+| transition | union:&nbsp;Function<br>&nbsp;Element<*><br> |  | Object with Transition component, props & create Fn. |
 
 Any other properties supplied will be spread to the root element.
 

--- a/docs/src/pages/component-api/Snackbar/SnackbarContent.md
+++ b/docs/src/pages/component-api/Snackbar/SnackbarContent.md
@@ -5,9 +5,9 @@
 ## Props
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| action | node |  | The action to display. |
-| classes | object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">message *</span> | node |  | The message to display. |
+| action | Element |  | The action to display. |
+| classes | Object |  | Useful to extend the style applied to components. |
+| <span style="color: #31a148">message *</span> | Element |  | The message to display. |
 
 Any other properties supplied will be spread to the root element.
 

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -115,7 +115,7 @@ type Props = DefaultProps & {
    * e.g. <Snackbar key={message} />, otherwise, the message may update-in-place and
    * features such as autoHideDuration may be canceled.
    */
-  key: any,
+  key?: any,
   /**
    * Customizes duration of leave animation (ms)
    */

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -110,6 +110,13 @@ type Props = DefaultProps & {
    */
   enterTransitionDuration?: number,
   /**
+   * When displaying multiple consecutive Snackbars from a parent renedering a single
+   * <Snackbar/>, add the key property to ensure independent treatment of each message.
+   * e.g. <Snackbar key={message} />, otherwise, the message may update-in-place and
+   * features such as autoHideDuration may be canceled.
+   */
+  key: any,
+  /**
    * Customizes duration of leave animation (ms)
    */
   leaveTransitionDuration?: number,


### PR DESCRIPTION
When converting to the v1 Snackbar, this was a bit of a gotcha.  We have a `NotificationCenter` that queues messages in the UI and allows each individual Snackbar message to display as configured (in isolation).  When multiple messages were queued, the first would come and go, then the second would replace message 1 regardless of `autoHideDuration` and remain forever. 

Adding `key` ensured that each individual `Snackbar` render was isolated (instead of replacing the message text, resetting the timer and making it infinite)

Any other thoughts on changing the implementation or is this documentation sufficient?

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

