### PR TITLE
Fix for alpha docs site

### DIFF
--- a/docs/src/components/AppDrawer.js
+++ b/docs/src/components/AppDrawer.js
@@ -83,7 +83,6 @@ function AppDrawer(props) {
       open={props.open}
       onRequestClose={props.onRequestClose}
       docked={props.docked}
-      keepMounted
     >
       <div className={classes.nav}>
         <Toolbar className={classes.toolbar}>


### PR DESCRIPTION
Removing the keepMounted prop from the drawer component fixes [#7376](https://github.com/callemall/material-ui/issues/7376).
