### PR TITLE
[ListItemText] Repurpose text class

### DIFF
--- a/docs/src/pages/component-api/List/ListItemText.md
+++ b/docs/src/pages/component-api/List/ListItemText.md
@@ -23,6 +23,7 @@ This property accepts the following keys:
 - `inset`
 - `dense`
 - `text`
+- `textDense`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes)
 section for more detail.

--- a/src/List/ListItemText.js
+++ b/src/List/ListItemText.js
@@ -23,7 +23,8 @@ export const styleSheet = createStyleSheet('MuiListItemText', theme => ({
   dense: {
     fontSize: 13,
   },
-  text: {
+  text: {},
+  textDense: {
     fontSize: 'inherit',
   },
 }));
@@ -53,7 +54,10 @@ function ListItemText(props, context) {
       {primary &&
         (disableTypography
           ? primary
-          : <Typography type="subheading" className={classNames({ [classes.text]: dense })}>
+          : <Typography
+              type="subheading"
+              className={classNames({ [classes.text]: true, [classes.textDense]: dense })}
+            >
               {primary}
             </Typography>)}
       {secondary &&
@@ -62,7 +66,7 @@ function ListItemText(props, context) {
           : <Typography
               color="secondary"
               type="body1"
-              className={classNames({ [classes.text]: dense })}
+              className={classNames({ [classes.text]: true, [classes.textDense]: dense })}
             >
               {secondary}
             </Typography>)}

--- a/src/List/ListItemText.js
+++ b/src/List/ListItemText.js
@@ -56,7 +56,7 @@ function ListItemText(props, context) {
           ? primary
           : <Typography
               type="subheading"
-              className={classNames({ [classes.text]: true, [classes.textDense]: dense })}
+              className={classNames(classes.text, { [classes.textDense]: dense })}
             >
               {primary}
             </Typography>)}
@@ -66,7 +66,7 @@ function ListItemText(props, context) {
           : <Typography
               color="secondary"
               type="body1"
-              className={classNames({ [classes.text]: true, [classes.textDense]: dense })}
+              className={classNames(classes.text, { [classes.textDense]: dense })}
             >
               {secondary}
             </Typography>)}


### PR DESCRIPTION
After running into an issue similar to #7067 I discovered that the _text_ class is only applied to the Typography component when the List is dense. Ideally, there would be two classes:

- _text_, applied to the inner Typography component
- _textDense_, applied to the Typography component when the list is dense

There may be an argument for breaking it into classes for primary, secondary, but this would be a simple and clear offering. At this point, the text class is confusing, but the other classes make sense:

- _root_, applied to the root element
- _dense_, applied to the root element when the list is dense
- _inset_, applied to the root element when the list item text is inset

This PR:

- Is a reference to closed issue #7067
- Exposes _text_ as a class that can be used to style the inner Typography component, whether the List is dense or not.
- Adds new _textDense_ class that can be used to specifically style the Typography component when the list is dense

This will introduce a breaking change for users who expect the _text_ class to apply when the containing list is dense.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [X] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

