### PR TITLE
[Snackbar] Handle inactive tabs

### DIFF
--- a/docs/src/pages/style/Icons.js
+++ b/docs/src/pages/style/Icons.js
@@ -8,7 +8,7 @@ import Icon from 'material-ui/Icon';
 const styleSheet = createStyleSheet('Icons', {
   root: {
     display: 'flex',
-    alignItems: 'center',
+    alignItems: 'flex-end',
     justifyContent: 'space-around',
     width: '70%',
   },
@@ -22,8 +22,12 @@ function Icons(props) {
       <Icon color="action">add_circle</Icon>
       <Icon color="contrast">add_circle</Icon>
       <Icon color="disabled">add_circle</Icon>
-      <Icon color="error">add_circle</Icon>
-      <Icon color="primary">add_circle</Icon>
+      <Icon color="primary" style={{ fontSize: 30 }}>
+        add_circle
+      </Icon>
+      <Icon color="error" style={{ fontSize: 36 }}>
+        add_circle
+      </Icon>
     </div>
   );
 }

--- a/docs/src/pages/style/SvgIcons.js
+++ b/docs/src/pages/style/SvgIcons.js
@@ -34,8 +34,20 @@ function SvgIcons(props) {
   return (
     <div>
       <HomeIcon className={classes.icon} />
-      <HomeIcon className={classNames(classes.icon, classes.iconBlue)} />
-      <HomeIcon className={classNames(classes.icon, classes.iconHover)} />
+      <HomeIcon
+        className={classNames(classes.icon, classes.iconBlue)}
+        style={{
+          width: 30,
+          height: 30,
+        }}
+      />
+      <HomeIcon
+        className={classNames(classes.icon, classes.iconHover)}
+        style={{
+          width: 36,
+          height: 36,
+        }}
+      />
     </div>
   );
 }

--- a/src/Snackbar/Snackbar.spec.js
+++ b/src/Snackbar/Snackbar.spec.js
@@ -22,11 +22,11 @@ describe('<Snackbar />', () => {
     mount.cleanUp();
   });
 
-  it('should render a ClickAwayListener with classes', () => {
+  it('should render a EventListener with classes', () => {
     const wrapper = shallow(<Snackbar open message="message" />);
-    assert.strictEqual(wrapper.name(), 'ClickAwayListener');
+    assert.strictEqual(wrapper.name(), 'EventListener');
     assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.root),
+      wrapper.childAt(0).childAt(0).hasClass(classes.root),
       true,
       'should have the root class',
     );
@@ -76,6 +76,30 @@ describe('<Snackbar />', () => {
       clock.tick(autoHideDuration);
       assert.strictEqual(handleRequestClose.callCount, 1);
       assert.deepEqual(handleRequestClose.args[0], [null, 'timeout']);
+    });
+
+    it('should not call onRequestClose when the autoHideDuration is reseted', () => {
+      const handleRequestClose = spy();
+      const autoHideDuration = 2e3;
+      const wrapper = mount(
+        <Snackbar
+          open={false}
+          onRequestClose={handleRequestClose}
+          message="message"
+          autoHideDuration={autoHideDuration}
+        />,
+      );
+
+      wrapper.setProps({
+        open: true,
+      });
+      assert.strictEqual(handleRequestClose.callCount, 0);
+      clock.tick(autoHideDuration / 2);
+      wrapper.setProps({
+        autoHideDuration: null,
+      });
+      clock.tick(autoHideDuration / 2);
+      assert.strictEqual(handleRequestClose.callCount, 0);
     });
 
     it('should be able to interrupt the timer', () => {

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -91,7 +91,7 @@ class Tabs extends Component {
   handleResize = debounce(() => {
     this.updateIndicatorState(this.props);
     this.updateScrollButtonState();
-  }, 100);
+  }, 166);
 
   handleLeftScrollClick = () => {
     this.moveTabsScroll(-this.tabs.clientWidth);
@@ -111,7 +111,7 @@ class Tabs extends Component {
 
   handleTabsScroll = debounce(() => {
     this.updateScrollButtonState();
-  }, 100);
+  }, 166);
 
   getConditionalElements = () => {
     const { buttonClassName, scrollable, scrollButtons, width } = this.props;

--- a/src/Tabs/Tabs.spec.js
+++ b/src/Tabs/Tabs.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { spy, stub } from 'sinon';
+import { spy, stub, useFakeTimers } from 'sinon';
 import scroll from 'scroll';
 import { createShallow, createMount } from '../test-utils';
 import consoleErrorMock from '../../test/utils/consoleErrorMock';
@@ -147,34 +147,40 @@ describe('<Tabs />', () => {
   });
 
   describe('prop: scrollable', () => {
+    let clock;
     let wrapper;
+
     before(() => {
+      clock = useFakeTimers();
       wrapper = shallowWithWidth(
         <Tabs width="md" onChange={noop} index={0} scrollable>
           <Tab />
         </Tabs>,
       );
     });
+
+    after(() => {
+      clock.restore();
+    });
+
     it('should render with the scrollable class', () => {
       const selector = `.${classes.scrollingContainer}.${classes.scrollable}`;
       assert.strictEqual(wrapper.find(selector).is('div'), true, 'should be a div');
       assert.lengthOf(wrapper.find(selector), 1, 'should only be one');
     });
 
-    it('should response to scroll events', done => {
+    it('should response to scroll events', () => {
       const instance = wrapper.instance();
       instance.tabs = { scrollLeft: 100 };
       spy(instance, 'updateScrollButtonState');
       const selector = `.${classes.scrollingContainer}.${classes.scrollable}`;
       wrapper.find(selector).simulate('scroll');
-      setTimeout(() => {
-        assert.strictEqual(
-          instance.updateScrollButtonState.called,
-          true,
-          'should have called updateScrollButtonState',
-        );
-        done();
-      }, 150);
+      clock.tick(166);
+      assert.strictEqual(
+        instance.updateScrollButtonState.called,
+        true,
+        'should have called updateScrollButtonState',
+      );
     });
 
     it('should get a scrollbar size listener', () => {
@@ -204,6 +210,16 @@ describe('<Tabs />', () => {
   });
 
   describe('prop: scrollButtons', () => {
+    let clock;
+
+    before(() => {
+      clock = useFakeTimers();
+    });
+
+    after(() => {
+      clock.restore();
+    });
+
     it('should render scroll buttons', () => {
       const wrapper = shallowWithWidth(
         <Tabs width="md" onChange={noop} index={0} scrollable scrollButtons="on">
@@ -231,7 +247,7 @@ describe('<Tabs />', () => {
       assert.lengthOf(wrapper.find(TabScrollButton), 0, 'should be zero');
     });
 
-    it('should handle window resize event', done => {
+    it('should handle window resize event', () => {
       const wrapper = shallowWithWidth(
         <Tabs width="md" onChange={noop} index={0} scrollable scrollButtons="on">
           <Tab />
@@ -241,19 +257,17 @@ describe('<Tabs />', () => {
       stub(instance, 'updateScrollButtonState');
       stub(instance, 'updateIndicatorState');
       wrapper.find('EventListener').at(0).simulate('resize');
-      setTimeout(() => {
-        assert.strictEqual(
-          instance.updateScrollButtonState.called,
-          true,
-          'should have called updateScrollButtonState',
-        );
-        assert.strictEqual(
-          instance.updateIndicatorState.called,
-          true,
-          'should have called updateIndicatorState',
-        );
-        done();
-      }, 150);
+      clock.tick(166);
+      assert.strictEqual(
+        instance.updateScrollButtonState.called,
+        true,
+        'should have called updateScrollButtonState',
+      );
+      assert.strictEqual(
+        instance.updateIndicatorState.called,
+        true,
+        'should have called updateIndicatorState',
+      );
     });
 
     describe('scroll button visibility states', () => {

--- a/src/internal/ClickAwayListener.js
+++ b/src/internal/ClickAwayListener.js
@@ -1,24 +1,15 @@
-// @flow weak
+// @flow
 
-import { Component } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
-import addEventListener from 'dom-helpers/events/on';
-import removeEventListener from 'dom-helpers/events/off';
+import EventListener from 'react-event-listener';
 
 const isDescendant = (el, target) => {
-  if (target !== null) {
+  if (target !== null && target.parentNode) {
     return el === target || isDescendant(el, target.parentNode);
   }
   return false;
-};
-
-const clickAwayEvents = ['mouseup', 'touchend'];
-const bind = callback => {
-  clickAwayEvents.forEach(event => addEventListener(document, event, callback));
-};
-const unbind = callback => {
-  clickAwayEvents.forEach(event => removeEventListener(document, event, callback));
 };
 
 class ClickAwayListener extends Component {
@@ -29,17 +20,15 @@ class ClickAwayListener extends Component {
 
   componentDidMount() {
     this.mounted = true;
-    bind(this.handleClickAway);
   }
 
   componentWillUnmount() {
     this.mounted = false;
-    unbind(this.handleClickAway);
   }
 
   mounted = false;
 
-  handleClickAway = event => {
+  handleClickAway = (event: Event) => {
     // Ignore events that have been `event.preventDefault()` marked.
     if (event.defaultPrevented) {
       return;
@@ -50,7 +39,7 @@ class ClickAwayListener extends Component {
       const el = findDOMNode(this);
 
       if (
-        document &&
+        event.target instanceof HTMLElement &&
         document.documentElement &&
         document.documentElement.contains(event.target) &&
         !isDescendant(el, event.target)
@@ -61,7 +50,15 @@ class ClickAwayListener extends Component {
   };
 
   render() {
-    return this.props.children;
+    return (
+      <EventListener
+        target="document"
+        onMouseup={this.handleClickAway}
+        onTouchend={this.handleClickAway}
+      >
+        {this.props.children}
+      </EventListener>
+    );
   }
 }
 

--- a/src/utils/withWidth.js
+++ b/src/utils/withWidth.js
@@ -3,6 +3,7 @@
 import React, { Component } from 'react';
 import EventListener from 'react-event-listener';
 import PropTypes from 'prop-types';
+import debounce from 'lodash/debounce';
 import createEagerFactory from 'recompose/createEagerFactory';
 import wrapDisplayName from 'recompose/wrapDisplayName';
 import customPropTypes from '../utils/customPropTypes';
@@ -52,17 +53,12 @@ function withWidth(options = {}) {
       }
 
       componentWillUnmount() {
-        clearTimeout(this.deferTimer);
+        this.handleResize.cancel();
       }
 
-      deferTimer = null;
-
-      handleResize = () => {
-        clearTimeout(this.deferTimer);
-        this.deferTimer = setTimeout(() => {
-          this.updateWidth(window.innerWidth);
-        }, resizeInterval);
-      };
+      handleResize = debounce(() => {
+        this.updateWidth(window.innerWidth);
+      }, resizeInterval);
 
       updateWidth(innerWidth) {
         const breakpoints = this.context.styleManager.theme.breakpoints;

--- a/test/integration/fixtures/menus/SimpleMenu.js
+++ b/test/integration/fixtures/menus/SimpleMenu.js
@@ -12,7 +12,7 @@ export default class SimpleMenu extends Component {
     selectedIndex: undefined,
   };
 
-  handleMenuItemClick = (event: Event, index: number) => {
+  handleMenuItemClick = (event: SyntheticUIEvent, index: number) => {
     this.setState({ selectedIndex: index, open: false });
   };
 


### PR DESCRIPTION
We make sure the snackbar can be seen before triggering the request close callback.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

