### PR TITLE
[ListItem] Apply paddingRight to automatic expand icon

### DIFF
--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -12,10 +12,12 @@ import NestedList from './NestedList';
 
 function getStyles(props, context, state) {
   const {
+    autoGenerateNestedIndicator,
     insetChildren,
     leftAvatar,
     leftCheckbox,
     leftIcon,
+    nestedItems,
     nestedLevel,
     rightAvatar,
     rightIcon,
@@ -55,7 +57,7 @@ function getStyles(props, context, state) {
     innerDiv: {
       marginLeft: nestedLevel * listItem.nestedLevelDepth,
       paddingLeft: leftIcon || leftAvatar || leftCheckbox || insetChildren ? 72 : 16,
-      paddingRight: rightIcon || rightAvatar || rightIconButton ? 56 : rightToggle ? 72 : 16,
+      paddingRight: rightIcon || rightAvatar || rightIconButton || (nestedItems && autoGenerateNestedIndicator) ? 56 : rightToggle ? 72 : 16,
       paddingBottom: singleAvatar ? 20 : 16,
       paddingTop: singleNoAvatar || threeLine ? 16 : 20,
       position: 'relative',

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -57,7 +57,7 @@ function getStyles(props, context, state) {
     innerDiv: {
       marginLeft: nestedLevel * listItem.nestedLevelDepth,
       paddingLeft: leftIcon || leftAvatar || leftCheckbox || insetChildren ? 72 : 16,
-      paddingRight: rightIcon || rightAvatar || rightIconButton || (nestedItems && autoGenerateNestedIndicator) ? 56 : rightToggle ? 72 : 16,
+      paddingRight: rightIcon || rightAvatar || rightIconButton || (nestedItems.length && autoGenerateNestedIndicator) ? 56 : rightToggle ? 72 : 16,
       paddingBottom: singleAvatar ? 20 : 16,
       paddingTop: singleNoAvatar || threeLine ? 16 : 20,
       position: 'relative',

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -57,7 +57,9 @@ function getStyles(props, context, state) {
     innerDiv: {
       marginLeft: nestedLevel * listItem.nestedLevelDepth,
       paddingLeft: leftIcon || leftAvatar || leftCheckbox || insetChildren ? 72 : 16,
-      paddingRight: rightIcon || rightAvatar || rightIconButton || (nestedItems.length && autoGenerateNestedIndicator) ? 56 : rightToggle ? 72 : 16,
+      paddingRight: rightIcon || rightAvatar || rightIconButton ||
+                    (nestedItems.length && autoGenerateNestedIndicator) ?
+                    56 : rightToggle ? 72 : 16,
       paddingBottom: singleAvatar ? 20 : 16,
       paddingTop: singleNoAvatar || threeLine ? 16 : 20,
       position: 'relative',


### PR DESCRIPTION
PaddingRight is not added to the rightIcon when an automatic right icon is created by nested items

### Normal
* Create a ListItem
* Add a full-width child like a `<Slider />`
* Add a rightIcon
* Observe that the slider shrinks slightly

### Issue
* Create a ListItem
* Add a full-width child like a `<Slider />`
* Add nestedItems, which will automatically add a rightIcon for the expander
* Observe that the slider does not appropriately shrink to leave room for the expander icon

## Before: 
![image](https://user-images.githubusercontent.com/96122/27764242-601bece6-5e8c-11e7-9ecc-75a946a5baff.png)
## After:
![image](https://user-images.githubusercontent.com/96122/27764241-58357bdc-5e8c-11e7-829d-914b73ba5985.png)

