### PR TITLE
[core] add isMuiComponent helper

### DIFF
--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 import { isDirty } from '../Input/Input';
+import { isMuiComponent } from '../utils/reactHelpers';
 
 export const styleSheet = createStyleSheet('MuiFormControl', theme => ({
   root: {
@@ -127,7 +128,7 @@ class FormControl extends Component<DefaultProps, Props, State> {
     // We need to iterate through the children and find the Input in order
     // to fully support server side rendering.
     Children.forEach(this.props.children, child => {
-      if (child && child.type && child.type.muiName === 'Input' && isDirty(child.props, true)) {
+      if (isMuiComponent(child, 'Input') && isDirty(child.props, true)) {
         this.setState({ dirty: true });
       }
     });

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -8,6 +8,7 @@ import withStyles from '../styles/withStyles';
 import ButtonBase from '../internal/ButtonBase';
 import { capitalizeFirstLetter } from '../utils/helpers';
 import Icon from '../Icon';
+import { isMuiComponent } from '../utils/reactHelpers';
 
 export const styleSheet = createStyleSheet('MuiIconButton', theme => ({
   root: {
@@ -86,7 +87,7 @@ function IconButton(props) {
               {children}
             </Icon>
           : Children.map(children, child => {
-              if (child.type && child.type.muiName === 'Icon') {
+              if (isMuiComponent(child, 'Icon')) {
                 return cloneElement(child, {
                   className: classNames(classes.icon, child.props.className),
                 });

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 import ButtonBase from '../internal/ButtonBase';
+import { isMuiComponent } from '../utils/reactHelpers';
 
 export const styleSheet = createStyleSheet('MuiListItem', theme => ({
   root: {
@@ -135,9 +136,7 @@ class ListItem extends Component<DefaultProps, Props, void> {
     const isDense = dense || this.context.dense || false;
     const children = React.Children.toArray(childrenProp);
 
-    const hasAvatar = children.some(value => {
-      return value.type && value.type.muiName === 'ListItemAvatar';
-    });
+    const hasAvatar = children.some(value => isMuiComponent(value, 'ListItemAvatar'));
 
     const className = classNames(
       classes.root,
@@ -162,8 +161,7 @@ class ListItem extends Component<DefaultProps, Props, void> {
 
     if (
       children.length &&
-      children[children.length - 1].type &&
-      children[children.length - 1].type.muiName === 'ListItemSecondaryAction'
+      isMuiComponent(children[children.length - 1], 'ListItemSecondaryAction')
     ) {
       const secondaryAction = children.pop();
       return (

--- a/src/List/ListItem.spec.js
+++ b/src/List/ListItem.spec.js
@@ -6,6 +6,7 @@ import { createShallow, getClasses } from '../test-utils';
 import ListItemText from './ListItemText';
 import ListItemSecondaryAction from './ListItemSecondaryAction';
 import ListItem, { styleSheet } from './ListItem';
+import ListItemAvatar from './ListItemAvatar';
 
 describe('<ListItem />', () => {
   let shallow;
@@ -41,6 +42,21 @@ describe('<ListItem />', () => {
       false,
       'should not have the gutters class',
     );
+  });
+
+  it('should use dense class when ListItemAvatar is present', () => {
+    const wrapper = shallow(
+      <ListItem>
+        <ListItemAvatar />
+      </ListItem>,
+      {
+        context: {
+          dense: false,
+        },
+      },
+    );
+
+    assert.strictEqual(wrapper.hasClass(classes.dense), true);
   });
 
   describe('prop: button', () => {

--- a/src/utils/reactHelpers.js
+++ b/src/utils/reactHelpers.js
@@ -15,3 +15,7 @@ export function cloneChildrenWithClassName(children, className) {
     );
   });
 }
+
+export function isMuiComponent(element: any, muiName: string) {
+  return isValidElement(element) && element.type.muiName === muiName;
+}

--- a/src/utils/reactHelpers.spec.js
+++ b/src/utils/reactHelpers.spec.js
@@ -1,0 +1,30 @@
+// @flow
+import React from 'react';
+import { assert } from 'chai';
+import { isMuiComponent } from './reactHelpers';
+import { Input, ListItemAvatar, ListItemSecondaryAction, SvgIcon } from '../';
+
+describe('utils/reactHelpers.js', () => {
+  describe('isMuiComponent', () => {
+    it('should match static muiName property', () => {
+      const Component = () => null;
+      Component.muiName = 'Component';
+
+      assert.strictEqual(isMuiComponent(<Component />, 'Component'), true);
+      assert.strictEqual(isMuiComponent(<div />, 'Input'), false);
+      assert.strictEqual(isMuiComponent(null, 'SvgIcon'), false);
+      assert.strictEqual(isMuiComponent('TextNode', 'SvgIcon'), false);
+    });
+
+    it('should be truthy for matching components', () => {
+      [
+        [Input, 'Input'],
+        [ListItemAvatar, 'ListItemAvatar'],
+        [ListItemSecondaryAction, 'ListItemSecondaryAction'],
+        [SvgIcon, 'SvgIcon'],
+      ].forEach(([Component, muiName]) => {
+        assert.strictEqual(isMuiComponent(<Component />, muiName), true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR provides simple `isMuiComponent` React helper.

Closes #7410.

I've also added simple `ListItem` test to see whether `hasAvatar` logic works the same way as before.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

