### PR TITLE
[Modal] Fix concurrency issue

### DIFF
--- a/src/internal/Modal.js
+++ b/src/internal/Modal.js
@@ -400,7 +400,7 @@ class Modal extends Component<DefaultProps, Props, State> {
 
     let backdropProps;
 
-    if (backdropInvisible && modalChild.props.hasOwnProperty('in')) {
+    if (modalChild.props.hasOwnProperty('in')) {
       Object.keys(transitionCallbacks).forEach(key => {
         childProps[key] = createChainedFunction(transitionCallbacks[key], modalChild.props[key]);
       });

--- a/src/internal/Modal.spec.js
+++ b/src/internal/Modal.spec.js
@@ -7,6 +7,7 @@ import keycode from 'keycode';
 import contains from 'dom-helpers/query/contains';
 import { createShallow, createMount } from '../test-utils';
 import consoleErrorMock from '../../test/utils/consoleErrorMock';
+import Fade from '../transitions/Fade';
 import Backdrop from './Backdrop';
 import Modal, { styleSheet } from './Modal';
 
@@ -450,6 +451,32 @@ describe('<Modal />', () => {
         </Modal>,
       );
       assert.strictEqual(wrapper.contains(children), false);
+    });
+  });
+
+  describe('props: onExited', () => {
+    it('should avoid concurrency issue by chaining internal with the public API', () => {
+      const handleExited = spy();
+      const wrapper = shallow(
+        <Modal onExited={handleExited} show>
+          <Fade in />
+        </Modal>,
+      );
+      wrapper.find(Fade).at(1).simulate('exited');
+      assert.strictEqual(handleExited.callCount, 1);
+      assert.strictEqual(wrapper.state().exited, true);
+    });
+
+    it('should rely on the internal backdrop events', () => {
+      const handleExited = spy();
+      const wrapper = shallow(
+        <Modal onExited={handleExited} show>
+          <div />
+        </Modal>,
+      );
+      wrapper.find(Fade).at(0).simulate('exited');
+      assert.strictEqual(handleExited.callCount, 1);
+      assert.strictEqual(wrapper.state().exited, true);
     });
   });
 });

--- a/src/internal/Transition.js
+++ b/src/internal/Transition.js
@@ -47,12 +47,6 @@ type DefaultProps = {
   unmountOnExit: boolean,
   transitionAppear: boolean,
   timeout: number,
-  onEnter: TransitionCallback,
-  onEntering: TransitionCallback,
-  onEntered: TransitionCallback,
-  onExit: TransitionCallback,
-  onExiting: TransitionCallback,
-  onExited: TransitionCallback,
 };
 
 type Props = DefaultProps & {
@@ -132,9 +126,6 @@ type Props = DefaultProps & {
   unmountOnExit?: boolean,
 };
 
-// Name the function so it is clearer in the documentation
-function noop() {}
-
 /**
  * Drawn from https://raw.githubusercontent.com/react-bootstrap/react-overlays/master/src/Transition.js
  *
@@ -154,12 +145,6 @@ class Transition extends Component<DefaultProps, Props, State> {
     unmountOnExit: false,
     transitionAppear: false,
     timeout: 5000,
-    onEnter: noop,
-    onEntering: noop,
-    onEntered: noop,
-    onExit: noop,
-    onExiting: noop,
-    onExited: noop,
   };
 
   state: State = {
@@ -249,18 +234,24 @@ class Transition extends Component<DefaultProps, Props, State> {
     this.cancelNextCallback();
     const node = ReactDOM.findDOMNode(this);
     if (node instanceof HTMLElement) {
-      props.onEnter(node);
+      if (props.onEnter) {
+        props.onEnter(node);
+      }
       this.performEntering(node);
     }
   }
 
   performEntering(element: HTMLElement) {
     this.safeSetState({ status: ENTERING }, () => {
-      this.props.onEntering(element);
+      if (this.props.onEntering) {
+        this.props.onEntering(element);
+      }
 
       this.onTransitionEnd(element, () => {
         this.safeSetState({ status: ENTERED }, () => {
-          this.props.onEntered(element);
+          if (this.props.onEntered) {
+            this.props.onEntered(element);
+          }
         });
       });
     });
@@ -271,14 +262,20 @@ class Transition extends Component<DefaultProps, Props, State> {
     const node = ReactDOM.findDOMNode(this);
     if (node instanceof HTMLElement) {
       // Not this.props, because we might be about to receive new props.
-      props.onExit(node);
+      if (props.onExit) {
+        props.onExit(node);
+      }
 
       this.safeSetState({ status: EXITING }, () => {
-        this.props.onExiting(node);
+        if (this.props.onExiting) {
+          this.props.onExiting(node);
+        }
 
         this.onTransitionEnd(node, () => {
           this.safeSetState({ status: EXITED }, () => {
-            this.props.onExited(node);
+            if (this.props.onExited) {
+              this.props.onExited(node);
+            }
           });
         });
       });


### PR DESCRIPTION
### What was going on with the issue?

The resolution order of the two `onExited` callbacks was different between Firefox and Chrome.
That's not an issue on his own, but it starts to be one when having X before Y prevents Y from beeing called. That was what going on.

### The fix

In order to avoid that issue, we put all the callback on a single Transition instance, not two that can resolve in a nondeterministic order.

Closes #6363.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

