### PR TITLE
Document: Update ROADMAP.md with v1-alpha branch

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ The roadmap is a living document, and it is likely that priorities will change, 
 
 :warning: New features based on `v0.18.x` have low priority and will most likely not be reviewed nor merged. We want to focus on bug fixes.
 
-## Version 1 (formerly next)
+## Version 1 (published on NPM under the next tag)
 
 Version 1 release is going to be huge :sparkles:.
 We host a temporary [documentation](https://material-ui-1dab0.firebaseapp.com) for the pre-releases.
@@ -16,11 +16,9 @@ taking advantage of this knowledge to address long-standing issues.
 Expect various **breaking changes**.
 
 The core team is now helping him in the [v1-alpha](https://github.com/callemall/material-ui/tree/v1-alpha) branch.
-Here are some issues that we plan to fix along the way.
-
-We are tracking two milestones for version 1:
- * [v1.0.0-beta](https://github.com/callemall/material-ui/milestone/22)
- * [v1.0.0-prerelease](https://github.com/callemall/material-ui/milestone/14)
+Here are some issues that we plan to fix along the way. If you are interested in following our progress our if you want to help us reach that goal faster, you can have a look at two following milestones:
+- [v1.0.0-beta](https://github.com/callemall/material-ui/milestone/22)
+- [v1.0.0-prerelease](https://github.com/callemall/material-ui/milestone/14)
 
 ## Q&A with the v1-alpha branch
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ The roadmap is a living document, and it is likely that priorities will change, 
 
 :warning: New features based on `v0.18.x` have low priority and will most likely not be reviewed nor merged. We want to focus on bug fixes.
 
-## Version 1 (formelly next)
+## Version 1 (formerly next)
 
 Version 1 release is going to be huge :sparkles:.
 We host a temporary [documentation](https://material-ui-1dab0.firebaseapp.com) for the pre-releases.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,9 +4,9 @@ The roadmap is a living document, and it is likely that priorities will change, 
 
 :warning: New features based on `v0.18.x` have low priority and will most likely not be reviewed nor merged. We want to focus on bug fixes.
 
-## [next](https://github.com/callemall/material-ui/milestone/14)
+## Version 1 (formelly next)
 
-The `next` release is going to be huge :sparkles:.
+Version 1 release is going to be huge :sparkles:.
 We host a temporary [documentation](https://material-ui-1dab0.firebaseapp.com) for the pre-releases.
 
 Material-UI was started [3 years ago](https://github.com/callemall/material-ui/commit/28b768913b75752ecf9b6bb32766e27c241dbc46).
@@ -15,14 +15,16 @@ The ecosystem has evolved a lot since then, we have also learned a lot.
 taking advantage of this knowledge to address long-standing issues.
 Expect various **breaking changes**.
 
-The core team is now helping him in the [`next`](https://github.com/callemall/material-ui/tree/next) branch.
+The core team is now helping him in the [v1-alpha](https://github.com/callemall/material-ui/tree/v1-alpha) branch.
 Here are some issues that we plan to fix along the way.
 
-For more details, you can have a look a the [next milestone](https://github.com/callemall/material-ui/milestone/14) as well as the [next project](https://github.com/callemall/material-ui/projects/1).
+We are tracking two milestones for version 1:
+ * [v1.0.0-beta](https://github.com/callemall/material-ui/milestone/22)
+ * [v1.0.0-prerelease](https://github.com/callemall/material-ui/milestone/14)
 
-## Q&A with the next branch
+## Q&A with the v1-alpha branch
 
-The `next` branch has become more mature.
+The `v1-alpha` branch has become more mature.
 We think that it's a good time to communicate more on this effort.
 We have a lot of people opening PRs and getting them closed, this is not a good thing.
 This Q&A tries to answer some of your questions.
@@ -61,7 +63,7 @@ Yes, it does. You can have a look at [this presentation](https://github.com/oliv
 
 ## What does it mean to migrate a component? Should we discuss each one of them first?
 
-Migrating a component to the `next` branch isn't just a style migration.
+Migrating a component to the `v1-alpha` branch isn't just a style migration.
 We think that it's our best opportunity to clear the API and improve the implementation of the components.
 @nathanmarks ended up fixing a lot of long standing issues in the process.
 
@@ -74,28 +76,28 @@ We should answer the following questions:
 
 That conversation could start on one of the following [issues](https://github.com/callemall/material-ui/issues?q=is%3Aissue+is%3Aopen+label%3ARefactoring+label%3Anext).
 
-### How do I know if a component still needs to be migrated `next`?
+### How do I know if a component still needs to be migrated `v1-alpha`?
 
-We have [Github project](https://github.com/callemall/material-ui/projects/1) to **coordinate** the work toward the `next` release.
-You can check the *Component to migrate* column to know the ones needing to be migrated to `next`.
+We have [Github project](https://github.com/callemall/material-ui/projects/1) to **coordinate** the work toward the `v1-alpha` release.
+You can check the *Component to migrate* column to know the ones needing to be migrated to `v1-alpha`.
 
-### How do I start migrating components to the `next` branch?
+### How do I start migrating components to the `v1-alpha` branch?
 
 Once we agree on the migration plan you're gonna have to get your hands dirty.
 That's really up to you. At least, you gonna have to
-- clone the `next` branch
+- clone the `v1-alpha` branch
 - install the npm dependencies
 - play with the documentation site
 - write some documentation
 - write some tests (unit, integration, visual)
 
-### When do we intend to release `next`?
+### When do we intend to release `v1-alpha`?
 
-We don't have an ETA for the release of the `next` branch,
+We don't have an ETA for the release of the `v1-alpha` branch,
 however, it's going to follow a specific release plan:
 
-1. We focus on migrating the components to the `next` branch. They may not be fully migrated.
-2. We merge the `next` branch into master.
+1. We focus on migrating the components to the `v1-alpha` branch. They may not be fully migrated.
+2. We merge the `v1-alpha` branch into master.
 At that point, we're going to stop supporting the `v0.18.x` releases.
 3. We release our first alpha.
 4. We focus on finishing the migration of all the components to get a good feature parity with `v0.18.x`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,7 +16,7 @@ taking advantage of this knowledge to address long-standing issues.
 Expect various **breaking changes**.
 
 The core team is now helping him in the [v1-alpha](https://github.com/callemall/material-ui/tree/v1-alpha) branch.
-Here are some issues that we plan to fix along the way. If you are interested in following our progress our if you want to help us reach that goal faster, you can have a look at two following milestones:
+If you are interested in following our progress or if you want to help us reach that goal faster, you can have a look at the two following milestones:
 - [v1.0.0-beta](https://github.com/callemall/material-ui/milestone/22)
 - [v1.0.0-prerelease](https://github.com/callemall/material-ui/milestone/14)
 


### PR DESCRIPTION
Changed all reference to the legacy 'next' branch to 'v1-alpha`. Should be proof read by a team member to determine if language still holds with this change. fixes #7342.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

