### PR TITLE
[Typo] Fixed "initial" word in vars and typo v1

### DIFF
--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -154,7 +154,7 @@ class Drawer extends Component<DefaultProps, Props, State> {
   state: State = {
     // Let's assume that the Drawer will always be rendered on user space.
     // We use that state is order to skip the appear transition during the
-    // inital mount of the component.
+    // initial mount of the component.
     firstMount: true,
   };
 

--- a/src/styles/themeListener.spec.js
+++ b/src/styles/themeListener.spec.js
@@ -7,16 +7,16 @@ import themeListener from './themeListener';
 const CHANNEL = 'material-ui';
 
 describe('themeListener', () => {
-  it('should be able to get the inital state', () => {
+  it('should be able to get the initial state', () => {
     const broadcast = createBroadcast();
-    const initalState = {};
-    broadcast.setState(initalState);
+    const initialState = {};
+    broadcast.setState(initialState);
 
     assert.strictEqual(
       themeListener.initial({
         [CHANNEL]: broadcast,
       }),
-      initalState,
+      initialState,
     );
   });
 
@@ -26,9 +26,9 @@ describe('themeListener', () => {
 
   it('should be able to subscribe to the event stream', done => {
     const broadcast = createBroadcast();
-    const initalState = {};
+    const initialState = {};
     const secondState = {};
-    broadcast.setState(initalState);
+    broadcast.setState(initialState);
 
     themeListener.subscribe(
       {

--- a/src/utils/withWidth.js
+++ b/src/utils/withWidth.js
@@ -96,9 +96,9 @@ function withWidth(options = {}) {
       }
 
       render() {
-        const { initalWidth, theme, width, ...other } = this.props;
+        const { initialWidth, theme, width, ...other } = this.props;
         const props = {
-          width: width || this.state.width || initalWidth,
+          width: width || this.state.width || initialWidth,
           ...other,
         };
 
@@ -132,7 +132,7 @@ function withWidth(options = {}) {
        * For instance, you could be using the user-agent or the client-hints.
        * http://caniuse.com/#search=client%20hint
        */
-      initalWidth: PropTypes.oneOf(keys),
+      initialWidth: PropTypes.oneOf(keys),
       /**
        * @ignore
        */

--- a/src/utils/withWidth.spec.js
+++ b/src/utils/withWidth.spec.js
@@ -111,9 +111,9 @@ describe('withWidth', () => {
     });
   });
 
-  describe('prop: initalWidth', () => {
+  describe('prop: initialWidth', () => {
     it('should work as expected', () => {
-      const element = <EmptyWithWidth initalWidth="lg" />;
+      const element = <EmptyWithWidth initialWidth="lg" />;
 
       // First mount on the server
       const wrapper1 = shallow(element);


### PR DESCRIPTION
Maybe need to automate spelling check with something like this https://www.npmjs.com/package/eslint-plugin-spellcheck