### PR TITLE
Logged added return statement

### DIFF
--- a/docs/src/app/components/pages/components/AppBar/ExampleComposition.js
+++ b/docs/src/app/components/pages/components/AppBar/ExampleComposition.js
@@ -19,18 +19,20 @@ class Login extends Component {
 }
 
 const Logged = (props) => (
-  <IconMenu
-    {...props}
-    iconButtonElement={
-      <IconButton><MoreVertIcon /></IconButton>
-    }
-    targetOrigin={{horizontal: 'right', vertical: 'top'}}
-    anchorOrigin={{horizontal: 'right', vertical: 'top'}}
-  >
-    <MenuItem primaryText="Refresh" />
-    <MenuItem primaryText="Help" />
-    <MenuItem primaryText="Sign out" />
-  </IconMenu>
+  return (
+    <IconMenu
+      {...props}
+      iconButtonElement={
+        <IconButton><MoreVertIcon /></IconButton>
+      }
+      targetOrigin={{horizontal: 'right', vertical: 'top'}}
+      anchorOrigin={{horizontal: 'right', vertical: 'top'}}
+    >
+      <MenuItem primaryText="Refresh" />
+      <MenuItem primaryText="Help" />
+      <MenuItem primaryText="Sign out" />
+    </IconMenu>
+  )
 );
 
 Logged.muiName = 'IconMenu';


### PR DESCRIPTION
When recreating the Example Composition example of the AppBar in my own project a lack of a return statement in the Logged component meant that the stateless function didn't return a valid React Component. I've now added the return statement to the example.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

