### PR TITLE
[Toggle] Fix elementStyle prop not being used and tests to prove

### DIFF
--- a/src/Toggle/Toggle.js
+++ b/src/Toggle/Toggle.js
@@ -249,6 +249,7 @@ class Toggle extends Component {
     const enhancedSwitchProps = {
       ref: 'enhancedSwitch',
       inputType: 'checkbox',
+      elementStyle: elementStyle,
       switchElement: toggleElement,
       rippleStyle: styles.ripple,
       rippleColor: styles.ripple.color,

--- a/src/internal/EnhancedSwitch.js
+++ b/src/internal/EnhancedSwitch.js
@@ -77,6 +77,7 @@ class EnhancedSwitch extends Component {
     disableFocusRipple: PropTypes.bool,
     disableTouchRipple: PropTypes.bool,
     disabled: PropTypes.bool,
+    elementStyle: PropTypes.object,
     iconStyle: PropTypes.object,
     inputStyle: PropTypes.object,
     inputType: PropTypes.string.isRequired,
@@ -277,6 +278,7 @@ class EnhancedSwitch extends Component {
       style,
       switched, // eslint-disable-line no-unused-vars
       switchElement,
+      elementStyle,
       thumbStyle,
       trackStyle,
       ...other
@@ -355,7 +357,7 @@ class EnhancedSwitch extends Component {
         {ripples}
       </div>
     ) : (
-      <div style={prepareStyles(wrapStyles)}>
+      <div style={prepareStyles(Object.assign({}, wrapStyles, elementStyle))}>
         <div style={prepareStyles(Object.assign({}, trackStyle))} />
         <Paper style={thumbStyle} zDepth={1} circle={true}> {ripples} </Paper>
       </div>

--- a/test/integration/Toggle/Toggle.spec.js
+++ b/test/integration/Toggle/Toggle.spec.js
@@ -1,0 +1,23 @@
+/* eslint-env mocha */
+import React from 'react';
+import {mount} from 'enzyme';
+import {assert} from 'chai';
+import Toggle from 'src/Toggle';
+import getMuiTheme from 'src/styles/getMuiTheme';
+
+describe('<Toggle />', () => {
+  const muiTheme = getMuiTheme();
+  const mountWithContext = (node) => mount(node, {context: {muiTheme}});
+
+  it('renders and uses elementStyle', () => {
+    const toggle = mountWithContext(
+      <Toggle label="hello" elementStyle={{width: '100px'}} />
+    );
+
+    assert.strictEqual(
+      toggle.find('label').parent().children('div').prop('style').width,
+      '100px',
+      'elementStyle should be used on switchElement'
+    );
+  });
+});


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).


Toggle component elementStyle prop was not being used due to [this](https://github.com/callemall/material-ui/blob/master/src/Toggle/Toggle.js#L242-L246) and [this](https://github.com/callemall/material-ui/blob/master/src/internal/EnhancedSwitch.js#L352-L361). 

The test I provided fails before my change, and passes after, respectively.
