### PR TITLE
[TextField] vertical spacing to match visual spec

### DIFF
--- a/docs/src/pages/component-api/Form/FormControl.md
+++ b/docs/src/pages/component-api/Form/FormControl.md
@@ -12,7 +12,7 @@ Provides context such as dirty/focused/error/required for form inputs.
 | disabled | bool | false | If `true`, the label, input and helper text should be displayed in a disabled state. |
 | error | bool | false | If `true`, the label should be displayed in an error state. |
 | fullWidth | bool | false | If `true`, the label will take up the full width of its container. |
-| marginForm | bool | false | If `true`, add the margin top and bottom required when used in a form. |
+| marginForm | bool | false | If `true`, add the margin top and bottom |
 | required | bool | false | If `true`, the label will indicate that the input is required. |
 
 Any other properties supplied will be spread to the root element.

--- a/docs/src/pages/component-api/Form/FormControl.md
+++ b/docs/src/pages/component-api/Form/FormControl.md
@@ -12,7 +12,7 @@ Provides context such as dirty/focused/error/required for form inputs.
 | disabled | bool | false | If `true`, the label, input and helper text should be displayed in a disabled state. |
 | error | bool | false | If `true`, the label should be displayed in an error state. |
 | fullWidth | bool | false | If `true`, the label will take up the full width of its container. |
-| marginForm | bool | false | If `true`, add the margin top and bottom |
+| marginForm | bool | false | If `true`, add the margin top and bottom. |
 | required | bool | false | If `true`, the label will indicate that the input is required. |
 
 Any other properties supplied will be spread to the root element.

--- a/docs/src/pages/component-api/TextField/TextField.md
+++ b/docs/src/pages/component-api/TextField/TextField.md
@@ -25,6 +25,7 @@
 | inputRef | function |  | Use that property to pass a ref callback to the native input component. |
 | label | node |  | The label content. |
 | labelClassName | string |  | The CSS class name of the label element. |
+| marginForm | bool |  | If `true`, add the margin top and bottom inside the FormControl |
 | multiline | bool |  | If `true`, a textarea element will be rendered instead of an input. |
 | name | string |  | Name attribute of the `Input` element. |
 | placeholder | string |  |  |

--- a/docs/src/pages/component-api/TextField/TextField.md
+++ b/docs/src/pages/component-api/TextField/TextField.md
@@ -25,7 +25,7 @@
 | inputRef | function |  | Use that property to pass a ref callback to the native input component. |
 | label | node |  | The label content. |
 | labelClassName | string |  | The CSS class name of the label element. |
-| marginForm | bool |  | If `true`, add the margin top and bottom inside the FormControl |
+| marginForm | bool |  | If `true`, add the margin top and bottom inside the FormControl. |
 | multiline | bool |  | If `true`, a textarea element will be rendered instead of an input. |
 | name | string |  | Name attribute of the `Input` element. |
 | placeholder | string |  |  |

