### PR TITLE
Remove unnecessary pure usages

### DIFF
--- a/src/Avatar/Avatar.spec.js
+++ b/src/Avatar/Avatar.spec.js
@@ -106,7 +106,7 @@ describe('<Avatar />', () => {
 
     it('should render a div containing an svg icon', () => {
       assert.strictEqual(wrapper.name(), 'div');
-      assert.strictEqual(wrapper.childAt(0).is('pure(Cancel)'), true, 'should be an svg icon');
+      assert.strictEqual(wrapper.childAt(0).is('Cancel'), true, 'should be an svg icon');
     });
 
     it('should merge user classes & spread custom props to the root node', () => {

--- a/src/Chip/Chip.spec.js
+++ b/src/Chip/Chip.spec.js
@@ -109,7 +109,7 @@ describe('<Chip />', () => {
       assert.strictEqual(wrapper.name(), 'div');
       assert.strictEqual(wrapper.childAt(0).is(Avatar), true, 'should have an Avatar');
       assert.strictEqual(wrapper.childAt(1).is('span'), true, 'should have a span');
-      assert.strictEqual(wrapper.childAt(2).is('pure(Cancel)'), true, 'should be an svg icon');
+      assert.strictEqual(wrapper.childAt(2).is('Cancel'), true, 'should be an svg icon');
     });
 
     it('should merge user classes & spread custom props to the root node', () => {
@@ -132,7 +132,7 @@ describe('<Chip />', () => {
       const onRequestDeleteSpy = spy();
       wrapper.setProps({ onRequestDelete: onRequestDeleteSpy });
 
-      wrapper.find('pure(Cancel)').simulate('click', { stopPropagation: () => {} });
+      wrapper.find('Cancel').simulate('click', { stopPropagation: () => {} });
       assert.strictEqual(
         onRequestDeleteSpy.callCount,
         1,
@@ -145,7 +145,7 @@ describe('<Chip />', () => {
       const stopPropagationSpy = spy();
       wrapper.setProps({ onRequestDelete: onRequestDeleteSpy });
 
-      wrapper.find('pure(Cancel)').simulate('click', { stopPropagation: stopPropagationSpy });
+      wrapper.find('Cancel').simulate('click', { stopPropagation: stopPropagationSpy });
       assert.strictEqual(
         stopPropagationSpy.callCount,
         1,

--- a/src/internal/SwitchBase.spec.js
+++ b/src/internal/SwitchBase.spec.js
@@ -21,7 +21,7 @@ function assertIsChecked(wrapper) {
 
   const label = iconButton.childAt(0);
   const icon = label.childAt(0);
-  assert.strictEqual(icon.is('pure(CheckBox)'), true, 'should be the CheckBox icon');
+  assert.strictEqual(icon.is('CheckBox'), true, 'should be the CheckBox icon');
 }
 
 function assertIsNotChecked(wrapper) {
@@ -39,7 +39,7 @@ function assertIsNotChecked(wrapper) {
   const label = iconButton.childAt(0);
   const icon = label.childAt(0);
   assert.strictEqual(
-    icon.is('pure(CheckBoxOutlineBlank)'),
+    icon.is('CheckBoxOutlineBlank'),
     true,
     'should be the CheckBoxOutlineBlank icon',
   );
@@ -72,7 +72,7 @@ describe('<SwitchBase />', () => {
   it('should render an icon and input inside the button by default', () => {
     const wrapper = shallow(<SwitchBase />);
     assert.strictEqual(
-      wrapper.childAt(0).is('pure(CheckBoxOutlineBlank)'),
+      wrapper.childAt(0).is('CheckBoxOutlineBlank'),
       true,
       'should be an SVG icon',
     );

--- a/src/svg-icons/arrow-downward.js
+++ b/src/svg-icons/arrow-downward.js
@@ -1,15 +1,13 @@
 // @flow weak
 
 import React from 'react';
-import pure from 'recompose/pure';
 import SvgIcon from '../SvgIcon';
 
-let ArrowDownward = props =>
+const ArrowDownward = props =>
   <SvgIcon {...props}>
     <path d="M0 0h24v24H0V0z" fill="none" />
     <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z" />
   </SvgIcon>;
-ArrowDownward = pure(ArrowDownward);
 ArrowDownward.muiName = 'SvgIcon';
 
 export default ArrowDownward;

--- a/src/svg-icons/cancel.js
+++ b/src/svg-icons/cancel.js
@@ -1,14 +1,12 @@
 // @flow weak
 
 import React from 'react';
-import pure from 'recompose/pure';
 import SvgIcon from '../SvgIcon';
 
-let Cancel = props =>
+const Cancel = props =>
   <SvgIcon {...props}>
     <path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z" />
   </SvgIcon>;
-Cancel = pure(Cancel);
 Cancel.muiName = 'SvgIcon';
 
 export default Cancel;

--- a/src/svg-icons/check-box-outline-blank.js
+++ b/src/svg-icons/check-box-outline-blank.js
@@ -1,14 +1,12 @@
 // @flow weak
 
 import React from 'react';
-import pure from 'recompose/pure';
 import SvgIcon from '../SvgIcon';
 
-let CheckBoxOutlineBlank = props =>
+const CheckBoxOutlineBlank = props =>
   <SvgIcon {...props}>
     <path d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z" />
   </SvgIcon>;
-CheckBoxOutlineBlank = pure(CheckBoxOutlineBlank);
 CheckBoxOutlineBlank.muiName = 'SvgIcon';
 
 export default CheckBoxOutlineBlank;

--- a/src/svg-icons/check-box.js
+++ b/src/svg-icons/check-box.js
@@ -1,14 +1,12 @@
 // @flow weak
 
 import React from 'react';
-import pure from 'recompose/pure';
 import SvgIcon from '../SvgIcon';
 
-let CheckBox = props =>
+const CheckBox = props =>
   <SvgIcon {...props}>
     <path d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
   </SvgIcon>;
-CheckBox = pure(CheckBox);
 CheckBox.muiName = 'SvgIcon';
 
 export default CheckBox;

--- a/src/svg-icons/indeterminate-check-box.js
+++ b/src/svg-icons/indeterminate-check-box.js
@@ -1,14 +1,12 @@
 // @flow weak
 
 import React from 'react';
-import pure from 'recompose/pure';
 import SvgIcon from '../SvgIcon';
 
-let IndeterminateCheckBox = props =>
+const IndeterminateCheckBox = props =>
   <SvgIcon {...props}>
     <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10H7v-2h10v2z" />
   </SvgIcon>;
-IndeterminateCheckBox = pure(IndeterminateCheckBox);
 IndeterminateCheckBox.muiName = 'SvgIcon';
 
 export default IndeterminateCheckBox;

--- a/src/svg-icons/keyboard-arrow-left.js
+++ b/src/svg-icons/keyboard-arrow-left.js
@@ -1,14 +1,12 @@
 // @flow weak
 
 import React from 'react';
-import pure from 'recompose/pure';
 import SvgIcon from '../SvgIcon';
 
-let KeyboardArrowLeft = props =>
+const KeyboardArrowLeft = props =>
   <SvgIcon {...props}>
     <path d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z" />
   </SvgIcon>;
-KeyboardArrowLeft = pure(KeyboardArrowLeft);
 KeyboardArrowLeft.muiName = 'SvgIcon';
 
 export default KeyboardArrowLeft;

--- a/src/svg-icons/keyboard-arrow-right.js
+++ b/src/svg-icons/keyboard-arrow-right.js
@@ -1,14 +1,12 @@
 // @flow weak
 
 import React from 'react';
-import pure from 'recompose/pure';
 import SvgIcon from '../SvgIcon';
 
-let KeyboardArrowRight = props =>
+const KeyboardArrowRight = props =>
   <SvgIcon {...props}>
     <path d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z" />
   </SvgIcon>;
-KeyboardArrowRight = pure(KeyboardArrowRight);
 KeyboardArrowRight.muiName = 'SvgIcon';
 
 export default KeyboardArrowRight;

--- a/src/svg-icons/radio-button-checked.js
+++ b/src/svg-icons/radio-button-checked.js
@@ -1,14 +1,12 @@
 // @flow weak
 
 import React from 'react';
-import pure from 'recompose/pure';
 import SvgIcon from '../SvgIcon';
 
-let RadioButtonChecked = props =>
+const RadioButtonChecked = props =>
   <SvgIcon {...props}>
     <path d="M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zm0-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z" />
   </SvgIcon>;
-RadioButtonChecked = pure(RadioButtonChecked);
 RadioButtonChecked.muiName = 'SvgIcon';
 
 export default RadioButtonChecked;

--- a/src/svg-icons/radio-button-unchecked.js
+++ b/src/svg-icons/radio-button-unchecked.js
@@ -1,14 +1,12 @@
 // @flow weak
 
 import React from 'react';
-import pure from 'recompose/pure';
 import SvgIcon from '../SvgIcon';
 
-let RadioButtonUnchecked = props =>
+const RadioButtonUnchecked = props =>
   <SvgIcon {...props}>
     <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z" />
   </SvgIcon>;
-RadioButtonUnchecked = pure(RadioButtonUnchecked);
 RadioButtonUnchecked.muiName = 'SvgIcon';
 
 export default RadioButtonUnchecked;


### PR DESCRIPTION
The `src/svg-icons` were unnecessarily using `pure` on stateless functional components.


- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

