### PR TITLE
[docs] Better warning message for missing MuiThemeProvider

### DIFF
--- a/docs/src/pages/customization/overrides.md
+++ b/docs/src/pages/customization/overrides.md
@@ -1,7 +1,6 @@
 # Overrides
 
-We have identified four different types of customization needs as components evolve in different contexts.
-Going from the **most specific** to the **most generic** one:
+As components evolve in different contexts, we have identified four different types of customization needs going from **the most specific** to **the most generic** one:
 
 1. [Specific variation for a one-time situation](#1-specific-variation-for-a-one-time-situation)
 2. [Specific variation of a component](#2-specific-variation-of-a-component) **made by a user** used in different contexts

--- a/src/utils/customPropTypes.js
+++ b/src/utils/customPropTypes.js
@@ -20,13 +20,12 @@ customPropTypes.muiRequired = (props, propName, componentName, location, propFul
   );
 
   if (error) {
-    error.message =
-      'You need to provide a theme to Material-UI. ' +
-      'Wrap the root component in a `<MuiThemeProvider />`. ' +
-      '\n' +
-      'Have a look at http://www.material-ui.com/#/get-started/usage for an example.' +
-      '\n' +
-      error.message;
+    error.message = [
+      'Material-UI: You need to provide a theme.',
+      'Wrap the root component in a `<MuiThemeProvider />` component.',
+      '',
+      'Have a look at https://material-ui-1dab0.firebaseapp.com/getting-started/usage for an example.',
+    ].join('\n');
   }
 
   return error;

--- a/src/utils/customPropTypes.spec.js
+++ b/src/utils/customPropTypes.spec.js
@@ -33,7 +33,7 @@ describe('customPropTypes', () => {
           'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED',
         );
 
-        assert.match(error.message, /You need to provide a theme to Material-UI/);
+        assert.match(error.message, /Material-UI: You need to provide a theme/);
       });
     });
   });


### PR DESCRIPTION
Just an update of what we already have. The experience isn't perfect, but I can't think of anything better.

Closes #7393
Closes #7417

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

