### PR TITLE
Ignore the package-lock.json file generated by npm.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ tmp
 
 # npm files
 node_modules
+package-lock.json
 *.log
 
 # Editor files


### PR DESCRIPTION
I assume there's no component for `.gitignore`. :-)

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

