### PR TITLE
[Menu] Broken touch scroll on nested menu items

### DIFF
--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -235,6 +235,17 @@ class Menu extends Component {
       return;
     }
 
+    const {focusIndex} = this.state;
+    if (focusIndex < 0) {
+      return;
+    }
+
+    const filteredChildren = this.getFilteredChildren(this.props.children);
+    const focusedItem = filteredChildren[focusIndex];
+    if (focusedItem.props.menuItems && focusedItem.props.menuItems.length > 0) {
+      return;
+    }
+
     this.setFocusIndex(event, -1, false);
   };
 

--- a/src/Menu/Menu.spec.js
+++ b/src/Menu/Menu.spec.js
@@ -257,4 +257,27 @@ describe('<Menu />', () => {
       assert.deepEqual(wrapper.state().value, ['item2', 'item3']);
     });
   });
+
+  describe('Nested menu', () => {
+    it('should ignore loosing focus on click away for item with menu items', () => {
+      const menuItems = [<MenuItem />, <MenuItem />];
+
+      const wrapper = mountWithContext(
+        <Menu className="menu">
+          <MenuItem className="item1" />
+          <MenuItem className="item2" menuItems={menuItems} />
+        </Menu>
+      );
+
+      wrapper.find('.item1').simulate('touchTap');
+      assert.strictEqual(wrapper.state('focusIndex'), 0);
+      document.body.dispatchEvent(new window.Event('mouseup', {bubbles: true}));
+      assert.strictEqual(wrapper.state('focusIndex'), -1);
+
+      wrapper.find('.item2').simulate('touchTap');
+      assert.strictEqual(wrapper.state('focusIndex'), 1);
+      document.body.dispatchEvent(new window.Event('mouseup', {bubbles: true}));
+      assert.strictEqual(wrapper.state('focusIndex'), 1);
+    });
+  });
 });


### PR DESCRIPTION
All details are in https://github.com/callemall/material-ui/issues/7547

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