--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -156,7 +156,7 @@ FormControl.propTypes = {
    */
   fullWidth: PropTypes.bool,
   /**
-   * If `true`, add the margin top and bottom
+   * If `true`, add the margin top and bottom.
    */
   marginForm: PropTypes.bool,
   /**

--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -156,7 +156,7 @@ FormControl.propTypes = {
    */
   fullWidth: PropTypes.bool,
   /**
-   * If `true`, add the margin top and bottom required when used in a form.
+   * If `true`, add the margin top and bottom
    */
   marginForm: PropTypes.bool,
   /**

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -73,7 +73,8 @@ export const styleSheet = createStyleSheet('MuiInput', theme => {
     input: {
       font: 'inherit',
       color: 'currentColor',
-      padding: `${theme.spacing.unit}px 0`,
+      // slight alteration to spec spacing to match visual spec result
+      padding: `${theme.spacing.unit - 1}px 0`,
       border: 0,
       display: 'block',
       boxSizing: 'content-box',

--- a/src/Input/InputLabel.js
+++ b/src/Input/InputLabel.js
@@ -15,7 +15,8 @@ export const styleSheet = createStyleSheet('MuiInputLabel', theme => ({
     position: 'absolute',
     left: 0,
     top: 0,
-    transform: `translate(0, ${theme.spacing.unit * 3}px) scale(1)`,
+    // slight alteration to spec spacing to match visual spec result
+    transform: `translate(0, ${theme.spacing.unit * 3 - 1}px) scale(1)`,
   },
   shrink: {
     transform: 'translate(0, 1.5px) scale(0.75)',

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -156,6 +156,10 @@ TextField.propTypes = {
    */
   labelClassName: PropTypes.string,
   /**
+   * If `true`, add the margin top and bottom inside the FormControl
+   */
+  marginForm: PropTypes.bool,
+  /**
    * If `true`, a textarea element will be rendered instead of an input.
    */
   multiline: PropTypes.bool,

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -156,7 +156,7 @@ TextField.propTypes = {
    */
   labelClassName: PropTypes.string,
   /**
-   * If `true`, add the margin top and bottom inside the FormControl
+   * If `true`, add the margin top and bottom inside the FormControl.
    */
   marginForm: PropTypes.bool,
   /**

--- a/src/TextField/TextField.spec.js
+++ b/src/TextField/TextField.spec.js
@@ -5,7 +5,6 @@ import { assert } from 'chai';
 import { createShallow, createMount } from '../test-utils';
 import Input, { InputLabel } from '../Input';
 import FormHelperText from '../Form/FormHelperText';
-import FormControl from '../Form/FormControl';
 import TextField from './TextField';
 
 describe('<TextField />', () => {

--- a/src/TextField/TextField.spec.js
+++ b/src/TextField/TextField.spec.js
@@ -5,6 +5,7 @@ import { assert } from 'chai';
 import { createShallow, createMount } from '../test-utils';
 import Input, { InputLabel } from '../Input';
 import FormHelperText from '../Form/FormHelperText';
+import FormControl from '../Form/FormControl';
 import TextField from './TextField';
 
 describe('<TextField />', () => {
@@ -30,11 +31,17 @@ describe('<TextField />', () => {
     describe('structure', () => {
       it('should be a FormControl', () => {
         assert.strictEqual(wrapper.name(), 'withStyles(FormControl)');
+        assert.strictEqual(wrapper.dive().is('FormControl'), true);
       });
 
       it('should pass className to the FormControl', () => {
         wrapper.setProps({ className: 'foo' });
-        assert.strictEqual(wrapper.hasClass('foo'), true);
+        assert.strictEqual(wrapper.dive().hasClass('foo'), true);
+      });
+
+      it('should pass marginForm to the FormControl', () => {
+        wrapper.setProps({ marginForm: true });
+        assert.strictEqual(wrapper.dive().props().marginForm, true);
       });
 
       it('should have an Input as the only child', () => {

--- a/src/styles/muiThemeProviderFactory.js
+++ b/src/styles/muiThemeProviderFactory.js
@@ -8,6 +8,7 @@ import jssPreset from 'jss-preset-default';
 export const MUI_SHEET_ORDER = [
   'MuiTextarea',
   'MuiInput',
+  'MuiInputLabel',
   'MuiGrid',
   'MuiCollapse',
   'MuiFade',

--- a/src/styles/withStyles.js
+++ b/src/styles/withStyles.js
@@ -42,7 +42,9 @@ const withStyles = styleSheet => BaseComponent => {
               ].join('\n'),
             );
 
-            acc[key] = `${renderedClasses[key]} ${classesProp[key]}`;
+            if (classesProp[key] !== undefined) {
+              acc[key] = `${renderedClasses[key]} ${classesProp[key]}`;
+            }
             return acc;
           }, {}),
         };

--- a/src/styles/withStyles.spec.js
+++ b/src/styles/withStyles.spec.js
@@ -56,6 +56,15 @@ describe('withStyles', () => {
       assert.strictEqual(consoleErrorMock.callCount(), 0);
     });
 
+    it('should ignore undefined property', () => {
+      const wrapper = shallow(<StyledComponent classes={{ root: undefined }} />);
+
+      assert.deepEqual(wrapper.props().classes, {
+        root: `${classes.root}`,
+      });
+      assert.strictEqual(consoleErrorMock.callCount(), 0);
+    });
+
     it('should warn if providing a unknown key', () => {
       const wrapper = shallow(<StyledComponent classes={{ bar: 'foo' }} />);
 

--- a/test/README.md
+++ b/test/README.md
@@ -102,11 +102,6 @@ In our `vrtest` config this is set as the default, although it can be overridden
 testUrl: process.env.DOCKER_TEST_URL || 'http://10.200.10.1:3090',
 ```
 
-#### Update the baseline
-
-You can update the baseline images by running the following command:
-`npm run test:regressions -- --record`
-
 ## Writing Tests
 
 For all unit tests, please use the [shallow renderer](https://github.com/airbnb/enzyme/blob/master/docs/api/shallow.md) from `enzyme` unless the Component being tested requires a DOM. [Here's](https://github.com/callemall/material-ui/blob/master/src/Avatar/Avatar.spec.js) a small shallow rendered test to get you started.


### PR DESCRIPTION
Closes #7355
- expose docs for `marginForm` on `TextField`
- test `marginForm` pass through from `TextField` (existing code - no test)
- shrink vertical spacing slightly to match visual spec, see analysis in #7355 
- misc - omit rendering undefined styles passed

---
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

