### PR TITLE
[AutoComplete] Add onOpen callback, improve onClose callback

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -236,6 +236,14 @@ class AutoComplete extends Component {
     }
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    if (prevState.open !== this.state.open) {
+      if (!this.state.open && this.props.onClose) {
+        this.props.onClose();
+      }
+    }
+  }
+
   componentWillUnmount() {
     clearTimeout(this.timerTouchTapCloseId);
     clearTimeout(this.timerBlurClose);
@@ -246,10 +254,6 @@ class AutoComplete extends Component {
       open: false,
       anchorEl: null,
     });
-
-    if (this.props.onClose) {
-      this.props.onClose();
-    }
   }
 
   handleRequestClose = () => {

--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -141,6 +141,10 @@ class AutoComplete extends Component {
      */
     onNewRequest: PropTypes.func,
     /**
+     * Callback function fired when the menu is opened.
+     */
+    onOpen: PropTypes.func,
+    /**
      * Callback function that is fired when the user updates the `TextField`.
      *
      * @param {string} searchText The auto-complete's `searchText` value.
@@ -240,6 +244,9 @@ class AutoComplete extends Component {
     if (prevState.open !== this.state.open) {
       if (!this.state.open && this.props.onClose) {
         this.props.onClose();
+      }
+      if (this.state.open && this.props.onOpen) {
+        this.props.onOpen();
       }
     }
   }
@@ -422,6 +429,7 @@ class AutoComplete extends Component {
       onFocus, // eslint-disable-line no-unused-vars
       onKeyDown, // eslint-disable-line no-unused-vars
       onNewRequest, // eslint-disable-line no-unused-vars
+      onOpen, // eslint-disable-line no-unused-vars
       onUpdateInput, // eslint-disable-line no-unused-vars
       openOnFocus, // eslint-disable-line no-unused-vars
       popoverProps,

--- a/src/AutoComplete/AutoComplete.spec.js
+++ b/src/AutoComplete/AutoComplete.spec.js
@@ -215,6 +215,23 @@ describe('<AutoComplete />', () => {
     });
   });
 
+  describe('prop: onOpen', () => {
+    it('should call onOpen when the menu is opened', (done) => {
+      const handleOpen = spy();
+      const wrapper = shallowWithContext(
+        <AutoComplete dataSource={['foo', 'bar']} onOpen={handleOpen} />
+      );
+
+      assert.strictEqual(handleOpen.callCount, 0);
+      wrapper.setState({open: true});
+
+      setTimeout(() => {
+        assert.strictEqual(handleOpen.callCount, 1);
+        done();
+      }, 20);
+    });
+  });
+
   describe('prop: searchText', () => {
     it('onItemTouchTap should not call setState:searchText when searchText is controlled', () => {
       const wrapper = shallowWithContext(

--- a/src/AutoComplete/AutoComplete.spec.js
+++ b/src/AutoComplete/AutoComplete.spec.js
@@ -184,13 +184,34 @@ describe('<AutoComplete />', () => {
   });
 
   describe('prop: onClose', () => {
-    it('should call onClose when the menu is closed', () => {
+    it('should call onClose when the menu is closed', (done) => {
+      const handleClose = spy();
+      const wrapper = shallowWithContext(
+        <AutoComplete dataSource={['foo', 'bar']} open={true} onClose={handleClose} />
+      );
+
+      assert.strictEqual(handleClose.callCount, 0);
+      wrapper.instance().close();
+
+      setTimeout(() => {
+        assert.strictEqual(handleClose.callCount, 1);
+        done();
+      }, 20);
+    });
+
+    it('should not call onClose when the menu is not closed', (done) => {
       const handleClose = spy();
       const wrapper = shallowWithContext(
         <AutoComplete dataSource={['foo', 'bar']} onClose={handleClose} />
       );
+
+      assert.strictEqual(handleClose.callCount, 0);
       wrapper.instance().close();
-      assert.strictEqual(handleClose.callCount, 1);
+
+      setTimeout(() => {
+        assert.strictEqual(handleClose.callCount, 0);
+        done();
+      }, 20);
     });
   });
 


### PR DESCRIPTION
This PR is continuation/improvement of https://github.com/callemall/material-ui/pull/5294

My use case for this callback methods was to have information is AutoComplete open from outside of component to hide validation errors while user is typing to filler list.

I added `onOpen` callback and i moved `onClose` to `componentDidUpdate` lifecycle method to trigger it only when `open` actually changed, not only when `close` method is called. 


- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).
