### PR TITLE
[withWidth] Add a initalWidth property

### DIFF
--- a/src/utils/withWidth.spec.js
+++ b/src/utils/withWidth.spec.js
@@ -35,9 +35,9 @@ describe('withWidth', () => {
 
   describe('prop: width', () => {
     it('should be able to override it', () => {
-      const wrapper = mount(<EmptyWithWidth width="foo" />);
+      const wrapper = mount(<EmptyWithWidth width="xl" />);
 
-      assert.strictEqual(wrapper.find(Empty).props().width, 'foo');
+      assert.strictEqual(wrapper.find(Empty).props().width, 'xl');
     });
   });
 
@@ -102,9 +102,25 @@ describe('withWidth', () => {
 
     it('should handle resize event', () => {
       const wrapper = shallow(<EmptyWithWidth width="sm" />);
+      assert.strictEqual(wrapper.state().width, undefined);
       wrapper.simulate('resize');
       clock.tick(166);
       assert.strictEqual(wrapper.state().width, TEST_ENV_WIDTH);
+    });
+  });
+
+  describe('props: initalWidth', () => {
+    it('should work as expected', () => {
+      const element = <EmptyWithWidth initalWidth="lg" />;
+
+      // First mount on the server
+      const wrapper1 = shallow(element);
+      assert.strictEqual(wrapper1.find(Empty).props().width, 'lg');
+      const wrapper2 = mount(element);
+
+      // Second mount on the client
+      assert.strictEqual(wrapper2.find(Empty).props().width, TEST_ENV_WIDTH);
+      assert.strictEqual(TEST_ENV_WIDTH !== 'lg', true);
     });
   });
 });


### PR DESCRIPTION
Some side though on this new property.
People using it should have some mechanism so that the property stays the same
between the server side rendering and the client side rendering.

Closes #6068

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

