### PR TITLE
[CardHeader] Allow classes in title and subheader

### DIFF
--- a/src/Card/CardHeader.js
+++ b/src/Card/CardHeader.js
@@ -20,6 +20,8 @@ export const styleSheet = createStyleSheet('MuiCardHeader', theme => ({
   content: {
     flex: '1 1 auto',
   },
+  title: {},
+  subheader: {},
 }));
 
 type DefaultProps = {
@@ -67,10 +69,15 @@ function CardHeader(props: AllProps) {
           {avatar}
         </div>}
       <div className={classes.content}>
-        <Typography type={titleType} component="span">
+        <Typography type={titleType} component="span" className={classes.title}>
           {title}
         </Typography>
-        <Typography type={subheaderType} component="span" color="secondary">
+        <Typography
+          type={subheaderType}
+          component="span"
+          color="secondary"
+          className={classes.subheader}
+        >
           {subheader}
         </Typography>
       </div>

--- a/src/Card/CardHeader.spec.js
+++ b/src/Card/CardHeader.spec.js
@@ -24,6 +24,38 @@ describe('<CardHeader />', () => {
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
+  describe('with custom styles', () => {
+    let wrapper;
+    let extraClasses;
+
+    beforeEach(() => {
+      extraClasses = {
+        title: 'foo',
+        subheader: 'bar',
+      };
+      wrapper = shallow(
+        <CardHeader
+          title="Title"
+          subheader="Subheader"
+          classes={{
+            title: extraClasses.title,
+            subheader: extraClasses.subheader,
+          }}
+        />,
+      ).childAt(0);
+    });
+
+    it('should render with the title class', () => {
+      const title = wrapper.childAt(0);
+      assert.strictEqual(title.hasClass(extraClasses.title), true);
+    });
+
+    it('should render with the subheader class', () => {
+      const subheader = wrapper.childAt(1);
+      assert.strictEqual(subheader.hasClass(extraClasses.subheader), true);
+    });
+  });  
+
   describe('without an avatar', () => {
     let wrapper;
 

--- a/src/Card/CardHeader.spec.js
+++ b/src/Card/CardHeader.spec.js
@@ -54,7 +54,7 @@ describe('<CardHeader />', () => {
       const subheader = wrapper.childAt(1);
       assert.strictEqual(subheader.hasClass(extraClasses.subheader), true);
     });
-  });  
+  });
 
   describe('without an avatar', () => {
     let wrapper;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

Allows user to supply classes to cardheader title and subheader.

closes #7521 

Usage: https://gist.github.com/bmuenzenmeyer/84b75ce31c3f52b84d2680eca174ba6f

I decided to try my hand at this issue when looking over this repo for `good first issue` tags. One thing I wasn't sure of is having to define `title` and `subheader` as empty class objects - it seemed to work at runtime without, but complain during testing/linting. Feedback appreciated.  My code is linted, but running `npm run lint` seemed to get a bunch of errors from elsewhere in the codebase...

- [X] PR has tests / docs demo, and is linted. 
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

