### PR TITLE
[Docs] Proposed updates for supported components

### DIFF
--- a/docs/src/pages/getting-started/supported-components.md
+++ b/docs/src/pages/getting-started/supported-components.md
@@ -68,7 +68,7 @@ to discuss the approach before submitting a PR.
   - [Leave-behinds](https://www.google.com/design/spec/components/lists-controls.html#lists-controls-types-of-list-controls)
 - **[Menus](https://www.google.com/design/spec/components/menus.html) ✓**
   - **[Button menu](https://www.google.com/design/spec/components/menus.html#menus-usage) (Can be constructed) ✓**
-  - [Scrollable](https://www.google.com/design/spec/components/menus.html#menus-usage)
+  - **[Scrollable](https://www.google.com/design/spec/components/menus.html#menus-usage) ✓**
   - [Cascade](https://www.google.com/design/spec/components/menus.html#menus-usage)
   - [Textfield dropdown](https://www.google.com/design/spec/components/menus.html#menus-behavior) (DropDownMenu)
   - [Contextual / App bar dropdown](https://www.google.com/design/spec/components/menus.html#menus-usage) (IconMenu)
@@ -114,11 +114,11 @@ to discuss the approach before submitting a PR.
   - [Multi-line](https://www.google.com/design/spec/components/text-fields.html#text-fields-multi-line-text-field)
   - **[Full-width](https://www.google.com/design/spec/components/text-fields.html#text-fields-multi-line-text-field) ✓**
   - [Character counter](https://www.google.com/design/spec/components/text-fields.html#text-fields-character-counter)
-  - **[Auto-complete](https://www.google.com/design/spec/components/text-fields.html#text-fields-auto-complete-text-field) (Can be done using external libraries) ✓**
+  - **[Autocomplete](https://www.google.com/design/spec/components/text-fields.html#text-fields-auto-complete-text-field) (Can be done with external library such as [react-autosuggest](https://github.com/moroshko/react-autosuggest)) ✓**
   - [Search filter](https://www.google.com/design/spec/components/text-fields.html#text-fields-search-filter)
   - [Password](https://www.google.com/design/spec/components/text-fields.html#text-fields-password-input)
-- [Toolbars](https://www.google.com/design/spec/components/toolbars.html)
-- [Tooltips](https://www.google.com/design/spec/components/tooltips.html) (IconButton & TableHeader only)
+- **[Toolbars](https://www.google.com/design/spec/components/toolbars.html) ✓**
+- [Tooltips](https://www.google.com/design/spec/components/tooltips.html)
   - [Desktop](https://www.google.com/design/spec/components/tooltips.html#tooltips-tooltips-desktop-)
   - [Mobile](https://www.google.com/design/spec/components/tooltips.html#tooltips-tooltips-mobile-)
 - [Widgets](https://material.io/guidelines/components/widgets.html)


### PR DESCRIPTION
Scrollable menus seems to be supported as per https://material-ui-1dab0.firebaseapp.com/component-demos/menus#max-height-menus
Fix spelling of autocomplete and provide link to react-autosuggest
Toolbars seems to be supported https://github.com/callemall/material-ui/blob/v1-beta/src/Toolbar/Toolbar.js
Tooltips support seems to have been removed from both iconButton and tableHead
https://github.com/callemall/material-ui/blob/v1-beta/src/IconButton/IconButton.js
https://github.com/callemall/material-ui/blob/v1-beta/src/Table/TableHead.js

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [X] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

