### PR TITLE
[MenuItem] disabled focus for MenuItem on componentDidUpdate method 

### DIFF
--- a/src/MenuItem/MenuItem.js
+++ b/src/MenuItem/MenuItem.js
@@ -189,7 +189,6 @@ class MenuItem extends Component {
   }
 
   componentDidUpdate() {
-    this.applyFocusState();
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
I got a problem. Input always lost focus when i tried to type some letter inside a component whitch contained a MenuItem component. In source of this component i've found that in 'componentDidUpdate' method calls wierd method calls 'applyFocusState' method and it brokes the focus when each letter is typed.When i commened line with this method, everything started working fine and focus don't lose animore.
Why should we call this method each time when component is updating?
https://github.com/callemall/material-ui/blob/master/src/MenuItem/MenuItem.js#L192

