### PR TITLE
[TextField] Fix the mixed label issue for ‘type=date’ input

### DIFF
--- a/docs/src/pages/component-demos/text-fields/TextFields.js
+++ b/docs/src/pages/component-demos/text-fields/TextFields.js
@@ -99,9 +99,6 @@ class TextFields extends Component {
           defaultValue="2017-05-24"
           className={classes.textField}
           margin="normal"
-          InputLabelProps={{
-            shrink: true,
-          }}
         />
         <TextField
           id="helperText"

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -317,6 +317,7 @@ class Input extends Component<DefaultProps, Props, State> {
   componentDidMount() {
     if (!this.isControlled()) {
       this.checkDirty(this.input);
+      this.handleDateTypeInput(this.input);
     }
   }
 
@@ -331,12 +332,30 @@ class Input extends Component<DefaultProps, Props, State> {
 
   handleFocus = event => {
     this.setState({ focused: true });
+    const target = event.target;
+    if (target && target.type === 'text' && this.props.type === 'date') {
+      const convertStringToDate = textString => {
+        if (!textString) {
+          return null;
+        }
+        // to avoid bug caused by timezones
+        return new Date(textString.replace(/\//g, '-'));
+      };
+      const targetValue = target.value;
+      target.type = 'date';
+      // set value of the date type input
+      target.valueAsDate = convertStringToDate(targetValue);
+    }
     if (this.props.onFocus) {
       this.props.onFocus(event);
     }
   };
 
   handleBlur = event => {
+    const target = event.target;
+    if (target && target.type === 'date') {
+      this.handleDateTypeInput(target);
+    }
     this.setState({ focused: false });
     if (this.props.onBlur) {
       this.props.onBlur(event);
@@ -363,6 +382,33 @@ class Input extends Component<DefaultProps, Props, State> {
     this.input = node;
     if (this.props.inputRef) {
       this.props.inputRef(node);
+    }
+  };
+
+  handleDateTypeInput = obj => {
+    if (!obj || obj.type !== 'date') {
+      return;
+    }
+    if (!obj.value) {
+      obj.type = 'text';
+      obj.value = '';
+      return;
+    }
+    const dateVal = obj.value;
+    // format the text value as YYYY/MM/DD
+    const convertDateToString = inputDateStr => {
+      if (inputDateStr === null) {
+        return '';
+      }
+      const date = new Date(inputDateStr);
+      const d = date.getDate();
+      const m = date.getMonth() + 1;
+      const y = date.getUTCFullYear();
+      return `${y}/${m <= 9 ? `0${m}` : m}/${d <= 9 ? `0${d}` : d}`;
+    };
+    if (dateVal) {
+      obj.type = 'text';
+      obj.value = convertDateToString(dateVal);
     }
   };
 


### PR DESCRIPTION
Hi, this PR is a possible solution for the issue that, if no shrink option is given, the label of date type input would mix with the native date picker label when emptied. After this commit, the date input now looks like this:

![new date input](https://user-images.githubusercontent.com/3454734/28492587-c1255916-6f38-11e7-9df5-f543eb25767f.gif)

Fixes: https://github.com/callemall/material-ui/issues/7288

(It's my first PR to material-ui, pls kindly check and tell me if it needs revision. Thanks!)

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

