### PR TITLE
[Popover] Refactor popover transition - separation of concerns

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -29,4 +29,5 @@ module.system.node.resolve_dirname=node_modules
 module.system.node.resolve_dirname=.
 
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
+suppress_comment= \\(.\\|\n\\)*\\$FlowExpectedError
 suppress_type=$FlowToDo

--- a/docs/src/pages/component-api/Card/CardHeader.md
+++ b/docs/src/pages/component-api/Card/CardHeader.md
@@ -21,6 +21,8 @@ This property accepts the following keys:
 - `root`
 - `avatar`
 - `content`
+- `title`
+- `subheader`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes)
 section for more detail.

--- a/docs/src/pages/component-api/Card/CardMedia.md
+++ b/docs/src/pages/component-api/Card/CardMedia.md
@@ -8,6 +8,7 @@
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | classes | Object |  | Useful to extend the style applied to components. |
+| <span style="color: #31a148">image *</span> | string |  | Image to be displayed as a background image. Note that caller must specify height otherwise the image will not be visible. |
 
 Any other properties supplied will be spread to the root element.
 

--- a/docs/src/pages/component-api/transitions/Collapse.md
+++ b/docs/src/pages/component-api/transitions/Collapse.md
@@ -7,15 +7,15 @@
 ## Props
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| children | node |  | The content node to be collapsed. |
-| classes | object |  | Useful to extend the style applied to components. |
-| in | bool | false | If `true`, the component will transition in. |
-| onEnter | function |  | Callback fired before the component is entering. |
-| onEntered | function |  | Callback fired when the component has entered. |
-| onEntering | function |  | Callback fired when the component is entering. |
-| onExit | function |  | Callback fired before the component is exiting. |
-| onExited | function |  | Callback fired when the component has exited. |
-| onExiting | function |  | Callback fired when the component is exiting. |
+| children | Element |  | The content node to be collapsed. |
+| classes | Object | {} | Useful to extend the style applied to components. |
+| in | boolean | false | If `true`, the component will transition in. |
+| onEnter | TransitionCallback |  | Callback fired before the component is entering. |
+| onEntered | TransitionCallback |  | Callback fired when the component has entered. |
+| onEntering | TransitionCallback |  | Callback fired when the component is entering. |
+| onExit | TransitionCallback |  | Callback fired before the component is exiting. |
+| onExited | TransitionCallback |  | Callback fired when the component has exited. |
+| onExiting | TransitionCallback |  | Callback fired when the component is exiting. |
 | transitionDuration | union:&nbsp;number<br>&nbsp;string<br> | 300 | Set to 'auto' to automatically calculate transition time based on height. |
 
 Any other properties supplied will be spread to the root element.

--- a/docs/src/pages/component-api/transitions/Grow.md
+++ b/docs/src/pages/component-api/transitions/Grow.md
@@ -1,0 +1,21 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
+# Grow
+
+Grow transition used by popovers such as Menu.
+
+## Props
+| Name | Type | Default | Description |
+|:-----|:-----|:--------|:------------|
+| children | Element |  | The content of the component. |
+| onEnter | TransitionCallback |  | Callback fired before the component is entering |
+| onEntered | TransitionCallback |  | Callback fired when the component has entered |
+| onEntering | TransitionCallback |  | Callback fired when the component is entering |
+| onExit | TransitionCallback |  | Callback fired before the component is exiting |
+| onExited | TransitionCallback |  | Callback fired when the component has exited |
+| onExiting | TransitionCallback |  | Callback fired when the component is exiting |
+| rootRef | Function |  | Use that property to pass a ref callback to the root component. |
+| transitionDuration | union:&nbsp;number<br>&nbsp;'auto'<br> | 'auto' | Set to 'auto' to automatically calculate transition time based on height |
+
+Any other properties supplied will be spread to the root element.
+

--- a/docs/src/pages/component-api/transitions/Slide.md
+++ b/docs/src/pages/component-api/transitions/Slide.md
@@ -7,17 +7,17 @@
 ## Props
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| direction | enum:&nbsp;'left'<br>&nbsp;'right'<br>&nbsp;'up'<br>&nbsp;'down'<br> | 'down' | Direction the child element will enter from. |
+| direction | union:&nbsp;'left'<br>&nbsp;'right'<br>&nbsp;'up'<br>&nbsp;'down'<br> | 'down' | Direction the child element will enter from. |
 | enterTransitionDuration | number | duration.enteringScreen | Duration of the animation when the element is entering. |
-| in | bool |  | If `true`, show the component; triggers the enter or exit animation. |
+| in | boolean |  | If `true`, show the component; triggers the enter or exit animation. |
 | leaveTransitionDuration | number | duration.leavingScreen | Duration of the animation when the element is exiting. |
 | offset | string |  | Slide in by a fixed number of pixels or %. |
-| onEnter | function |  | Callback fired before the component enters. |
-| onEntered | function |  | Callback fired when the component has entered. |
-| onEntering | function |  | Callback fired when the component is entering. |
-| onExit | function |  | Callback fired before the component exits. |
-| onExited | function |  | Callback fired when the component has exited. |
-| onExiting | function |  | Callback fired when the component is exiting. |
+| onEnter | TransitionCallback |  | Callback fired before the component enters. |
+| onEntered | TransitionCallback |  | Callback fired when the component has entered. |
+| onEntering | TransitionCallback |  | Callback fired when the component is entering. |
+| onExit | TransitionCallback |  | Callback fired before the component exits. |
+| onExited | TransitionCallback |  | Callback fired when the component has exited. |
+| onExiting | TransitionCallback |  | Callback fired when the component is exiting. |
 
 Any other properties supplied will be spread to the root element.
 

