### PR TITLE
[Grid] Add baseline to container's align property

### DIFF
--- a/docs/src/pages/component-api/Grid/Grid.md
+++ b/docs/src/pages/component-api/Grid/Grid.md
@@ -7,7 +7,7 @@
 ## Props
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| align | union:&nbsp;'flex-start'<br>&nbsp;'center'<br>&nbsp;'flex-end'<br>&nbsp;'stretch'<br> | 'stretch' | Defines the `align-items` style property. It's applied for all screen sizes. |
+| align | union:&nbsp;'flex-start'<br>&nbsp;'center'<br>&nbsp;'flex-end'<br>&nbsp;'stretch'<br>&nbsp;'baseline'<br> | 'stretch' | Defines the `align-items` style property. It's applied for all screen sizes. |
 | children | Element |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | component | union:&nbsp;string<br>&nbsp;Function<br> | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
@@ -39,6 +39,7 @@ This property accepts the following keys:
 - `align-xs-center`
 - `align-xs-flex-start`
 - `align-xs-flex-end`
+- `align-xs-baseline`
 - `justify-xs-center`
 - `justify-xs-flex-end`
 - `justify-xs-space-between`

--- a/docs/src/pages/layout/grid/InteractiveGrid.js
+++ b/docs/src/pages/layout/grid/InteractiveGrid.js
@@ -41,7 +41,6 @@ class InteractiveGrid extends Component {
   render() {
     const classes = this.props.classes;
     const { align, direction, justify } = this.state;
-
     return (
       <Grid container className={classes.root}>
         <Grid item xs={12}>
@@ -54,7 +53,10 @@ class InteractiveGrid extends Component {
           >
             {[0, 1, 2].map(value =>
               <Grid key={value} item>
-                <Paper className={classes.paper}>
+                <Paper
+                  className={classes.paper}
+                  style={{ paddingTop: (value + 1) * 10, paddingBottom: (value + 1) * 10 }}
+                >
                   {`Cell ${value + 1}`}
                 </Paper>
               </Grid>,
@@ -113,6 +115,7 @@ class InteractiveGrid extends Component {
                   <FormControlLabel value="center" control={<Radio />} label="center" />
                   <FormControlLabel value="flex-end" control={<Radio />} label="flex-end" />
                   <FormControlLabel value="stretch" control={<Radio />} label="stretch" />
+                  <FormControlLabel value="baseline" control={<Radio />} label="baseline" />
                 </RadioGroup>
               </Grid>
             </Grid>

--- a/src/Grid/Grid.js
+++ b/src/Grid/Grid.js
@@ -123,6 +123,9 @@ export const styleSheet = createStyleSheet('MuiGrid', theme => {
     'align-xs-flex-end': {
       alignItems: 'flex-end',
     },
+    'align-xs-baseline': {
+      alignItems: 'baseline',
+    },
     'justify-xs-center': {
       justifyContent: 'center',
     },
@@ -179,7 +182,7 @@ type Props = {
    * Defines the `align-items` style property.
    * It's applied for all screen sizes.
    */
-  align?: 'flex-start' | 'center' | 'flex-end' | 'stretch',
+  align?: 'flex-start' | 'center' | 'flex-end' | 'stretch' | 'baseline',
   /**
    * Defines the `flex-direction` style property.
    * It is applied for all screen sizes.


### PR DESCRIPTION
A value of baseline is not provided for the implementation of align-items in the Grid component 

Closes #7620

- Rebuilt Grid docs
- Added prop type value of baseline to align
- Added align-xs-baseline style to Grid stylesheet
- Added baseline to interactive grid demo

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [X] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

