### PR TITLE
[Input] Add a fullWidth property

### DIFF
--- a/docs/src/pages/component-api/AppBar/AppBar.md
+++ b/docs/src/pages/component-api/AppBar/AppBar.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # AppBar
 
 

--- a/docs/src/pages/component-api/Avatar/Avatar.md
+++ b/docs/src/pages/component-api/Avatar/Avatar.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Avatar
 
 

--- a/docs/src/pages/component-api/Badge/Badge.md
+++ b/docs/src/pages/component-api/Badge/Badge.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Badge
 
 

--- a/docs/src/pages/component-api/BottomNavigation/BottomNavigation.md
+++ b/docs/src/pages/component-api/BottomNavigation/BottomNavigation.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # BottomNavigation
 
 

--- a/docs/src/pages/component-api/BottomNavigation/BottomNavigationButton.md
+++ b/docs/src/pages/component-api/BottomNavigation/BottomNavigationButton.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # BottomNavigationButton
 
 

--- a/docs/src/pages/component-api/Button/Button.md
+++ b/docs/src/pages/component-api/Button/Button.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Button
 
 

--- a/docs/src/pages/component-api/Card/Card.md
+++ b/docs/src/pages/component-api/Card/Card.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Card
 
 

--- a/docs/src/pages/component-api/Card/CardActions.md
+++ b/docs/src/pages/component-api/Card/CardActions.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # CardActions
 
 

--- a/docs/src/pages/component-api/Card/CardContent.md
+++ b/docs/src/pages/component-api/Card/CardContent.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # CardContent
 
 

--- a/docs/src/pages/component-api/Card/CardHeader.md
+++ b/docs/src/pages/component-api/Card/CardHeader.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # CardHeader
 
 

--- a/docs/src/pages/component-api/Card/CardMedia.md
+++ b/docs/src/pages/component-api/Card/CardMedia.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # CardMedia
 
 

--- a/docs/src/pages/component-api/Checkbox/Checkbox.md
+++ b/docs/src/pages/component-api/Checkbox/Checkbox.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Checkbox
 
 

--- a/docs/src/pages/component-api/Checkbox/LabelCheckbox.md
+++ b/docs/src/pages/component-api/Checkbox/LabelCheckbox.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # LabelCheckbox
 
 

--- a/docs/src/pages/component-api/Chip/Chip.md
+++ b/docs/src/pages/component-api/Chip/Chip.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Chip
 
 Chips represent complex entities in small blocks, such as a contact.

--- a/docs/src/pages/component-api/Dialog/Dialog.md
+++ b/docs/src/pages/component-api/Dialog/Dialog.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Dialog
 
 Dialogs are overlaid modal paper based components with a backdrop.

--- a/docs/src/pages/component-api/Dialog/DialogActions.md
+++ b/docs/src/pages/component-api/Dialog/DialogActions.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # DialogActions
 
 

--- a/docs/src/pages/component-api/Dialog/DialogContent.md
+++ b/docs/src/pages/component-api/Dialog/DialogContent.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # DialogContent
 
 

--- a/docs/src/pages/component-api/Dialog/DialogContentText.md
+++ b/docs/src/pages/component-api/Dialog/DialogContentText.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # DialogContentText
 
 

--- a/docs/src/pages/component-api/Dialog/DialogTitle.md
+++ b/docs/src/pages/component-api/Dialog/DialogTitle.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # DialogTitle
 
 

--- a/docs/src/pages/component-api/Divider/Divider.md
+++ b/docs/src/pages/component-api/Divider/Divider.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Divider
 
 

--- a/docs/src/pages/component-api/Drawer/Drawer.md
+++ b/docs/src/pages/component-api/Drawer/Drawer.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Drawer
 
 

--- a/docs/src/pages/component-api/Form/FormControl.md
+++ b/docs/src/pages/component-api/Form/FormControl.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # FormControl
 
 Provides context such as dirty/focused/error/required for form inputs.
@@ -9,6 +11,7 @@ Provides context such as dirty/focused/error/required for form inputs.
 | classes | object |  | Useful to extend the style applied to components. |
 | disabled | bool | false | If `true`, the label, input and helper text should be displayed in a disabled state. |
 | error | bool | false | If `true`, the label should be displayed in an error state. |
+| fullWidth | bool | false | If `true`, the label will take up the full width of its container. |
 | marginForm | bool | false | If `true`, add the margin top and bottom required when used in a form. |
 | required | bool | false | If `true`, the label will indicate that the input is required. |
 
