### PR TITLE
Removed Content prefix from ContentPaste ContentCopy ContentCut to increase consistency

### DIFF
--- a/packages/material-ui-icons/src/Copy.js
+++ b/packages/material-ui-icons/src/Copy.js
@@ -2,12 +2,12 @@ import React from 'react';
 import pure from 'recompose/pure';
 import SvgIcon from 'material-ui/SvgIcon';
 
-let ContentCopy = props =>
+let Copy = props =>
   <SvgIcon {...props}>
     <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
   </SvgIcon>;
 
-ContentCopy = pure(ContentCopy);
-ContentCopy.muiName = 'SvgIcon';
+Copy = pure(Copy);
+Copy.muiName = 'SvgIcon';
 
-export default ContentCopy;
+export default Copy;

--- a/packages/material-ui-icons/src/Cut.js
+++ b/packages/material-ui-icons/src/Cut.js
@@ -2,12 +2,12 @@ import React from 'react';
 import pure from 'recompose/pure';
 import SvgIcon from 'material-ui/SvgIcon';
 
-let ContentCut = props =>
+let Cut = props =>
   <SvgIcon {...props}>
     <path d="M9.64 7.64c.23-.5.36-1.05.36-1.64 0-2.21-1.79-4-4-4S2 3.79 2 6s1.79 4 4 4c.59 0 1.14-.13 1.64-.36L10 12l-2.36 2.36C7.14 14.13 6.59 14 6 14c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4c0-.59-.13-1.14-.36-1.64L12 14l7 7h3v-1L9.64 7.64zM6 8c-1.1 0-2-.89-2-2s.9-2 2-2 2 .89 2 2-.9 2-2 2zm0 12c-1.1 0-2-.89-2-2s.9-2 2-2 2 .89 2 2-.9 2-2 2zm6-7.5c-.28 0-.5-.22-.5-.5s.22-.5.5-.5.5.22.5.5-.22.5-.5.5zM19 3l-6 6 2 2 7-7V3z" />
   </SvgIcon>;
 
-ContentCut = pure(ContentCut);
-ContentCut.muiName = 'SvgIcon';
+Cut = pure(Cut);
+Cut.muiName = 'SvgIcon';
 
-export default ContentCut;
+export default Cut;

--- a/packages/material-ui-icons/src/Paste.js
+++ b/packages/material-ui-icons/src/Paste.js
@@ -2,12 +2,12 @@ import React from 'react';
 import pure from 'recompose/pure';
 import SvgIcon from 'material-ui/SvgIcon';
 
-let ContentPaste = props =>
+let Paste = props =>
   <SvgIcon {...props}>
     <path d="M19 2h-4.18C14.4.84 13.3 0 12 0c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm7 18H5V4h2v3h10V4h2v16z" />
   </SvgIcon>;
 
-ContentPaste = pure(ContentPaste);
-ContentPaste.muiName = 'SvgIcon';
+Paste = pure(Paste);
+Paste.muiName = 'SvgIcon';
 
-export default ContentPaste;
+export default Paste;


### PR DESCRIPTION
Removed Content prefix from ContentPaste ContentCopy ContentCut to increase consistency

As explained here : https://github.com/callemall/material-ui/pull/7302

Cheers !