### PR TITLE
[TextField/FormControl] dense implementation

### DIFF
--- a/docs/src/pages/component-api/Form/FormControl.md
+++ b/docs/src/pages/component-api/Form/FormControl.md
@@ -7,13 +7,13 @@ Provides context such as dirty/focused/error/required for form inputs.
 ## Props
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| children | node |  | The contents of the form control. |
-| classes | object |  | Useful to extend the style applied to components. |
-| disabled | bool | false | If `true`, the label, input and helper text should be displayed in a disabled state. |
-| error | bool | false | If `true`, the label should be displayed in an error state. |
-| fullWidth | bool | false | If `true`, the label will take up the full width of its container. |
-| marginForm | bool | false | If `true`, add the margin top and bottom. |
-| required | bool | false | If `true`, the label will indicate that the input is required. |
+| children | Element |  | The contents of the form control. |
+| classes | Object |  | Useful to extend the style applied to components. |
+| disabled | boolean | false | If `true`, the label, input and helper text should be displayed in a disabled state. |
+| error | boolean | false | If `true`, the label should be displayed in an error state. |
+| fullWidth | boolean | false | If `true`, the label will take up the full width of its container. |
+| margin | union:&nbsp;'none'<br>&nbsp;'dense'<br>&nbsp;'normal'<br> | 'none' | If `dense` | `normal`, will adjust vertical spacing of this and contained components. |
+| required | boolean | false | If `true`, the label will indicate that the input is required. |
 
 Any other properties supplied will be spread to the root element.
 
@@ -22,7 +22,8 @@ Any other properties supplied will be spread to the root element.
 You can overrides all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 - `root`
