### PR TITLE
[Table] Row click on empty cell to not die in IE

### DIFF
--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -291,7 +291,9 @@ class TableBody extends Component {
 
     if (this.props.selectable) {
       // Prevent text selection while selecting rows.
-      window.getSelection().removeAllRanges();
+      if (window.getSelection().getRangeAt(0).getClientRects.length > 0) {
+        window.getSelection().removeAllRanges();
+      }
       this.processRowSelection(event, rowNumber);
     }
   };

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -291,7 +291,7 @@ class TableBody extends Component {
 
     if (this.props.selectable) {
       // Prevent text selection while selecting rows.
-      if (window.getSelection().getRangeAt(0).getClientRects.length > 0) {
+      if (window.getSelection().rangeCount > 0 && window.getSelection().getRangeAt(0).getClientRects.length > 0) {
         window.getSelection().removeAllRanges();
       }
       this.processRowSelection(event, rowNumber);


### PR DESCRIPTION
When selecting a row, if the cell selected is empty, an error will be thrown.

https://github.com/callemall/material-ui/issues/3444

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