@@ -20,6 +23,7 @@ You can overrides all the class names injected by Material-UI thanks to the `cla
 This property accepts the following keys:
 - `root`
 - `marginForm`
+- `fullWidth`
 
 Have a look at [overriding with class names](/customization/overrides#overriding-with-class-names)
 section for more detail.

--- a/docs/src/pages/component-api/Form/FormGroup.md
+++ b/docs/src/pages/component-api/Form/FormGroup.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # FormGroup
 
 FormGroup wraps controls such as Checkbox and Switch.

--- a/docs/src/pages/component-api/Form/FormHelperText.md
+++ b/docs/src/pages/component-api/Form/FormHelperText.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # FormHelperText
 
 

--- a/docs/src/pages/component-api/Form/FormLabel.md
+++ b/docs/src/pages/component-api/Form/FormLabel.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # FormLabel
 
 

--- a/docs/src/pages/component-api/Grid/Grid.md
+++ b/docs/src/pages/component-api/Grid/Grid.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Grid
 
 

--- a/docs/src/pages/component-api/Hidden/Hidden.md
+++ b/docs/src/pages/component-api/Hidden/Hidden.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Hidden
 
 Responsively hides children based on the selected implementation.

--- a/docs/src/pages/component-api/Icon/Icon.md
+++ b/docs/src/pages/component-api/Icon/Icon.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Icon
 
 

--- a/docs/src/pages/component-api/IconButton/IconButton.md
+++ b/docs/src/pages/component-api/IconButton/IconButton.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # IconButton
 
 Refer to the [Icons](/style/icons) section of the documentation

--- a/docs/src/pages/component-api/Input/Input.md
+++ b/docs/src/pages/component-api/Input/Input.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Input
 
 
@@ -11,6 +13,7 @@
 | defaultValue | union:&nbsp;string<br>&nbsp;number<br> |  | The default input value, useful when not controlling the component. |
 | disableUnderline | bool | false | If `true`, the input will not have an underline. |
 | error | bool |  | If `true`, the input will indicate an error. |
+| fullWidth | bool | false | If `true`, the input will take up the full width of its container. |
 | id | string |  |  |
 | inputProps | object |  | Properties applied to the `input` element. |
 | inputRef | function |  | Use that property to pass a ref callback to the native input component. |
@@ -38,6 +41,7 @@ This property accepts the following keys:
 - `inputDisabled`
 - `inputSingleline`
 - `inputMultiline`
+- `fullWidth`
 
 Have a look at [overriding with class names](/customization/overrides#overriding-with-class-names)
 section for more detail.

--- a/docs/src/pages/component-api/Input/InputLabel.md
+++ b/docs/src/pages/component-api/Input/InputLabel.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # InputLabel
 
 

--- a/docs/src/pages/component-api/Input/Textarea.md
+++ b/docs/src/pages/component-api/Input/Textarea.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Textarea
 
 

--- a/docs/src/pages/component-api/List/List.md
+++ b/docs/src/pages/component-api/List/List.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # List
 
 

--- a/docs/src/pages/component-api/List/ListItem.md
+++ b/docs/src/pages/component-api/List/ListItem.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # ListItem
 
 

--- a/docs/src/pages/component-api/List/ListItemAvatar.md
+++ b/docs/src/pages/component-api/List/ListItemAvatar.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # ListItemAvatar
 
 It's a simple wrapper to apply the `dense` mode styles to `Avatar`.

--- a/docs/src/pages/component-api/List/ListItemIcon.md
+++ b/docs/src/pages/component-api/List/ListItemIcon.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # ListItemIcon
 
 A simple wrapper to apply `List` styles to an `Icon` or `SvgIcon`.

--- a/docs/src/pages/component-api/List/ListItemSecondaryAction.md
+++ b/docs/src/pages/component-api/List/ListItemSecondaryAction.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # ListItemSecondaryAction
 
 

--- a/docs/src/pages/component-api/List/ListItemText.md
+++ b/docs/src/pages/component-api/List/ListItemText.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # ListItemText
 
 

--- a/docs/src/pages/component-api/List/ListSubheader.md
+++ b/docs/src/pages/component-api/List/ListSubheader.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # ListSubheader
 
 

--- a/docs/src/pages/component-api/Menu/Menu.md
+++ b/docs/src/pages/component-api/Menu/Menu.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Menu
 
 

--- a/docs/src/pages/component-api/Menu/MenuItem.md
+++ b/docs/src/pages/component-api/Menu/MenuItem.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # MenuItem
 
 

--- a/docs/src/pages/component-api/Menu/MenuList.md
+++ b/docs/src/pages/component-api/Menu/MenuList.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # MenuList
 
 

--- a/docs/src/pages/component-api/MobileStepper/MobileStepper.md
+++ b/docs/src/pages/component-api/MobileStepper/MobileStepper.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # MobileStepper
 
 

--- a/docs/src/pages/component-api/Paper/Paper.md
+++ b/docs/src/pages/component-api/Paper/Paper.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Paper
 
 

--- a/docs/src/pages/component-api/Progress/CircularProgress.md
+++ b/docs/src/pages/component-api/Progress/CircularProgress.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # CircularProgress
 
 

--- a/docs/src/pages/component-api/Progress/LinearProgress.md
+++ b/docs/src/pages/component-api/Progress/LinearProgress.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # LinearProgress
 
 

--- a/docs/src/pages/component-api/Radio/LabelRadio.md
+++ b/docs/src/pages/component-api/Radio/LabelRadio.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # LabelRadio
 
 

--- a/docs/src/pages/component-api/Radio/Radio.md
+++ b/docs/src/pages/component-api/Radio/Radio.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Radio
 
 

--- a/docs/src/pages/component-api/Radio/RadioGroup.md
+++ b/docs/src/pages/component-api/Radio/RadioGroup.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # RadioGroup
 
 

--- a/docs/src/pages/component-api/Snackbar/Snackbar.md
+++ b/docs/src/pages/component-api/Snackbar/Snackbar.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Snackbar
 
 
@@ -15,6 +17,12 @@
 | key | any |  | When displaying multiple consecutive Snackbars from a parent renedering a single <Snackbar/>, add the key property to ensure independent treatment of each message. e.g. <Snackbar key={message} />, otherwise, the message may update-in-place and features such as autoHideDuration may be canceled. |
 | leaveTransitionDuration | number | duration.leavingScreen | Customizes duration of leave animation (ms) |
 | message | Element |  | The message to display. |
+| onEnter | Function |  | Callback fired before the transition is entering. |
+| onEntered | Function |  | Callback fired when the transition has entered. |
+| onEntering | Function |  | Callback fired when the transition is entering. |
+| onExit | Function |  | Callback fired before the transition is exiting. |
+| onExited | Function |  | Callback fired when the transition has exited. |
+| onExiting | Function |  | Callback fired when the transition is exiting. |
 | onRequestClose | signature |  | Callback fired when the component requests to be closed.<br>Typically `onRequestClose` is used to set state in the parent component, which is used to control the `Snackbar` `open` prop.<br>The `reason` parameter can optionally be used to control the response to `onRequestClose`, for example ignoring `clickaway`. |
 | <span style="color: #31a148">open *</span> | boolean |  | If true, `Snackbar` is open. |
 | transition | union:&nbsp;Function<br>&nbsp;Element<*><br> |  | Object with Transition component, props & create Fn. |

--- a/docs/src/pages/component-api/Snackbar/SnackbarContent.md
+++ b/docs/src/pages/component-api/Snackbar/SnackbarContent.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # SnackbarContent
 
 

--- a/docs/src/pages/component-api/SvgIcon/SvgIcon.md
+++ b/docs/src/pages/component-api/SvgIcon/SvgIcon.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # SvgIcon
 
 

--- a/docs/src/pages/component-api/Switch/LabelSwitch.md
+++ b/docs/src/pages/component-api/Switch/LabelSwitch.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # LabelSwitch
 
 

--- a/docs/src/pages/component-api/Switch/Switch.md
+++ b/docs/src/pages/component-api/Switch/Switch.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Switch
 
 

--- a/docs/src/pages/component-api/Table/Table.md
+++ b/docs/src/pages/component-api/Table/Table.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Table
 
 

--- a/docs/src/pages/component-api/Table/TableBody.md
+++ b/docs/src/pages/component-api/Table/TableBody.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # TableBody
 
 

--- a/docs/src/pages/component-api/Table/TableCell.md
+++ b/docs/src/pages/component-api/Table/TableCell.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # TableCell
 
 

--- a/docs/src/pages/component-api/Table/TableHead.md
+++ b/docs/src/pages/component-api/Table/TableHead.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # TableHead
 
 

--- a/docs/src/pages/component-api/Table/TableRow.md
+++ b/docs/src/pages/component-api/Table/TableRow.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # TableRow
 
 Will automatically set dynamic row height

--- a/docs/src/pages/component-api/Table/TableSortLabel.md
+++ b/docs/src/pages/component-api/Table/TableSortLabel.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # TableSortLabel
 
 A button based label for placing inside `TableCell` for column sorting.

--- a/docs/src/pages/component-api/Tabs/Tab.md
+++ b/docs/src/pages/component-api/Tabs/Tab.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Tab
 
 

--- a/docs/src/pages/component-api/Tabs/TabIndicator.md
+++ b/docs/src/pages/component-api/Tabs/TabIndicator.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # TabIndicator
 
 @ignore - internal component.

--- a/docs/src/pages/component-api/Tabs/TabScrollButton.md
+++ b/docs/src/pages/component-api/Tabs/TabScrollButton.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # TabScrollButton
 
 @ignore - internal component.

--- a/docs/src/pages/component-api/Tabs/Tabs.md
+++ b/docs/src/pages/component-api/Tabs/Tabs.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Tabs
 
 Notice that this Component is incompatible with server side rendering.

--- a/docs/src/pages/component-api/TextField/TextField.md
+++ b/docs/src/pages/component-api/TextField/TextField.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # TextField
 
 
@@ -9,9 +11,12 @@
 | InputClassName | string |  | The CSS class name of the `Input` element. |
 | InputLabelProps | object |  | Properties applied to the `InputLabel` element. |
 | InputProps | object |  | Properties applied to the `Input` element. |
+| autoComplete | bool |  |  |
+| autoFocus | bool |  |  |
 | defaultValue | string |  | The default value of the `Input` element. |
 | disabled | bool |  | If `true`, the input will be disabled. |
 | error | bool |  | If `true`, the label will be displayed in an error state. |
+| fullWidth | bool |  | If `true`, the input will take up the full width of its container. |
 | helperText | node |  | The helper text content. |
 | helperTextClassName | string |  | The CSS class name of the helper text element. |
 | id | string |  |  |
@@ -22,6 +27,7 @@
 | labelClassName | string |  | The CSS class name of the label element. |
 | multiline | bool |  | If `true`, a textarea element will be rendered instead of an input. |
 | name | string |  | Name attribute of the `Input` element. |
+| placeholder | string |  |  |
 | required | bool | false | If `true`, the label is displayed as required. |
 | rootRef | function |  | Use that property to pass a ref callback to the root component. |
 | rows | union:&nbsp;string<br>&nbsp;number<br> |  | Number of rows to display when multiline option is set to true. |

--- a/docs/src/pages/component-api/Toolbar/Toolbar.md
+++ b/docs/src/pages/component-api/Toolbar/Toolbar.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Toolbar
 
 

--- a/docs/src/pages/component-api/Typography/Typography.md
+++ b/docs/src/pages/component-api/Typography/Typography.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Typography
 
 

--- a/docs/src/pages/component-api/styles/MuiThemeProvider.md
+++ b/docs/src/pages/component-api/styles/MuiThemeProvider.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # MuiThemeProvider
 
 

--- a/docs/src/pages/component-api/transitions/Collapse.md
+++ b/docs/src/pages/component-api/transitions/Collapse.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Collapse
 
 

--- a/docs/src/pages/component-api/transitions/Fade.md
+++ b/docs/src/pages/component-api/transitions/Fade.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Fade
 
 

--- a/docs/src/pages/component-api/transitions/Slide.md
+++ b/docs/src/pages/component-api/transitions/Slide.md
@@ -1,3 +1,5 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
 # Slide
 
 

--- a/docs/src/pages/component-demos/text-fields/TextFields.js
+++ b/docs/src/pages/component-demos/text-fields/TextFields.js
@@ -103,10 +103,10 @@ class TextFields extends Component {
         <TextField
           id="placeholder"
           label="Label"
-          className={classes.input}
           type="text"
           InputProps={{ placeholder: 'Placeholder' }}
-          helperText="Helper text"
+          helperText="Full width!!!"
+          fullWidth
           marginForm
         />
       </div>

--- a/scripts/generate-docs-markdown.js
+++ b/scripts/generate-docs-markdown.js
@@ -201,6 +201,7 @@ you need to use the following style sheet name: \`${styles.name}\`.`
 
 export default function generateMarkdown(name, reactAPI) {
   return (
+    '<!--- This documentation is automatically generated, do not try to edit it. -->\n\n' +
     `${generateTitle(name)}\n` +
     `${generateDescription(reactAPI.description)}\n` +
     `${generateProps(reactAPI.props)}\n` +

--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -17,6 +17,9 @@ export const styleSheet = createStyleSheet('MuiFormControl', theme => ({
     marginTop: theme.spacing.unit * 2,
     marginBottom: theme.spacing.unit,
   },
+  fullWidth: {
+    width: '100%',
+  },
 }));
 
 /**
@@ -26,6 +29,7 @@ class FormControl extends Component {
   static defaultProps = {
     disabled: false,
     error: false,
+    fullWidth: false,
     marginForm: false,
     required: false,
   };
@@ -95,7 +99,16 @@ class FormControl extends Component {
   };
 
   render() {
-    const { children, classes, className, disabled, error, marginForm, ...other } = this.props;
+    const {
+      children,
+      classes,
+      className,
+      disabled,
+      error,
+      fullWidth,
+      marginForm,
+      ...other
+    } = this.props;
 
     return (
       <div
@@ -103,6 +116,7 @@ class FormControl extends Component {
           classes.root,
           {
             [classes.marginForm]: marginForm,
+            [classes.fullWidth]: fullWidth,
           },
           className,
         )}
@@ -137,6 +151,10 @@ FormControl.propTypes = {
    * If `true`, the label should be displayed in an error state.
    */
   error: PropTypes.bool,
+  /**
+   * If `true`, the label will take up the full width of its container.
+   */
+  fullWidth: PropTypes.bool,
   /**
    * If `true`, add the margin top and bottom required when used in a form.
    */

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -150,15 +150,19 @@ export const styleSheet = createStyleSheet('MuiInput', theme => {
       resize: 'none',
       padding: 0,
     },
+    fullWidth: {
+      width: '100%',
+    },
   };
 });
 
 class Input extends Component {
   static muiName = 'Input';
   static defaultProps = {
-    type: 'text',
     disableUnderline: false,
+    fullWidth: false,
     multiline: false,
+    type: 'text',
   };
 
   state = {
@@ -259,6 +263,7 @@ class Input extends Component {
       disabled: disabledProp,
       disableUnderline,
       error: errorProp,
+      fullWidth,
       id,
       inputProps: inputPropsProp,
       inputRef,
@@ -297,6 +302,7 @@ class Input extends Component {
       {
         [classes.disabled]: disabled,
         [classes.error]: error,
+        [classes.fullWidth]: fullWidth,
         [classes.focused]: this.state.focused,
         [classes.formControl]: muiFormControl,
         [classes.inkbar]: !disableUnderline,
@@ -409,6 +415,10 @@ Input.propTypes = {
    * If `true`, the input will indicate an error.
    */
   error: PropTypes.bool,
+  /**
+   * If `true`, the input will take up the full width of its container.
+   */
+  fullWidth: PropTypes.bool,
   /*
    * @ignore
    */

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -26,6 +26,7 @@ function TextField(props) {
     helperText,
     helperTextClassName,
     FormHelperTextProps,
+    fullWidth,
     required,
     type,
     multiline,
@@ -48,7 +49,14 @@ function TextField(props) {
   }
 
   return (
-    <FormControl ref={rootRef} className={className} error={error} required={required} {...other}>
+    <FormControl
+      fullWidth={fullWidth}
+      ref={rootRef}
+      className={className}
+      error={error}
+      required={required}
+      {...other}
+    >
       {label &&
         <InputLabel className={labelClassName} {...InputLabelProps}>
           {label}
@@ -80,13 +88,7 @@ function TextField(props) {
 }
 
 TextField.propTypes = {
-  /**
-   * @ignore
-   */
   autoComplete: PropTypes.bool,
-  /**
-   * @ignore
-   */
   autoFocus: PropTypes.bool,
   /**
    * @ignore
@@ -109,6 +111,10 @@ TextField.propTypes = {
    */
   FormHelperTextProps: PropTypes.object,
   /**
+   * If `true`, the input will take up the full width of its container.
+   */
+  fullWidth: PropTypes.bool,
+  /**
    * The helper text content.
    */
   helperText: PropTypes.node,
@@ -116,9 +122,6 @@ TextField.propTypes = {
    * The CSS class name of the helper text element.
    */
   helperTextClassName: PropTypes.string,
-  /*
-   * @ignore
-   */
   id: PropTypes.string,
   /**
    * The CSS class name of the `input` element.
@@ -160,9 +163,6 @@ TextField.propTypes = {
    * Name attribute of the `Input` element.
    */
   name: PropTypes.string,
-  /**
-   * @ignore
-   */
   placeholder: PropTypes.string,
   /**
    * If `true`, the label is displayed as required.


### PR DESCRIPTION
That concern has been raised multiple times, I like the idea too. We had to write `100%` many times using the v1-alpha branch. I think that it fit into the 80%/20% tradeoff.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

