### PR TITLE
[Menu] maxHeight spec compliance

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "fs-extra": "^3.0.1",
     "glob": "^7.1.2",
     "jsdom": "^11.1.0",
+    "jsdom-global": "^3.0.2",
     "json-loader": "^0.5.4",
     "karma": "^1.7.0",
     "karma-browserstack-launcher": "^1.3.0",

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -10,6 +10,7 @@ import Modal from '../internal/Modal';
 import Fade from '../transitions/Fade';
 import { duration } from '../styles/transitions';
 import Paper from '../Paper';
+import type { TransitionCallback } from '../internal/Transition';
 
 export const styleSheet = createStyleSheet('MuiDialog', theme => ({
   root: {
@@ -91,15 +92,15 @@ type Props = {
   /**
    * Callback fired before the dialog enters.
    */
-  onEnter?: Function,
+  onEnter?: TransitionCallback,
   /**
    * Callback fired when the dialog is entering.
    */
-  onEntering?: Function,
+  onEntering?: TransitionCallback,
   /**
    * Callback fired when the dialog has entered.
    */
-  onEntered?: Function, // eslint-disable-line react/sort-prop-types
+  onEntered?: TransitionCallback, // eslint-disable-line react/sort-prop-types
   /**
    * Callback fires when the escape key is released and the modal is in focus.
    */
@@ -107,15 +108,15 @@ type Props = {
   /**
    * Callback fired before the dialog exits.
    */
-  onExit?: Function,
+  onExit?: TransitionCallback,
   /**
    * Callback fired when the dialog is exiting.
    */
-  onExiting?: Function,
+  onExiting?: TransitionCallback,
   /**
    * Callback fired when the dialog has exited.
    */
-  onExited?: Function, // eslint-disable-line react/sort-prop-types
+  onExited?: TransitionCallback, // eslint-disable-line react/sort-prop-types
   /**
    * Callback fired when the dialog requests to be closed.
    */

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -2,7 +2,6 @@
 
 import React, { Component } from 'react';
 import type { Element } from 'react';
-import classNames from 'classnames';
 import { findDOMNode } from 'react-dom';
 import { createStyleSheet } from 'jss-theme-reactor';
 import getScrollbarSize from 'dom-helpers/util/scrollbarSize';
@@ -76,11 +75,7 @@ type Props = DefaultProps & {
   transitionDuration?: number | 'auto',
 };
 
-export const styleSheet = createStyleSheet('MuiMenu', {
-  root: {
-    maxHeight: 250,
-  },
-});
+export const styleSheet = createStyleSheet('MuiMenu', {});
 
 class Menu extends Component<DefaultProps, Props, void> {
   static defaultProps: DefaultProps = {
@@ -159,7 +154,7 @@ class Menu extends Component<DefaultProps, Props, void> {
       <Popover
         anchorEl={anchorEl}
         getContentAnchorEl={this.getContentAnchorEl}
-        className={classNames(classes.root, className)}
+        className={className}
         open={open}
         enteredClassName={classes.entered}
         onEnter={this.handleEnter}

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -2,9 +2,12 @@
 
 import React, { Component } from 'react';
 import type { Element } from 'react';
+import classNames from 'classnames';
 import { findDOMNode } from 'react-dom';
+import { createStyleSheet } from 'jss-theme-reactor';
 import getScrollbarSize from 'dom-helpers/util/scrollbarSize';
 import Popover from '../internal/Popover';
+import withStyles from '../styles/withStyles';
 import MenuList from './MenuList';
 import type { TransitionCallback } from '../internal/Transition';
 
@@ -22,6 +25,10 @@ type Props = DefaultProps & {
    * Menu contents, normally `MenuItem`s.
    */
   children?: Element<*>,
+  /**
+   * Useful to extend the style applied to components.
+   */
+  classes: Object,
   /**
    * @ignore
    */
@@ -69,6 +76,17 @@ type Props = DefaultProps & {
    */
   transitionDuration?: number | 'auto',
 };
+
+export const styleSheet = createStyleSheet('MuiMenu', {
+  root: {
+    /**
+     * specZ: The maximum height of a simple menu should be one or more rows less than the view
+     * height. This ensures a tappable area outside of the simple menu with which to dismiss
+     * the menu.
+     */
+    maxHeight: 'calc(100vh - 96px)',
+  },
+});
 
 class Menu extends Component<DefaultProps, Props, void> {
   static defaultProps: DefaultProps = {
@@ -128,6 +146,7 @@ class Menu extends Component<DefaultProps, Props, void> {
     const {
       anchorEl,
       children,
+      classes,
       className,
       open,
       MenuListProps,
@@ -146,7 +165,7 @@ class Menu extends Component<DefaultProps, Props, void> {
       <Popover
         anchorEl={anchorEl}
         getContentAnchorEl={this.getContentAnchorEl}
-        className={className}
+        className={classNames(classes.root, className)}
         open={open}
         onEnter={this.handleEnter}
         onEntering={onEntering}
@@ -174,4 +193,4 @@ class Menu extends Component<DefaultProps, Props, void> {
   }
 }
 
-export default Menu;
+export default withStyles(styleSheet)(Menu);

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -3,11 +3,10 @@
 import React, { Component } from 'react';
 import type { Element } from 'react';
 import { findDOMNode } from 'react-dom';
-import { createStyleSheet } from 'jss-theme-reactor';
 import getScrollbarSize from 'dom-helpers/util/scrollbarSize';
 import Popover from '../internal/Popover';
-import withStyles from '../styles/withStyles';
 import MenuList from './MenuList';
+import type { TransitionCallback } from '../internal/Transition';
 
 type DefaultProps = {
   open: boolean,
@@ -24,10 +23,6 @@ type Props = DefaultProps & {
    */
   children?: Element<*>,
   /**
-   * Useful to extend the style applied to components.
-   */
-  classes: Object,
-  /**
    * @ignore
    */
   className?: string,
@@ -38,27 +33,27 @@ type Props = DefaultProps & {
   /**
    * Callback fired before the Menu enters.
    */
-  onEnter?: Function,
+  onEnter?: TransitionCallback,
   /**
    * Callback fired when the Menu is entering.
    */
-  onEntering?: Function,
+  onEntering?: TransitionCallback,
   /**
    * Callback fired when the Menu has entered.
    */
-  onEntered?: Function, // eslint-disable-line react/sort-prop-types
+  onEntered?: TransitionCallback, // eslint-disable-line react/sort-prop-types
   /**
    * Callback fired before the Menu exits.
    */
-  onExit?: Function,
+  onExit?: TransitionCallback,
   /**
    * Callback fired when the Menu is exiting.
    */
-  onExiting?: Function,
+  onExiting?: TransitionCallback,
   /**
    * Callback fired when the Menu has exited.
    */
-  onExited?: Function, // eslint-disable-line react/sort-prop-types
+  onExited?: TransitionCallback, // eslint-disable-line react/sort-prop-types
   /**
    * Callback function fired when the menu is requested to be closed.
    *
@@ -75,8 +70,6 @@ type Props = DefaultProps & {
   transitionDuration?: number | 'auto',
 };
 
-export const styleSheet = createStyleSheet('MuiMenu', {});
-
 class Menu extends Component<DefaultProps, Props, void> {
   static defaultProps: DefaultProps = {
     open: false,
@@ -85,7 +78,7 @@ class Menu extends Component<DefaultProps, Props, void> {
 
   menuList = undefined;
 
-  handleEnter = element => {
+  handleEnter = (element: HTMLElement) => {
     const list = findDOMNode(this.menuList);
 
     if (this.menuList && this.menuList.selectedItem) {
@@ -110,7 +103,7 @@ class Menu extends Component<DefaultProps, Props, void> {
     }
   };
 
-  handleListKeyDown = (event, key) => {
+  handleListKeyDown = (event: SyntheticUIEvent, key: string) => {
     if (key === 'tab') {
       event.preventDefault();
       const { onRequestClose } = this.props;
@@ -135,7 +128,6 @@ class Menu extends Component<DefaultProps, Props, void> {
     const {
       anchorEl,
       children,
-      classes,
       className,
       open,
       MenuListProps,
@@ -156,7 +148,6 @@ class Menu extends Component<DefaultProps, Props, void> {
         getContentAnchorEl={this.getContentAnchorEl}
         className={className}
         open={open}
-        enteredClassName={classes.entered}
         onEnter={this.handleEnter}
         onEntering={onEntering}
         onEntered={onEntered}
@@ -183,4 +174,4 @@ class Menu extends Component<DefaultProps, Props, void> {
   }
 }
 
-export default withStyles(styleSheet)(Menu);
+export default Menu;

--- a/src/Menu/Menu.spec.js
+++ b/src/Menu/Menu.spec.js
@@ -38,11 +38,6 @@ describe('<Menu />', () => {
     });
   });
 
-  it('should pass `classes.root` to the Popover for the className', () => {
-    const wrapper = shallow(<Menu />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true, 'should be classes.root');
-  });
-
   it('should pass `classes.entered` to the Popover for the enteredClassName', () => {
     const wrapper = shallow(<Menu />);
     assert.strictEqual(

--- a/src/Menu/Menu.spec.js
+++ b/src/Menu/Menu.spec.js
@@ -5,18 +5,20 @@ import { spy, stub } from 'sinon';
 import { assert } from 'chai';
 import ReactDOM from 'react-dom';
 import { createShallow, createMount } from '../test-utils';
-import Menu from './Menu';
+import Menu, { styleSheet } from './Menu';
 
 describe('<Menu />', () => {
   let shallow;
+  let classes;
 
   before(() => {
     shallow = createShallow({ dive: true });
+    classes = shallow.context.styleManager.render(styleSheet);
   });
 
   it('should render a Popover', () => {
     const wrapper = shallow(<Menu />);
-    assert.strictEqual(wrapper.name(), 'Popover');
+    assert.strictEqual(wrapper.name(), 'withStyles(Popover)');
   });
 
   it('should fire Popover transition event callbacks', () => {
@@ -36,10 +38,15 @@ describe('<Menu />', () => {
     });
   });
 
+  it('should pass `classes.root` to the Popover for the className', () => {
+    const wrapper = shallow(<Menu />);
+    assert.strictEqual(wrapper.hasClass(classes.root), true, 'should be classes.root');
+  });
+
   it('should pass the instance function `getContentAnchorEl` to Popover', () => {
-    const wrapper = createMount()(<Menu />);
+    const wrapper = shallow(<Menu />);
     assert.strictEqual(
-      wrapper.find('Popover').props().getContentAnchorEl,
+      wrapper.props().getContentAnchorEl,
       wrapper.instance().getContentAnchorEl,
       'should be the same function',
     );
@@ -108,7 +115,7 @@ describe('<Menu />', () => {
 
     before(() => {
       mount = createMount();
-      wrapper = mount(<Menu />);
+      wrapper = mount(<Menu.Naked classes={classes} />);
       instance = wrapper.instance();
 
       selectedItemFocusSpy = spy();

--- a/src/Menu/Menu.spec.js
+++ b/src/Menu/Menu.spec.js
@@ -5,20 +5,18 @@ import { spy, stub } from 'sinon';
 import { assert } from 'chai';
 import ReactDOM from 'react-dom';
 import { createShallow, createMount } from '../test-utils';
-import Menu, { styleSheet } from './Menu';
+import Menu from './Menu';
 
 describe('<Menu />', () => {
   let shallow;
-  let classes;
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = shallow.context.styleManager.render(styleSheet);
   });
 
   it('should render a Popover', () => {
     const wrapper = shallow(<Menu />);
-    assert.strictEqual(wrapper.name(), 'withStyles(Popover)');
+    assert.strictEqual(wrapper.name(), 'Popover');
   });
 
   it('should fire Popover transition event callbacks', () => {
@@ -38,19 +36,10 @@ describe('<Menu />', () => {
     });
   });
 
-  it('should pass `classes.entered` to the Popover for the enteredClassName', () => {
-    const wrapper = shallow(<Menu />);
-    assert.strictEqual(
-      wrapper.props().enteredClassName,
-      classes.entered,
-      'should be classes.entered',
-    );
-  });
-
   it('should pass the instance function `getContentAnchorEl` to Popover', () => {
-    const wrapper = shallow(<Menu />);
+    const wrapper = createMount()(<Menu />);
     assert.strictEqual(
-      wrapper.props().getContentAnchorEl,
+      wrapper.find('Popover').props().getContentAnchorEl,
       wrapper.instance().getContentAnchorEl,
       'should be the same function',
     );
@@ -119,7 +108,7 @@ describe('<Menu />', () => {
 
     before(() => {
       mount = createMount();
-      wrapper = mount(<Menu.Naked classes={classes} />);
+      wrapper = mount(<Menu />);
       instance = wrapper.instance();
 
       selectedItemFocusSpy = spy();

--- a/src/Menu/MenuList.js
+++ b/src/Menu/MenuList.js
@@ -25,7 +25,7 @@ type Props = {
   /**
    * @ignore
    */
-  onKeyDown?: Function,
+  onKeyDown?: (event: SyntheticUIEvent, key: string) => void,
 };
 
 type State = {

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -10,6 +10,7 @@ import ClickAwayListener from '../internal/ClickAwayListener';
 import { capitalizeFirstLetter, createChainedFunction } from '../utils/helpers';
 import Slide from '../transitions/Slide';
 import SnackbarContent from './SnackbarContent';
+import type { TransitionCallback } from '../internal/Transition';
 
 export const styleSheet = createStyleSheet('MuiSnackbar', theme => {
   const gutter = theme.spacing.unit * 3;
@@ -127,27 +128,27 @@ type Props = DefaultProps & {
   /**
    * Callback fired before the transition is entering.
    */
-  onEnter?: Function,
+  onEnter?: TransitionCallback,
   /**
    * Callback fired when the transition is entering.
    */
-  onEntering?: Function,
+  onEntering?: TransitionCallback,
   /**
    * Callback fired when the transition has entered.
    */
-  onEntered?: Function,
+  onEntered?: TransitionCallback,
   /**
    * Callback fired before the transition is exiting.
    */
-  onExit?: Function,
+  onExit?: TransitionCallback,
   /**
    * Callback fired when the transition is exiting.
    */
-  onExiting?: Function,
+  onExiting?: TransitionCallback,
   /**
    * Callback fired when the transition has exited.
    */
-  onExited?: Function,
+  onExited?: TransitionCallback,
   /**
    * @ignore
    */

--- a/src/internal/Modal.js
+++ b/src/internal/Modal.js
@@ -18,6 +18,7 @@ import withStyles from '../styles/withStyles';
 import createModalManager from './modalManager';
 import Backdrop from './Backdrop';
 import Portal from './Portal';
+import type { TransitionCallback } from './Transition';
 
 /**
  * Modals don't open on the server so this won't break concurrency.
@@ -109,15 +110,15 @@ type Props = DefaultProps & {
   /**
    * Callback fired before the modal is entering.
    */
-  onEnter?: Function,
+  onEnter?: TransitionCallback,
   /**
    * Callback fired when the modal is entering.
    */
-  onEntering?: Function,
+  onEntering?: TransitionCallback,
   /**
    * Callback fired when the modal has entered.
    */
-  onEntered?: Function, // eslint-disable-line react/sort-prop-types
+  onEntered?: TransitionCallback, // eslint-disable-line react/sort-prop-types
   /**
    * Callback fires when the escape key is pressed and the modal is in focus.
    */
@@ -125,15 +126,15 @@ type Props = DefaultProps & {
   /**
    * Callback fired before the modal is exiting.
    */
-  onExit?: Function,
+  onExit?: TransitionCallback,
   /**
    * Callback fired when the modal is exiting.
    */
-  onExiting?: Function,
+  onExiting?: TransitionCallback,
   /**
    * Callback fired when the modal has exited.
    */
-  onExited?: Function, // eslint-disable-line react/sort-prop-types
+  onExited?: TransitionCallback, // eslint-disable-line react/sort-prop-types
   /**
    * Callback fired when the modal requests to be closed.
    */

--- a/src/internal/Popover.js
+++ b/src/internal/Popover.js
@@ -1,4 +1,4 @@
-// @flow weak
+// @flow
 
 import React, { Component } from 'react';
 import type { Element } from 'react';
@@ -10,6 +10,7 @@ import customPropTypes from '../utils/customPropTypes';
 import Modal from './Modal';
 import Transition from './Transition';
 import Paper from '../Paper';
+import type { TransitionCallback } from './Transition';
 
 function getOffsetTop(rect, vertical) {
   let offset = 0;
@@ -127,27 +128,27 @@ type Props = DefaultProps & {
   /**
    * Callback fired before the component is entering
    */
-  onEnter?: Function,
+  onEnter?: TransitionCallback,
   /**
    * Callback fired when the component is entering
    */
-  onEntering?: Function,
+  onEntering?: TransitionCallback,
   /**
    * Callback fired when the component has entered
    */
-  onEntered?: Function, // eslint-disable-line react/sort-prop-types
+  onEntered?: TransitionCallback, // eslint-disable-line react/sort-prop-types
   /**
    * Callback fired before the component is exiting
    */
-  onExit?: Function,
+  onExit?: TransitionCallback,
   /**
    * Callback fired when the component is exiting
    */
-  onExiting?: Function,
+  onExiting?: TransitionCallback,
   /**
    * Callback fired when the component has exited
    */
-  onExited?: Function, // eslint-disable-line react/sort-prop-types
+  onExited?: TransitionCallback, // eslint-disable-line react/sort-prop-types
   /**
    * Callback function fired when the popover is requested to be closed.
    *
@@ -197,8 +198,8 @@ class Popover extends Component<DefaultProps, Props, void> {
 
   autoTransitionDuration = undefined;
 
-  handleEnter = element => {
-    element.style.opacity = 0;
+  handleEnter = (element: HTMLElement) => {
+    element.style.opacity = '0';
     element.style.transform = Popover.getScale(0.75);
 
     if (this.props.onEnter) {
@@ -229,16 +230,16 @@ class Popover extends Component<DefaultProps, Props, void> {
     ].join(',');
   };
 
-  handleEntering = element => {
-    element.style.opacity = 1;
+  handleEntering = (element: HTMLElement) => {
+    element.style.opacity = '1';
     element.style.transform = Popover.getScale(1);
 
     if (this.props.onEntering) {
-      this.props.onEntering();
+      this.props.onEntering(element);
     }
   };
 
-  handleExit = element => {
+  handleExit = (element: HTMLElement) => {
     let { transitionDuration } = this.props;
     const { transitions } = this.context.styleManager.theme;
 
@@ -257,11 +258,11 @@ class Popover extends Component<DefaultProps, Props, void> {
       }),
     ].join(',');
 
-    element.style.opacity = 0;
+    element.style.opacity = '0';
     element.style.transform = Popover.getScale(0.75);
 
     if (this.props.onExit) {
-      this.props.onExit();
+      this.props.onExit(element);
     }
   };
 

--- a/src/internal/Popover.spec.js
+++ b/src/internal/Popover.spec.js
@@ -224,7 +224,7 @@ describe('<Popover />', () => {
       });
 
       it('should set the inline styles for the enter phase', () => {
-        assert.strictEqual(element.style.opacity, 0, 'should be transparent');
+        assert.strictEqual(element.style.opacity, '0', 'should be transparent');
         assert.strictEqual(
           element.style.transform,
           Popover.getScale(0.75),
@@ -263,7 +263,7 @@ describe('<Popover />', () => {
       });
 
       it('should set the inline styles for the entering phase', () => {
-        assert.strictEqual(element.style.opacity, 1, 'should be visible');
+        assert.strictEqual(element.style.opacity, '1', 'should be visible');
         assert.strictEqual(
           element.style.transform,
           Popover.getScale(1),
@@ -287,7 +287,7 @@ describe('<Popover />', () => {
       });
 
       it('should set the inline styles for the exit phase', () => {
-        assert.strictEqual(element.style.opacity, 0, 'should be transparent');
+        assert.strictEqual(element.style.opacity, '0', 'should be transparent');
         assert.strictEqual(
           element.style.transform,
           Popover.getScale(0.75),

--- a/src/internal/types.js
+++ b/src/internal/types.js
@@ -1,0 +1,12 @@
+// @flow
+
+export type SyntheticUIEventHandler = (event?: SyntheticUIEvent) => void;
+
+/**
+ * return type of ReactDOM.findDOMNode()
+ *
+ * NOTE: `Element` is NOT the same as `type { Element } from 'react'` a.k.a React$Element
+ *
+ * To use it as a typical node, check with `if (node instanceof HTMLElement) { ... }`
+ */
+export type DOMNode = Element | Text | null;

--- a/src/transitions/Fade.js
+++ b/src/transitions/Fade.js
@@ -5,6 +5,7 @@ import type { Element } from 'react';
 import Transition from '../internal/Transition';
 import { duration } from '../styles/transitions';
 import customPropTypes from '../utils/customPropTypes';
+import type { TransitionCallback } from '../internal/Transition';
 
 type DefaultProps = {
   in: boolean,
@@ -29,27 +30,27 @@ type Props = DefaultProps & {
   /**
    * Callback fired before the component enters.
    */
-  onEnter?: Function,
+  onEnter?: TransitionCallback,
   /**
    * Callback fired when the component is entering.
    */
-  onEntering?: Function,
+  onEntering?: TransitionCallback,
   /**
    * Callback fired when the component has entered.
    */
-  onEntered?: Function, // eslint-disable-line react/sort-prop-types
+  onEntered?: TransitionCallback, // eslint-disable-line react/sort-prop-types
   /**
    * Callback fired before the component exits.
    */
-  onExit?: Function,
+  onExit?: TransitionCallback,
   /**
    * Callback fired when the component is exiting.
    */
-  onExiting?: Function,
+  onExiting?: TransitionCallback,
   /**
    * Callback fired when the component has exited.
    */
-  onExited?: Function, // eslint-disable-line react/sort-prop-types
+  onExited?: TransitionCallback, // eslint-disable-line react/sort-prop-types
 };
 
 class Fade extends Component<DefaultProps, Props, void> {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,5 @@
 --require babel-register
+--require jsdom-global/register
 --reporter dot
 --recursive
 test/utils/setup.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -3601,6 +3601,10 @@ jschardet@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.4.2.tgz#2aa107f142af4121d145659d44f50830961e699a"
 
+jsdom-global@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/jsdom-global/-/jsdom-global-3.0.2.tgz#6bd299c13b0c4626b2da2c0393cd4385d606acb9"
+
 jsdom@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.1.0.tgz#6c48d7a48ffc5c300283c312904d15da8360509b"
@@ -4988,11 +4992,7 @@ punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-q@^1.0.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/q/-/q-1.4.1.tgz#55705bcd93c5f3673530c2c2cbc0c2b3addc286e"
-
-q@~1.5.0:
+q@^1.0.1, q@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.0.tgz#dd01bac9d06d30e6f219aecb8253ee9ebdc308f1"
 


### PR DESCRIPTION
The current menu `maxHeight` is arbitrarily set to be `250px`, and this is too prescriptive for general use.

[The spec states](https://material.io/guidelines/components/menus.html#menus-simple-menus):

> The maximum height of a simple menu should be one or more rows less than the view height. This ensures a tappable area outside of the simple menu with which to dismiss the menu.

Therefore, it is up to userland to set this limitation unless someone wants to create a smart height listener/implementation.

As a note, I left an empty stylesheet as `withStyles` requires one and classes are passed down (and tested).

This fixes a situation like this:
<img src="https://user-images.githubusercontent.com/136564/27974988-fe2fe656-6325-11e7-8e17-7438835525ab.png"  width=400 />


---
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

