### PR TITLE
Fix Drawer onRequestClose prop warning

### DIFF
--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -177,6 +177,7 @@ class Drawer extends Component<DefaultProps, Props, State> {
       open,
       SlideProps,
       theme,
+      onRequestClose,
       ...other
     } = this.props;
 


### PR DESCRIPTION
Simple fix for `onRequestClose` prop warning.

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