--- a/src/Avatar/Avatar.spec.js
+++ b/src/Avatar/Avatar.spec.js
@@ -18,14 +18,19 @@ describe('<Avatar />', () => {
   describe('image avatar', () => {
     it('should render a div containing an img', () => {
       const wrapper = shallow(
-        <Avatar className="my-avatar" src="something.jpg" alt="Hello World!" data-my-prop="woof" />,
+        <Avatar
+          className="my-avatar"
+          src="something.jpg"
+          alt="Hello World!"
+          data-my-prop="woofAvatar"
+        />,
       );
 
       assert.strictEqual(wrapper.name(), 'div');
       assert.strictEqual(wrapper.childAt(0).is('img'), true, 'should be an img');
       assert.strictEqual(wrapper.hasClass(classes.root), true);
       assert.strictEqual(wrapper.hasClass('my-avatar'), true);
-      assert.strictEqual(wrapper.prop('data-my-prop'), 'woof');
+      assert.strictEqual(wrapper.prop('data-my-prop'), 'woofAvatar');
       assert.strictEqual(
         wrapper.hasClass(classes.colorDefault),
         false,
@@ -64,7 +69,7 @@ describe('<Avatar />', () => {
 
     before(() => {
       wrapper = shallow(
-        <Avatar className="my-avatar" data-my-prop="woof" childrenClassName="my-children">
+        <Avatar className="my-avatar" data-my-prop="woofAvatar" childrenClassName="my-children">
           <span className="my-icon-font">icon</span>
         </Avatar>,
       );
@@ -81,7 +86,7 @@ describe('<Avatar />', () => {
     it('should merge user classes & spread custom props to the root node', () => {
       assert.strictEqual(wrapper.hasClass(classes.root), true);
       assert.strictEqual(wrapper.hasClass('my-avatar'), true);
-      assert.strictEqual(wrapper.prop('data-my-prop'), 'woof');
+      assert.strictEqual(wrapper.prop('data-my-prop'), 'woofAvatar');
     });
 
     it('should apply the colorDefault class', () => {
@@ -98,7 +103,7 @@ describe('<Avatar />', () => {
 
     before(() => {
       wrapper = shallow(
-        <Avatar className="my-avatar" data-my-prop="woof" childrenClassName="my-children">
+        <Avatar className="my-avatar" data-my-prop="woofAvatar" childrenClassName="my-children">
           <CancelIcon />
         </Avatar>,
       );
@@ -112,7 +117,7 @@ describe('<Avatar />', () => {
     it('should merge user classes & spread custom props to the root node', () => {
       assert.strictEqual(wrapper.hasClass(classes.root), true);
       assert.strictEqual(wrapper.hasClass('my-avatar'), true);
-      assert.strictEqual(wrapper.prop('data-my-prop'), 'woof');
+      assert.strictEqual(wrapper.prop('data-my-prop'), 'woofAvatar');
     });
 
     it('should apply the colorDefault class', () => {
@@ -129,7 +134,7 @@ describe('<Avatar />', () => {
 
     before(() => {
       wrapper = shallow(
-        <Avatar className="my-avatar" data-my-prop="woof">
+        <Avatar className="my-avatar" data-my-prop="woofAvatar">
           OT
         </Avatar>,
       );
@@ -143,7 +148,7 @@ describe('<Avatar />', () => {
     it('should merge user classes & spread custom props to the root node', () => {
       assert.strictEqual(wrapper.hasClass(classes.root), true);
       assert.strictEqual(wrapper.hasClass('my-avatar'), true);
-      assert.strictEqual(wrapper.prop('data-my-prop'), 'woof');
+      assert.strictEqual(wrapper.prop('data-my-prop'), 'woofAvatar');
     });
 
     it('should apply the colorDefault class', () => {

--- a/src/BottomNavigation/BottomNavigation.spec.js
+++ b/src/BottomNavigation/BottomNavigation.spec.js
@@ -36,11 +36,11 @@ describe('<BottomNavigation />', () => {
 
   it('should render with the user and root classes', () => {
     const wrapper = shallow(
-      <BottomNavigation showLabels className="woof">
+      <BottomNavigation showLabels className="woofBottomNavigation">
         <BottomNavigationButton icon={icon} />
       </BottomNavigation>,
     );
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    assert.strictEqual(wrapper.hasClass('woofBottomNavigation'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 

--- a/src/BottomNavigation/BottomNavigationButton.spec.js
+++ b/src/BottomNavigation/BottomNavigationButton.spec.js
@@ -28,8 +28,8 @@ describe('<BottomNavigationButton />', () => {
   });
 
   it('should render with the user and root classes', () => {
-    const wrapper = shallow(<BottomNavigationButton className="woof" icon={icon} />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<BottomNavigationButton className="woofBottomNavigationButton" icon={icon} />);
+    assert.strictEqual(wrapper.hasClass('woofBottomNavigationButton'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 

--- a/src/BottomNavigation/BottomNavigationButton.spec.js
+++ b/src/BottomNavigation/BottomNavigationButton.spec.js
@@ -28,7 +28,9 @@ describe('<BottomNavigationButton />', () => {
   });
 
   it('should render with the user and root classes', () => {
-    const wrapper = shallow(<BottomNavigationButton className="woofBottomNavigationButton" icon={icon} />);
+    const wrapper = shallow(
+      <BottomNavigationButton className="woofBottomNavigationButton" icon={icon} />,
+    );
     assert.strictEqual(wrapper.hasClass('woofBottomNavigationButton'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });

--- a/src/Card/Card.spec.js
+++ b/src/Card/Card.spec.js
@@ -24,7 +24,7 @@ describe('<Card />', () => {
   });
 
   it('should spread custom props on the root node', () => {
-    const wrapper = shallow(<Card data-my-prop="woof" />);
-    assert.strictEqual(wrapper.prop('data-my-prop'), 'woof', 'custom prop should be woof');
+    const wrapper = shallow(<Card data-my-prop="woofCard" />);
+    assert.strictEqual(wrapper.prop('data-my-prop'), 'woofCard', 'custom prop should be woofCard');
   });
 });

--- a/src/Card/CardMedia.spec.js
+++ b/src/Card/CardMedia.spec.js
@@ -15,9 +15,9 @@ describe('<CardMedia />', () => {
   });
 
   it('should have the root and custom class', () => {
-    const wrapper = shallow(<CardMedia className="woof" image="/foo.jpg" />);
+    const wrapper = shallow(<CardMedia className="woofCardMedia" image="/foo.jpg" />);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    assert.strictEqual(wrapper.hasClass('woofCardMedia'), true);
   });
 
   it('should have the backgroundImage specified', () => {
@@ -26,7 +26,11 @@ describe('<CardMedia />', () => {
   });
 
   it('should spread custom props on the root node', () => {
-    const wrapper = shallow(<CardMedia image="/foo.jpg" data-my-prop="woof" />);
-    assert.strictEqual(wrapper.prop('data-my-prop'), 'woof', 'custom prop should be woof');
+    const wrapper = shallow(<CardMedia image="/foo.jpg" data-my-prop="woofCardMedia" />);
+    assert.strictEqual(
+      wrapper.prop('data-my-prop'),
+      'woofCardMedia',
+      'custom prop should be woofCardMedia',
+    );
   });
 });

--- a/src/Chip/Chip.spec.js
+++ b/src/Chip/Chip.spec.js
@@ -22,7 +22,7 @@ describe('<Chip />', () => {
 
     before(() => {
       wrapper = shallow(
-        <Chip className="my-Chip" data-my-prop="woof">
+        <Chip className="my-Chip" data-my-prop="woofChip">
           Text Chip
         </Chip>,
       );
@@ -36,7 +36,7 @@ describe('<Chip />', () => {
     it('should merge user classes & spread custom props to the root node', () => {
       assert.strictEqual(wrapper.hasClass(classes.root), true);
       assert.strictEqual(wrapper.hasClass('my-Chip'), true);
-      assert.strictEqual(wrapper.prop('data-my-prop'), 'woof');
+      assert.strictEqual(wrapper.prop('data-my-prop'), 'woofChip');
     });
 
     it('should have a tabIndex prop with value -1', () => {
@@ -51,7 +51,7 @@ describe('<Chip />', () => {
     before(() => {
       handleClick = () => {};
       wrapper = shallow(
-        <Chip className="my-Chip" data-my-prop="woof" onClick={handleClick}>
+        <Chip className="my-Chip" data-my-prop="woofChip" onClick={handleClick}>
           Text Chip
         </Chip>,
       );
@@ -65,7 +65,7 @@ describe('<Chip />', () => {
     it('should merge user classes & spread custom props to the root node', () => {
       assert.strictEqual(wrapper.hasClass(classes.root), true);
       assert.strictEqual(wrapper.hasClass('my-Chip'), true);
-      assert.strictEqual(wrapper.prop('data-my-prop'), 'woof');
+      assert.strictEqual(wrapper.prop('data-my-prop'), 'woofChip');
       assert.strictEqual(wrapper.props().onClick, handleClick);
     });
 
@@ -93,14 +93,14 @@ describe('<Chip />', () => {
       wrapper = shallow(
         <Chip
           avatar={
-            <Avatar className="my-Avatar" data-my-prop="woof">
+            <Avatar className="my-Avatar" data-my-prop="woofChip">
               MB
             </Avatar>
           }
           label="Text Avatar Chip"
           onRequestDelete={() => {}}
           className="my-Chip"
-          data-my-prop="woof"
+          data-my-prop="woofChip"
         />,
       );
     });
@@ -115,13 +115,13 @@ describe('<Chip />', () => {
     it('should merge user classes & spread custom props to the root node', () => {
       assert.strictEqual(wrapper.hasClass(classes.root), true);
       assert.strictEqual(wrapper.hasClass('my-Chip'), true);
-      assert.strictEqual(wrapper.prop('data-my-prop'), 'woof');
+      assert.strictEqual(wrapper.prop('data-my-prop'), 'woofChip');
     });
 
     it('should merge user classes & spread custom props to the Avatar node', () => {
       assert.strictEqual(wrapper.childAt(0).hasClass(classes.avatar), true);
       assert.strictEqual(wrapper.childAt(0).hasClass('my-Avatar'), true);
-      assert.strictEqual(wrapper.childAt(0).prop('data-my-prop'), 'woof');
+      assert.strictEqual(wrapper.childAt(0).prop('data-my-prop'), 'woofChip');
     });
 
     it('should have a tabIndex prop', () => {
@@ -160,7 +160,7 @@ describe('<Chip />', () => {
 
     before(() => {
       wrapper = shallow(
-        <Chip className="my-Chip" data-my-prop="woof">
+        <Chip className="my-Chip" data-my-prop="woofChip">
           Text Chip
         </Chip>,
       );

--- a/src/Dialog/Dialog.spec.js
+++ b/src/Dialog/Dialog.spec.js
@@ -57,7 +57,11 @@ describe('<Dialog />', () => {
 
   it('should spread custom props on the paper (dialog "root") node', () => {
     const wrapper = shallow(<Dialog data-my-prop="woofDialog" />);
-    assert.strictEqual(wrapper.prop('data-my-prop'), 'woofDialog', 'custom prop should be woofDialog');
+    assert.strictEqual(
+      wrapper.prop('data-my-prop'),
+      'woofDialog',
+      'custom prop should be woofDialog',
+    );
   });
 
   it('should render with the user classes on the root node', () => {

--- a/src/Dialog/Dialog.spec.js
+++ b/src/Dialog/Dialog.spec.js
@@ -56,13 +56,13 @@ describe('<Dialog />', () => {
   });
 
   it('should spread custom props on the paper (dialog "root") node', () => {
-    const wrapper = shallow(<Dialog data-my-prop="woof" />);
-    assert.strictEqual(wrapper.prop('data-my-prop'), 'woof', 'custom prop should be woof');
+    const wrapper = shallow(<Dialog data-my-prop="woofDialog" />);
+    assert.strictEqual(wrapper.prop('data-my-prop'), 'woofDialog', 'custom prop should be woofDialog');
   });
 
   it('should render with the user classes on the root node', () => {
-    const wrapper = shallow(<Dialog className="woof" />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<Dialog className="woofDialog" />);
+    assert.strictEqual(wrapper.hasClass('woofDialog'), true);
   });
 
   it('should render Fade > Paper > children inside the Modal', () => {

--- a/src/Dialog/DialogActions.spec.js
+++ b/src/Dialog/DialogActions.spec.js
@@ -20,20 +20,20 @@ describe('<DialogActions />', () => {
   });
 
   it('should spread custom props on the root node', () => {
-    const wrapper = shallow(<DialogActions data-my-prop="woof" />);
-    assert.strictEqual(wrapper.prop('data-my-prop'), 'woof', 'custom prop should be woof');
+    const wrapper = shallow(<DialogActions data-my-prop="woofDialogActions" />);
+    assert.strictEqual(wrapper.prop('data-my-prop'), 'woofDialogActions', 'custom prop should be woofDialogActions');
   });
 
   it('should render with the user and root classes', () => {
-    const wrapper = shallow(<DialogActions className="woof" />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<DialogActions className="woofDialogActions" />);
+    assert.strictEqual(wrapper.hasClass('woofDialogActions'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
   it('should render children with the button class wrapped in a div with the action class', () => {
     const wrapper = shallow(
       <DialogActions>
-        <button className="woof">Hello</button>
+        <button className="woofDialogActions">Hello</button>
       </DialogActions>,
     );
     const container = wrapper.childAt(0);
@@ -41,7 +41,7 @@ describe('<DialogActions />', () => {
     assert.strictEqual(container.is('div'), true, 'should be a div');
     const button = container.childAt(0);
     assert.strictEqual(button.is('button'), true, 'should be a button');
-    assert.strictEqual(button.hasClass('woof'), true, 'should have the user class');
+    assert.strictEqual(button.hasClass('woofDialogActions'), true, 'should have the user class');
     assert.strictEqual(button.hasClass(classes.button), true, 'should have the button class');
   });
 
@@ -49,7 +49,7 @@ describe('<DialogActions />', () => {
     const showButton = true;
     const wrapper = shallow(
       <DialogActions>
-        {showButton ? <button className="woof">Hello</button> : null}
+        {showButton ? <button className="woofDialogActions">Hello</button> : null}
         {!showButton ? <button>false button</button> : null}
       </DialogActions>,
     );
@@ -59,7 +59,7 @@ describe('<DialogActions />', () => {
     assert.strictEqual(container.is('div'), true, 'should be a div');
     const button = container.childAt(0);
     assert.strictEqual(button.is('button'), true, 'should be a button');
-    assert.strictEqual(button.hasClass('woof'), true, 'should have the user class');
+    assert.strictEqual(button.hasClass('woofDialogActions'), true, 'should have the user class');
     assert.strictEqual(button.hasClass(classes.button), true, 'should have the button class');
   });
 });

--- a/src/Dialog/DialogActions.spec.js
+++ b/src/Dialog/DialogActions.spec.js
@@ -21,7 +21,11 @@ describe('<DialogActions />', () => {
 
   it('should spread custom props on the root node', () => {
     const wrapper = shallow(<DialogActions data-my-prop="woofDialogActions" />);
-    assert.strictEqual(wrapper.prop('data-my-prop'), 'woofDialogActions', 'custom prop should be woofDialogActions');
+    assert.strictEqual(
+      wrapper.prop('data-my-prop'),
+      'woofDialogActions',
+      'custom prop should be woofDialogActions',
+    );
   });
 
   it('should render with the user and root classes', () => {

--- a/src/Dialog/DialogContent.spec.js
+++ b/src/Dialog/DialogContent.spec.js
@@ -20,13 +20,13 @@ describe('<DialogContent />', () => {
   });
 
   it('should spread custom props on the root node', () => {
-    const wrapper = shallow(<DialogContent data-my-prop="woof" />);
-    assert.strictEqual(wrapper.prop('data-my-prop'), 'woof', 'custom prop should be woof');
+    const wrapper = shallow(<DialogContent data-my-prop="woofDialogContent" />);
+    assert.strictEqual(wrapper.prop('data-my-prop'), 'woofDialogContent', 'custom prop should be woofDialogContent');
   });
 
   it('should render with the user and root classes', () => {
-    const wrapper = shallow(<DialogContent className="woof" />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<DialogContent className="woofDialogContent" />);
+    assert.strictEqual(wrapper.hasClass('woofDialogContent'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 

--- a/src/Dialog/DialogContent.spec.js
+++ b/src/Dialog/DialogContent.spec.js
@@ -21,7 +21,11 @@ describe('<DialogContent />', () => {
 
   it('should spread custom props on the root node', () => {
     const wrapper = shallow(<DialogContent data-my-prop="woofDialogContent" />);
-    assert.strictEqual(wrapper.prop('data-my-prop'), 'woofDialogContent', 'custom prop should be woofDialogContent');
+    assert.strictEqual(
+      wrapper.prop('data-my-prop'),
+      'woofDialogContent',
+      'custom prop should be woofDialogContent',
+    );
   });
 
   it('should render with the user and root classes', () => {

--- a/src/Dialog/DialogContentText.spec.js
+++ b/src/Dialog/DialogContentText.spec.js
@@ -16,8 +16,8 @@ describe('<DialogContentText />', () => {
 
   describe('prop: className', () => {
     it('should render with the user and root classes', () => {
-      const wrapper = shallow(<DialogContentText className="woof" />);
-      assert.strictEqual(wrapper.hasClass('woof'), true);
+      const wrapper = shallow(<DialogContentText className="woofDialogContentText" />);
+      assert.strictEqual(wrapper.hasClass('woofDialogContentText'), true);
       assert.strictEqual(wrapper.hasClass(classes.root), true);
     });
   });

--- a/src/Dialog/DialogTitle.spec.js
+++ b/src/Dialog/DialogTitle.spec.js
@@ -20,13 +20,13 @@ describe('<DialogTitle />', () => {
   });
 
   it('should spread custom props on the root node', () => {
-    const wrapper = shallow(<DialogTitle data-my-prop="woof" />);
-    assert.strictEqual(wrapper.prop('data-my-prop'), 'woof', 'custom prop should be woof');
+    const wrapper = shallow(<DialogTitle data-my-prop="woofDialogTitle" />);
+    assert.strictEqual(wrapper.prop('data-my-prop'), 'woofDialogTitle', 'custom prop should be woofDialogTitle');
   });
 
   it('should render with the user and root classes', () => {
-    const wrapper = shallow(<DialogTitle className="woof" />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<DialogTitle className="woofDialogTitle" />);
+    assert.strictEqual(wrapper.hasClass('woofDialogTitle'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 

--- a/src/Dialog/DialogTitle.spec.js
+++ b/src/Dialog/DialogTitle.spec.js
@@ -21,7 +21,11 @@ describe('<DialogTitle />', () => {
 
   it('should spread custom props on the root node', () => {
     const wrapper = shallow(<DialogTitle data-my-prop="woofDialogTitle" />);
-    assert.strictEqual(wrapper.prop('data-my-prop'), 'woofDialogTitle', 'custom prop should be woofDialogTitle');
+    assert.strictEqual(
+      wrapper.prop('data-my-prop'),
+      'woofDialogTitle',
+      'custom prop should be woofDialogTitle',
+    );
   });
 
   it('should render with the user and root classes', () => {

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -88,13 +88,13 @@ describe('<Drawer />', () => {
 
   it('should set the Paper className', () => {
     const wrapper = shallow(
-      <Drawer classes={{ paper: 'woof' }}>
+      <Drawer classes={{ paper: 'woofDrawer' }}>
         <h1>Hello</h1>
       </Drawer>,
     );
     const paper = wrapper.find(Paper);
     assert.strictEqual(paper.hasClass(classes.paper), true, 'should have the paper class');
-    assert.strictEqual(paper.hasClass('woof'), true, 'should have the woof class');
+    assert.strictEqual(paper.hasClass('woofDrawer'), true, 'should have the woofDrawer class');
   });
 
   it('should be closed by default', () => {

--- a/src/Form/FormControl.spec.js
+++ b/src/Form/FormControl.spec.js
@@ -18,19 +18,19 @@ describe('<FormControl />', () => {
 
   describe('initial state', () => {
     it('should render a div with the root and user classes', () => {
-      const wrapper = shallow(<FormControl className="woof" />);
+      const wrapper = shallow(<FormControl className="woofFormControl" />);
 
       assert.strictEqual(wrapper.name(), 'div');
       assert.strictEqual(wrapper.hasClass(classes.root), true);
-      assert.strictEqual(wrapper.hasClass('woof'), true);
+      assert.strictEqual(wrapper.hasClass('woofFormControl'), true);
     });
 
     it('should have the focused class', () => {
-      const wrapper = shallow(<FormControl className="woof" />);
+      const wrapper = shallow(<FormControl className="woofFormControl" />);
 
       assert.strictEqual(wrapper.name(), 'div');
       assert.strictEqual(wrapper.hasClass(classes.root), true);
-      assert.strictEqual(wrapper.hasClass('woof'), true);
+      assert.strictEqual(wrapper.hasClass('woofFormControl'), true);
     });
 
     it('should have no margin', () => {

--- a/src/Form/FormGroup.spec.js
+++ b/src/Form/FormGroup.spec.js
@@ -15,22 +15,22 @@ describe('<FormGroup />', () => {
   });
 
   it('should render a div with the root and user classes', () => {
-    const wrapper = shallow(<FormGroup className="woof" />);
+    const wrapper = shallow(<FormGroup className="woofFormGroup" />);
 
     assert.strictEqual(wrapper.name(), 'div');
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    assert.strictEqual(wrapper.hasClass('woofFormGroup'), true);
   });
 
   it('should render a div with a div child', () => {
     const wrapper = shallow(
       <FormGroup>
-        <div className="woof" />
+        <div className="woofFormGroup" />
       </FormGroup>,
     );
 
     assert.strictEqual(wrapper.children('span').length, 0);
     assert.strictEqual(wrapper.children('div').length, 1);
-    assert.strictEqual(wrapper.children('div').first().hasClass('woof'), true);
+    assert.strictEqual(wrapper.children('div').first().hasClass('woofFormGroup'), true);
   });
 });

--- a/src/Form/FormHelperText.spec.js
+++ b/src/Form/FormHelperText.spec.js
@@ -15,10 +15,10 @@ describe('<FormHelperText />', () => {
   });
 
   it('should render a <p />', () => {
-    const wrapper = shallow(<FormHelperText className="woof" />);
+    const wrapper = shallow(<FormHelperText className="woofHelperText" />);
     assert.strictEqual(wrapper.name(), 'p');
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass('woof'), true, 'should have the user class');
+    assert.strictEqual(wrapper.hasClass('woofHelperText'), true, 'should have the user class');
   });
 
   describe('prop: error', () => {

--- a/src/Form/FormLabel.spec.js
+++ b/src/Form/FormLabel.spec.js
@@ -15,10 +15,10 @@ describe('<FormLabel />', () => {
   });
 
   it('should render a <label />', () => {
-    const wrapper = shallow(<FormLabel className="woof" />);
+    const wrapper = shallow(<FormLabel className="woofFormLabel" />);
     assert.strictEqual(wrapper.name(), 'label');
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass('woof'), true, 'should have the user class');
+    assert.strictEqual(wrapper.hasClass('woofFormLabel'), true, 'should have the user class');
   });
 
   describe('prop: required', () => {

--- a/src/Grid/Grid.spec.js
+++ b/src/Grid/Grid.spec.js
@@ -23,9 +23,9 @@ describe('<Grid />', () => {
   });
 
   it('should render', () => {
-    const wrapper = shallow(<Grid className="woof" />);
+    const wrapper = shallow(<Grid className="woofGrid" />);
     assert.strictEqual(wrapper.name(), 'div');
-    assert.strictEqual(wrapper.hasClass('woof'), true, 'should have the user class');
+    assert.strictEqual(wrapper.hasClass('woofGrid'), true, 'should have the user class');
   });
 
   describe('prop: container', () => {

--- a/src/IconButton/IconButton.spec.js
+++ b/src/IconButton/IconButton.spec.js
@@ -84,8 +84,8 @@ describe('<IconButton />', () => {
   });
 
   it('should render with the user and root classes', () => {
-    const wrapper = shallow(<IconButton className="woof">book</IconButton>);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<IconButton className="woofIconButton">book</IconButton>);
+    assert.strictEqual(wrapper.hasClass('woofIconButton'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 

--- a/src/Input/Input.spec.js
+++ b/src/Input/Input.spec.js
@@ -313,7 +313,7 @@ describe('<Input />', () => {
 
     it('should call checkDirty with input value', () => {
       instance.isControlled = () => false;
-      instance.input = 'woof';
+      instance.input = 'woofinput';
       instance.componentDidMount();
       assert.strictEqual(instance.checkDirty.calledWith(instance.input), true);
     });

--- a/src/List/List.spec.js
+++ b/src/List/List.spec.js
@@ -26,8 +26,8 @@ describe('<List />', () => {
   });
 
   it('should render with the user, root and padding classes', () => {
-    const wrapper = shallow(<List className="woof" />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<List className="woofList" />);
+    assert.strictEqual(wrapper.hasClass('woofList'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
     assert.strictEqual(wrapper.hasClass(classes.padding), true, 'should have the padding class');
   });

--- a/src/List/ListItem.spec.js
+++ b/src/List/ListItem.spec.js
@@ -28,8 +28,8 @@ describe('<ListItem />', () => {
   });
 
   it('should render with the user, root and gutters classes', () => {
-    const wrapper = shallow(<ListItem className="woof" />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<ListItem className="woofListItem" />);
+    assert.strictEqual(wrapper.hasClass('woofListItem'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
     assert.strictEqual(wrapper.hasClass(classes.gutters), true, 'should have the gutters class');
   });

--- a/src/List/ListItemSecondaryAction.spec.js
+++ b/src/List/ListItemSecondaryAction.spec.js
@@ -21,8 +21,8 @@ describe('<ListItemSecondaryAction />', () => {
   });
 
   it('should render with the user and root classes', () => {
-    const wrapper = shallow(<ListItemSecondaryAction className="woof" />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<ListItemSecondaryAction className="woofListItemSecondaryAction" />);
+    assert.strictEqual(wrapper.hasClass('woofListItemSecondaryAction'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 });

--- a/src/List/ListItemText.spec.js
+++ b/src/List/ListItemText.spec.js
@@ -21,8 +21,8 @@ describe('<ListItemText />', () => {
   });
 
   it('should render with the user and root classes', () => {
-    const wrapper = shallow(<ListItemText className="woof" />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<ListItemText className="woofListItemText" />);
+    assert.strictEqual(wrapper.hasClass('woofListItemText'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 

--- a/src/List/ListSubheader.spec.js
+++ b/src/List/ListSubheader.spec.js
@@ -20,8 +20,8 @@ describe('<ListSubheader />', () => {
   });
 
   it('should render with the user and root classes', () => {
-    const wrapper = shallow(<ListSubheader className="woof" />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<ListSubheader className="woofListSubheader" />);
+    assert.strictEqual(wrapper.hasClass('woofListSubheader'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -153,38 +153,12 @@ class Menu extends Component<DefaultProps, AllProps, void> {
   };
 
   render() {
-    const {
-      anchorEl,
-      children,
-      classes,
-      className,
-      open,
-      MenuListProps,
-      onEnter,
-      onEntering,
-      onEntered,
-      onExit,
-      onExiting,
-      onExited,
-      onRequestClose,
-      transitionDuration,
-      ...other
-    } = this.props;
-
+    const { children, classes, className, MenuListProps, onEnter, ...other } = this.props;
     return (
       <Popover
-        anchorEl={anchorEl}
         getContentAnchorEl={this.getContentAnchorEl}
         className={classNames(classes.root, className)}
-        open={open}
         onEnter={this.handleEnter}
-        onEntering={onEntering}
-        onEntered={onEntered}
-        onExiting={onExiting}
-        onExit={onExit}
-        onExited={onExited}
-        onRequestClose={onRequestClose}
-        transitionDuration={transitionDuration}
         {...other}
       >
         <MenuList

--- a/src/Menu/MenuItem.spec.js
+++ b/src/Menu/MenuItem.spec.js
@@ -23,8 +23,8 @@ describe('<MenuItem />', () => {
   });
 
   it('should render with the user and root classes', () => {
-    const wrapper = shallow(<MenuItem className="woof" />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<MenuItem className="woofMenuItem" />);
+    assert.strictEqual(wrapper.hasClass('woofMenuItem'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 

--- a/src/Progress/CircularProgress.spec.js
+++ b/src/Progress/CircularProgress.spec.js
@@ -47,8 +47,8 @@ describe('<CircularProgress />', () => {
   });
 
   it('should render with the user and root classes', () => {
-    const wrapper = shallow(<CircularProgress className="woof" />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<CircularProgress className="woofCircularProgress" />);
+    assert.strictEqual(wrapper.hasClass('woofCircularProgress'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
     assert.strictEqual(wrapper.props().role, 'progressbar');
   });

--- a/src/Progress/LinearProgress.spec.js
+++ b/src/Progress/LinearProgress.spec.js
@@ -21,8 +21,8 @@ describe('<LinearProgress />', () => {
   });
 
   it('should render with the user and root classes', () => {
-    const wrapper = shallow(<LinearProgress className="woof" />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<LinearProgress className="woofLinearProgress" />);
+    assert.strictEqual(wrapper.hasClass('woofLinearProgress'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 

--- a/src/Radio/RadioGroup.spec.js
+++ b/src/Radio/RadioGroup.spec.js
@@ -122,7 +122,7 @@ describe('<RadioGroup />', () => {
 
     it('should fire onChange', () => {
       const internalRadio = wrapper.children().first();
-      const event = { target: { value: 'woof' } };
+      const event = { target: { value: 'woofRadioGroup' } };
       const onChangeSpy = spy();
       wrapper.setProps({ onChange: onChangeSpy });
 
@@ -135,7 +135,7 @@ describe('<RadioGroup />', () => {
       const internalRadio = wrapper.children().first();
       const onChangeSpy = spy();
       wrapper.setProps({ onChange: onChangeSpy });
-      internalRadio.simulate('change', { target: { value: 'woof' } }, false);
+      internalRadio.simulate('change', { target: { value: 'woofRadioGroup' } }, false);
       assert.strictEqual(onChangeSpy.callCount, 0);
     });
   });

--- a/src/Table/Table.spec.js
+++ b/src/Table/Table.spec.js
@@ -21,7 +21,11 @@ describe('<Table />', () => {
 
   it('should spread custom props on the root node', () => {
     const wrapper = shallow(<Table data-my-prop="woofTable" />);
-    assert.strictEqual(wrapper.prop('data-my-prop'), 'woofTable', 'custom prop should be woofTable');
+    assert.strictEqual(
+      wrapper.prop('data-my-prop'),
+      'woofTable',
+      'custom prop should be woofTable',
+    );
   });
 
   it('should render with the user and root classes', () => {

--- a/src/Table/Table.spec.js
+++ b/src/Table/Table.spec.js
@@ -20,13 +20,13 @@ describe('<Table />', () => {
   });
 
   it('should spread custom props on the root node', () => {
-    const wrapper = shallow(<Table data-my-prop="woof" />);
-    assert.strictEqual(wrapper.prop('data-my-prop'), 'woof', 'custom prop should be woof');
+    const wrapper = shallow(<Table data-my-prop="woofTable" />);
+    assert.strictEqual(wrapper.prop('data-my-prop'), 'woofTable', 'custom prop should be woofTable');
   });
 
   it('should render with the user and root classes', () => {
-    const wrapper = shallow(<Table className="woof" />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<Table className="woofTable" />);
+    assert.strictEqual(wrapper.hasClass('woofTable'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 

--- a/src/Table/TableBody.spec.js
+++ b/src/Table/TableBody.spec.js
@@ -20,8 +20,8 @@ describe('<TableBody />', () => {
   });
 
   it('should render with the user and root classes', () => {
-    const wrapper = shallow(<TableBody className="woof" />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<TableBody className="woofTableBody" />);
+    assert.strictEqual(wrapper.hasClass('woofTableBody'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 

--- a/src/Table/TableCell.spec.js
+++ b/src/Table/TableCell.spec.js
@@ -20,20 +20,20 @@ describe('<TableCell />', () => {
   });
 
   it('should spread custom props on the root node', () => {
-    const wrapper = shallow(<TableCell data-my-prop="woof" />);
-    assert.strictEqual(wrapper.prop('data-my-prop'), 'woof', 'custom prop should be woof');
+    const wrapper = shallow(<TableCell data-my-prop="woofTableCell" />);
+    assert.strictEqual(wrapper.prop('data-my-prop'), 'woofTableCell', 'custom prop should be woofTableCell');
   });
 
   it('should render with the user, root and padding classes', () => {
-    const wrapper = shallow(<TableCell className="woof" />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<TableCell className="woofTableCell" />);
+    assert.strictEqual(wrapper.hasClass('woofTableCell'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
     assert.strictEqual(wrapper.hasClass(classes.padding), true, 'should have the padding class');
   });
 
   it('should render with the user, root and padding classes', () => {
-    const wrapper = shallow(<TableCell className="woof" disablePadding />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<TableCell className="woofTableCell" disablePadding />);
+    assert.strictEqual(wrapper.hasClass('woofTableCell'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
     assert.strictEqual(
       wrapper.hasClass(classes.padding),

--- a/src/Table/TableCell.spec.js
+++ b/src/Table/TableCell.spec.js
@@ -21,7 +21,11 @@ describe('<TableCell />', () => {
 
   it('should spread custom props on the root node', () => {
     const wrapper = shallow(<TableCell data-my-prop="woofTableCell" />);
-    assert.strictEqual(wrapper.prop('data-my-prop'), 'woofTableCell', 'custom prop should be woofTableCell');
+    assert.strictEqual(
+      wrapper.prop('data-my-prop'),
+      'woofTableCell',
+      'custom prop should be woofTableCell',
+    );
   });
 
   it('should render with the user, root and padding classes', () => {

--- a/src/Table/TableHead.spec.js
+++ b/src/Table/TableHead.spec.js
@@ -20,8 +20,8 @@ describe('<TableHead />', () => {
   });
 
   it('should render with the user and root classes', () => {
-    const wrapper = shallow(<TableHead className="woof" />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<TableHead className="woofTableHead" />);
+    assert.strictEqual(wrapper.hasClass('woofTableHead'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 

--- a/src/Table/TableRow.spec.js
+++ b/src/Table/TableRow.spec.js
@@ -21,7 +21,11 @@ describe('<TableRow />', () => {
 
   it('should spread custom props on the root node', () => {
     const wrapper = shallow(<TableRow data-my-prop="woofTableRow" />);
-    assert.strictEqual(wrapper.prop('data-my-prop'), 'woofTableRow', 'custom prop should be woofTableRow');
+    assert.strictEqual(
+      wrapper.prop('data-my-prop'),
+      'woofTableRow',
+      'custom prop should be woofTableRow',
+    );
   });
 
   it('should render with the user and root classes', () => {

--- a/src/Table/TableRow.spec.js
+++ b/src/Table/TableRow.spec.js
@@ -20,13 +20,13 @@ describe('<TableRow />', () => {
   });
 
   it('should spread custom props on the root node', () => {
-    const wrapper = shallow(<TableRow data-my-prop="woof" />);
-    assert.strictEqual(wrapper.prop('data-my-prop'), 'woof', 'custom prop should be woof');
+    const wrapper = shallow(<TableRow data-my-prop="woofTableRow" />);
+    assert.strictEqual(wrapper.prop('data-my-prop'), 'woofTableRow', 'custom prop should be woofTableRow');
   });
 
   it('should render with the user and root classes', () => {
-    const wrapper = shallow(<TableRow className="woof" />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<TableRow className="woofTableRow" />);
+    assert.strictEqual(wrapper.hasClass('woofTableRow'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 

--- a/src/Tabs/Tab.spec.js
+++ b/src/Tabs/Tab.spec.js
@@ -31,8 +31,8 @@ describe('<Tab />', () => {
 
   describe('prop: className', () => {
     it('should render with the user and root classes', () => {
-      const wrapper = shallow(<Tab textColor="inherit" className="woof" />);
-      assert.strictEqual(wrapper.hasClass('woof'), true);
+      const wrapper = shallow(<Tab textColor="inherit" className="woofTab" />);
+      assert.strictEqual(wrapper.hasClass('woofTab'), true);
       assert.strictEqual(wrapper.hasClass(classes.root), true);
     });
   });

--- a/src/Tabs/TabScrollButton.spec.js
+++ b/src/Tabs/TabScrollButton.spec.js
@@ -43,9 +43,9 @@ describe('<TabScrollButton />', () => {
 
   describe('prop: className', () => {
     it('should render with the user and root classes', () => {
-      const wrapper = shallow(<TabScrollButton className="woof" />);
+      const wrapper = shallow(<TabScrollButton className="woofTabScrollButton" />);
       assert.strictEqual(wrapper.hasClass(classes.root), true);
-      assert.strictEqual(wrapper.hasClass('woof'), true);
+      assert.strictEqual(wrapper.hasClass('woofTabScrollButton'), true);
     });
   });
 

--- a/src/Tabs/Tabs.spec.js
+++ b/src/Tabs/Tabs.spec.js
@@ -41,11 +41,11 @@ describe('<Tabs />', () => {
   describe('prop: className', () => {
     it('should render with the user and root classes', () => {
       const wrapper = shallow(
-        <Tabs width="md" onChange={noop} index={0} className="woof">
+        <Tabs width="md" onChange={noop} index={0} className="woofTabs">
           <Tab />
         </Tabs>,
       );
-      assert.strictEqual(wrapper.hasClass('woof'), true);
+      assert.strictEqual(wrapper.hasClass('woofTabs'), true);
       assert.strictEqual(wrapper.hasClass(classes.root), true);
     });
   });

--- a/src/Toolbar/Toolbar.spec.js
+++ b/src/Toolbar/Toolbar.spec.js
@@ -20,8 +20,8 @@ describe('<Toolbar />', () => {
   });
 
   it('should render with the user, root and gutters classes', () => {
-    const wrapper = shallow(<Toolbar className="woof" />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<Toolbar className="woofToolbar" />);
+    assert.strictEqual(wrapper.hasClass('woofToolbar'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
     assert.strictEqual(wrapper.hasClass(classes.gutters), true);
   });

--- a/src/Typography/Typography.spec.js
+++ b/src/Typography/Typography.spec.js
@@ -31,14 +31,14 @@ describe('<Typography />', () => {
   });
 
   it('should merge user classes', () => {
-    const wrapper = shallow(<Typography className="woof">Hello</Typography>);
+    const wrapper = shallow(<Typography className="woofTypography">Hello</Typography>);
     assert.strictEqual(wrapper.hasClass(classes.body1), true);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    assert.strictEqual(wrapper.hasClass('woofTypography'), true);
   });
 
   it('should center text', () => {
     const wrapper = shallow(
-      <Typography align="center" className="woof">
+      <Typography align="center" className="woofTypography">
         Hello
       </Typography>,
     );

--- a/src/internal/Backdrop.spec.js
+++ b/src/internal/Backdrop.spec.js
@@ -15,8 +15,8 @@ describe('<Backdrop />', () => {
   });
 
   it('should render a backdrop div', () => {
-    const wrapper = shallow(<Backdrop className="woof" />);
+    const wrapper = shallow(<Backdrop className="woofBackdrop" />);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    assert.strictEqual(wrapper.hasClass('woofBackdrop'), true);
   });
 });

--- a/src/internal/ButtonBase.spec.js
+++ b/src/internal/ButtonBase.spec.js
@@ -399,7 +399,7 @@ describe('<ButtonBase />', () => {
     });
 
     it('onKeyboardFocusHandler() should propogate call to onKeyboardFocus prop', () => {
-      const eventMock = 'woof';
+      const eventMock = 'woofButtonBase';
       const onKeyboardFocusSpy = spy();
       const wrapper = mount(
         <ButtonBase.Naked classes={{}} component="span" onKeyboardFocus={onKeyboardFocusSpy}>
@@ -498,10 +498,10 @@ describe('<ButtonBase />', () => {
         const onClickSpy = spy();
         wrapper.setProps({
           onClick: onClickSpy,
-          component: 'woof',
+          component: 'woofButtonBase',
         });
 
-        const eventTargetMock = 'woof';
+        const eventTargetMock = 'woofButtonBase';
         event = {
           persist: spy(),
           preventDefault: spy(),

--- a/src/internal/Modal.spec.js
+++ b/src/internal/Modal.spec.js
@@ -40,7 +40,7 @@ describe('<Modal />', () => {
 
     before(() => {
       wrapper = shallow(
-        <Modal show data-my-prop="woof">
+        <Modal show data-my-prop="woofModal">
           <p>Hello World</p>
         </Modal>,
       );

--- a/src/internal/Popover.js
+++ b/src/internal/Popover.js
@@ -189,10 +189,6 @@ export type Props = {
    * Set to 'auto' to automatically calculate transition time based on height
    */
   transitionDuration?: number | 'auto',
-  /**
-   * @ignore
-   */
-  theme: Object,
 };
 
 type AllProps = DefaultProps & Props;
@@ -377,7 +373,6 @@ class Popover extends Component<DefaultProps, AllProps, void> {
       onExiting,
       onExited,
       elevation,
-      theme,
       ...other
     } = this.props;
 
@@ -417,4 +412,4 @@ class Popover extends Component<DefaultProps, AllProps, void> {
   }
 }
 
-export default withStyles(styleSheet, { withTheme: true })(Popover);
+export default withStyles(styleSheet)(Popover);

--- a/src/internal/Popover.js
+++ b/src/internal/Popover.js
@@ -10,7 +10,7 @@ import EventListener from 'react-event-listener';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 import Modal from './Modal';
-import Transition from './Transition';
+import PopoverTransition from '../transitions/Popover';
 import Paper from '../Paper';
 import type { TransitionCallback } from './Transition';
 
@@ -218,15 +218,10 @@ class Popover extends Component<DefaultProps, AllProps, void> {
     elevation: 8,
   };
 
-  static getScale(value) {
-    return `scale(${value}, ${value ** 2})`;
-  }
-
   componentWillUnmount = () => {
     this.handleResize.cancel();
   };
 
-  autoTransitionDuration = undefined;
   transitionEl = undefined;
 
   setPositioningStyles = (element: HTMLElement) => {
@@ -240,80 +235,17 @@ class Popover extends Component<DefaultProps, AllProps, void> {
   };
 
   handleEnter = (element: HTMLElement) => {
-    element.style.opacity = '0';
-    element.style.transform = Popover.getScale(0.75);
-
     if (this.props.onEnter) {
       this.props.onEnter(element);
     }
 
     this.setPositioningStyles(element);
-
-    let { transitionDuration } = this.props;
-    const { transitions } = this.props.theme;
-
-    if (transitionDuration === 'auto') {
-      transitionDuration = transitions.getAutoHeightDuration(element.clientHeight);
-      this.autoTransitionDuration = transitionDuration;
-    }
-
-    element.style.transition = [
-      transitions.create('opacity', {
-        duration: transitionDuration,
-      }),
-      transitions.create('transform', {
-        duration: transitionDuration * 0.666,
-      }),
-    ].join(',');
-  };
-
-  handleEntering = (element: HTMLElement) => {
-    element.style.opacity = '1';
-    element.style.transform = Popover.getScale(1);
-
-    if (this.props.onEntering) {
-      this.props.onEntering(element);
-    }
-  };
-
-  handleExit = (element: HTMLElement) => {
-    let { transitionDuration } = this.props;
-    const { transitions } = this.props.theme;
-
-    if (transitionDuration === 'auto') {
-      transitionDuration = transitions.getAutoHeightDuration(element.clientHeight);
-      this.autoTransitionDuration = transitionDuration;
-    }
-
-    element.style.transition = [
-      transitions.create('opacity', {
-        duration: transitionDuration,
-      }),
-      transitions.create('transform', {
-        duration: transitionDuration * 0.666,
-        delay: transitionDuration * 0.333,
-      }),
-    ].join(',');
-
-    element.style.opacity = '0';
-    element.style.transform = Popover.getScale(0.75);
-
-    if (this.props.onExit) {
-      this.props.onExit(element);
-    }
   };
 
   handleResize = debounce(() => {
     const element: any = ReactDOM.findDOMNode(this.transitionEl);
     this.setPositioningStyles(element);
   }, 166);
-
-  handleRequestTimeout = () => {
-    if (this.props.transitionDuration === 'auto') {
-      return (this.autoTransitionDuration || 0) + 20;
-    }
-    return this.props.transitionDuration + 20;
-  };
 
   marginThreshold = 16;
 
@@ -449,24 +381,24 @@ class Popover extends Component<DefaultProps, AllProps, void> {
       ...other
     } = this.props;
 
+    // FIXME: props API consistency problem? - `...other` not spread over the root
     return (
       <Modal show={open} backdropInvisible onRequestClose={onRequestClose}>
-        <Transition
+        <PopoverTransition
           in={open}
           enteredClassName={enteredClassName}
           enteringClassName={enteringClassName}
           exitedClassName={exitedClassName}
           exitingClassName={exitingClassName}
           onEnter={this.handleEnter}
-          onEntering={this.handleEntering}
+          onEntering={onEntering}
           onEntered={onEntered}
-          onExit={this.handleExit}
+          onExit={onExit}
           onExiting={onExiting}
           onExited={onExited}
           role={role}
-          onRequestTimeout={this.handleRequestTimeout}
           transitionAppear
-          ref={node => {
+          rootRef={node => {
             this.transitionEl = node;
           }}
         >
@@ -479,7 +411,7 @@ class Popover extends Component<DefaultProps, AllProps, void> {
             <EventListener target="window" onResize={this.handleResize} />
             {children}
           </Paper>
-        </Transition>
+        </PopoverTransition>
       </Modal>
     );
   }

--- a/src/internal/Popover.js
+++ b/src/internal/Popover.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import type { Element } from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
@@ -200,7 +200,7 @@ type AllProps = DefaultProps & Props;
 /**
  * @ignore - internal component.
  */
-class Popover extends PureComponent<DefaultProps, AllProps, void> {
+class Popover extends Component<DefaultProps, AllProps, void> {
   props: AllProps;
   static defaultProps: DefaultProps = {
     anchorOrigin: {

--- a/src/internal/Popover.js
+++ b/src/internal/Popover.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import type { Element } from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
@@ -200,7 +200,7 @@ type AllProps = DefaultProps & Props;
 /**
  * @ignore - internal component.
  */
-class Popover extends Component<DefaultProps, AllProps, void> {
+class Popover extends PureComponent<DefaultProps, AllProps, void> {
   props: AllProps;
   static defaultProps: DefaultProps = {
     anchorOrigin: {

--- a/src/internal/Popover.js
+++ b/src/internal/Popover.js
@@ -10,7 +10,7 @@ import EventListener from 'react-event-listener';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 import Modal from './Modal';
-import PopoverTransition from '../transitions/Popover';
+import Grow from '../transitions/Grow';
 import Paper from '../Paper';
 import type { TransitionCallback } from './Transition';
 
@@ -384,7 +384,7 @@ class Popover extends PureComponent<DefaultProps, AllProps, void> {
     // FIXME: props API consistency problem? - `...other` not spread over the root
     return (
       <Modal show={open} backdropInvisible onRequestClose={onRequestClose}>
-        <PopoverTransition
+        <Grow
           in={open}
           enteredClassName={enteredClassName}
           enteringClassName={enteringClassName}
@@ -411,7 +411,7 @@ class Popover extends PureComponent<DefaultProps, AllProps, void> {
             <EventListener target="window" onResize={this.handleResize} />
             {children}
           </Paper>
-        </PopoverTransition>
+        </Grow>
       </Modal>
     );
   }

--- a/src/internal/Popover.js
+++ b/src/internal/Popover.js
@@ -188,7 +188,7 @@ export type Props = {
   /**
    * Set to 'auto' to automatically calculate transition time based on height
    */
-  transitionDuration: number | 'auto',
+  transitionDuration?: number | 'auto',
   /**
    * @ignore
    */

--- a/src/internal/Popover.spec.js
+++ b/src/internal/Popover.spec.js
@@ -127,7 +127,11 @@ describe('<Popover />', () => {
     it('should have Transition as the only child of Modal', () => {
       const wrapper = shallow(<Popover />);
       assert.strictEqual(wrapper.children().length, 1, 'should have one child');
-      assert.strictEqual(wrapper.childAt(0).is('Transition'), true, 'should be Transition');
+      assert.strictEqual(
+        wrapper.childAt(0).is('withTheme(Popover)'),
+        true,
+        'should be withTheme(Popover) Transition',
+      );
       assert.strictEqual(
         wrapper.childAt(0).prop('transitionAppear'),
         true,
@@ -144,15 +148,8 @@ describe('<Popover />', () => {
       assert.strictEqual(wrapper.childAt(0).props().in, false, 'should not be in');
     });
 
-    it('should fire transition event callbacks', () => {
-      const events = [
-        // 'onEnter', this is currently async in Popover, test separately
-        'onEntering',
-        'onEntered',
-        'onExit',
-        'onExiting',
-        'onExited',
-      ];
+    it('should fire Popover transition event callbacks', () => {
+      const events = ['onEntering', 'onEnter', 'onEntered', 'onExit', 'onExiting', 'onExited'];
 
       const handlers = events.reduce((result, n) => {
         result[n] = spy();
@@ -163,7 +160,7 @@ describe('<Popover />', () => {
 
       events.forEach(n => {
         const event = n.charAt(2).toLowerCase() + n.slice(3);
-        wrapper.childAt(0).simulate(event, { style: {} });
+        wrapper.find('withTheme(Popover)').simulate(event, { style: {} });
         assert.strictEqual(handlers[n].callCount, 1, `should have called the ${n} handler`);
       });
     });
@@ -222,79 +219,16 @@ describe('<Popover />', () => {
       });
 
       it('should set the inline styles for the enter phase', () => {
-        assert.strictEqual(element.style.opacity, '0', 'should be transparent');
-        assert.strictEqual(
-          element.style.transform,
-          Popover.getScale(0.75),
-          'should have the starting scale',
-        );
         assert.strictEqual(
           element.style.top === '16px' && element.style.left === '16px',
           true,
           'should offset the element from the top left of the screen by 16px',
         );
         assert.strictEqual(
-          element.style.transition,
-          'opacity 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms', // eslint-disable-line max-len
-          'should apply a transition for transform and opacity',
-        );
-        assert.strictEqual(
           element.style.transformOrigin,
           wrapper.instance().getPositioningStyle(element).transformOrigin,
           'should have a transformOrigin',
         );
-      });
-
-      it('should invoke the callback', () => {
-        assert.strictEqual(handleEnter.callCount, 1, 'should have been called once');
-      });
-    });
-
-    describe('handleEntering(element)', () => {
-      let wrapper;
-      let handleEntering;
-
-      before(() => {
-        handleEntering = spy();
-        wrapper = shallow(<Popover onEntering={handleEntering} />);
-        wrapper.instance().handleEntering(element);
-      });
-
-      it('should set the inline styles for the entering phase', () => {
-        assert.strictEqual(element.style.opacity, '1', 'should be visible');
-        assert.strictEqual(
-          element.style.transform,
-          Popover.getScale(1),
-          'should have the full scale',
-        );
-      });
-
-      it('should invoke the callback', () => {
-        assert.strictEqual(handleEntering.callCount, 1, 'should have been called once');
-      });
-    });
-
-    describe('handleExit(element)', () => {
-      let wrapper;
-      let handleExit;
-
-      before(() => {
-        handleExit = spy();
-        wrapper = shallow(<Popover onExit={handleExit} />);
-        wrapper.instance().handleExit(element);
-      });
-
-      it('should set the inline styles for the exit phase', () => {
-        assert.strictEqual(element.style.opacity, '0', 'should be transparent');
-        assert.strictEqual(
-          element.style.transform,
-          Popover.getScale(0.75),
-          'should have the exit scale',
-        );
-      });
-
-      it('should invoke the callback', () => {
-        assert.strictEqual(handleExit.callCount, 1, 'should have been called once');
       });
     });
   });
@@ -597,47 +531,6 @@ describe('<Popover />', () => {
 
       it('should transformOrigin according to marginThreshold', () => {
         assert.strictEqual(positioningStyle.transformOrigin, '1px 0px');
-      });
-    });
-  });
-
-  describe('handleRequestTimeout()', () => {
-    let wrapper;
-    let instance;
-
-    before(() => {
-      wrapper = shallow(<Popover />);
-    });
-
-    describe('transitionDuration is auto', () => {
-      before(() => {
-        wrapper.setProps({ transitionDuration: 'auto' });
-        instance = wrapper.instance();
-      });
-
-      it('should return autoTransitionDuration + 20', () => {
-        const autoTransitionDuration = 10;
-        instance.autoTransitionDuration = autoTransitionDuration;
-        assert.strictEqual(instance.handleRequestTimeout(), autoTransitionDuration + 20);
-      });
-
-      it('should return 20', () => {
-        instance.autoTransitionDuration = undefined;
-        assert.strictEqual(instance.handleRequestTimeout(), 20);
-      });
-    });
-
-    describe('transitionDuration is number', () => {
-      let transitionDuration;
-
-      before(() => {
-        transitionDuration = 10;
-        wrapper.setProps({ transitionDuration });
-        instance = wrapper.instance();
-      });
-
-      it('should return props.transitionDuration + 20', () => {
-        assert.strictEqual(instance.handleRequestTimeout(), transitionDuration + 20);
       });
     });
   });

--- a/src/internal/Popover.spec.js
+++ b/src/internal/Popover.spec.js
@@ -128,7 +128,7 @@ describe('<Popover />', () => {
       const wrapper = shallow(<Popover />);
       assert.strictEqual(wrapper.children().length, 1, 'should have one child');
       assert.strictEqual(
-        wrapper.childAt(0).is('withTheme(Popover)'),
+        wrapper.childAt(0).is('withTheme(Grow)'),
         true,
         'should be withTheme(Popover) Transition',
       );
@@ -160,7 +160,7 @@ describe('<Popover />', () => {
 
       events.forEach(n => {
         const event = n.charAt(2).toLowerCase() + n.slice(3);
-        wrapper.find('withTheme(Popover)').simulate(event, { style: {} });
+        wrapper.find('withTheme(Grow)').simulate(event, { style: {} });
         assert.strictEqual(handlers[n].callCount, 1, `should have called the ${n} handler`);
       });
     });

--- a/src/internal/Portal.spec.js
+++ b/src/internal/Portal.spec.js
@@ -61,7 +61,7 @@ describe('<Portal />', () => {
       it('should render nothing directly', () => {
         const wrapper = mount(
           <Portal>
-            <h1 className="woof">Hello</h1>
+            <h1 className="woofPortal">Hello</h1>
           </Portal>,
         );
         assert.strictEqual(wrapper.children().length, 0, 'should have no children');
@@ -70,7 +70,7 @@ describe('<Portal />', () => {
       it('should not open by default', () => {
         const wrapper = mount(
           <Portal>
-            <h1 className="woof">Hello</h1>
+            <h1 className="woofPortal">Hello</h1>
           </Portal>,
         );
         const instance = wrapper.instance();
@@ -86,7 +86,7 @@ describe('<Portal />', () => {
         before(() => {
           wrapper = mount(
             <Portal open>
-              <h1 id="woof">Hello</h1>
+              <h1 id="woofPortal">Hello</h1>
             </Portal>,
           );
           instance = wrapper.instance();
@@ -106,8 +106,8 @@ describe('<Portal />', () => {
           );
           assert.strictEqual(
             portal.firstChild.getAttribute('id'),
-            'woof',
-            'should have the woof id',
+            'woofPortal',
+            'should have the woofPortal id',
           );
           assert.strictEqual(portal.firstChild.innerHTML, 'Hello', 'have the contents');
           portal.setAttribute('id', 'meow');
@@ -117,7 +117,7 @@ describe('<Portal />', () => {
             'should have the portal in the DOM',
           );
           assert.strictEqual(
-            document.getElementById('woof'),
+            document.getElementById('woofPortal'),
             portal.firstChild,
             'should have the heading in the DOM',
           );
@@ -131,7 +131,7 @@ describe('<Portal />', () => {
             'should not have the portal in the DOM',
           );
           assert.strictEqual(
-            document.getElementById('woof'),
+            document.getElementById('woofPortal'),
             null,
             'should not have the heading in the DOM',
           );

--- a/src/internal/SwitchBase.spec.js
+++ b/src/internal/SwitchBase.spec.js
@@ -95,14 +95,14 @@ describe('<SwitchBase />', () => {
 
   // className is put on the root node, this is a special case!
   it('should render with the user and root classes', () => {
-    const wrapper = shallow(<SwitchBase className="woof" />);
-    assert.strictEqual(wrapper.hasClass('woof'), true);
+    const wrapper = shallow(<SwitchBase className="woofSwitchBase" />);
+    assert.strictEqual(wrapper.hasClass('woofSwitchBase'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
   it('should spread custom props on the root node', () => {
-    const wrapper = shallow(<SwitchBase data-my-prop="woof" />);
-    assert.strictEqual(wrapper.props()['data-my-prop'], 'woof', 'custom prop should be woof');
+    const wrapper = shallow(<SwitchBase data-my-prop="woofSwitchBase" />);
+    assert.strictEqual(wrapper.props()['data-my-prop'], 'woofSwitchBase', 'custom prop should be woofSwitchBase');
   });
 
   it('should pass tabIndex to the input so it can be taken out of focus rotation', () => {
@@ -237,7 +237,7 @@ describe('<SwitchBase />', () => {
     let onChangeSpy;
 
     before(() => {
-      event = 'woof';
+      event = 'woofSwitchBase';
       onChangeSpy = spy();
       wrapper = mount(<SwitchBase.Naked classes={{}} />);
       wrapper.setProps({ onChange: onChangeSpy });

--- a/src/internal/SwitchBase.spec.js
+++ b/src/internal/SwitchBase.spec.js
@@ -102,7 +102,11 @@ describe('<SwitchBase />', () => {
 
   it('should spread custom props on the root node', () => {
     const wrapper = shallow(<SwitchBase data-my-prop="woofSwitchBase" />);
-    assert.strictEqual(wrapper.props()['data-my-prop'], 'woofSwitchBase', 'custom prop should be woofSwitchBase');
+    assert.strictEqual(
+      wrapper.props()['data-my-prop'],
+      'woofSwitchBase',
+      'custom prop should be woofSwitchBase',
+    );
   });
 
   it('should pass tabIndex to the input so it can be taken out of focus rotation', () => {

--- a/src/styles/transitions.js
+++ b/src/styles/transitions.js
@@ -1,4 +1,4 @@
-// @flow weak
+// @flow
 /* eslint-disable no-param-reassign */
 
 import warning from 'warning';
@@ -44,11 +44,14 @@ export const isNumber = (value: any) => !isNaN(parseFloat(value));
  * @param {number} param.duration
  * @param {string} param.easing
  * @param {number} param.delay
-*/
+ */
 export default {
   easing,
   duration,
-  create(props = ['all'], options: Object = {}) {
+  create(
+    props: string | Array<string> = ['all'],
+    options: { prop?: string, duration?: number, easing?: string, delay?: number } = {},
+  ) {
     const {
       duration: durationOption = duration.standard,
       easing: easingOption = easing.easeInOut,

--- a/src/styles/transitions.js
+++ b/src/styles/transitions.js
@@ -63,7 +63,10 @@ export default {
       isString(props) || Array.isArray(props),
       'Material-UI: argument "props" must be a string or Array',
     );
-    warning(isNumber(durationOption), 'Material-UI: argument "duration" must be a number');
+    warning(
+      isNumber(durationOption),
+      `Material-UI: argument "duration" must be a number but found ${durationOption}`,
+    );
     warning(isString(easingOption), 'Material-UI: argument "easing" must be a string');
     warning(isNumber(delay), 'Material-UI: argument "delay" must be a string');
     warning(

--- a/src/styles/transitions.spec.js
+++ b/src/styles/transitions.spec.js
@@ -94,7 +94,9 @@ describe('transitions', () => {
     });
 
     it('should warn when first argument is of bad type', () => {
+      // $FlowExpectedError
       transitions.create(5554);
+      // $FlowExpectedError
       transitions.create({});
       assert.strictEqual(consoleErrorStub.callCount, 2, 'Wrong number of calls of warning()');
     });
@@ -112,7 +114,9 @@ describe('transitions', () => {
     });
 
     it('should warn when bad "duration" option type', () => {
+      // $FlowExpectedError
       transitions.create('font', { duration: '' });
+      // $FlowExpectedError
       transitions.create('font', { duration: {} });
       assert.strictEqual(consoleErrorStub.callCount, 2, 'Wrong number of calls of warning()');
     });
@@ -124,7 +128,9 @@ describe('transitions', () => {
     });
 
     it('should warn when bad "easing" option type', () => {
+      // $FlowExpectedError
       transitions.create('transform', { easing: 123 });
+      // $FlowExpectedError
       transitions.create('transform', { easing: {} });
       assert.strictEqual(consoleErrorStub.callCount, 2, 'Wrong number of calls of warning()');
     });
@@ -142,7 +148,9 @@ describe('transitions', () => {
     });
 
     it('should warn when bad "delay" option type', () => {
+      // $FlowExpectedError
       transitions.create('size', { delay: '' });
+      // $FlowExpectedError
       transitions.create('size', { delay: {} });
       assert.strictEqual(consoleErrorStub.callCount, 2, 'Wrong number of calls of warning()');
     });

--- a/src/transitions/Collapse.spec.js
+++ b/src/transitions/Collapse.spec.js
@@ -21,10 +21,10 @@ describe('<Collapse />', () => {
   });
 
   it('should render a container around the wrapper', () => {
-    const wrapper = shallow(<Collapse classes={{ container: 'woof' }} />);
+    const wrapper = shallow(<Collapse classes={{ container: 'woofCollapse' }} />);
     assert.strictEqual(wrapper.childAt(0).is('div'), true, 'should be a div');
     assert.strictEqual(wrapper.childAt(0).hasClass(classes.container), true);
-    assert.strictEqual(wrapper.childAt(0).hasClass('woof'), true);
+    assert.strictEqual(wrapper.childAt(0).hasClass('woofCollapse'), true);
   });
 
   it('should render a wrapper around the children', () => {
@@ -113,7 +113,7 @@ describe('<Collapse />', () => {
 
         before(() => {
           theme = instance.props.theme;
-          theme.transitions.getAutoHeightDuration = stub().returns('woof');
+          theme.transitions.getAutoHeightDuration = stub().returns('woofCollapse');
           wrapper.setProps({ transitionDuration: 'auto' });
           instance = wrapper.instance();
         });
@@ -147,7 +147,7 @@ describe('<Collapse />', () => {
         });
 
         it('string should set transitionDuration to string', () => {
-          transitionDurationMock = 'woof';
+          transitionDurationMock = 'woofCollapse';
           wrapper.setProps({ transitionDuration: transitionDurationMock });
           instance = wrapper.instance();
           instance.handleEntering(element);
@@ -239,7 +239,7 @@ describe('<Collapse />', () => {
 
         before(() => {
           theme = instance.props.theme;
-          theme.transitions.getAutoHeightDuration = stub().returns('woof');
+          theme.transitions.getAutoHeightDuration = stub().returns('woofCollapse');
           wrapper.setProps({ transitionDuration: 'auto' });
           instance = wrapper.instance();
         });
@@ -273,7 +273,7 @@ describe('<Collapse />', () => {
         });
 
         it('string should set transitionDuration to string', () => {
-          transitionDurationMock = 'woof';
+          transitionDurationMock = 'woofCollapse';
           wrapper.setProps({ transitionDuration: transitionDurationMock });
           instance = wrapper.instance();
           instance.handleExiting(element);

--- a/src/transitions/Collapse.spec.js
+++ b/src/transitions/Collapse.spec.js
@@ -110,12 +110,17 @@ describe('<Collapse />', () => {
       describe('transitionDuration', () => {
         let theme;
         let transitionDurationMock;
+        let restore;
 
         before(() => {
           theme = instance.props.theme;
+          restore = theme.transitions.getAutoHeightDuration;
           theme.transitions.getAutoHeightDuration = stub().returns('woofCollapseStub');
           wrapper.setProps({ transitionDuration: 'auto' });
           instance = wrapper.instance();
+        });
+        after(() => {
+          theme.transitions.getAutoHeightDuration = restore;
         });
 
         it('no wrapper', () => {
@@ -236,12 +241,17 @@ describe('<Collapse />', () => {
       describe('transitionDuration', () => {
         let theme;
         let transitionDurationMock;
+        let restore;
 
         before(() => {
           theme = instance.props.theme;
+          restore = theme.transitions.getAutoHeightDuration;
           theme.transitions.getAutoHeightDuration = stub().returns('woofCollapseStub2');
           wrapper.setProps({ transitionDuration: 'auto' });
           instance = wrapper.instance();
+        });
+        after(() => {
+          theme.transitions.getAutoHeightDuration = restore;
         });
 
         it('no wrapper', () => {

--- a/src/transitions/Collapse.spec.js
+++ b/src/transitions/Collapse.spec.js
@@ -119,6 +119,7 @@ describe('<Collapse />', () => {
           wrapper.setProps({ transitionDuration: 'auto' });
           instance = wrapper.instance();
         });
+
         after(() => {
           theme.transitions.getAutoHeightDuration = restore;
         });
@@ -250,6 +251,7 @@ describe('<Collapse />', () => {
           wrapper.setProps({ transitionDuration: 'auto' });
           instance = wrapper.instance();
         });
+
         after(() => {
           theme.transitions.getAutoHeightDuration = restore;
         });

--- a/src/transitions/Collapse.spec.js
+++ b/src/transitions/Collapse.spec.js
@@ -21,10 +21,10 @@ describe('<Collapse />', () => {
   });
 
   it('should render a container around the wrapper', () => {
-    const wrapper = shallow(<Collapse classes={{ container: 'woofCollapse' }} />);
+    const wrapper = shallow(<Collapse classes={{ container: 'woofCollapse1' }} />);
     assert.strictEqual(wrapper.childAt(0).is('div'), true, 'should be a div');
     assert.strictEqual(wrapper.childAt(0).hasClass(classes.container), true);
-    assert.strictEqual(wrapper.childAt(0).hasClass('woofCollapse'), true);
+    assert.strictEqual(wrapper.childAt(0).hasClass('woofCollapse1'), true);
   });
 
   it('should render a wrapper around the children', () => {
@@ -113,7 +113,7 @@ describe('<Collapse />', () => {
 
         before(() => {
           theme = instance.props.theme;
-          theme.transitions.getAutoHeightDuration = stub().returns('woofCollapse');
+          theme.transitions.getAutoHeightDuration = stub().returns('woofCollapseStub');
           wrapper.setProps({ transitionDuration: 'auto' });
           instance = wrapper.instance();
         });
@@ -147,7 +147,7 @@ describe('<Collapse />', () => {
         });
 
         it('string should set transitionDuration to string', () => {
-          transitionDurationMock = 'woofCollapse';
+          transitionDurationMock = 'woofCollapseStub';
           wrapper.setProps({ transitionDuration: transitionDurationMock });
           instance = wrapper.instance();
           instance.handleEntering(element);
@@ -239,7 +239,7 @@ describe('<Collapse />', () => {
 
         before(() => {
           theme = instance.props.theme;
-          theme.transitions.getAutoHeightDuration = stub().returns('woofCollapse');
+          theme.transitions.getAutoHeightDuration = stub().returns('woofCollapseStub2');
           wrapper.setProps({ transitionDuration: 'auto' });
           instance = wrapper.instance();
         });
@@ -273,7 +273,7 @@ describe('<Collapse />', () => {
         });
 
         it('string should set transitionDuration to string', () => {
-          transitionDurationMock = 'woofCollapse';
+          transitionDurationMock = 'woofCollapseStub2';
           wrapper.setProps({ transitionDuration: transitionDurationMock });
           instance = wrapper.instance();
           instance.handleExiting(element);

--- a/src/transitions/Grow.js
+++ b/src/transitions/Grow.js
@@ -6,6 +6,7 @@ import withTheme from '../styles/withTheme';
 import Transition from '../internal/Transition';
 import type { TransitionCallback } from '../internal/Transition';
 
+// only exported for tests
 export function getScale(value: number) {
   return `scale(${value}, ${value ** 2})`;
 }

--- a/src/transitions/Grow.js
+++ b/src/transitions/Grow.js
@@ -63,7 +63,7 @@ type AllProps = DefaultProps & Props;
 /**
  * @ignore - internal component.
  */
-class Popover extends PureComponent<DefaultProps, AllProps, void> {
+class Grow extends PureComponent<DefaultProps, AllProps, void> {
   props: AllProps;
   static defaultProps: DefaultProps = {
     theme: {},
@@ -169,4 +169,4 @@ class Popover extends PureComponent<DefaultProps, AllProps, void> {
   }
 }
 
-export default withTheme(Popover);
+export default withTheme(Grow);

--- a/src/transitions/Grow.js
+++ b/src/transitions/Grow.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import type { Element } from 'react';
 import withTheme from '../styles/withTheme';
 import Transition from '../internal/Transition';
@@ -61,9 +61,9 @@ export type Props = {
 type AllProps = DefaultProps & Props;
 
 /**
- * @ignore - internal component.
+ * Grow transition used by popovers such as Menu.
  */
-class Grow extends PureComponent<DefaultProps, AllProps, void> {
+class Grow extends Component<DefaultProps, AllProps, void> {
   props: AllProps;
   static defaultProps: DefaultProps = {
     theme: {},

--- a/src/transitions/Grow.spec.js
+++ b/src/transitions/Grow.spec.js
@@ -4,9 +4,9 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
 import { createShallow } from '../test-utils';
-import Popover, { getScale } from './Popover';
+import Grow, { getScale } from './Grow';
 
-describe('<Popover />', () => {
+describe('<Grow />', () => {
   let shallow;
 
   before(() => {
@@ -22,7 +22,7 @@ describe('<Popover />', () => {
         return result;
       }, {});
 
-      const wrapper = shallow(<Popover {...handlers} />);
+      const wrapper = shallow(<Grow {...handlers} />);
 
       events.forEach(n => {
         const event = n.charAt(2).toLowerCase() + n.slice(3);
@@ -51,7 +51,7 @@ describe('<Popover />', () => {
 
       before(() => {
         handleEnter = spy();
-        wrapper = shallow(<Popover onEnter={handleEnter} />);
+        wrapper = shallow(<Grow onEnter={handleEnter} />);
         wrapper.instance().handleEnter(element);
       });
 
@@ -80,7 +80,7 @@ describe('<Popover />', () => {
 
       before(() => {
         handleEntering = spy();
-        wrapper = shallow(<Popover onEntering={handleEntering} />);
+        wrapper = shallow(<Grow onEntering={handleEntering} />);
         wrapper.instance().handleEntering(element);
       });
 
@@ -100,7 +100,7 @@ describe('<Popover />', () => {
 
       before(() => {
         handleExit = spy();
-        wrapper = shallow(<Popover onExit={handleExit} />);
+        wrapper = shallow(<Grow onExit={handleExit} />);
         wrapper.instance().handleExit(element);
       });
 
@@ -120,7 +120,7 @@ describe('<Popover />', () => {
     let instance;
 
     before(() => {
-      wrapper = shallow(<Popover />);
+      wrapper = shallow(<Grow />);
     });
 
     describe('transitionDuration is auto', () => {

--- a/src/transitions/Popover.js
+++ b/src/transitions/Popover.js
@@ -1,10 +1,14 @@
 // @flow
 
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import type { Element } from 'react';
 import withTheme from '../styles/withTheme';
 import Transition from '../internal/Transition';
 import type { TransitionCallback } from '../internal/Transition';
+
+export function getScale(value: number) {
+  return `scale(${value}, ${value ** 2})`;
+}
 
 type DefaultProps = {
   theme: Object,
@@ -43,7 +47,7 @@ export type Props = {
   /**
    * Use that property to pass a ref callback to the root component.
    */
-  rootRef: Function,
+  rootRef?: Function,
   /**
    * @ignore
    */
@@ -59,22 +63,18 @@ type AllProps = DefaultProps & Props;
 /**
  * @ignore - internal component.
  */
-class Popover extends Component<DefaultProps, AllProps, void> {
+class Popover extends PureComponent<DefaultProps, AllProps, void> {
   props: AllProps;
   static defaultProps: DefaultProps = {
     theme: {},
     transitionDuration: 'auto',
   };
 
-  static getScale(value) {
-    return `scale(${value}, ${value ** 2})`;
-  }
-
   autoTransitionDuration = undefined;
 
   handleEnter = (element: HTMLElement) => {
     element.style.opacity = '0';
-    element.style.transform = Popover.getScale(0.75);
+    element.style.transform = getScale(0.75);
 
     if (this.props.onEnter) {
       this.props.onEnter(element);
@@ -100,7 +100,7 @@ class Popover extends Component<DefaultProps, AllProps, void> {
 
   handleEntering = (element: HTMLElement) => {
     element.style.opacity = '1';
-    element.style.transform = Popover.getScale(1);
+    element.style.transform = getScale(1);
 
     if (this.props.onEntering) {
       this.props.onEntering(element);
@@ -127,7 +127,7 @@ class Popover extends Component<DefaultProps, AllProps, void> {
     ].join(',');
 
     element.style.opacity = '0';
-    element.style.transform = Popover.getScale(0.75);
+    element.style.transform = getScale(0.75);
 
     if (this.props.onExit) {
       this.props.onExit(element);

--- a/src/transitions/Popover.js
+++ b/src/transitions/Popover.js
@@ -1,0 +1,170 @@
+// @flow
+
+import React, { Component } from 'react';
+import type { Element } from 'react';
+import withTheme from '../styles/withTheme';
+import Transition from '../internal/Transition';
+import type { TransitionCallback } from '../internal/Transition';
+
+type DefaultProps = {
+  theme: Object,
+  transitionDuration: 'auto',
+};
+
+export type Props = {
+  /**
+   * The content of the component.
+   */
+  children?: Element<*>,
+  /**
+   * Callback fired before the component is entering
+   */
+  onEnter?: TransitionCallback,
+  /**
+   * Callback fired when the component is entering
+   */
+  onEntering?: TransitionCallback,
+  /**
+   * Callback fired when the component has entered
+   */
+  onEntered?: TransitionCallback, // eslint-disable-line react/sort-prop-types
+  /**
+   * Callback fired before the component is exiting
+   */
+  onExit?: TransitionCallback,
+  /**
+   * Callback fired when the component is exiting
+   */
+  onExiting?: TransitionCallback,
+  /**
+   * Callback fired when the component has exited
+   */
+  onExited?: TransitionCallback, // eslint-disable-line react/sort-prop-types
+  /**
+   * @ignore
+   */
+  theme?: Object,
+  /**
+   * Set to 'auto' to automatically calculate transition time based on height
+   */
+  transitionDuration?: number | 'auto',
+};
+
+type AllProps = DefaultProps & Props;
+
+/**
+ * @ignore - internal component.
+ */
+class Popover extends Component<DefaultProps, AllProps, void> {
+  props: AllProps;
+  static defaultProps: DefaultProps = {
+    theme: {},
+    transitionDuration: 'auto',
+  };
+
+  static getScale(value) {
+    return `scale(${value}, ${value ** 2})`;
+  }
+
+  autoTransitionDuration = undefined;
+  transitionEl = undefined;
+
+  handleEnter = (element: HTMLElement) => {
+    element.style.opacity = '0';
+    element.style.transform = Popover.getScale(0.75);
+
+    if (this.props.onEnter) {
+      this.props.onEnter(element);
+    }
+
+    let { transitionDuration } = this.props;
+    const { transitions } = this.props.theme;
+
+    if (transitionDuration === 'auto') {
+      transitionDuration = transitions.getAutoHeightDuration(element.clientHeight);
+      this.autoTransitionDuration = transitionDuration;
+    }
+
+    element.style.transition = [
+      transitions.create('opacity', {
+        duration: transitionDuration,
+      }),
+      transitions.create('transform', {
+        duration: transitionDuration * 0.666,
+      }),
+    ].join(',');
+  };
+
+  handleEntering = (element: HTMLElement) => {
+    element.style.opacity = '1';
+    element.style.transform = Popover.getScale(1);
+
+    if (this.props.onEntering) {
+      this.props.onEntering(element);
+    }
+  };
+
+  handleExit = (element: HTMLElement) => {
+    let { transitionDuration } = this.props;
+    const { transitions } = this.props.theme;
+
+    if (transitionDuration === 'auto') {
+      transitionDuration = transitions.getAutoHeightDuration(element.clientHeight);
+      this.autoTransitionDuration = transitionDuration;
+    }
+
+    element.style.transition = [
+      transitions.create('opacity', {
+        duration: transitionDuration,
+      }),
+      transitions.create('transform', {
+        duration: transitionDuration * 0.666,
+        delay: transitionDuration * 0.333,
+      }),
+    ].join(',');
+
+    element.style.opacity = '0';
+    element.style.transform = Popover.getScale(0.75);
+
+    if (this.props.onExit) {
+      this.props.onExit(element);
+    }
+  };
+
+  handleRequestTimeout = () => {
+    if (this.props.transitionDuration === 'auto') {
+      return (this.autoTransitionDuration || 0) + 20;
+    }
+    return this.props.transitionDuration + 20;
+  };
+
+  render() {
+    const {
+      children,
+      transitionDuration,
+      onEnter,
+      onEntering,
+      onExit,
+      theme,
+      ...other
+    } = this.props;
+
+    return (
+      <Transition
+        onEnter={this.handleEnter}
+        onEntering={this.handleEntering}
+        onExit={this.handleExit}
+        onRequestTimeout={this.handleRequestTimeout}
+        transitionAppear
+        {...other}
+        ref={node => {
+          this.transitionEl = node;
+        }}
+      >
+        {children}
+      </Transition>
+    );
+  }
+}
+
+export default withTheme(Popover);

--- a/src/transitions/Popover.js
+++ b/src/transitions/Popover.js
@@ -41,6 +41,10 @@ export type Props = {
    */
   onExited?: TransitionCallback, // eslint-disable-line react/sort-prop-types
   /**
+   * Use that property to pass a ref callback to the root component.
+   */
+  rootRef: Function,
+  /**
    * @ignore
    */
   theme?: Object,
@@ -67,7 +71,6 @@ class Popover extends Component<DefaultProps, AllProps, void> {
   }
 
   autoTransitionDuration = undefined;
-  transitionEl = undefined;
 
   handleEnter = (element: HTMLElement) => {
     element.style.opacity = '0';
@@ -145,6 +148,7 @@ class Popover extends Component<DefaultProps, AllProps, void> {
       onEnter,
       onEntering,
       onExit,
+      rootRef,
       theme,
       ...other
     } = this.props;
@@ -157,9 +161,7 @@ class Popover extends Component<DefaultProps, AllProps, void> {
         onRequestTimeout={this.handleRequestTimeout}
         transitionAppear
         {...other}
-        ref={node => {
-          this.transitionEl = node;
-        }}
+        ref={rootRef}
       >
         {children}
       </Transition>

--- a/src/transitions/Popover.spec.js
+++ b/src/transitions/Popover.spec.js
@@ -1,0 +1,158 @@
+// @flow
+
+import React from 'react';
+import { assert } from 'chai';
+import { spy } from 'sinon';
+import { createShallow } from '../test-utils';
+import Popover, { getScale } from './Popover';
+
+describe('<Popover />', () => {
+  let shallow;
+
+  before(() => {
+    shallow = createShallow({ dive: true });
+  });
+
+  describe('event callbacks', () => {
+    it('should fire event callbacks', () => {
+      const events = ['onEnter', 'onEntering', 'onEntered', 'onExit', 'onExiting', 'onExited'];
+
+      const handlers = events.reduce((result, n) => {
+        result[n] = spy();
+        return result;
+      }, {});
+
+      const wrapper = shallow(<Popover {...handlers} />);
+
+      events.forEach(n => {
+        const event = n.charAt(2).toLowerCase() + n.slice(3);
+        wrapper.simulate(event, { style: {} });
+        assert.strictEqual(handlers[n].callCount, 1, `should have called the ${n} handler`);
+        assert.strictEqual(handlers[n].args[0].length, 1, 'should forward the element');
+      });
+    });
+  });
+
+  describe('transition lifecycle', () => {
+    const element = {
+      style: {
+        top: 'auto',
+        left: 'auto',
+        opacity: 1,
+        transform: undefined,
+        transformOrigin: undefined,
+        transition: undefined,
+      },
+    };
+
+    describe('handleEnter(element)', () => {
+      let wrapper;
+      let handleEnter;
+
+      before(() => {
+        handleEnter = spy();
+        wrapper = shallow(<Popover onEnter={handleEnter} />);
+        wrapper.instance().handleEnter(element);
+      });
+
+      it('should set the inline styles for the enter phase', () => {
+        assert.strictEqual(element.style.opacity, '0', 'should be transparent');
+        assert.strictEqual(
+          element.style.transform,
+          getScale(0.75),
+          'should have the starting scale',
+        );
+        assert.strictEqual(
+          element.style.transition,
+          'opacity 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms', // eslint-disable-line max-len
+          'should apply a transition for transform and opacity',
+        );
+      });
+
+      it('should invoke the callback', () => {
+        assert.strictEqual(handleEnter.callCount, 1, 'should have been called once');
+      });
+    });
+
+    describe('handleEntering(element)', () => {
+      let wrapper;
+      let handleEntering;
+
+      before(() => {
+        handleEntering = spy();
+        wrapper = shallow(<Popover onEntering={handleEntering} />);
+        wrapper.instance().handleEntering(element);
+      });
+
+      it('should set the inline styles for the entering phase', () => {
+        assert.strictEqual(element.style.opacity, '1', 'should be visible');
+        assert.strictEqual(element.style.transform, getScale(1), 'should have the full scale');
+      });
+
+      it('should invoke the callback', () => {
+        assert.strictEqual(handleEntering.callCount, 1, 'should have been called once');
+      });
+    });
+
+    describe('handleExit(element)', () => {
+      let wrapper;
+      let handleExit;
+
+      before(() => {
+        handleExit = spy();
+        wrapper = shallow(<Popover onExit={handleExit} />);
+        wrapper.instance().handleExit(element);
+      });
+
+      it('should set the inline styles for the exit phase', () => {
+        assert.strictEqual(element.style.opacity, '0', 'should be transparent');
+        assert.strictEqual(element.style.transform, getScale(0.75), 'should have the exit scale');
+      });
+
+      it('should invoke the callback', () => {
+        assert.strictEqual(handleExit.callCount, 1, 'should have been called once');
+      });
+    });
+  });
+
+  describe('handleRequestTimeout()', () => {
+    let wrapper;
+    let instance;
+
+    before(() => {
+      wrapper = shallow(<Popover />);
+    });
+
+    describe('transitionDuration is auto', () => {
+      before(() => {
+        wrapper.setProps({ transitionDuration: 'auto' });
+        instance = wrapper.instance();
+      });
+
+      it('should return autoTransitionDuration + 20', () => {
+        const autoTransitionDuration = 10;
+        instance.autoTransitionDuration = autoTransitionDuration;
+        assert.strictEqual(instance.handleRequestTimeout(), autoTransitionDuration + 20);
+      });
+
+      it('should return 20', () => {
+        instance.autoTransitionDuration = undefined;
+        assert.strictEqual(instance.handleRequestTimeout(), 20);
+      });
+    });
+
+    describe('transitionDuration is number', () => {
+      let transitionDuration;
+
+      before(() => {
+        transitionDuration = 10;
+        wrapper.setProps({ transitionDuration });
+        instance = wrapper.instance();
+      });
+
+      it('should return props.transitionDuration + 20', () => {
+        assert.strictEqual(instance.handleRequestTimeout(), transitionDuration + 20);
+      });
+    });
+  });
+});

--- a/src/transitions/Slide.js
+++ b/src/transitions/Slide.js
@@ -44,10 +44,6 @@ export type Props = {
    */
   children?: ReactElement<*>,
   /**
-   * @ignore
-   */
-  className?: string,
-  /**
    * Direction the child element will enter from.
    */
   direction?: Direction,

--- a/src/utils/helpers.spec.js
+++ b/src/utils/helpers.spec.js
@@ -12,12 +12,12 @@ describe('utils/helpers.js', () => {
 
   describe('find(arr, pred)', () => {
     it('should search for an item in an array containing the predicate', () => {
-      const array = ['woof', 'meow', { foo: 'bar' }, { woof: 'meow' }];
+      const array = ['woofHelpers', 'meow', { foo: 'bar' }, { woofHelpers: 'meow' }];
       assert.strictEqual(find(array, 'lol'), undefined, 'should work for primitives');
-      assert.strictEqual(find(array, 'woof'), array[0], 'should work for primitives');
+      assert.strictEqual(find(array, 'woofHelpers'), array[0], 'should work for primitives');
       assert.strictEqual(find(array, { foo: 'bar' }), array[2], 'should work for objects');
       assert.strictEqual(
-        find(array, n => n && n.woof === 'meow'),
+        find(array, n => n && n.woofHelpers === 'meow'),
         array[3],
         'should work for functions',
       );
@@ -27,7 +27,7 @@ describe('utils/helpers.js', () => {
   describe('contains(obj, pred)', () => {
     it('should check if an object contains the partial object', () => {
       const obj = {
-        woof: 'meow',
+        woofHelpers: 'meow',
         cat: 'dog',
       };
       const pred = { cat: 'dog' };


### PR DESCRIPTION
`squash+merge`

For simplification and external reuse of the `Popover` transition (now called `Grow`) with `react-autosuggest`, I have  refactored `Popover`.  `Popover` is currently used exclusively by `Menu`.

As it stands, here are the purposes:

- `internal/Popover` = positioning + `Modal` + `Grow` + `Paper` (used by `Menu`)
- `transitions/Grow` = only the effect exhibited by popovers - grow with a bit of fade in.

There are also various small fixes I encountered as I refactored.

I should also mention that this is possibly the lead-in to deleting the positioning code in `Popover` in lieu of using `react-popper`, but I'll wait to take that on after I've used it a bit with `react-autosuggest`.

----
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

