### PR TITLE
Add prefix option to createGenerateClassName

### DIFF
--- a/src/styles/createGenerateClassName.js
+++ b/src/styles/createGenerateClassName.js
@@ -10,7 +10,7 @@ import type { Rule, generateClassName } from 'jss/lib/types';
 //
 // It's an improved version of
 // https://github.com/cssinjs/jss/blob/4e6a05dd3f7b6572fdd3ab216861d9e446c20331/src/utils/createGenerateClassName.js
-export default function createGenerateClassName(): generateClassName {
+export default function createGenerateClassName(prefix: string = "c"): generateClassName {
   let ruleCounter = 0;
 
   return (rule: Rule, sheet?: StyleSheet): string => {
@@ -24,7 +24,7 @@ export default function createGenerateClassName(): generateClassName {
     );
 
     if (process.env.NODE_ENV === 'production') {
-      return `c${ruleCounter}`;
+      return `${prefix}${ruleCounter}`;
     }
 
     if (sheet && sheet.options.meta) {


### PR DESCRIPTION
This allow user to change the prefix of generated classNames in production.

I'm made this change from Github Editor so this PR is definitely not ready to be merged, just want to propose the idea. The problem I'm encountering is that I have some global styles (can not change) that also use /^c\d+/ pattern (same ideas with you guys)

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

