### PR TITLE
[Tabs] Fix Scroll button visibility state when child tab items are modified

### DIFF
--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -73,6 +73,7 @@ class Tabs extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
+    this.updateScrollButtonState();
     if (
       this.props.width !== prevProps.width ||
       this.state.indicatorStyle !== prevState.indicatorStyle


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has ~tests / docs demo~, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

When a render of the `<Tabs>` container alters the scrollWidth of the container (such as if a new tab was added after initial render) the visibility state of the scroll buttons is not examined and updated.  This PR adds a check of the visibility state in `componentDidMount`.  Resolves #7569.