### PR TITLE
[DialogActions] Fix allow have Children with null values

### DIFF
--- a/src/Dialog/DialogActions.js
+++ b/src/Dialog/DialogActions.js
@@ -27,7 +27,7 @@ function DialogActions(props) {
 
   return (
     <div data-mui-test="DialogActions" className={classNames(classes.root, className)} {...other}>
-      {Children.map(children, button =>
+      {Children.map(Children.toArray(children), button =>
         <div className={classes.action}>
           {cloneElement(button, { className: classNames(classes.button, button.props.className) })}
         </div>,

--- a/src/Dialog/DialogActions.js
+++ b/src/Dialog/DialogActions.js
@@ -1,6 +1,6 @@
 // @flow weak
 
-import React, { Children, cloneElement } from 'react';
+import React, { Children, cloneElement, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { createStyleSheet } from 'jss-theme-reactor';
@@ -27,10 +27,15 @@ function DialogActions(props) {
 
   return (
     <div data-mui-test="DialogActions" className={classNames(classes.root, className)} {...other}>
-      {Children.map(Children.toArray(children), button =>
-        <div className={classes.action}>
-          {cloneElement(button, { className: classNames(classes.button, button.props.className) })}
-        </div>,
+      {Children.map(
+        children,
+        button =>
+          isValidElement(button) &&
+          <div className={classes.action}>
+            {cloneElement(button, {
+              className: classNames(classes.button, button.props.className),
+            })}
+          </div>,
       )}
     </div>
   );

--- a/src/Dialog/DialogActions.spec.js
+++ b/src/Dialog/DialogActions.spec.js
@@ -44,4 +44,22 @@ describe('<DialogActions />', () => {
     assert.strictEqual(button.hasClass('woof'), true, 'should have the user class');
     assert.strictEqual(button.hasClass(classes.button), true, 'should have the button class');
   });
+
+  it('should render children with the conditional buttons', () => {
+    const showButton = true;
+    const wrapper = shallow(
+      <DialogActions>
+        {showButton ? <button className="woof">Hello</button> : null}
+        {!showButton ? <button>false button</button> : null}
+      </DialogActions>,
+    );
+
+    const container = wrapper.childAt(0);
+    assert.strictEqual(container.hasClass(classes.action), true, 'should have the action wrapper');
+    assert.strictEqual(container.is('div'), true, 'should be a div');
+    const button = container.childAt(0);
+    assert.strictEqual(button.is('button'), true, 'should be a button');
+    assert.strictEqual(button.hasClass('woof'), true, 'should have the user class');
+    assert.strictEqual(button.hasClass(classes.button), true, 'should have the button class');
+  });
 });


### PR DESCRIPTION
Hello

DialogActions don't allow use, common partner, that select element you want to show or send null value.

You will find this case in the test file:

```jsx
<DialogActions>
  {showButton ? <button className="woof">Hello</button> : null}
  {!showButton ? <button>false button</button> : null}
</DialogActions>
```

Use `Children.toArray` to remove null/undefined values and then avoid emit error when trying access props of children.