-- `marginForm`
+- `marginNormal`
+- `marginDense`
 - `fullWidth`
 
 Have a look at [overriding with class names](/customization/overrides#overriding-with-class-names)

--- a/docs/src/pages/component-api/Input/Input.md
+++ b/docs/src/pages/component-api/Input/Input.md
@@ -8,16 +8,16 @@
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | className | string |  | The CSS class name of the wrapper element. |
-| classes | object |  | Useful to extend the style applied to components. |
-| component | union:&nbsp;string<br>&nbsp;func<br> |  | The component used for the root node. Either a string to use a DOM element or a component. It's an `input` by default. |
+| classes | Object |  | Useful to extend the style applied to components. |
+| component | union:&nbsp;string<br>&nbsp;Function<br> |  | The component used for the root node. Either a string to use a DOM element or a component. It's an `input` by default. |
 | defaultValue | union:&nbsp;string<br>&nbsp;number<br> |  | The default input value, useful when not controlling the component. |
-| disableUnderline | bool | false | If `true`, the input will not have an underline. |
-| error | bool |  | If `true`, the input will indicate an error. |
-| fullWidth | bool | false | If `true`, the input will take up the full width of its container. |
+| disableUnderline | boolean | false | If `true`, the input will not have an underline. |
+| error | boolean |  | If `true`, the input will indicate an error. |
+| fullWidth | boolean | false | If `true`, the input will take up the full width of its container. |
 | id | string |  |  |
-| inputProps | object |  | Properties applied to the `input` element. |
-| inputRef | function |  | Use that property to pass a ref callback to the native input component. |
-| multiline | bool | false | If `true`, a textarea element will be rendered. |
+| inputProps | Object |  | Properties applied to the `input` element. |
+| inputRef | Function |  | Use that property to pass a ref callback to the native input component. |
+| multiline | boolean | false | If `true`, a textarea element will be rendered. |
 | rows | union:&nbsp;string<br>&nbsp;number<br> |  | Number of rows to display when multiline option is set to true. |
 | rowsMax | union:&nbsp;string<br>&nbsp;number<br> |  | Maxium number of rows to display when multiline option is set to true. |
 | type | string | 'text' | Type of the input element. It should be a valid HTML5 input type. |
@@ -34,6 +34,7 @@ This property accepts the following keys:
 - `inkbar`
 - `error`
 - `input`
+- `inputDense`
 - `disabled`
 - `focused`
 - `underline`

--- a/docs/src/pages/component-api/TextField/TextField.md
+++ b/docs/src/pages/component-api/TextField/TextField.md
@@ -7,30 +7,30 @@
 ## Props
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| FormHelperTextProps | object |  | Properties applied to the `FormHelperText` element. |
+| FormHelperTextProps | Object |  | Properties applied to the `FormHelperText` element. |
 | InputClassName | string |  | The CSS class name of the `Input` element. |
-| InputLabelProps | object |  | Properties applied to the `InputLabel` element. |
-| InputProps | object |  | Properties applied to the `Input` element. |
-| autoComplete | bool |  |  |
-| autoFocus | bool |  |  |
+| InputLabelProps | Object |  | Properties applied to the `InputLabel` element. |
+| InputProps | Object |  | Properties applied to the `Input` element. |
+| autoComplete | boolean |  |  |
+| autoFocus | boolean |  |  |
 | defaultValue | string |  | The default value of the `Input` element. |
-| disabled | bool |  | If `true`, the input will be disabled. |
-| error | bool |  | If `true`, the label will be displayed in an error state. |
-| fullWidth | bool |  | If `true`, the input will take up the full width of its container. |
-| helperText | node |  | The helper text content. |
+| disabled | boolean |  | If `true`, the input will be disabled. |
+| error | boolean |  | If `true`, the label will be displayed in an error state. |
+| fullWidth | boolean |  | If `true`, the input will take up the full width of its container. |
+| helperText | union:&nbsp;string<br>&nbsp;Element<*><br> |  | The helper text content. |
 | helperTextClassName | string |  | The CSS class name of the helper text element. |
 | id | string |  |  |
 | inputClassName | string |  | The CSS class name of the `input` element. |
-| inputProps | object |  | Properties applied to the `input` element. |
-| inputRef | function |  | Use that property to pass a ref callback to the native input component. |
-| label | node |  | The label content. |
+| inputProps | Object |  | Properties applied to the `input` element. |
+| inputRef | Function |  | Use that property to pass a ref callback to the native input component. |
+| label | union:&nbsp;string<br>&nbsp;Element<*><br> |  | The label content. |
 | labelClassName | string |  | The CSS class name of the label element. |
-| marginForm | bool |  | If `true`, add the margin top and bottom inside the FormControl. |
-| multiline | bool |  | If `true`, a textarea element will be rendered instead of an input. |
+| margin | union:&nbsp;'none'<br>&nbsp;'dense'<br>&nbsp;'normal'<br> |  | If `dense` | `normal`, will adjust vertical spacing of this and contained components. |
+| multiline | boolean |  | If `true`, a textarea element will be rendered instead of an input. |
 | name | string |  | Name attribute of the `Input` element. |
 | placeholder | string |  |  |
-| required | bool | false | If `true`, the label is displayed as required. |
-| rootRef | function |  | Use that property to pass a ref callback to the root component. |
+| required | boolean | false | If `true`, the label is displayed as required. |
+| rootRef | Function |  | Use that property to pass a ref callback to the root component. |
 | rows | union:&nbsp;string<br>&nbsp;number<br> |  | Number of rows to display when multiline option is set to true. |
 | rowsMax | union:&nbsp;string<br>&nbsp;number<br> |  | Maxium number of rows to display when multiline option is set to true. |
 | type | string |  | Type attribute of the `Input` element. It should be a valid HTML5 input type. |

--- a/docs/src/pages/component-demos/text-fields/ComposedTextField.js
+++ b/docs/src/pages/component-demos/text-fields/ComposedTextField.js
@@ -13,7 +13,7 @@ const styleSheet = createStyleSheet('ComposedTextField', theme => ({
     display: 'flex',
     flexWrap: 'wrap',
   },
-  input: {
+  formControl: {
     margin: theme.spacing.unit,
   },
 }));
@@ -32,21 +32,21 @@ class ComposedTextField extends Component {
 
     return (
       <div className={classes.container}>
-        <FormControl className={classes.input}>
+        <FormControl className={classes.formControl}>
           <InputLabel htmlFor="name">Name</InputLabel>
           <Input id="name" value={this.state.name} onChange={this.handleChange} />
         </FormControl>
-        <FormControl className={classes.input}>
-          <InputLabel htmlFor="name">Name</InputLabel>
-          <Input id="name" value={this.state.name} onChange={this.handleChange} />
-          <FormHelperText>Some important helper text</FormHelperText>
-        </FormControl>
-        <FormControl className={classes.input} disabled>
+        <FormControl className={classes.formControl}>
           <InputLabel htmlFor="name">Name</InputLabel>
           <Input id="name" value={this.state.name} onChange={this.handleChange} />
           <FormHelperText>Some important helper text</FormHelperText>
         </FormControl>
-        <FormControl className={classes.input} error>
+        <FormControl className={classes.formControl} disabled>
+          <InputLabel htmlFor="name">Name</InputLabel>
+          <Input id="name" value={this.state.name} onChange={this.handleChange} />
+          <FormHelperText>Some important helper text</FormHelperText>
+        </FormControl>
+        <FormControl className={classes.formControl} error>
           <InputLabel htmlFor="name">Name</InputLabel>
           <Input id="name" value={this.state.name} onChange={this.handleChange} />
           <FormHelperText>Some important helper text</FormHelperText>

--- a/docs/src/pages/component-demos/text-fields/Inputs.js
+++ b/docs/src/pages/component-demos/text-fields/Inputs.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Input from 'material-ui/Input/Input';
 
-const styleSheet = createStyleSheet('TextInputs', theme => ({
+const styleSheet = createStyleSheet('Inputs', theme => ({
   container: {
     display: 'flex',
     flexWrap: 'wrap',
@@ -15,7 +15,7 @@ const styleSheet = createStyleSheet('TextInputs', theme => ({
   },
 }));
 
-function TextInputs(props) {
+function Inputs(props) {
   const classes = props.classes;
   return (
     <div className={classes.container}>
@@ -27,8 +27,8 @@ function TextInputs(props) {
   );
 }
 
-TextInputs.propTypes = {
+Inputs.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default withStyles(styleSheet)(TextInputs);
+export default withStyles(styleSheet)(Inputs);

--- a/docs/src/pages/component-demos/text-fields/TextFieldMargins.js
+++ b/docs/src/pages/component-demos/text-fields/TextFieldMargins.js
@@ -1,0 +1,53 @@
+// @flow
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
+import TextField from 'material-ui/TextField';
+
+const styleSheet = createStyleSheet('TextFieldMargins', theme => ({
+  container: {
+    display: 'flex',
+    flexWrap: 'wrap',
+  },
+  input: {
+    marginLeft: theme.spacing.unit,
+    marginRight: theme.spacing.unit,
+    width: 200,
+  },
+}));
+
+const TextFieldMargins = props => {
+  const classes = props.classes;
+
+  return (
+    <div className={classes.container}>
+      <TextField
+        label="None"
+        defaultValue="Default Value"
+        className={classes.input}
+        helperText="Some important text"
+      />
+      <TextField
+        label="Dense"
+        defaultValue="Default Value"
+        className={classes.input}
+        helperText="Some important text"
+        margin="dense"
+      />
+      <TextField
+        label="Normal"
+        defaultValue="Default Value"
+        className={classes.input}
+        helperText="Some important text"
+        margin="normal"
+      />
+    </div>
+  );
+};
+
+TextFieldMargins.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(TextFieldMargins);

--- a/docs/src/pages/component-demos/text-fields/TextFieldMargins.js
+++ b/docs/src/pages/component-demos/text-fields/TextFieldMargins.js
@@ -10,7 +10,7 @@ const styleSheet = createStyleSheet('TextFieldMargins', theme => ({
     display: 'flex',
     flexWrap: 'wrap',
   },
-  input: {
+  textField: {
     marginLeft: theme.spacing.unit,
     marginRight: theme.spacing.unit,
     width: 200,
@@ -25,20 +25,20 @@ const TextFieldMargins = props => {
       <TextField
         label="None"
         defaultValue="Default Value"
-        className={classes.input}
+        className={classes.textField}
         helperText="Some important text"
       />
       <TextField
         label="Dense"
         defaultValue="Default Value"
-        className={classes.input}
+        className={classes.textField}
         helperText="Some important text"
         margin="dense"
       />
       <TextField
         label="Normal"
         defaultValue="Default Value"
-        className={classes.input}
+        className={classes.textField}
         helperText="Some important text"
         margin="normal"
       />

--- a/docs/src/pages/component-demos/text-fields/TextFields.js
+++ b/docs/src/pages/component-demos/text-fields/TextFields.js
@@ -10,7 +10,7 @@ const styleSheet = createStyleSheet('TextFields', theme => ({
     display: 'flex',
     flexWrap: 'wrap',
   },
-  input: {
+  textField: {
     marginLeft: theme.spacing.unit,
     marginRight: theme.spacing.unit,
     width: 200,
@@ -30,7 +30,7 @@ class TextFields extends Component {
         <TextField
           id="name"
           label="Name"
-          className={classes.input}
+          className={classes.textField}
           value={this.state.name}
           onChange={event => this.setState({ name: event.target.value })}
           margin="normal"
@@ -39,7 +39,7 @@ class TextFields extends Component {
           id="uncontrolled"
           label="Uncontrolled"
           defaultValue="foo"
-          className={classes.input}
+          className={classes.textField}
           margin="normal"
         />
         <TextField
@@ -47,7 +47,7 @@ class TextFields extends Component {
           id="required"
           label="Required"
           defaultValue="Hello World"
-          className={classes.input}
+          className={classes.textField}
           margin="normal"
         />
         <TextField
@@ -55,13 +55,13 @@ class TextFields extends Component {
           id="error"
           label="Error"
           defaultValue="Hello World"
-          className={classes.input}
+          className={classes.textField}
           margin="normal"
         />
         <TextField
           id="password"
           label="Password"
-          className={classes.input}
+          className={classes.textField}
           type="password"
           margin="normal"
         />
@@ -71,7 +71,7 @@ class TextFields extends Component {
           multiline
           rowsMax="4"
           defaultValue="Default Value"
-          className={classes.input}
+          className={classes.textField}
           margin="normal"
         />
         <TextField
@@ -80,7 +80,7 @@ class TextFields extends Component {
           multiline
           rows="4"
           defaultValue="Default Value"
-          className={classes.input}
+          className={classes.textField}
           margin="normal"
         />
         <TextField
@@ -88,14 +88,14 @@ class TextFields extends Component {
           label="From date"
           type="date"
           defaultValue="2017-05-24"
-          className={classes.input}
+          className={classes.textField}
           margin="normal"
         />
         <TextField
           id="helperText"
           label="Helper text"
           defaultValue="Default Value"
-          className={classes.input}
+          className={classes.textField}
           helperText="Some important text"
           margin="normal"
         />

--- a/docs/src/pages/component-demos/text-fields/TextFields.js
+++ b/docs/src/pages/component-demos/text-fields/TextFields.js
@@ -33,14 +33,14 @@ class TextFields extends Component {
           className={classes.input}
           value={this.state.name}
           onChange={event => this.setState({ name: event.target.value })}
-          marginForm
+          margin="normal"
         />
         <TextField
           id="uncontrolled"
           label="Uncontrolled"
           defaultValue="foo"
           className={classes.input}
-          marginForm
+          margin="normal"
         />
         <TextField
           required
@@ -48,7 +48,7 @@ class TextFields extends Component {
           label="Required"
           defaultValue="Hello World"
           className={classes.input}
-          marginForm
+          margin="normal"
         />
         <TextField
           error
@@ -56,14 +56,14 @@ class TextFields extends Component {
           label="Error"
           defaultValue="Hello World"
           className={classes.input}
-          marginForm
+          margin="normal"
         />
         <TextField
           id="password"
           label="Password"
           className={classes.input}
           type="password"
-          marginForm
+          margin="normal"
         />
         <TextField
           id="multiline-flexible"
@@ -72,7 +72,7 @@ class TextFields extends Component {
           rowsMax="4"
           defaultValue="Default Value"
           className={classes.input}
-          marginForm
+          margin="normal"
         />
         <TextField
           id="multiline-static"
@@ -81,7 +81,7 @@ class TextFields extends Component {
           rows="4"
           defaultValue="Default Value"
           className={classes.input}
-          marginForm
+          margin="normal"
         />
         <TextField
           id="date"
@@ -89,25 +89,23 @@ class TextFields extends Component {
           type="date"
           defaultValue="2017-05-24"
           className={classes.input}
-          marginForm
+          margin="normal"
         />
         <TextField
           id="helperText"
           label="Helper text"
-          type="text"
           defaultValue="Default Value"
           className={classes.input}
           helperText="Some important text"
-          marginForm
+          margin="normal"
         />
         <TextField
           id="placeholder"
           label="Label"
-          type="text"
           InputProps={{ placeholder: 'Placeholder' }}
           helperText="Full width!!!"
           fullWidth
-          marginForm
+          margin="normal"
         />
       </div>
     );

--- a/docs/src/pages/component-demos/text-fields/text-fields.md
+++ b/docs/src/pages/component-demos/text-fields/text-fields.md
@@ -19,7 +19,9 @@ can leverage directly to significantly customize your form inputs.
 {{demo='pages/component-demos/text-fields/ComposedTextField.js'}}
 
 ## Layout
-`TextField`, `FormControl` allow the specification of `margin` to alter the vertical spacing of inputs. 
+`TextField`, `FormControl` allow the specification of `margin` to alter the vertical spacing of inputs. Using
+`none` (default) will not apply margins to the `FormControl`, whereas `dense` and `normal` will as well as alter
+other styles to meet the specification.
 
 {{demo='pages/component-demos/text-fields/TextFieldMargins.js'}}
 

--- a/docs/src/pages/component-demos/text-fields/text-fields.md
+++ b/docs/src/pages/component-demos/text-fields/text-fields.md
@@ -7,16 +7,21 @@ components: Input, TextField, FormHelperText
 [Text fields](https://material.google.com/components/text-fields.html) allow users to input text and usually appear in forms.
 Users may enter text, numbers, or mixed-format types of input.
 
-## Input
-
-{{demo='pages/component-demos/text-fields/TextInputs.js'}}
-
 ## TextField
-
 The `<TextField>` wrapper component is a complete form control including a label, input and help text.
 
 {{demo='pages/component-demos/text-fields/TextFields.js'}}
 
-This component is composed of smaller components that you can also leverage yourself to significantly customize your input.
+## Components
+`TextField` is composed of smaller components (`FormControl`, `InputLabel`, `Input`, and `FormHelperText`) that you 
+can leverage directly to significantly customize your form inputs.
 
 {{demo='pages/component-demos/text-fields/ComposedTextField.js'}}
+
+## Layout
+`TextField`, `FormControl` allow the specification of `margin` to alter the vertical spacing of inputs. 
+
+{{demo='pages/component-demos/text-fields/TextFieldMargins.js'}}
+
+## Inputs
+{{demo='pages/component-demos/text-fields/Inputs.js'}}

--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -1,6 +1,7 @@
-// @flow weak
+// @flow
 
 import React, { Children, Component } from 'react';
+import type { Element } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { createStyleSheet } from 'jss-theme-reactor';
@@ -13,28 +14,91 @@ export const styleSheet = createStyleSheet('MuiFormControl', theme => ({
     flexDirection: 'column',
     position: 'relative',
   },
-  marginForm: {
+  verticalSpacingNormal: {
     marginTop: theme.spacing.unit * 2,
     marginBottom: theme.spacing.unit,
+  },
+  verticalSpacingDense: {
+    marginTop: theme.spacing.unit,
+    marginBottom: theme.spacing.unit / 2,
   },
   fullWidth: {
     width: '100%',
   },
 }));
 
+type DefaultProps = {
+  disabled: boolean,
+  error: boolean,
+  fullWidth: boolean,
+  verticalSpacing: 'none',
+  required: boolean,
+};
+
+type Props = DefaultProps & {
+  /**
+   * The contents of the form control.
+   */
+  children?: Element<*>,
+  /**
+   * Useful to extend the style applied to components.
+   */
+  classes: Object,
+  /**
+   * @ignore
+   */
+  className?: string,
+  /**
+   * If `true`, the label, input and helper text should be displayed in a disabled state.
+   */
+  disabled?: boolean,
+  /**
+   * If `true`, the label should be displayed in an error state.
+   */
+  error?: boolean,
+  /**
+   * If `true`, the label will take up the full width of its container.
+   */
+  fullWidth?: boolean,
+  /**
+   * @ignore
+   */
+  onBlur?: Function,
+  /**
+   * @ignore
+   */
+  onFocus?: Function,
+  /**
+   * If `true`, the label will indicate that the input is required.
+   */
+  required?: boolean,
+  /**
+   * If `dense` | `normal`, will adjust vertical spacing of this and contained components.
+   */
+  verticalSpacing?: 'none' | 'dense' | 'normal',
+};
+
+type State = {
+  dirty: boolean,
+  focused: boolean,
+};
+
 /**
  * Provides context such as dirty/focused/error/required for form inputs.
  */
-class FormControl extends Component {
+class FormControl extends Component<DefaultProps, Props, State> {
   static defaultProps = {
     disabled: false,
     error: false,
     fullWidth: false,
-    marginForm: false,
+    verticalSpacing: 'none',
     required: false,
   };
+  static childContextTypes = {
+    muiFormControl: PropTypes.object.isRequired,
+  };
 
-  state = {
+  state: State = {
     dirty: false,
     focused: false,
   };
@@ -106,7 +170,7 @@ class FormControl extends Component {
       disabled,
       error,
       fullWidth,
-      marginForm,
+      verticalSpacing,
       ...other
     } = this.props;
 
@@ -115,7 +179,8 @@ class FormControl extends Component {
         className={classNames(
           classes.root,
           {
-            [classes.marginForm]: marginForm,
+            [classes.verticalSpacingNormal]: verticalSpacing === 'normal',
+            [classes.verticalSpacingDense]: verticalSpacing === 'dense',
             [classes.fullWidth]: fullWidth,
           },
           className,
@@ -129,52 +194,5 @@ class FormControl extends Component {
     );
   }
 }
-
-FormControl.propTypes = {
-  /**
-   * The contents of the form control.
-   */
-  children: PropTypes.node,
-  /**
-   * Useful to extend the style applied to components.
-   */
-  classes: PropTypes.object.isRequired,
-  /**
-   * @ignore
-   */
-  className: PropTypes.string,
-  /**
-   * If `true`, the label, input and helper text should be displayed in a disabled state.
-   */
-  disabled: PropTypes.bool,
-  /**
-   * If `true`, the label should be displayed in an error state.
-   */
-  error: PropTypes.bool,
-  /**
-   * If `true`, the label will take up the full width of its container.
-   */
-  fullWidth: PropTypes.bool,
-  /**
-   * If `true`, add the margin top and bottom.
-   */
-  marginForm: PropTypes.bool,
-  /**
-   * @ignore
-   */
-  onBlur: PropTypes.func,
-  /**
-   * @ignore
-   */
-  onFocus: PropTypes.func,
-  /**
-   * If `true`, the label will indicate that the input is required.
-   */
-  required: PropTypes.bool,
-};
-
-FormControl.childContextTypes = {
-  muiFormControl: PropTypes.object.isRequired,
-};
 
 export default withStyles(styleSheet)(FormControl);

--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -14,11 +14,11 @@ export const styleSheet = createStyleSheet('MuiFormControl', theme => ({
     flexDirection: 'column',
     position: 'relative',
   },
-  verticalSpacingNormal: {
+  marginNormal: {
     marginTop: theme.spacing.unit * 2,
     marginBottom: theme.spacing.unit,
   },
-  verticalSpacingDense: {
+  marginDense: {
     marginTop: theme.spacing.unit,
     marginBottom: theme.spacing.unit / 2,
   },
@@ -31,7 +31,7 @@ type DefaultProps = {
   disabled: boolean,
   error: boolean,
   fullWidth: boolean,
-  verticalSpacing: 'none',
+  margin: 'none',
   required: boolean,
 };
 
@@ -75,7 +75,7 @@ type Props = DefaultProps & {
   /**
    * If `dense` | `normal`, will adjust vertical spacing of this and contained components.
    */
-  verticalSpacing?: 'none' | 'dense' | 'normal',
+  margin?: 'none' | 'dense' | 'normal',
 };
 
 type State = {
@@ -91,7 +91,7 @@ class FormControl extends Component<DefaultProps, Props, State> {
     disabled: false,
     error: false,
     fullWidth: false,
-    verticalSpacing: 'none',
+    margin: 'none',
     required: false,
   };
   static childContextTypes = {
@@ -104,7 +104,7 @@ class FormControl extends Component<DefaultProps, Props, State> {
   };
 
   getChildContext() {
-    const { disabled, error, required } = this.props;
+    const { disabled, error, required, margin } = this.props;
     const { dirty, focused } = this.state;
 
     return {
@@ -113,6 +113,7 @@ class FormControl extends Component<DefaultProps, Props, State> {
         disabled,
         error,
         focused,
+        margin,
         required,
         onDirty: this.handleDirty,
         onClean: this.handleClean,
@@ -170,7 +171,7 @@ class FormControl extends Component<DefaultProps, Props, State> {
       disabled,
       error,
       fullWidth,
-      verticalSpacing,
+      margin,
       ...other
     } = this.props;
 
@@ -179,8 +180,8 @@ class FormControl extends Component<DefaultProps, Props, State> {
         className={classNames(
           classes.root,
           {
-            [classes.verticalSpacingNormal]: verticalSpacing === 'normal',
-            [classes.verticalSpacingDense]: verticalSpacing === 'dense',
+            [classes.marginNormal]: margin === 'normal',
+            [classes.marginDense]: margin === 'dense',
             [classes.fullWidth]: fullWidth,
           },
           className,

--- a/src/Form/FormControl.spec.js
+++ b/src/Form/FormControl.spec.js
@@ -136,6 +136,13 @@ describe('<FormControl />', () => {
         loadChildContext();
         assert.strictEqual(muiFormControlContext.error, true);
       });
+
+      it('should have the margin prop from the instance', () => {
+        assert.strictEqual(muiFormControlContext.margin, 'none');
+        wrapper.setProps({ margin: 'dense' });
+        loadChildContext();
+        assert.strictEqual(muiFormControlContext.margin, 'dense');
+      });
     });
 
     describe('callbacks', () => {

--- a/src/Form/FormControl.spec.js
+++ b/src/Form/FormControl.spec.js
@@ -33,27 +33,27 @@ describe('<FormControl />', () => {
       assert.strictEqual(wrapper.hasClass('woof'), true);
     });
 
-    it('should have no verticalSpacing', () => {
+    it('should have no margin', () => {
       const wrapper = shallow(<FormControl />);
 
       assert.strictEqual(wrapper.name(), 'div');
-      assert.strictEqual(wrapper.hasClass(classes.verticalSpacingNormal), false);
-      assert.strictEqual(wrapper.hasClass(classes.verticalSpacingDense), false);
+      assert.strictEqual(wrapper.hasClass(classes.marginNormal), false);
+      assert.strictEqual(wrapper.hasClass(classes.marginDense), false);
     });
 
-    it('should have the verticalSpacing normal class', () => {
-      const wrapper = shallow(<FormControl verticalSpacing="normal" />);
+    it('should have the margin normal class', () => {
+      const wrapper = shallow(<FormControl margin="normal" />);
 
       assert.strictEqual(wrapper.name(), 'div');
-      assert.strictEqual(wrapper.hasClass(classes.verticalSpacingNormal), true);
+      assert.strictEqual(wrapper.hasClass(classes.marginNormal), true);
     });
 
-    it('should have the verticalSpacing dense class', () => {
-      const wrapper = shallow(<FormControl verticalSpacing="dense" />);
+    it('should have the margin dense class', () => {
+      const wrapper = shallow(<FormControl margin="dense" />);
 
       assert.strictEqual(wrapper.name(), 'div');
-      assert.strictEqual(wrapper.hasClass(classes.verticalSpacingDense), true);
-      assert.strictEqual(wrapper.hasClass(classes.verticalSpacingNormal), false);
+      assert.strictEqual(wrapper.hasClass(classes.marginDense), true);
+      assert.strictEqual(wrapper.hasClass(classes.marginNormal), false);
     });
   });
 

--- a/src/Form/FormControl.spec.js
+++ b/src/Form/FormControl.spec.js
@@ -16,20 +16,45 @@ describe('<FormControl />', () => {
     classes = shallow.context.styleManager.render(styleSheet);
   });
 
-  it('should render a div with the root and user classes', () => {
-    const wrapper = shallow(<FormControl className="woof" />);
+  describe('initial state', () => {
+    it('should render a div with the root and user classes', () => {
+      const wrapper = shallow(<FormControl className="woof" />);
 
-    assert.strictEqual(wrapper.name(), 'div');
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
-  });
+      assert.strictEqual(wrapper.name(), 'div');
+      assert.strictEqual(wrapper.hasClass(classes.root), true);
+      assert.strictEqual(wrapper.hasClass('woof'), true);
+    });
 
-  it('should have the focused class', () => {
-    const wrapper = shallow(<FormControl className="woof" />);
+    it('should have the focused class', () => {
+      const wrapper = shallow(<FormControl className="woof" />);
 
-    assert.strictEqual(wrapper.name(), 'div');
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+      assert.strictEqual(wrapper.name(), 'div');
+      assert.strictEqual(wrapper.hasClass(classes.root), true);
+      assert.strictEqual(wrapper.hasClass('woof'), true);
+    });
+
+    it('should have no verticalSpacing', () => {
+      const wrapper = shallow(<FormControl />);
+
+      assert.strictEqual(wrapper.name(), 'div');
+      assert.strictEqual(wrapper.hasClass(classes.verticalSpacingNormal), false);
+      assert.strictEqual(wrapper.hasClass(classes.verticalSpacingDense), false);
+    });
+
+    it('should have the verticalSpacing normal class', () => {
+      const wrapper = shallow(<FormControl verticalSpacing="normal" />);
+
+      assert.strictEqual(wrapper.name(), 'div');
+      assert.strictEqual(wrapper.hasClass(classes.verticalSpacingNormal), true);
+    });
+
+    it('should have the verticalSpacing dense class', () => {
+      const wrapper = shallow(<FormControl verticalSpacing="dense" />);
+
+      assert.strictEqual(wrapper.name(), 'div');
+      assert.strictEqual(wrapper.hasClass(classes.verticalSpacingDense), true);
+      assert.strictEqual(wrapper.hasClass(classes.verticalSpacingNormal), false);
+    });
   });
 
   describe('initial state', () => {

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -104,6 +104,9 @@ export const styleSheet = createStyleSheet('MuiInput', theme => {
         '&:focus::-ms-input-placeholder': placeholderFormFocus, // Edge
       },
     },
+    inputDense: {
+      paddingTop: `${theme.spacing.unit / 2}px 0`,
+    },
     disabled: {
       color: theme.palette.text.disabled,
     },
@@ -157,7 +160,131 @@ export const styleSheet = createStyleSheet('MuiInput', theme => {
   };
 });
 
-class Input extends Component {
+type DefaultProps = {
+  disableUnderline: boolean,
+  fullWidth: boolean,
+  multiline: boolean,
+  type: string,
+};
+
+type Props = DefaultProps & {
+  /**
+   * @ignore
+   */
+  autoComplete?: boolean,
+  /**
+   * @ignore
+   */
+  autoFocus?: boolean,
+  /**
+   * Useful to extend the style applied to components.
+   */
+  classes: Object,
+  /**
+   * The CSS class name of the wrapper element.
+   */
+  className?: string,
+  /**
+   * The component used for the root node.
+   * Either a string to use a DOM element or a component.
+   * It's an `input` by default.
+   */
+  component?: string | Function,
+  /**
+   * The default input value, useful when not controlling the component.
+   */
+  defaultValue?: string | number,
+  /**
+   * @ignore
+   */
+  disabled?: boolean,
+  /**
+   * If `true`, the input will not have an underline.
+   */
+  disableUnderline?: boolean,
+  /**
+   * If `true`, the input will indicate an error.
+   */
+  error?: boolean,
+  /**
+   * If `true`, the input will take up the full width of its container.
+   */
+  fullWidth?: boolean,
+  /*
+   * @ignore
+   */
+  id?: string,
+  /**
+   * Properties applied to the `input` element.
+   */
+  inputProps?: Object,
+  /**
+   * Use that property to pass a ref callback to the native input component.
+   */
+  inputRef?: Function,
+  /**
+   * If `true`, a textarea element will be rendered.
+   */
+  multiline?: boolean,
+  /**
+   * @ignore
+   */
+  name?: string,
+  /**
+   * @ignore
+   */
+  onBlur?: Function,
+  /**
+   * @ignore
+   */
+  onChange?: Function,
+  /**
+   * @ignore
+   */
+  onClean?: Function,
+  /**
+   * @ignore
+   */
+  onDirty?: Function,
+  /**
+   * @ignore
+   */
+  onFocus?: Function,
+  /**
+   * @ignore
+   */
+  onKeyDown?: Function,
+  /**
+   * @ignore
+   */
+  onKeyUp?: Function,
+  /**
+   * @ignore
+   */
+  placeholder?: string,
+  /**
+   * Number of rows to display when multiline option is set to true.
+   */
+  rows?: string | number,
+  /**
+   * Maxium number of rows to display when multiline option is set to true.
+   */
+  rowsMax?: string | number,
+  /**
+   * Type of the input element. It should be a valid HTML5 input type.
+   */
+  type?: string,
+  /**
+   * The input value, required for a controlled component.
+   */
+  value?: string | number,
+};
+
+type State = {
+  focused: boolean,
+};
+
+class Input extends Component<DefaultProps, Props, State> {
   static muiName = 'Input';
   static defaultProps = {
     disableUnderline: false,
@@ -165,7 +292,9 @@ class Input extends Component {
     multiline: false,
     type: 'text',
   };
-
+  static contextTypes = {
+    muiFormControl: PropTypes.object,
+  };
   state = {
     focused: false,
   };
@@ -289,13 +418,18 @@ class Input extends Component {
 
     let disabled = disabledProp;
     let error = errorProp;
+    let margin;
 
-    if (muiFormControl && typeof disabled === 'undefined') {
-      disabled = muiFormControl.disabled;
-    }
+    if (muiFormControl) {
+      if (typeof disabled === 'undefined') {
+        disabled = muiFormControl.disabled;
+      }
 
-    if (typeof error === 'undefined' && muiFormControl) {
-      error = muiFormControl.error;
+      if (typeof error === 'undefined') {
+        error = muiFormControl.error;
+      }
+
+      margin = muiFormControl.margin;
     }
 
     const className = classNames(
@@ -317,6 +451,7 @@ class Input extends Component {
       [classes.inputDisabled]: disabled,
       [classes.inputSingleline]: !multiline,
       [classes.inputMultiline]: multiline,
+      [classes.inputDense]: margin === 'dense',
     });
 
     const required = muiFormControl && muiFormControl.required === true;
@@ -376,122 +511,5 @@ class Input extends Component {
     );
   }
 }
-
-Input.propTypes = {
-  /**
-   * @ignore
-   */
-  autoComplete: PropTypes.bool,
-  /**
-   * @ignore
-   */
-  autoFocus: PropTypes.bool,
-  /**
-   * Useful to extend the style applied to components.
-   */
-  classes: PropTypes.object.isRequired,
-  /**
-   * The CSS class name of the wrapper element.
-   */
-  className: PropTypes.string,
-  /**
-   * The component used for the root node.
-   * Either a string to use a DOM element or a component.
-   * It's an `input` by default.
-   */
-  component: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-  /**
-   * The default input value, useful when not controlling the component.
-   */
-  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  /**
-   * @ignore
-   */
-  disabled: PropTypes.bool,
-  /**
-   * If `true`, the input will not have an underline.
-   */
-  disableUnderline: PropTypes.bool,
-  /**
-   * If `true`, the input will indicate an error.
-   */
-  error: PropTypes.bool,
-  /**
-   * If `true`, the input will take up the full width of its container.
-   */
-  fullWidth: PropTypes.bool,
-  /*
-   * @ignore
-   */
-  id: PropTypes.string,
-  /**
-   * Properties applied to the `input` element.
-   */
-  inputProps: PropTypes.object,
-  /**
-   * Use that property to pass a ref callback to the native input component.
-   */
-  inputRef: PropTypes.func,
-  /**
-   * If `true`, a textarea element will be rendered.
-   */
-  multiline: PropTypes.bool,
-  /**
-   * @ignore
-   */
-  name: PropTypes.string,
-  /**
-   * @ignore
-   */
-  onBlur: PropTypes.func,
-  /**
-   * @ignore
-   */
-  onChange: PropTypes.func,
-  /**
-   * @ignore
-   */
-  onClean: PropTypes.func,
-  /**
-   * @ignore
-   */
-  onDirty: PropTypes.func,
-  /**
-   * @ignore
-   */
-  onFocus: PropTypes.func,
-  /**
-   * @ignore
-   */
-  onKeyDown: PropTypes.func,
-  /**
-   * @ignore
-   */
-  onKeyUp: PropTypes.func,
-  /**
-   * @ignore
-   */
-  placeholder: PropTypes.string,
-  /**
-   * Number of rows to display when multiline option is set to true.
-   */
-  rows: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  /**
-   * Maxium number of rows to display when multiline option is set to true.
-   */
-  rowsMax: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  /**
-   * Type of the input element. It should be a valid HTML5 input type.
-   */
-  type: PropTypes.string,
-  /**
-   * The input value, required for a controlled component.
-   */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-};
-
-Input.contextTypes = {
-  muiFormControl: PropTypes.object,
-};
 
 export default withStyles(styleSheet)(Input);

--- a/src/Input/Input.spec.js
+++ b/src/Input/Input.spec.js
@@ -259,6 +259,16 @@ describe('<Input />', () => {
       });
     });
 
+    describe('margin', () => {
+      beforeEach(() => {
+        setFormControlContext({ margin: 'dense' });
+      });
+
+      it('should have the inputDense class', () => {
+        assert.strictEqual(wrapper.find('input').hasClass(classes.inputDense), true);
+      });
+    });
+
     describe('required', () => {
       it('should have the aria-required prop with value true', () => {
         setFormControlContext({ required: true });

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -110,7 +110,7 @@ type Props = {
   /**
    * If `dense` | `normal`, will adjust vertical spacing of this and contained components.
    */
-  verticalSpacing?: 'none' | 'dense' | 'normal',
+  margin?: 'none' | 'dense' | 'normal',
 };
 
 function TextField(props: Props) {

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -1,12 +1,119 @@
-// @flow weak
+// @flow
 
 import React from 'react';
-import PropTypes from 'prop-types';
+import type { Element } from 'react';
 import Input, { InputLabel } from '../Input';
 import FormControl from '../Form/FormControl';
 import FormHelperText from '../Form/FormHelperText';
 
-function TextField(props) {
+type Props = {
+  autoComplete?: boolean,
+  autoFocus?: boolean,
+  /**
+   * @ignore
+   */
+  className?: string,
+  /**
+   * The default value of the `Input` element.
+   */
+  defaultValue?: string,
+  /**
+   * If `true`, the input will be disabled.
+   */
+  disabled?: boolean,
+  /**
+   * If `true`, the label will be displayed in an error state.
+   */
+  error?: boolean,
+  /**
+   * Properties applied to the `FormHelperText` element.
+   */
+  FormHelperTextProps?: Object,
+  /**
+   * If `true`, the input will take up the full width of its container.
+   */
+  fullWidth?: boolean,
+  /**
+   * The helper text content.
+   */
+  helperText?: string | Element<*>,
+  /**
+   * The CSS class name of the helper text element.
+   */
+  helperTextClassName?: string,
+  id?: string,
+  /**
+   * The CSS class name of the `input` element.
+   */
+  inputClassName?: string,
+  /**
+   * The CSS class name of the `Input` element.
+   */
+  InputClassName?: string,
+  /**
+   * Properties applied to the `InputLabel` element.
+   */
+  InputLabelProps?: Object,
+  /**
+   * Properties applied to the `input` element.
+   */
+  inputProps?: Object,
+  /**
+   * Properties applied to the `Input` element.
+   */
+  InputProps?: Object,
+  /**
+   * Use that property to pass a ref callback to the native input component.
+   */
+  inputRef?: Function,
+  /**
+   * The label content.
+   */
+  label?: string | Element<*>,
+  /**
+   * The CSS class name of the label element.
+   */
+  labelClassName?: string,
+  /**
+   * If `true`, a textarea element will be rendered instead of an input.
+   */
+  multiline?: boolean,
+  /**
+   * Name attribute of the `Input` element.
+   */
+  name?: string,
+  placeholder?: string,
+  /**
+   * If `true`, the label is displayed as required.
+   */
+  required?: boolean,
+  /**
+   * Use that property to pass a ref callback to the root component.
+   */
+  rootRef?: Function,
+  /**
+   * Number of rows to display when multiline option is set to true.
+   */
+  rows?: string | number,
+  /**
+   * Maxium number of rows to display when multiline option is set to true.
+   */
+  rowsMax?: string | number,
+  /**
+   * Type attribute of the `Input` element. It should be a valid HTML5 input type.
+   */
+  type?: string,
+  /**
+   * The value of the `Input` element, required for a controlled component.
+   */
+  value?: string | number,
+  /**
+   * If `dense` | `normal`, will adjust vertical spacing of this and contained components.
+   */
+  verticalSpacing?: 'none' | 'dense' | 'normal',
+};
+
+function TextField(props: Props) {
   const {
     autoComplete,
     autoFocus,
@@ -86,113 +193,6 @@ function TextField(props) {
     </FormControl>
   );
 }
-
-TextField.propTypes = {
-  autoComplete: PropTypes.bool,
-  autoFocus: PropTypes.bool,
-  /**
-   * @ignore
-   */
-  className: PropTypes.string,
-  /**
-   * The default value of the `Input` element.
-   */
-  defaultValue: PropTypes.string,
-  /**
-   * If `true`, the input will be disabled.
-   */
-  disabled: PropTypes.bool,
-  /**
-   * If `true`, the label will be displayed in an error state.
-   */
-  error: PropTypes.bool,
-  /**
-   * Properties applied to the `FormHelperText` element.
-   */
-  FormHelperTextProps: PropTypes.object,
-  /**
-   * If `true`, the input will take up the full width of its container.
-   */
-  fullWidth: PropTypes.bool,
-  /**
-   * The helper text content.
-   */
-  helperText: PropTypes.node,
-  /**
-   * The CSS class name of the helper text element.
-   */
-  helperTextClassName: PropTypes.string,
-  id: PropTypes.string,
-  /**
-   * The CSS class name of the `input` element.
-   */
-  inputClassName: PropTypes.string,
-  /**
-   * The CSS class name of the `Input` element.
-   */
-  InputClassName: PropTypes.string,
-  /**
-   * Properties applied to the `InputLabel` element.
-   */
-  InputLabelProps: PropTypes.object,
-  /**
-   * Properties applied to the `input` element.
-   */
-  inputProps: PropTypes.object,
-  /**
-   * Properties applied to the `Input` element.
-   */
-  InputProps: PropTypes.object,
-  /**
-   * Use that property to pass a ref callback to the native input component.
-   */
-  inputRef: PropTypes.func,
-  /**
-   * The label content.
-   */
-  label: PropTypes.node,
-  /**
-   * The CSS class name of the label element.
-   */
-  labelClassName: PropTypes.string,
-  /**
-   * If `true`, add the margin top and bottom inside the FormControl.
-   */
-  marginForm: PropTypes.bool,
-  /**
-   * If `true`, a textarea element will be rendered instead of an input.
-   */
-  multiline: PropTypes.bool,
-  /**
-   * Name attribute of the `Input` element.
-   */
-  name: PropTypes.string,
-  placeholder: PropTypes.string,
-  /**
-   * If `true`, the label is displayed as required.
-   */
-  required: PropTypes.bool,
-  /**
-   * Use that property to pass a ref callback to the root component.
-   */
-  rootRef: PropTypes.func,
-  /**
-   * Number of rows to display when multiline option is set to true.
-   */
-  rows: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  /**
-   * Maxium number of rows to display when multiline option is set to true.
-   */
-  rowsMax: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  /**
-   * Type attribute of the `Input` element. It should be a valid HTML5 input type.
-   */
-  type: PropTypes.string,
-  /**
-   * The value of the `Input` element, required for a controlled component.
-   */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-};
 
 TextField.defaultProps = {
   required: false,

--- a/src/TextField/TextField.spec.js
+++ b/src/TextField/TextField.spec.js
@@ -38,9 +38,9 @@ describe('<TextField />', () => {
         assert.strictEqual(wrapper.dive().hasClass('foo'), true);
       });
 
-      it('should pass verticalSpacing to the FormControl', () => {
-        wrapper.setProps({ verticalSpacing: 'normal' });
-        assert.strictEqual(wrapper.dive().props().verticalSpacing, 'normal');
+      it('should pass margin to the FormControl', () => {
+        wrapper.setProps({ margin: 'normal' });
+        assert.strictEqual(wrapper.dive().props().margin, 'normal');
       });
 
       it('should have an Input as the only child', () => {

--- a/src/TextField/TextField.spec.js
+++ b/src/TextField/TextField.spec.js
@@ -38,9 +38,9 @@ describe('<TextField />', () => {
         assert.strictEqual(wrapper.dive().hasClass('foo'), true);
       });
 
-      it('should pass marginForm to the FormControl', () => {
-        wrapper.setProps({ marginForm: true });
-        assert.strictEqual(wrapper.dive().props().marginForm, true);
+      it('should pass verticalSpacing to the FormControl', () => {
+        wrapper.setProps({ verticalSpacing: 'normal' });
+        assert.strictEqual(wrapper.dive().props().verticalSpacing, 'normal');
       });
 
       it('should have an Input as the only child', () => {

--- a/test/regressions/tests/TextField/TextFieldMargin.js
+++ b/test/regressions/tests/TextField/TextFieldMargin.js
@@ -1,0 +1,14 @@
+// @flow
+
+import React from 'react';
+import TextField from 'material-ui/TextField';
+
+export default function TextFieldMargin() {
+  return (
+    <div>
+      <TextField label="Foo" helperText="Bar" />
+      <TextField label="Foo" helperText="Bar" margin="dense" />
+      <TextField label="Foo" helperText="Bar" margin="normal" />
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #7358 

The previous approach was using `marginForm` to implement what the spec called `normal` spacing, whereas the default was to omit the margins.  `dense` by spec is more than our default `none`, but less than spec `normal`.

Breaking change removes `marginForm` and replaces it with `margin: 'none' | 'dense' | 'normal'`, where the default of `none` is unchanged.

Also:
- converted more to flow 
- regenerated api docs  
- during implementation of demo, found a few renames needed for clarity
- added regression test

---

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

