### PR TITLE
[Table] Don't set height to tbody

### DIFF
--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -186,7 +186,6 @@ class Table extends Component {
         onRowHoverExit: this.onRowHoverExit,
         onRowSelection: this.onRowSelection,
         selectable: this.props.selectable,
-        style: Object.assign({}, base.props.style),
       }
     );
   }

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -186,7 +186,7 @@ class Table extends Component {
         onRowHoverExit: this.onRowHoverExit,
         onRowSelection: this.onRowSelection,
         selectable: this.props.selectable,
-        style: Object.assign({height: this.props.height}, base.props.style),
+        style: Object.assign({}, base.props.style),
       }
     );
   }


### PR DESCRIPTION
Since the height of the table component is already set elsewhere
it is no longer necessary to set it the tbody tag.

Closes #5721

### Before

Table height: 500px
![ff-before-500](https://user-images.githubusercontent.com/5729175/28401316-d957c2f0-6cde-11e7-963a-d453080c7a36.png)

### After

Table height: 500px
![ff-after-500](https://user-images.githubusercontent.com/5729175/28401332-e5bdd91c-6cde-11e7-82a1-54bec838403a.png)

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

