### PR TITLE
[Snackbar] expose transition onExited to allow for consecutive messages with completed transitions

### DIFF
--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -7,7 +7,7 @@ import { createStyleSheet } from 'jss-theme-reactor';
 import withStyles from '../styles/withStyles';
 import { duration } from '../styles/transitions';
 import ClickAwayListener from '../internal/ClickAwayListener';
-import { capitalizeFirstLetter } from '../utils/helpers';
+import { capitalizeFirstLetter, createChainedFunction } from '../utils/helpers';
 import Slide from '../transitions/Slide';
 import SnackbarContent from './SnackbarContent';
 
@@ -124,6 +124,10 @@ type Props = DefaultProps & {
    * The message to display.
    */
   message?: Element<*>,
+  /**
+   * Callback fired when the transition has exited.
+   */
+  onExited?: Function, // eslint-disable-line react/sort-prop-types
   /**
    * @ignore
    */
@@ -260,6 +264,7 @@ class Snackbar extends Component<DefaultProps, Props, State> {
       enterTransitionDuration,
       leaveTransitionDuration,
       message,
+      onExited,
       onMouseEnter,
       onMouseLeave,
       onRequestClose,
@@ -296,7 +301,7 @@ class Snackbar extends Component<DefaultProps, Props, State> {
               transitionAppear: true,
               enterTransitionDuration,
               leaveTransitionDuration,
-              onExited: this.handleTransitionExited,
+              onExited: createChainedFunction(this.handleTransitionExited, onExited),
             },
             children ||
               <SnackbarContent message={message} action={action} {...SnackbarContentProps} />,

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -127,7 +127,7 @@ type Props = DefaultProps & {
   /**
    * Callback fired when the transition has exited.
    */
-  onExited?: Function, // eslint-disable-line react/sort-prop-types
+  onExited?: Function,
   /**
    * @ignore
    */

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -125,6 +125,26 @@ type Props = DefaultProps & {
    */
   message?: Element<*>,
   /**
+   * Callback fired before the transition is entering.
+   */
+  onEnter?: Function,
+  /**
+   * Callback fired when the transition is entering.
+   */
+  onEntering?: Function,
+  /**
+   * Callback fired when the transition has entered.
+   */
+  onEntered?: Function,
+  /**
+   * Callback fired before the transition is exiting.
+   */
+  onExit?: Function,
+  /**
+   * Callback fired when the transition is exiting.
+   */
+  onExiting?: Function,
+  /**
    * Callback fired when the transition has exited.
    */
   onExited?: Function,
@@ -264,6 +284,11 @@ class Snackbar extends Component<DefaultProps, Props, State> {
       enterTransitionDuration,
       leaveTransitionDuration,
       message,
+      onEnter,
+      onEntering,
+      onEntered,
+      onExit,
+      onExiting,
       onExited,
       onMouseEnter,
       onMouseLeave,
@@ -301,6 +326,11 @@ class Snackbar extends Component<DefaultProps, Props, State> {
               transitionAppear: true,
               enterTransitionDuration,
               leaveTransitionDuration,
+              onEnter,
+              onEntering,
+              onEntered,
+              onExit,
+              onExiting,
               onExited: createChainedFunction(this.handleTransitionExited, onExited),
             },
             children ||


### PR DESCRIPTION
To successfully display multiple snackbars and allow for transitions to complete needed to expose the `onExited` callback.

This actually gets kind of tricky to do, but the callback allows everything to work well.  [Here's a gist in use](https://gist.github.com/rosskevin/6585499c7f6d97a232a80b3e3f982c92) in case anyone runs into this.


- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

