### PR TITLE
[docs] Optional style sheet name

### DIFF
--- a/docs/src/components/AppContent.js
+++ b/docs/src/components/AppContent.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import MarkdownElement from 'docs/src/components/MarkdownElement';
 
-const styleSheet = createStyleSheet('AppContent', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   content: theme.mixins.gutters({
     paddingTop: 80,
     flex: '1 1 100%',

--- a/docs/src/components/AppDrawer.js
+++ b/docs/src/components/AppDrawer.js
@@ -11,7 +11,7 @@ import Divider from 'material-ui/Divider';
 import AppDrawerNavItem from 'docs/src/components/AppDrawerNavItem';
 import Link from 'docs/src/components/Link';
 
-const styleSheet = createStyleSheet('AppDrawer', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   paper: {
     width: 250,
     backgroundColor: theme.palette.background.paper,

--- a/docs/src/components/AppDrawerNavItem.js
+++ b/docs/src/components/AppDrawerNavItem.js
@@ -9,7 +9,7 @@ import { ListItem } from 'material-ui/List';
 import Button from 'material-ui/Button';
 import Collapse from 'material-ui/transitions/Collapse';
 
-const styleSheet = createStyleSheet('AppDrawerNavItem', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   button: theme.mixins.gutters({
     borderRadius: 0,
     justifyContent: 'flex-start',

--- a/docs/src/components/AppFrame.js
+++ b/docs/src/components/AppFrame.js
@@ -51,7 +51,7 @@ const styleSheet = createStyleSheet('AppFrame', theme => ({
       width: 'auto',
     },
   },
-  appFrame: {
+  root: {
     display: 'flex',
     alignItems: 'stretch',
     minHeight: '100vh',
@@ -121,7 +121,7 @@ class AppFrame extends Component {
     }
 
     return (
-      <div className={classes.appFrame}>
+      <div className={classes.root}>
         <AppBar className={appBarClassName}>
           <Toolbar>
             <IconButton

--- a/docs/src/components/Demo.js
+++ b/docs/src/components/Demo.js
@@ -11,7 +11,7 @@ import MarkdownElement from 'docs/src/components/MarkdownElement';
 const requireDemos = require.context('docs/src', true, /\.js$/);
 const requireDemoSource = require.context('!raw-loader!docs/src', true, /\.js$/);
 
-const styleSheet = createStyleSheet('Demo', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     fontFamily: theme.typography.fontFamily,
     position: 'relative',

--- a/docs/src/components/Link.js
+++ b/docs/src/components/Link.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import { Link as LinkRouter } from 'react-router';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 
-const styleSheet = createStyleSheet('Link', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     color: 'inherit',
     textDecoration: 'none',

--- a/docs/src/components/MarkdownDocs.js
+++ b/docs/src/components/MarkdownDocs.js
@@ -7,7 +7,7 @@ import Button from 'material-ui/Button';
 import MarkdownElement from 'docs/src/components/MarkdownElement';
 import Demo from 'docs/src/components/Demo';
 
-const styleSheet = createStyleSheet('MarkdownDocs', {
+const styleSheet = createStyleSheet({
   root: {
     marginBottom: 100,
   },

--- a/docs/src/components/MarkdownElement.js
+++ b/docs/src/components/MarkdownElement.js
@@ -55,7 +55,7 @@ const anchorLinkStyle = theme => ({
   },
 });
 
-const styleSheet = createStyleSheet('MarkdownElement', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     fontFamily: theme.typography.fontFamily,
     marginTop: theme.spacing.unit * 2,

--- a/docs/src/pages/component-demos/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/component-demos/app-bar/ButtonAppBar.js
@@ -10,7 +10,7 @@ import Button from 'material-ui/Button';
 import IconButton from 'material-ui/IconButton';
 import MenuIcon from 'material-ui-icons/Menu';
 
-const styleSheet = createStyleSheet('ButtonAppBar', {
+const styleSheet = createStyleSheet({
   root: {
     marginTop: 30,
     width: '100%',

--- a/docs/src/pages/component-demos/app-bar/SimpleAppBar.js
+++ b/docs/src/pages/component-demos/app-bar/SimpleAppBar.js
@@ -7,7 +7,7 @@ import AppBar from 'material-ui/AppBar';
 import Toolbar from 'material-ui/Toolbar';
 import Typography from 'material-ui/Typography';
 
-const styleSheet = createStyleSheet('SimpleAppBar', {
+const styleSheet = createStyleSheet({
   root: {
     marginTop: 30,
     width: '100%',

--- a/docs/src/pages/component-demos/autocomplete/IntegrationAutosuggest.js
+++ b/docs/src/pages/component-demos/autocomplete/IntegrationAutosuggest.js
@@ -121,7 +121,7 @@ function getSuggestions(value) {
       });
 }
 
-const styleSheet = createStyleSheet('IntegrationAutosuggest', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   container: {
     flexGrow: 1,
     position: 'relative',

--- a/docs/src/pages/component-demos/avatars/IconAvatars.js
+++ b/docs/src/pages/component-demos/avatars/IconAvatars.js
@@ -10,7 +10,7 @@ import FolderIcon from 'material-ui-icons/Folder';
 import PageviewIcon from 'material-ui-icons/Pageview';
 import AssignmentIcon from 'material-ui-icons/Assignment';
 
-const styleSheet = createStyleSheet('IconAvatars', {
+const styleSheet = createStyleSheet({
   avatar: {
     margin: 10,
   },

--- a/docs/src/pages/component-demos/avatars/ImageAvatars.js
+++ b/docs/src/pages/component-demos/avatars/ImageAvatars.js
@@ -8,7 +8,7 @@ import Avatar from 'material-ui/Avatar';
 import remyImage from 'docs/src/assets/images/remy.jpg';
 import uxecoImage from 'docs/src/assets/images/uxceo-128.jpg';
 
-const styleSheet = createStyleSheet('ImageAvatars', {
+const styleSheet = createStyleSheet({
   row: {
     display: 'flex',
     justifyContent: 'center',

--- a/docs/src/pages/component-demos/avatars/LetterAvatars.js
+++ b/docs/src/pages/component-demos/avatars/LetterAvatars.js
@@ -7,7 +7,7 @@ import Avatar from 'material-ui/Avatar';
 import deepOrange from 'material-ui/colors/deepOrange';
 import deepPurple from 'material-ui/colors/deepPurple';
 
-const styleSheet = createStyleSheet('LetterAvatars', {
+const styleSheet = createStyleSheet({
   avatar: {
     margin: 10,
   },

--- a/docs/src/pages/component-demos/badges/SimpleBadge.js
+++ b/docs/src/pages/component-demos/badges/SimpleBadge.js
@@ -7,7 +7,7 @@ import Badge from 'material-ui/Badge';
 import MailIcon from 'material-ui-icons/Mail';
 import FolderIcon from 'material-ui-icons/Folder';
 
-const styleSheet = createStyleSheet('SimpleBadge', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   badge: {
     margin: `0 ${theme.spacing.unit * 2}px`,
   },

--- a/docs/src/pages/component-demos/bottom-navigation/LabelBottomNavigation.js
+++ b/docs/src/pages/component-demos/bottom-navigation/LabelBottomNavigation.js
@@ -9,7 +9,7 @@ import FavoriteIcon from 'material-ui-icons/Favorite';
 import LocationOnIcon from 'material-ui-icons/LocationOn';
 import FolderIcon from 'material-ui-icons/Folder';
 
-const styleSheet = createStyleSheet('LabelBottomNavigation', {
+const styleSheet = createStyleSheet({
   root: {
     width: 500,
   },

--- a/docs/src/pages/component-demos/bottom-navigation/SimpleBottomNavigation.js
+++ b/docs/src/pages/component-demos/bottom-navigation/SimpleBottomNavigation.js
@@ -8,7 +8,7 @@ import RestoreIcon from 'material-ui-icons/Restore';
 import FavoriteIcon from 'material-ui-icons/Favorite';
 import LocationOnIcon from 'material-ui-icons/LocationOn';
 
-const styleSheet = createStyleSheet('SimpleBottomNavigation', {
+const styleSheet = createStyleSheet({
   root: {
     width: 500,
   },

--- a/docs/src/pages/component-demos/buttons/FlatButtons.js
+++ b/docs/src/pages/component-demos/buttons/FlatButtons.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Button from 'material-ui/Button';
 
-const styleSheet = createStyleSheet('FlatButtons', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   button: {
     margin: theme.spacing.unit,
   },

--- a/docs/src/pages/component-demos/buttons/FloatingActionButtons.js
+++ b/docs/src/pages/component-demos/buttons/FloatingActionButtons.js
@@ -7,7 +7,7 @@ import Button from 'material-ui/Button';
 import AddIcon from 'material-ui-icons/Add';
 import ModeEditIcon from 'material-ui-icons/ModeEdit';
 
-const styleSheet = createStyleSheet('FloatingActionButtons', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   button: {
     margin: theme.spacing.unit,
   },

--- a/docs/src/pages/component-demos/buttons/IconButtons.js
+++ b/docs/src/pages/component-demos/buttons/IconButtons.js
@@ -8,7 +8,7 @@ import IconButton from 'material-ui/IconButton';
 import DeleteIcon from 'material-ui-icons/Delete';
 import AddShoppingCartIcon from 'material-ui-icons/AddShoppingCart';
 
-const styleSheet = createStyleSheet('IconButtons', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   button: {
     margin: theme.spacing.unit,
   },

--- a/docs/src/pages/component-demos/buttons/RaisedButtons.js
+++ b/docs/src/pages/component-demos/buttons/RaisedButtons.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Button from 'material-ui/Button';
 
-const styleSheet = createStyleSheet('RaisedButtons', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   button: {
     margin: theme.spacing.unit,
   },

--- a/docs/src/pages/component-demos/cards/NowPlayingCard.js
+++ b/docs/src/pages/component-demos/cards/NowPlayingCard.js
@@ -11,7 +11,7 @@ import PlayArrowIcon from 'material-ui-icons/PlayArrow';
 import SkipNextIcon from 'material-ui-icons/SkipNext';
 import albumCover from 'docs/src/assets/images/live-from-space.jpg';
 
-const styleSheet = createStyleSheet('NowPlayingCard', {
+const styleSheet = createStyleSheet({
   card: {
     display: 'flex',
   },

--- a/docs/src/pages/component-demos/cards/RecipeReviewCard.js
+++ b/docs/src/pages/component-demos/cards/RecipeReviewCard.js
@@ -15,7 +15,7 @@ import ShareIcon from 'material-ui-icons/Share';
 import ExpandMoreIcon from 'material-ui-icons/ExpandMore';
 import paellaImage from 'docs/src/assets/images/paella.jpg';
 
-const styleSheet = createStyleSheet('RecipeReviewCard', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   card: { maxWidth: 400 },
   expand: {
     transform: 'rotate(0deg)',

--- a/docs/src/pages/component-demos/cards/SimpleCard.js
+++ b/docs/src/pages/component-demos/cards/SimpleCard.js
@@ -7,7 +7,7 @@ import Card, { CardActions, CardContent } from 'material-ui/Card';
 import Button from 'material-ui/Button';
 import Typography from 'material-ui/Typography';
 
-const styleSheet = createStyleSheet('SimpleCard', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   card: {
     minWidth: 275,
   },

--- a/docs/src/pages/component-demos/cards/SimpleMediaCard.js
+++ b/docs/src/pages/component-demos/cards/SimpleMediaCard.js
@@ -8,7 +8,7 @@ import Button from 'material-ui/Button';
 import Typography from 'material-ui/Typography';
 import reptileImage from 'docs/src/assets/images/contemplative-reptile.jpg';
 
-const styleSheet = createStyleSheet('SimpleMediaCard', {
+const styleSheet = createStyleSheet({
   card: {
     maxWidth: 345,
   },

--- a/docs/src/pages/component-demos/chips/Chips.js
+++ b/docs/src/pages/component-demos/chips/Chips.js
@@ -9,7 +9,7 @@ import FaceIcon from 'material-ui-icons/Face';
 import grey from 'material-ui/colors/grey';
 import uxecoImage from 'docs/src/assets/images/uxceo-128.jpg';
 
-const styleSheet = createStyleSheet('Chips', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   chip: {
     margin: theme.spacing.unit,
   },

--- a/docs/src/pages/component-demos/chips/ChipsArray.js
+++ b/docs/src/pages/component-demos/chips/ChipsArray.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Chip from 'material-ui/Chip';
 
-const styleSheet = createStyleSheet('ChipsArray', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   chip: {
     margin: theme.spacing.unit / 2,
   },

--- a/docs/src/pages/component-demos/dialogs/ConfirmationDialog.js
+++ b/docs/src/pages/component-demos/dialogs/ConfirmationDialog.js
@@ -106,7 +106,7 @@ ConfirmationDialog.propTypes = {
   selectedValue: PropTypes.string,
 };
 
-const styleSheet = createStyleSheet('ConfirmationDialogDemo', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     maxWidth: 360,

--- a/docs/src/pages/component-demos/dialogs/FullScreenDialog.js
+++ b/docs/src/pages/component-demos/dialogs/FullScreenDialog.js
@@ -14,7 +14,7 @@ import Typography from 'material-ui/Typography';
 import CloseIcon from 'material-ui-icons/Close';
 import Slide from 'material-ui/transitions/Slide';
 
-const styleSheet = createStyleSheet('FullScreenDialog', {
+const styleSheet = createStyleSheet({
   appBar: {
     position: 'relative',
   },

--- a/docs/src/pages/component-demos/dialogs/SimpleDialog.js
+++ b/docs/src/pages/component-demos/dialogs/SimpleDialog.js
@@ -15,7 +15,7 @@ import blue from 'material-ui/colors/blue';
 
 const emails = ['username@gmail.com', 'user02@gmail.com'];
 
-const styleSheet = createStyleSheet('SimpleDialog', () => ({
+const styleSheet = createStyleSheet(() => ({
   avatar: {
     background: blue[100],
     color: blue[600],

--- a/docs/src/pages/component-demos/dividers/InsetDividers.js
+++ b/docs/src/pages/component-demos/dividers/InsetDividers.js
@@ -9,7 +9,7 @@ import Divider from 'material-ui/Divider';
 import FolderIcon from 'material-ui-icons/Folder';
 import ImageIcon from 'material-ui-icons/Image';
 
-const styleSheet = createStyleSheet('InsetDividers', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     maxWidth: '360px',

--- a/docs/src/pages/component-demos/dividers/ListDividers.js
+++ b/docs/src/pages/component-demos/dividers/ListDividers.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import List, { ListItem, ListItemText } from 'material-ui/List';
 import Divider from 'material-ui/Divider';
 
-const styleSheet = createStyleSheet('ListDividers', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     maxWidth: '360px',

--- a/docs/src/pages/component-demos/drawers/UndockedDrawer.js
+++ b/docs/src/pages/component-demos/drawers/UndockedDrawer.js
@@ -15,7 +15,7 @@ import MailIcon from 'material-ui-icons/Mail';
 import DeleteIcon from 'material-ui-icons/Delete';
 import ReportIcon from 'material-ui-icons/Report';
 
-const styleSheet = createStyleSheet('UndockedDrawer', {
+const styleSheet = createStyleSheet({
   list: {
     width: 250,
     flex: 'initial',

--- a/docs/src/pages/component-demos/lists/CheckboxList.js
+++ b/docs/src/pages/component-demos/lists/CheckboxList.js
@@ -8,7 +8,7 @@ import Checkbox from 'material-ui/Checkbox';
 import IconButton from 'material-ui/IconButton';
 import CommentIcon from 'material-ui-icons/Comment';
 
-const styleSheet = createStyleSheet('CheckboxList', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     maxWidth: 360,

--- a/docs/src/pages/component-demos/lists/CheckboxListSecondary.js
+++ b/docs/src/pages/component-demos/lists/CheckboxListSecondary.js
@@ -8,7 +8,7 @@ import Checkbox from 'material-ui/Checkbox';
 import Avatar from 'material-ui/Avatar';
 import remyImage from 'docs/src/assets/images/remy.jpg';
 
-const styleSheet = createStyleSheet('CheckboxListSecondary', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     maxWidth: 360,

--- a/docs/src/pages/component-demos/lists/FolderList.js
+++ b/docs/src/pages/component-demos/lists/FolderList.js
@@ -7,7 +7,7 @@ import List, { ListItem, ListItemText } from 'material-ui/List';
 import Avatar from 'material-ui/Avatar';
 import FolderIcon from 'material-ui-icons/Folder';
 
-const styleSheet = createStyleSheet('FolderList', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     maxWidth: 360,

--- a/docs/src/pages/component-demos/lists/InsetList.js
+++ b/docs/src/pages/component-demos/lists/InsetList.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import List, { ListItem, ListItemIcon, ListItemText } from 'material-ui/List';
 import StarIcon from 'material-ui-icons/Star';
 
-const styleSheet = createStyleSheet('InsetList', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     maxWidth: 360,

--- a/docs/src/pages/component-demos/lists/InteractiveList.js
+++ b/docs/src/pages/component-demos/lists/InteractiveList.js
@@ -19,7 +19,7 @@ import Typography from 'material-ui/Typography';
 import FolderIcon from 'material-ui-icons/Folder';
 import DeleteIcon from 'material-ui-icons/Delete';
 
-const styleSheet = createStyleSheet('InteractiveList', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     maxWidth: 752,

--- a/docs/src/pages/component-demos/lists/SimpleList.js
+++ b/docs/src/pages/component-demos/lists/SimpleList.js
@@ -8,7 +8,7 @@ import Divider from 'material-ui/Divider';
 import InboxIcon from 'material-ui-icons/Inbox';
 import DraftsIcon from 'material-ui-icons/Drafts';
 
-const styleSheet = createStyleSheet('SimpleList', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     maxWidth: 360,

--- a/docs/src/pages/component-demos/lists/SwitchListSecondary.js
+++ b/docs/src/pages/component-demos/lists/SwitchListSecondary.js
@@ -14,7 +14,7 @@ import Switch from 'material-ui/Switch';
 import WifiIcon from 'material-ui-icons/Wifi';
 import BluetoothIcon from 'material-ui-icons/Bluetooth';
 
-const styleSheet = createStyleSheet('SwitchListSecondary', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     maxWidth: 360,

--- a/docs/src/pages/component-demos/menus/SimpleListMenu.js
+++ b/docs/src/pages/component-demos/menus/SimpleListMenu.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import List, { ListItem, ListItemText } from 'material-ui/List';
 import Menu, { MenuItem } from 'material-ui/Menu';
 
-const styleSheet = createStyleSheet('SimpleListMenu', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     maxWidth: 360,

--- a/docs/src/pages/component-demos/paper/PaperSheet.js
+++ b/docs/src/pages/component-demos/paper/PaperSheet.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Typography from 'material-ui/Typography';
 
-const styleSheet = createStyleSheet('PaperSheet', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: theme.mixins.gutters({
     paddingTop: 16,
     paddingBottom: 16,

--- a/docs/src/pages/component-demos/progress/CircularDeterminate.js
+++ b/docs/src/pages/component-demos/progress/CircularDeterminate.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { CircularProgress } from 'material-ui/Progress';
 
-const styleSheet = createStyleSheet('CircularDeterminate', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   progress: {
     margin: `0 ${theme.spacing.unit * 2}px`,
   },

--- a/docs/src/pages/component-demos/progress/CircularFab.js
+++ b/docs/src/pages/component-demos/progress/CircularFab.js
@@ -9,7 +9,7 @@ import Button from 'material-ui/Button';
 import CheckIcon from 'material-ui-icons/Check';
 import SaveIcon from 'material-ui-icons/Save';
 
-const styleSheet = createStyleSheet('CircularFab', {
+const styleSheet = createStyleSheet({
   wrapper: {
     position: 'relative',
   },

--- a/docs/src/pages/component-demos/progress/CircularIndeterminate.js
+++ b/docs/src/pages/component-demos/progress/CircularIndeterminate.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { CircularProgress } from 'material-ui/Progress';
 
-const styleSheet = createStyleSheet('CircularIndeterminate', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   progress: {
     margin: `0 ${theme.spacing.unit * 2}px`,
   },

--- a/docs/src/pages/component-demos/progress/LinearBuffer.js
+++ b/docs/src/pages/component-demos/progress/LinearBuffer.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { LinearProgress } from 'material-ui/Progress';
 
-const styleSheet = createStyleSheet('LinearBuffer', {
+const styleSheet = createStyleSheet({
   root: {
     width: '100%',
     marginTop: 30,

--- a/docs/src/pages/component-demos/progress/LinearDeterminate.js
+++ b/docs/src/pages/component-demos/progress/LinearDeterminate.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { LinearProgress } from 'material-ui/Progress';
 
-const styleSheet = createStyleSheet('LinearDeterminate', {
+const styleSheet = createStyleSheet({
   root: {
     width: '100%',
     marginTop: 30,

--- a/docs/src/pages/component-demos/progress/LinearIndeterminate.js
+++ b/docs/src/pages/component-demos/progress/LinearIndeterminate.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { LinearProgress } from 'material-ui/Progress';
 
-const styleSheet = createStyleSheet('LinearIndeterminate', {
+const styleSheet = createStyleSheet({
   root: {
     width: '100%',
     marginTop: 30,

--- a/docs/src/pages/component-demos/progress/LinearQuery.js
+++ b/docs/src/pages/component-demos/progress/LinearQuery.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { LinearProgress } from 'material-ui/Progress';
 
-const styleSheet = createStyleSheet('LinearQuery', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     marginTop: theme.spacing.unit * 3,

--- a/docs/src/pages/component-demos/selection-controls/Checkboxes.js
+++ b/docs/src/pages/component-demos/selection-controls/Checkboxes.js
@@ -7,7 +7,7 @@ import green from 'material-ui/colors/green';
 import { FormGroup, FormControlLabel } from 'material-ui/Form';
 import Checkbox from 'material-ui/Checkbox';
 
-const styleSheet = createStyleSheet('Checkboxes', {
+const styleSheet = createStyleSheet({
   checked: {
     color: green[500],
   },

--- a/docs/src/pages/component-demos/selection-controls/RadioButtonsGroup.js
+++ b/docs/src/pages/component-demos/selection-controls/RadioButtonsGroup.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Radio, { RadioGroup } from 'material-ui/Radio';
 import { FormLabel, FormControl, FormControlLabel } from 'material-ui/Form';
 
-const styleSheet = createStyleSheet('RadioButtonsGroup', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   group: {
     margin: `${theme.spacing.unit}px 0`,
   },

--- a/docs/src/pages/component-demos/selection-controls/Switches.js
+++ b/docs/src/pages/component-demos/selection-controls/Switches.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import green from 'material-ui/colors/green';
 import Switch from 'material-ui/Switch';
 
-const styleSheet = createStyleSheet('Switches', {
+const styleSheet = createStyleSheet({
   bar: {},
   checked: {
     color: green[500],

--- a/docs/src/pages/component-demos/snackbars/LongTextSnackbar.js
+++ b/docs/src/pages/component-demos/snackbars/LongTextSnackbar.js
@@ -12,7 +12,7 @@ const action = (
   </Button>
 );
 
-const styleSheet = createStyleSheet('LongTextSnackbar', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     marginTop: theme.spacing.unit * 3,
   },

--- a/docs/src/pages/component-demos/snackbars/SimpleSnackbar.js
+++ b/docs/src/pages/component-demos/snackbars/SimpleSnackbar.js
@@ -8,7 +8,7 @@ import Snackbar from 'material-ui/Snackbar';
 import IconButton from 'material-ui/IconButton';
 import CloseIcon from 'material-ui-icons/Close';
 
-const styleSheet = createStyleSheet('SimpleSnackbar', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   close: {
     width: theme.spacing.unit * 4,
     height: theme.spacing.unit * 4,

--- a/docs/src/pages/component-demos/stepper/DotsMobileStepper.js
+++ b/docs/src/pages/component-demos/stepper/DotsMobileStepper.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import MobileStepper from 'material-ui/MobileStepper';
 
-const styleSheet = createStyleSheet('DotsMobileStepper', {
+const styleSheet = createStyleSheet({
   root: {
     maxWidth: 400,
     flexGrow: 1,

--- a/docs/src/pages/component-demos/stepper/ProgressMobileStepper.js
+++ b/docs/src/pages/component-demos/stepper/ProgressMobileStepper.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import MobileStepper from 'material-ui/MobileStepper';
 
-const styleSheet = createStyleSheet('ProgressMobileStepper', {
+const styleSheet = createStyleSheet({
   root: {
     maxWidth: 400,
     flexGrow: 1,

--- a/docs/src/pages/component-demos/stepper/TextMobileStepper.js
+++ b/docs/src/pages/component-demos/stepper/TextMobileStepper.js
@@ -7,7 +7,7 @@ import MobileStepper from 'material-ui/MobileStepper';
 import Paper from 'material-ui/Paper';
 import Typography from 'material-ui/Typography';
 
-const styleSheet = createStyleSheet('TextMobileStepper', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     maxWidth: 400,
     flexGrow: 1,

--- a/docs/src/pages/component-demos/tables/BasicTable.js
+++ b/docs/src/pages/component-demos/tables/BasicTable.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Table, { TableBody, TableCell, TableHead, TableRow } from 'material-ui/Table';
 import Paper from 'material-ui/Paper';
 
-const styleSheet = createStyleSheet('BasicTable', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   paper: {
     width: '100%',
     marginTop: theme.spacing.unit * 3,

--- a/docs/src/pages/component-demos/tables/EnhancedTable.js
+++ b/docs/src/pages/component-demos/tables/EnhancedTable.js
@@ -79,7 +79,7 @@ class EnhancedTableHead extends Component {
   }
 }
 
-const toolbarStyleSheet = createStyleSheet('EnhancedTableToolbar', theme => ({
+const toolbarStyleSheet = createStyleSheet(theme => ({
   root: {
     paddingRight: 2,
   },
@@ -141,7 +141,7 @@ EnhancedTableToolbar.propTypes = {
 
 EnhancedTableToolbar = withStyles(toolbarStyleSheet)(EnhancedTableToolbar);
 
-const styleSheet = createStyleSheet('EnhancedTable', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   paper: {
     width: '100%',
     marginTop: theme.spacing.unit * 3,

--- a/docs/src/pages/component-demos/tabs/BasicTabs.js
+++ b/docs/src/pages/component-demos/tabs/BasicTabs.js
@@ -16,7 +16,7 @@ TabContainer.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const styleSheet = createStyleSheet('BasicTabs', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     marginTop: theme.spacing.unit * 3,

--- a/docs/src/pages/component-demos/tabs/BasicTabsWrappedLabel.js
+++ b/docs/src/pages/component-demos/tabs/BasicTabsWrappedLabel.js
@@ -16,7 +16,7 @@ TabContainer.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const styleSheet = createStyleSheet('BasicTabsWrappedLabel', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     marginTop: theme.spacing.unit * 3,

--- a/docs/src/pages/component-demos/tabs/CenteredTabs.js
+++ b/docs/src/pages/component-demos/tabs/CenteredTabs.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Tabs, { Tab } from 'material-ui/Tabs';
 
-const styleSheet = createStyleSheet('CenteredTabs', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     marginTop: theme.spacing.unit * 3,

--- a/docs/src/pages/component-demos/tabs/FullWidthTabs.js
+++ b/docs/src/pages/component-demos/tabs/FullWidthTabs.js
@@ -17,7 +17,7 @@ TabContainer.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const styleSheet = createStyleSheet('FullWidthTabs', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     backgroundColor: theme.palette.background.paper,
   },

--- a/docs/src/pages/component-demos/tabs/ScrollableTabsButtonAuto.js
+++ b/docs/src/pages/component-demos/tabs/ScrollableTabsButtonAuto.js
@@ -16,7 +16,7 @@ TabContainer.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const styleSheet = createStyleSheet('ScrollableTabsButtonAuto', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     width: '100%',

--- a/docs/src/pages/component-demos/tabs/ScrollableTabsButtonForce.js
+++ b/docs/src/pages/component-demos/tabs/ScrollableTabsButtonForce.js
@@ -23,7 +23,7 @@ TabContainer.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const styleSheet = createStyleSheet('ScrollableTabsButtonForce', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     width: '100%',

--- a/docs/src/pages/component-demos/tabs/ScrollableTabsButtonPrevent.js
+++ b/docs/src/pages/component-demos/tabs/ScrollableTabsButtonPrevent.js
@@ -23,7 +23,7 @@ TabContainer.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const styleSheet = createStyleSheet('ScrollableTabsButtonPrevent', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     width: '100%',

--- a/docs/src/pages/component-demos/text-fields/ComposedTextField.js
+++ b/docs/src/pages/component-demos/text-fields/ComposedTextField.js
@@ -8,7 +8,7 @@ import InputLabel from 'material-ui/Input/InputLabel';
 import FormControl from 'material-ui/Form/FormControl';
 import FormHelperText from 'material-ui/Form/FormHelperText';
 
-const styleSheet = createStyleSheet('ComposedTextField', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   container: {
     display: 'flex',
     flexWrap: 'wrap',

--- a/docs/src/pages/component-demos/text-fields/Inputs.js
+++ b/docs/src/pages/component-demos/text-fields/Inputs.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Input from 'material-ui/Input/Input';
 
-const styleSheet = createStyleSheet('Inputs', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   container: {
     display: 'flex',
     flexWrap: 'wrap',

--- a/docs/src/pages/component-demos/text-fields/TextFieldMargins.js
+++ b/docs/src/pages/component-demos/text-fields/TextFieldMargins.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import TextField from 'material-ui/TextField';
 
-const styleSheet = createStyleSheet('TextFieldMargins', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   container: {
     display: 'flex',
     flexWrap: 'wrap',

--- a/docs/src/pages/component-demos/text-fields/TextFields.js
+++ b/docs/src/pages/component-demos/text-fields/TextFields.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import TextField from 'material-ui/TextField';
 
-const styleSheet = createStyleSheet('TextFields', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   container: {
     display: 'flex',
     flexWrap: 'wrap',

--- a/docs/src/pages/customization/BusinessVariables.js
+++ b/docs/src/pages/customization/BusinessVariables.js
@@ -6,7 +6,7 @@ import Checkbox from 'material-ui/Checkbox';
 import { createMuiTheme, createStyleSheet, MuiThemeProvider, withStyles } from 'material-ui/styles';
 import orange from 'material-ui/colors/orange';
 
-const styleSheet = createStyleSheet('BusinessCheckbox', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   danger: {
     color: theme.status.danger,
   },

--- a/docs/src/pages/customization/Nested.js
+++ b/docs/src/pages/customization/Nested.js
@@ -8,7 +8,7 @@ import orange from 'material-ui/colors/orange';
 import green from 'material-ui/colors/green';
 import pink from 'material-ui/colors/pink';
 
-const styleSheet = createStyleSheet('NestedCheckbox', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   danger: {
     color: theme.status.color,
   },

--- a/docs/src/pages/customization/OverridesClassNames.js
+++ b/docs/src/pages/customization/OverridesClassNames.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Button from 'material-ui/Button';
 
 // We can inject some CSS into the DOM.
-const styleSheet = createStyleSheet('OverridesClassNames', {
+const styleSheet = createStyleSheet({
   button: {
     background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
     borderRadius: 3,

--- a/docs/src/pages/customization/OverridesClasses.js
+++ b/docs/src/pages/customization/OverridesClasses.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Button from 'material-ui/Button';
 
-const styleSheet = createStyleSheet('OverridesClasses', {
+const styleSheet = createStyleSheet({
   root: {
     background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
     borderRadius: 3,

--- a/docs/src/pages/customization/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js.md
@@ -55,13 +55,14 @@ They are easy to debug in development and as short as possible in production:
 
 ## API
 
-### `createStyleSheet(name, styles) => styleSheet`
+### `createStyleSheet([name], styles) => styleSheet`
 
 Generate a new style sheet that represents the style you want to inject in the DOM.
 
 #### Arguments
 
-1. `name` (*String*): The name of the style sheet. Useful for debugging.
+1. `name` (*String* [optional]): The name of the style sheet. Useful for debugging.
+If the value isn't provided, we will try to fallback to the name of the component.
 2. `styles` (*Function | Object*): A function generating the styles or an object.
 
 Use the function if you need to have access to the theme. It's provided as the first argument.
@@ -75,7 +76,7 @@ Use the function if you need to have access to the theme. It's provided as the f
 ```js
 import { createStyleSheet } from 'material-ui/styles';
 
-const styleSheet = createStyleSheet('MyLink', (theme) => ({
+const styleSheet = createStyleSheet((theme) => ({
   root: {
     color: 'inherit',
     textDecoration: 'inherit',

--- a/docs/src/pages/layout/css-in-js/MediaQuery.js
+++ b/docs/src/pages/layout/css-in-js/MediaQuery.js
@@ -7,7 +7,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import withWidth from 'material-ui/utils/withWidth';
 import Typography from 'material-ui/Typography';
 
-const styleSheet = createStyleSheet('MediaQuery', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     padding: theme.spacing.unit,
     [theme.breakpoints.up('md')]: {

--- a/docs/src/pages/layout/grid/AutoGrid.js
+++ b/docs/src/pages/layout/grid/AutoGrid.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Grid from 'material-ui/Grid';
 
-const styleSheet = createStyleSheet('AutoGrid', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     marginTop: 30,

--- a/docs/src/pages/layout/grid/CenteredGrid.js
+++ b/docs/src/pages/layout/grid/CenteredGrid.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Grid from 'material-ui/Grid';
 
-const styleSheet = createStyleSheet('CenteredGrid', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     marginTop: 30,

--- a/docs/src/pages/layout/grid/FullWidthGrid.js
+++ b/docs/src/pages/layout/grid/FullWidthGrid.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Grid from 'material-ui/Grid';
 
-const styleSheet = createStyleSheet('FullWidthGrid', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     marginTop: 30,

--- a/docs/src/pages/layout/grid/GuttersGrid.js
+++ b/docs/src/pages/layout/grid/GuttersGrid.js
@@ -8,7 +8,7 @@ import { FormLabel, FormControlLabel } from 'material-ui/Form';
 import Radio, { RadioGroup } from 'material-ui/Radio';
 import Paper from 'material-ui/Paper';
 
-const styleSheet = createStyleSheet('GuttersGrid', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
   },

--- a/docs/src/pages/layout/grid/InteractiveGrid.js
+++ b/docs/src/pages/layout/grid/InteractiveGrid.js
@@ -8,7 +8,7 @@ import { FormLabel, FormControlLabel } from 'material-ui/Form';
 import Radio, { RadioGroup } from 'material-ui/Radio';
 import Paper from 'material-ui/Paper';
 
-const styleSheet = createStyleSheet('InteractiveGrid', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
   },

--- a/docs/src/pages/layout/hidden/BreakpointDown.js
+++ b/docs/src/pages/layout/hidden/BreakpointDown.js
@@ -8,7 +8,7 @@ import Hidden from 'material-ui/Hidden';
 import withWidth from 'material-ui/utils/withWidth';
 import Typography from 'material-ui/Typography';
 
-const styleSheet = createStyleSheet('BreakpointDown', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   container: {
     flexGrow: 1,
     paddingTop: 30,

--- a/docs/src/pages/layout/hidden/BreakpointOnly.js
+++ b/docs/src/pages/layout/hidden/BreakpointOnly.js
@@ -8,7 +8,7 @@ import Hidden from 'material-ui/Hidden';
 import withWidth from 'material-ui/utils/withWidth';
 import Typography from 'material-ui/Typography';
 
-const styleSheet = createStyleSheet('BreakpointOnly', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   container: {
     flexGrow: 1,
     paddingTop: 30,

--- a/docs/src/pages/layout/hidden/BreakpointUp.js
+++ b/docs/src/pages/layout/hidden/BreakpointUp.js
@@ -8,7 +8,7 @@ import Hidden from 'material-ui/Hidden';
 import withWidth from 'material-ui/utils/withWidth';
 import Typography from 'material-ui/Typography';
 
-const styleSheet = createStyleSheet('BreakpointUp', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   container: {
     flexGrow: 1,
     paddingTop: 30,

--- a/docs/src/pages/layout/hidden/GridIntegration.js
+++ b/docs/src/pages/layout/hidden/GridIntegration.js
@@ -8,7 +8,7 @@ import Grid from 'material-ui/Grid';
 import withWidth from 'material-ui/utils/withWidth';
 import Typography from 'material-ui/Typography';
 
-const styleSheet = createStyleSheet('GridIntegration', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     paddingTop: 42,

--- a/docs/src/pages/style/Color.js
+++ b/docs/src/pages/style/Color.js
@@ -28,7 +28,7 @@ const neutralColors = ['Brown', 'Grey', 'Blue Grey'];
 const mainPalette = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900];
 const altPalette = ['A100', 'A200', 'A400', 'A700'];
 
-export const styleSheet = createStyleSheet('colors', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     display: 'flex',
     flexWrap: 'wrap',

--- a/docs/src/pages/style/Icons.js
+++ b/docs/src/pages/style/Icons.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Icon from 'material-ui/Icon';
 
-const styleSheet = createStyleSheet('Icons', {
+const styleSheet = createStyleSheet({
   root: {
     display: 'flex',
     alignItems: 'flex-end',

--- a/docs/src/pages/style/SvgIcons.js
+++ b/docs/src/pages/style/SvgIcons.js
@@ -9,7 +9,7 @@ import green from 'material-ui/colors/green';
 import red from 'material-ui/colors/red';
 import SvgIcon from 'material-ui/SvgIcon';
 
-const styleSheet = createStyleSheet('SvgIcons', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   icon: {
     margin: theme.spacing.unit,
   },

--- a/docs/src/pages/style/SvgMaterialIcons.js
+++ b/docs/src/pages/style/SvgMaterialIcons.js
@@ -6,7 +6,7 @@ import AccessAlarmIcon from 'material-ui-icons/AccessAlarm';
 import ThreeDRotation from 'material-ui-icons/ThreeDRotation';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 
-const styleSheet = createStyleSheet('SvgMaterialIcons', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   icon: {
     margin: theme.spacing.unit,
   },

--- a/docs/src/pages/style/TypographyTheme.js
+++ b/docs/src/pages/style/TypographyTheme.js
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 
-const styleSheet = createStyleSheet('TypograpghyTheme', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: theme.typography.button,
 }));
 

--- a/src/styles/withStyles.js
+++ b/src/styles/withStyles.js
@@ -134,8 +134,17 @@ const withStyles = (styleSheet: Array<Object> | Object, options: Object = {}) =>
 
         if (sheetManagerTheme.refs === 0) {
           const styles = currentStyleSheet.createStyles(theme);
+          let meta;
+
+          if (process.env.NODE_ENV !== 'production') {
+            meta = currentStyleSheet.name ? currentStyleSheet.name : getDisplayName(BaseComponent);
+            // Sanitize the string as will be used in development to prefix the generated
+            // class name.
+            meta = meta.replace(new RegExp(/[!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~]/g), '-');
+          }
+
           const sheet = this.jss.createStyleSheet(styles, {
-            meta: currentStyleSheet.name ? currentStyleSheet.name : getDisplayName(BaseComponent),
+            meta,
             link: false,
             ...this.sheetOptions,
             ...currentStyleSheet.options,

--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { createStyleSheet, withStyles } from 'material-ui/styles';
 
-const styleSheet = createStyleSheet('TestViewer', theme => {
+const styleSheet = createStyleSheet(theme => {
   return {
     '@global': {
       html: {

--- a/test/regressions/tests/Grid/AutoGrid.js
+++ b/test/regressions/tests/Grid/AutoGrid.js
@@ -6,7 +6,7 @@ import Paper from 'material-ui/Paper';
 import { createStyleSheet, withStyles } from 'material-ui/styles';
 import Grid from 'material-ui/Grid';
 
-const styleSheet = createStyleSheet('AutoGrid', () => ({
+const styleSheet = createStyleSheet(() => ({
   root: {
     width: 400,
   },

--- a/test/regressions/tests/Grid/SimpleGrid.js
+++ b/test/regressions/tests/Grid/SimpleGrid.js
@@ -6,7 +6,7 @@ import Paper from 'material-ui/Paper';
 import { createStyleSheet, withStyles } from 'material-ui/styles';
 import Grid from 'material-ui/Grid';
 
-const styleSheet = createStyleSheet('SimpleGrid', () => ({
+const styleSheet = createStyleSheet(() => ({
   root: {
     width: 400,
   },

--- a/test/regressions/tests/Grid/StressGrid.js
+++ b/test/regressions/tests/Grid/StressGrid.js
@@ -6,7 +6,7 @@ import Paper from 'material-ui/Paper';
 import { createStyleSheet, withStyles } from 'material-ui/styles';
 import Grid from 'material-ui/Grid';
 
-const styleSheet = createStyleSheet('StressGrid', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: 400,
     backgroundColor: theme.palette.primary.A400,

--- a/test/regressions/tests/Input/InputLabels.js
+++ b/test/regressions/tests/Input/InputLabels.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { createStyleSheet, withStyles } from 'material-ui/styles';
 import InputLabel from 'material-ui/Input/InputLabel';
 
-const styleSheet = createStyleSheet('InputLabels', () => ({
+const styleSheet = createStyleSheet(() => ({
   container: {
     display: 'flex',
     flexDirection: 'column',

--- a/test/regressions/tests/Input/Inputs.js
+++ b/test/regressions/tests/Input/Inputs.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import { createStyleSheet, withStyles } from 'material-ui/styles';
 import Input from 'material-ui/Input/Input';
 
-const styleSheet = createStyleSheet('Inputs', () => ({
+const styleSheet = createStyleSheet(() => ({
   container: {
     display: 'flex',
     flexDirection: 'column',

--- a/test/regressions/tests/Tabs/AdvancedTabs.js
+++ b/test/regressions/tests/Tabs/AdvancedTabs.js
@@ -8,7 +8,7 @@ import Paper from 'material-ui/Paper';
 import Tabs from 'material-ui/Tabs';
 import Tab from 'material-ui/Tabs/Tab';
 
-const styleSheet = createStyleSheet('AdvancedTabs', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: 600,
   },

--- a/test/regressions/tests/Tabs/SimpleTabs.js
+++ b/test/regressions/tests/Tabs/SimpleTabs.js
@@ -8,7 +8,7 @@ import Paper from 'material-ui/Paper';
 import Tabs from 'material-ui/Tabs';
 import Tab from 'material-ui/Tabs/Tab';
 
-const styleSheet = createStyleSheet('SimpleTabs', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: 600,
   },


### PR DESCRIPTION
I have seen too many people copy pasting the same component template and forgetting to rename the sheet name. **Wouldn't it be better if we could rely on the component name to get a nice debuggable class name in development?**

That's what this PR is about:

```diff
-const styleSheet = createStyleSheet('AppFrame', theme => ({
+const styleSheet = createStyleSheet(theme => ({
```

and in development, the class name is correct:
![capture d ecran 2017-07-29 a 22 14 48](https://user-images.githubusercontent.com/3165635/28747948-653a2a5a-74ab-11e7-8989-3bf0beb0a723.png)

in production we still have the following:
![capture d ecran 2017-07-29 a 22 15 59](https://user-images.githubusercontent.com/3165635/28747955-904e43f2-74ab-11e7-8a77-a51ad5cb5ef7.png)


*P.S. I have been using the following regexp on the codebase: `createStyleSheet\('((?!Mui)\w+)', `.*