### PR TITLE
[core] Start simplifying styling API

### DIFF
--- a/docs/src/components/AppFrame.js
+++ b/docs/src/components/AppFrame.js
@@ -28,7 +28,7 @@ function getTitle(routes) {
   return null;
 }
 
-const styleSheet = createStyleSheet('AppFrame', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   '@global': {
     html: {
       boxSizing: 'border-box',
@@ -174,4 +174,10 @@ AppFrame.propTypes = {
   width: PropTypes.string.isRequired,
 };
 
-export default compose(withStyles(styleSheet), withWidth(), connect())(AppFrame);
+export default compose(
+  withStyles(styleSheet, {
+    name: 'AppFrame',
+  }),
+  withWidth(),
+  connect(),
+)(AppFrame);

--- a/docs/src/components/AppSearch.js
+++ b/docs/src/components/AppSearch.js
@@ -37,7 +37,7 @@ function removeDocsearch() {
   clearInterval(searchTimer);
 }
 
-const styleSheet = createStyleSheet('AppSearch', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   '@global': {
     '.algolia-autocomplete': {
       fontFamily: theme.typography.fontFamily,
@@ -128,4 +128,4 @@ AppSearch.propTypes = {
   width: PropTypes.string.isRequired,
 };
 
-export default compose(pure, withStyles(styleSheet), withWidth())(AppSearch);
+export default compose(pure, withStyles(styleSheet, { name: 'AppSearch' }), withWidth())(AppSearch);

--- a/docs/src/pages/customization/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js.md
@@ -55,15 +55,14 @@ They are easy to debug in development and as short as possible in production:
 
 ## API
 
-### `createStyleSheet([name], styles) => styleSheet`
+### `createStyleSheet(styles) => styleSheet`
 
 Generate a new style sheet that represents the style you want to inject in the DOM.
 
 #### Arguments
 
-1. `name` (*String* [optional]): The name of the style sheet. Useful for debugging.
 If the value isn't provided, we will try to fallback to the name of the component.
-2. `styles` (*Function | Object*): A function generating the styles or an object.
+1. `styles` (*Function | Object*): A function generating the styles or an object.
 
 Use the function if you need to have access to the theme. It's provided as the first argument.
 
@@ -97,15 +96,17 @@ It does not modify the component passed to it; instead, it returns a new compone
 This `classes` object contains the name of the class names injected in the DOM.
 
 Some implementation details that might be interesting to being aware of:
- - It's forwarding *non react static* properties so this HOC is more "transparent".
- - It's adding a `innerRef` property so you can get a reference to the wrapped component.
- - It's adding a `classes` property so you can override the injected class names from the outside.
+- It's adding a `classes` property so you can override the injected class names from the outside.
+- It's adding a `innerRef` property so you can get a reference to the wrapped component.
+- It's forwarding *non react static* properties so this HOC is more "transparent".
+For instance, it can be used to defined a `getInitialProps()` static method (next.js).
 
 #### Arguments
 
 1. `styleSheet` (*Object*): The style sheet to link to the component. This object can be created with `createStyleSheet`.
 2. `options` (*Object* [optional]):
   - `options.withTheme` (Boolean [optional]): Provide the `theme` object to the component as a property.
+  - `options.name` (*String* [optional]): The name of the style sheet. Useful for debugging.
 
 #### Returns
 
@@ -117,20 +118,24 @@ Some implementation details that might be interesting to being aware of:
 import { withStyles } from 'material-ui/styles';
 
 class MyComponent extends Component {
-  render () {}
+  render () {
+    return <div />;
+  }
 }
 
 export default withStyles(styleSheet)(MyComponent);
 ```
 
-You can use as [decorators](https://babeljs.io/docs/plugins/transform-decorators/) like so:
+Also, you can use as [decorators](https://babeljs.io/docs/plugins/transform-decorators/) like so:
 
 ```js
 import { withStyles } from 'material-ui/styles';
 
 @withStyles(styleSheet)
 class MyComponent extends Component {
-  render () {}
+  render () {
+    return <div />;
+  }
 }
 
 export default MyComponent

--- a/docs/src/pages/guides/server-rendering.md
+++ b/docs/src/pages/guides/server-rendering.md
@@ -95,7 +95,7 @@ function handleRender(req, res) {
   // Render the component to a string.
   const html = renderToString(
     <JssProvider registry={sheetsRegistry} jss={jss}>
-      <MuiThemeProvider theme={theme} sheetsManager={new WeakMap()}>
+      <MuiThemeProvider theme={theme} sheetsManager={new Map()}>
         <App />
       </MuiThemeProvider>
     </JssProvider>

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -8,7 +8,7 @@ import withStyles from '../styles/withStyles';
 import { capitalizeFirstLetter } from '../utils/helpers';
 import Paper from '../Paper';
 
-export const styleSheet = createStyleSheet('MuiAppBar', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     display: 'flex',
     flexDirection: 'column',
@@ -101,4 +101,4 @@ AppBar.defaultProps = {
   position: 'fixed',
 };
 
-export default withStyles(styleSheet)(AppBar);
+export default withStyles(styleSheet, { name: 'MuiAppBar' })(AppBar);

--- a/src/AppBar/AppBar.spec.js
+++ b/src/AppBar/AppBar.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import AppBar, { styleSheet } from './AppBar';
+import AppBar from './AppBar';
 
 describe('<AppBar />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<AppBar />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<AppBar />);
   });
 
   it('should render a Paper component', () => {

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -7,7 +7,7 @@ import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 import { emphasize } from '../styles/colorManipulator';
 
-export const styleSheet = createStyleSheet('MuiAvatar', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     position: 'relative',
     display: 'flex',
@@ -147,4 +147,4 @@ Avatar.defaultProps = {
   component: 'div',
 };
 
-export default withStyles(styleSheet)(Avatar);
+export default withStyles(styleSheet, { name: 'MuiAvatar' })(Avatar);

--- a/src/Avatar/Avatar.spec.js
+++ b/src/Avatar/Avatar.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
 import CancelIcon from '../svg-icons/cancel';
-import Avatar, { styleSheet } from './Avatar';
+import Avatar from './Avatar';
 
 describe('<Avatar />', () => {
   let shallow;
@@ -12,7 +12,7 @@ describe('<Avatar />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Avatar />);
   });
 
   describe('image avatar', () => {

--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -9,7 +9,7 @@ import { capitalizeFirstLetter } from '../utils/helpers';
 
 const RADIUS = 12;
 
-export const styleSheet = createStyleSheet('MuiBadge', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     position: 'relative',
     display: 'inline-block',
@@ -87,4 +87,4 @@ Badge.defaultProps = {
   color: 'default',
 };
 
-export default withStyles(styleSheet)(Badge);
+export default withStyles(styleSheet, { name: 'MuiBadge' })(Badge);

--- a/src/Badge/Badge.spec.js
+++ b/src/Badge/Badge.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import Badge, { styleSheet } from './Badge';
+import Badge from './Badge';
 
 describe('<Badge />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<Badge />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Badge badgeContent={1}>Hello World</Badge>);
   });
 
   const testChildren = <div className="unique">Hello World</div>;

--- a/src/BottomNavigation/BottomNavigation.js
+++ b/src/BottomNavigation/BottomNavigation.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiBottomNavigation', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     display: 'flex',
     justifyContent: 'center',
@@ -79,4 +79,4 @@ BottomNavigation.defaultProps = {
   showLabels: false,
 };
 
-export default withStyles(styleSheet)(BottomNavigation);
+export default withStyles(styleSheet, 'MuiBottomNavigation')(BottomNavigation);

--- a/src/BottomNavigation/BottomNavigation.spec.js
+++ b/src/BottomNavigation/BottomNavigation.spec.js
@@ -6,7 +6,7 @@ import { spy } from 'sinon';
 import { createShallow, createMount, getClasses } from '../test-utils';
 import BottomNavigationButton from './BottomNavigationButton';
 import Icon from '../Icon';
-import BottomNavigation, { styleSheet } from './BottomNavigation';
+import BottomNavigation from './BottomNavigation';
 
 describe('<BottomNavigation />', () => {
   let shallow;
@@ -16,7 +16,11 @@ describe('<BottomNavigation />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(
+      <BottomNavigation showLabels>
+        <BottomNavigationButton icon={icon} />
+      </BottomNavigation>,
+    );
     mount = createMount();
   });
 

--- a/src/BottomNavigation/BottomNavigationButton.js
+++ b/src/BottomNavigation/BottomNavigationButton.js
@@ -8,7 +8,7 @@ import withStyles from '../styles/withStyles';
 import ButtonBase from '../ButtonBase';
 import Icon from '../Icon';
 
-export const styleSheet = createStyleSheet('MuiBottomNavigationButton', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     transition: theme.transitions.create(['color', 'padding-top'], {
       duration: theme.transitions.duration.short,
@@ -151,4 +151,6 @@ BottomNavigationButton.propTypes = {
   value: PropTypes.number,
 };
 
-export default withStyles(styleSheet)(BottomNavigationButton);
+export default withStyles(styleSheet, { name: 'MuiBottomNavigationButton' })(
+  BottomNavigationButton,
+);

--- a/src/BottomNavigation/BottomNavigationButton.spec.js
+++ b/src/BottomNavigation/BottomNavigationButton.spec.js
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 import { spy } from 'sinon';
 import { createShallow, getClasses } from '../test-utils';
 import Icon from '../Icon';
-import BottomNavigationButton, { styleSheet } from './BottomNavigationButton';
+import BottomNavigationButton from './BottomNavigationButton';
 
 describe('<BottomNavigationButton />', () => {
   let shallow;
@@ -14,7 +14,7 @@ describe('<BottomNavigationButton />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<BottomNavigationButton />);
   });
 
   it('should render a ButtonBase', () => {

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -8,7 +8,7 @@ import withStyles from '../styles/withStyles';
 import { fade } from '../styles/colorManipulator';
 import ButtonBase from '../ButtonBase';
 
-export const styleSheet = createStyleSheet('MuiButton', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     ...theme.typography.button,
     lineHeight: '1em',
@@ -285,4 +285,4 @@ Button.defaultProps = {
   type: 'button',
 };
 
-export default withStyles(styleSheet)(Button);
+export default withStyles(styleSheet, { name: 'MuiButton' })(Button);

--- a/src/Button/Button.spec.js
+++ b/src/Button/Button.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, createRender, getClasses } from '../test-utils';
-import Button, { styleSheet } from './Button';
+import Button from './Button';
 
 describe('<Button />', () => {
   let shallow;
@@ -13,7 +13,7 @@ describe('<Button />', () => {
   before(() => {
     shallow = createShallow({ dive: true });
     render = createRender();
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Button>Hello World</Button>);
   });
 
   it('should render a <ButtonBase> element', () => {

--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -12,7 +12,7 @@ import { listenForFocusKeys, detectKeyboardFocus, focusKeyPressed } from '../uti
 import TouchRipple from './TouchRipple';
 import createRippleHandler from './createRippleHandler';
 
-export const styleSheet = createStyleSheet('MuiButtonBase', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     position: 'relative',
     // Remove grey highlight
@@ -390,4 +390,4 @@ class ButtonBase extends Component<DefaultProps, AllProps, State> {
   }
 }
 
-export default withStyles(styleSheet)(ButtonBase);
+export default withStyles(styleSheet, { name: 'MuiButtonBase' })(ButtonBase);

--- a/src/ButtonBase/ButtonBase.spec.js
+++ b/src/ButtonBase/ButtonBase.spec.js
@@ -8,7 +8,7 @@ import { createShallow, createMount, getClasses } from '../test-utils';
 import { focusKeyPressed } from '../utils/keyboardFocus';
 import consoleErrorMock from '../../test/utils/consoleErrorMock';
 import TouchRipple from './TouchRipple';
-import ButtonBase, { styleSheet } from './ButtonBase';
+import ButtonBase from './ButtonBase';
 
 describe('<ButtonBase />', () => {
   let mount;
@@ -19,8 +19,8 @@ describe('<ButtonBase />', () => {
     shallow = createShallow({
       dive: true,
     });
-    classes = getClasses(styleSheet);
     mount = createMount();
+    classes = getClasses(<ButtonBase />);
   });
 
   after(() => {

--- a/src/ButtonBase/TouchRipple.js
+++ b/src/ButtonBase/TouchRipple.js
@@ -11,7 +11,7 @@ import Ripple from './Ripple';
 
 const DURATION = 550;
 
-export const styleSheet = createStyleSheet('MuiTouchRipple', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     display: 'block',
     position: 'absolute',
@@ -252,4 +252,4 @@ TouchRipple.propTypes = {
   className: PropTypes.string,
 };
 
-export default withStyles(styleSheet)(TouchRipple);
+export default withStyles(styleSheet, { name: 'MuiTouchRipple' })(TouchRipple);

--- a/src/ButtonBase/TouchRipple.spec.js
+++ b/src/ButtonBase/TouchRipple.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import TouchRipple, { styleSheet } from './TouchRipple';
+import TouchRipple from './TouchRipple';
 
 describe('<TouchRipple />', () => {
   let shallow;
@@ -13,7 +13,7 @@ describe('<TouchRipple />', () => {
     shallow = createShallow({
       dive: true,
     });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<TouchRipple />);
   });
 
   it('should render a <ReactTransitionGroup> component', () => {

--- a/src/Card/CardActions.js
+++ b/src/Card/CardActions.js
@@ -7,7 +7,7 @@ import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 import { cloneChildrenWithClassName } from '../utils/reactHelpers';
 
-export const styleSheet = createStyleSheet('MuiCardActions', {
+export const styleSheet = createStyleSheet({
   root: {
     height: 52,
     display: 'flex',
@@ -61,4 +61,4 @@ CardActions.defaultProps = {
   disableActionSpacing: false,
 };
 
-export default withStyles(styleSheet)(CardActions);
+export default withStyles(styleSheet, { name: 'MuiCardActions' })(CardActions);

--- a/src/Card/CardActions.spec.js
+++ b/src/Card/CardActions.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import CardActions, { styleSheet } from './CardActions';
+import CardActions from './CardActions';
 
 describe('<CardActions />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<CardActions />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<CardActions />);
   });
 
   it('should render a div with the root class', () => {

--- a/src/Card/CardContent.js
+++ b/src/Card/CardContent.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiCardContent', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     padding: theme.spacing.unit * 2,
     '&:last-child': {
@@ -37,4 +37,4 @@ function CardContent(props: AllProps) {
   return <div className={classNames(classes.root, className)} {...other} />;
 }
 
-export default withStyles(styleSheet)(CardContent);
+export default withStyles(styleSheet, { name: 'MuiCardContent' })(CardContent);

--- a/src/Card/CardContent.spec.js
+++ b/src/Card/CardContent.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import CardContent, { styleSheet } from './CardContent';
+import CardContent from './CardContent';
 
 describe('<CardContent />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<CardContent />', () => {
 
   before(() => {
     shallow = createShallow({ untilSelector: 'CardContent' });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<CardContent />);
   });
 
   it('should render a div with the root class', () => {

--- a/src/Card/CardHeader.js
+++ b/src/Card/CardHeader.js
@@ -8,7 +8,7 @@ import withStyles from '../styles/withStyles';
 import Typography from '../Typography';
 import CardContent from './CardContent';
 
-export const styleSheet = createStyleSheet('MuiCardHeader', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     display: 'flex',
     alignItems: 'center',
@@ -85,4 +85,4 @@ function CardHeader(props: AllProps) {
   );
 }
 
-export default withStyles(styleSheet)(CardHeader);
+export default withStyles(styleSheet, { name: 'MuiCardHeader' })(CardHeader);

--- a/src/Card/CardHeader.spec.js
+++ b/src/Card/CardHeader.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import CardHeader, { styleSheet } from './CardHeader';
+import CardHeader from './CardHeader';
 
 describe('<CardHeader />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<CardHeader />', () => {
 
   before(() => {
     shallow = createShallow({ untilSelector: 'div' });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<CardHeader />);
   });
 
   it('should render CardContent', () => {

--- a/src/Card/CardMedia.js
+++ b/src/Card/CardMedia.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiCardMedia', {
+export const styleSheet = createStyleSheet({
   root: {
     backgroundSize: 'cover',
     backgroundRepeat: 'no-repeat',
@@ -46,4 +46,4 @@ function CardMedia(props: AllProps) {
   );
 }
 
-export default withStyles(styleSheet)(CardMedia);
+export default withStyles(styleSheet, { name: 'MuiCardMedia' })(CardMedia);

--- a/src/Card/CardMedia.spec.js
+++ b/src/Card/CardMedia.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import CardMedia, { styleSheet } from './CardMedia';
+import CardMedia from './CardMedia';
 
 describe('<CardMedia />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<CardMedia />', () => {
 
   before(() => {
     shallow = createShallow({ untilSelector: 'CardMedia' });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<CardMedia image="/foo.jpg" />);
   });
 
   it('should have the root and custom class', () => {

--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -3,10 +3,11 @@
 import React from 'react';
 import type { Element } from 'react';
 import createStyleSheet from '../styles/createStyleSheet';
+import withStyles from '../styles/withStyles';
 import createSwitch from '../internal/SwitchBase';
 import IndeterminateCheckBoxIcon from '../svg-icons/indeterminate-check-box';
 
-export const styleSheet = createStyleSheet('MuiCheckbox', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   default: {
     color: theme.palette.text.secondary,
   },
@@ -18,7 +19,7 @@ export const styleSheet = createStyleSheet('MuiCheckbox', theme => ({
   },
 }));
 
-const SwitchBase = createSwitch({ styleSheet });
+export const SwitchBase = withStyles(styleSheet, { name: 'MuiCheckbox' })(createSwitch());
 
 export type Props = {
   /**

--- a/src/Checkbox/Checkbox.spec.js
+++ b/src/Checkbox/Checkbox.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import Checkbox, { styleSheet } from './Checkbox';
+import Checkbox, { SwitchBase } from './Checkbox';
 
 describe('<Checkbox />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<Checkbox />', () => {
 
   before(() => {
     shallow = createShallow();
-    classes = getClasses(styleSheet);
+    classes = getClasses(<SwitchBase />);
   });
 
   describe('styleSheet', () => {
@@ -25,6 +25,6 @@ describe('<Checkbox />', () => {
   it('should render a div with a SwitchBase', () => {
     assert.strictEqual(Checkbox.name, 'Checkbox', 'set for debugging');
     const wrapper = shallow(<Checkbox />);
-    assert.strictEqual(wrapper.name(), 'withStyles(SwitchBase)');
+    assert.strictEqual(wrapper.name(), 'withStyles(withStyles(SwitchBase))');
   });
 });

--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -9,7 +9,7 @@ import withStyles from '../styles/withStyles';
 import DeleteIcon from '../svg-icons/cancel';
 import { emphasize, fade } from '../styles/colorManipulator';
 
-export const styleSheet = createStyleSheet('MuiChip', theme => {
+export const styleSheet = createStyleSheet(theme => {
   const height = 32;
   const backgroundColor = emphasize(theme.palette.background.default, 0.12);
   const deleteIconColor = fade(theme.palette.text.primary, 0.26);
@@ -212,4 +212,4 @@ Chip.propTypes = {
   tabIndex: PropTypes.number,
 };
 
-export default withStyles(styleSheet)(Chip);
+export default withStyles(styleSheet, { name: 'MuiChip' })(Chip);

--- a/src/Chip/Chip.spec.js
+++ b/src/Chip/Chip.spec.js
@@ -6,7 +6,7 @@ import { assert } from 'chai';
 import { spy } from 'sinon';
 import { createShallow, createMount, getClasses } from '../test-utils';
 import Avatar from '../Avatar';
-import Chip, { styleSheet } from './Chip';
+import Chip from './Chip';
 
 describe('<Chip />', () => {
   let shallow;
@@ -14,7 +14,7 @@ describe('<Chip />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Chip />);
   });
 
   describe('text only', () => {

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -12,7 +12,7 @@ import { duration } from '../styles/transitions';
 import Paper from '../Paper';
 import type { TransitionCallback } from '../internal/Transition';
 
-export const styleSheet = createStyleSheet('MuiDialog', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     justifyContent: 'center',
     alignItems: 'center',
@@ -227,4 +227,4 @@ Dialog.defaultProps = {
   transition: Fade,
 };
 
-export default withStyles(styleSheet)(Dialog);
+export default withStyles(styleSheet, { name: 'MuiDialog' })(Dialog);

--- a/src/Dialog/Dialog.spec.js
+++ b/src/Dialog/Dialog.spec.js
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
 import Paper from '../Paper';
 import Fade from '../transitions/Fade';
-import Dialog, { styleSheet } from './Dialog';
+import Dialog from './Dialog';
 
 describe('<Dialog />', () => {
   let shallow;
@@ -13,7 +13,7 @@ describe('<Dialog />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Dialog />);
   });
 
   it('should render a Modal', () => {

--- a/src/Dialog/DialogActions.js
+++ b/src/Dialog/DialogActions.js
@@ -7,7 +7,7 @@ import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 import '../Button'; // So we don't have any override priority issue.
 
-export const styleSheet = createStyleSheet('MuiDialogActions', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     display: 'flex',
     justifyContent: 'flex-end',
@@ -57,4 +57,4 @@ DialogActions.propTypes = {
   className: PropTypes.string,
 };
 
-export default withStyles(styleSheet)(DialogActions);
+export default withStyles(styleSheet, { name: 'MuiDialogActions' })(DialogActions);

--- a/src/Dialog/DialogActions.spec.js
+++ b/src/Dialog/DialogActions.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import DialogActions, { styleSheet } from './DialogActions';
+import DialogActions from './DialogActions';
 
 describe('<DialogActions />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<DialogActions />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<DialogActions />);
   });
 
   it('should render a div', () => {

--- a/src/Dialog/DialogContent.js
+++ b/src/Dialog/DialogContent.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiDialogContent', theme => {
+export const styleSheet = createStyleSheet(theme => {
   const spacing = theme.spacing.unit * 3;
   return {
     root: {
@@ -45,4 +45,4 @@ DialogContent.propTypes = {
   className: PropTypes.string,
 };
 
-export default withStyles(styleSheet)(DialogContent);
+export default withStyles(styleSheet, { name: 'MuiDialogContent' })(DialogContent);

--- a/src/Dialog/DialogContent.spec.js
+++ b/src/Dialog/DialogContent.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import DialogContent, { styleSheet } from './DialogContent';
+import DialogContent from './DialogContent';
 
 describe('<DialogContent />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<DialogContent />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<DialogContent />);
   });
 
   it('should render a div', () => {

--- a/src/Dialog/DialogContentText.js
+++ b/src/Dialog/DialogContentText.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiDialogContentText', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     ...theme.typography.subheading,
     color: theme.palette.text.secondary,
@@ -39,4 +39,4 @@ DialogContentText.propTypes = {
   className: PropTypes.string,
 };
 
-export default withStyles(styleSheet)(DialogContentText);
+export default withStyles(styleSheet, { name: 'MuiDialogContentText' })(DialogContentText);

--- a/src/Dialog/DialogContentText.spec.js
+++ b/src/Dialog/DialogContentText.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import DialogContentText, { styleSheet } from './DialogContentText';
+import DialogContentText from './DialogContentText';
 
 describe('<DialogContentText />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<DialogContentText />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<DialogContentText />);
   });
 
   describe('prop: className', () => {

--- a/src/Dialog/DialogTitle.js
+++ b/src/Dialog/DialogTitle.js
@@ -7,7 +7,7 @@ import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 import Typography from '../Typography';
 
-export const styleSheet = createStyleSheet('MuiDialogTitle', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     margin: 0,
     padding: `${theme.spacing.unit * 3}px ${theme.spacing.unit * 3}px \
@@ -54,4 +54,4 @@ DialogTitle.defaultProps = {
   disableTypography: false,
 };
 
-export default withStyles(styleSheet)(DialogTitle);
+export default withStyles(styleSheet, { name: 'MuiDialogTitle' })(DialogTitle);

--- a/src/Dialog/DialogTitle.spec.js
+++ b/src/Dialog/DialogTitle.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import DialogTitle, { styleSheet } from './DialogTitle';
+import DialogTitle from './DialogTitle';
 
 describe('<DialogTitle />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<DialogTitle />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<DialogTitle />);
   });
 
   it('should render a div', () => {

--- a/src/Dialog/withResponsiveFullScreen.spec.js
+++ b/src/Dialog/withResponsiveFullScreen.spec.js
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
 import Paper from '../Paper';
 import type { Breakpoint } from '../styles/breakpoints';
-import Dialog, { styleSheet } from './Dialog';
+import Dialog from './Dialog';
 import withResponsiveFullScreen from './withResponsiveFullScreen';
 
 describe('withResponsiveFullScreen', () => {
@@ -16,7 +16,7 @@ describe('withResponsiveFullScreen', () => {
     shallow = createShallow({
       untilSelector: 'Dialog',
     });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Dialog />);
   });
 
   function isFullScreen(breakpoints: Array<Breakpoint>, width: Breakpoint) {

--- a/src/Divider/Divider.js
+++ b/src/Divider/Divider.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiDivider', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     height: 1,
     margin: 0, // Reset browser default style.
@@ -71,4 +71,4 @@ Divider.defaultProps = {
   light: false,
 };
 
-export default withStyles(styleSheet)(Divider);
+export default withStyles(styleSheet, { name: 'MuiDivider' })(Divider);

--- a/src/Divider/Divider.spec.js
+++ b/src/Divider/Divider.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import Divider, { styleSheet } from './Divider';
+import Divider from './Divider';
 
 describe('<Divider />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<Divider />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Divider />);
   });
 
   it('should render a hr', () => {

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -24,7 +24,7 @@ function getSlideDirection(anchor) {
   return 'up';
 }
 
-export const styleSheet = createStyleSheet('MuiDrawer', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   paper: {
     overflowY: 'auto',
     display: 'flex',
@@ -232,4 +232,4 @@ class Drawer extends Component<DefaultProps, AllProps, State> {
   }
 }
 
-export default withStyles(styleSheet, { withTheme: true })(Drawer);
+export default withStyles(styleSheet, { withTheme: true, name: 'MuiDrawer' })(Drawer);

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -6,7 +6,7 @@ import { createShallow, getClasses } from '../test-utils';
 import Slide from '../transitions/Slide';
 import Modal from '../internal/Modal';
 import Paper from '../Paper';
-import Drawer, { styleSheet } from './Drawer';
+import Drawer from './Drawer';
 
 describe('<Drawer />', () => {
   let shallow;
@@ -14,7 +14,7 @@ describe('<Drawer />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Drawer />);
   });
 
   it('should render a Modal', () => {

--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -9,7 +9,7 @@ import withStyles from '../styles/withStyles';
 import { isDirty } from '../Input/Input';
 import { isMuiComponent } from '../utils/reactHelpers';
 
-export const styleSheet = createStyleSheet('MuiFormControl', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     display: 'inline-flex',
     flexDirection: 'column',
@@ -202,4 +202,4 @@ class FormControl extends Component<DefaultProps, AllProps, State> {
   }
 }
 
-export default withStyles(styleSheet)(FormControl);
+export default withStyles(styleSheet, { name: 'MuiFormControl' })(FormControl);

--- a/src/Form/FormControl.spec.js
+++ b/src/Form/FormControl.spec.js
@@ -5,7 +5,7 @@ import { spy } from 'sinon';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
 import Input from '../Input';
-import FormControl, { styleSheet } from './FormControl';
+import FormControl from './FormControl';
 
 describe('<FormControl />', () => {
   let shallow;
@@ -13,7 +13,7 @@ describe('<FormControl />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<FormControl />);
   });
 
   describe('initial state', () => {

--- a/src/Form/FormControlLabel.js
+++ b/src/Form/FormControlLabel.js
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiFormControlLabel', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     display: 'inline-flex',
     alignItems: 'center',
@@ -126,4 +126,4 @@ FormControlLabel.defaultProps = {
   disabled: false,
 };
 
-export default withStyles(styleSheet)(FormControlLabel);
+export default withStyles(styleSheet, { name: 'MuiFormControlLabel' })(FormControlLabel);

--- a/src/Form/FormControlLabel.spec.js
+++ b/src/Form/FormControlLabel.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { createShallow, createMount, getClasses } from '../test-utils';
 import Checkbox from '../Checkbox';
-import FormControlLabel, { styleSheet } from './FormControlLabel';
+import FormControlLabel from './FormControlLabel';
 
 describe('FormControlLabel', () => {
   let shallow;
@@ -15,7 +15,7 @@ describe('FormControlLabel', () => {
   before(() => {
     shallow = createShallow({ dive: true });
     mount = createMount();
-    classes = getClasses(styleSheet);
+    classes = getClasses(<FormControlLabel label="Pizza" control={<div />} />);
     wrapper = shallow(<FormControlLabel label="Pizza" control={<div />} />);
   });
 

--- a/src/Form/FormGroup.js
+++ b/src/Form/FormGroup.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiFormGroup', {
+export const styleSheet = createStyleSheet({
   root: {
     display: 'flex',
     flexDirection: 'column',
@@ -67,4 +67,4 @@ FormGroup.defaultProps = {
   row: false,
 };
 
-export default withStyles(styleSheet)(FormGroup);
+export default withStyles(styleSheet, { name: 'MuiFormGroup' })(FormGroup);

--- a/src/Form/FormGroup.spec.js
+++ b/src/Form/FormGroup.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import FormGroup, { styleSheet } from './FormGroup';
+import FormGroup from './FormGroup';
 
 describe('<FormGroup />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<FormGroup />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<FormGroup />);
   });
 
   it('should render a div with the root and user classes', () => {

--- a/src/Form/FormHelperText.js
+++ b/src/Form/FormHelperText.js
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiFormHelperText', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     color: theme.palette.input.helperText,
     fontFamily: theme.typography.fontFamily,
@@ -114,4 +114,4 @@ FormHelperText.contextTypes = {
   muiFormControl: PropTypes.object,
 };
 
-export default withStyles(styleSheet)(FormHelperText);
+export default withStyles(styleSheet, { name: 'MuiFormHelperText' })(FormHelperText);

--- a/src/Form/FormHelperText.spec.js
+++ b/src/Form/FormHelperText.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import FormHelperText, { styleSheet } from './FormHelperText';
+import FormHelperText from './FormHelperText';
 
 describe('<FormHelperText />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<FormHelperText />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<FormHelperText />);
   });
 
   it('should render a <p />', () => {

--- a/src/Form/FormLabel.js
+++ b/src/Form/FormLabel.js
@@ -8,7 +8,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiFormLabel', theme => {
+export const styleSheet = createStyleSheet(theme => {
   const focusColor = theme.palette.primary[theme.palette.type === 'light' ? 'A700' : 'A200'];
   return {
     root: {
@@ -128,4 +128,4 @@ FormLabel.contextTypes = {
   muiFormControl: PropTypes.object,
 };
 
-export default withStyles(styleSheet)(FormLabel);
+export default withStyles(styleSheet, { name: 'MuiFormLabel' })(FormLabel);

--- a/src/Form/FormLabel.spec.js
+++ b/src/Form/FormLabel.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import FormLabel, { styleSheet } from './FormLabel';
+import FormLabel from './FormLabel';
 
 describe('<FormLabel />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<FormLabel />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<FormLabel />);
   });
 
   it('should render a <label />', () => {

--- a/src/Grid/Grid.js
+++ b/src/Grid/Grid.js
@@ -82,7 +82,7 @@ function generateGutter(theme, breakpoint) {
   return styles;
 }
 
-export const styleSheet = createStyleSheet('MuiGrid', theme => {
+export const styleSheet = createStyleSheet(theme => {
   // Default CSS values
   // flex: '0 1 auto',
   // flexDirection: 'row',
@@ -335,4 +335,4 @@ if (process.env.NODE_ENV !== 'production') {
   };
 }
 
-export default withStyles(styleSheet)(GridWrapper);
+export default withStyles(styleSheet, { name: 'MuiGrid' })(GridWrapper);

--- a/src/Grid/Grid.spec.js
+++ b/src/Grid/Grid.spec.js
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 import forOwn from 'lodash/forOwn';
 import { createShallow, getClasses } from '../test-utils';
 import Hidden from '../Hidden';
-import Grid, { styleSheet } from './Grid';
+import Grid from './Grid';
 
 describe('<Grid />', () => {
   let shallow;
@@ -19,7 +19,7 @@ describe('<Grid />', () => {
         context: shallowInner.context,
       });
     };
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Grid />);
   });
 
   it('should render', () => {

--- a/src/GridList/GridList.js
+++ b/src/GridList/GridList.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiGridList', {
+export const styleSheet = createStyleSheet({
   root: {
     display: 'flex',
     flexWrap: 'wrap',
@@ -99,4 +99,4 @@ GridList.defaultProps = {
   component: 'ul',
 };
 
-export default withStyles(styleSheet)(GridList);
+export default withStyles(styleSheet, { name: 'MuiGridList' })(GridList);

--- a/src/GridList/GridListTile.js
+++ b/src/GridList/GridListTile.js
@@ -8,7 +8,7 @@ import debounce from 'lodash/debounce';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiGridListTile', {
+export const styleSheet = createStyleSheet({
   root: {
     boxSizing: 'border-box',
   },
@@ -157,4 +157,4 @@ GridListTile.propTypes = {
   rows: PropTypes.number,
 };
 
-export default withStyles(styleSheet)(GridListTile);
+export default withStyles(styleSheet, { name: 'MuiGridListTile' })(GridListTile);

--- a/src/GridList/GridListTile.spec.js
+++ b/src/GridList/GridListTile.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { createShallow, createMount, getClasses } from '../test-utils';
-import GridListTile, { styleSheet } from './GridListTile';
+import GridListTile from './GridListTile';
 
 describe('<GridListTile />', () => {
   let shallow;
@@ -16,7 +16,7 @@ describe('<GridListTile />', () => {
       dive: true,
     });
     mount = createMount();
-    classes = getClasses(styleSheet);
+    classes = getClasses(<GridListTile />);
   });
 
   after(() => {

--- a/src/GridList/GridListTileBar.js
+++ b/src/GridList/GridListTileBar.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiGridListTileBar', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     position: 'absolute',
     left: 0,
@@ -151,4 +151,4 @@ GridListTileBar.defaultProps = {
   actionPosition: 'right',
 };
 
-export default withStyles(styleSheet)(GridListTileBar);
+export default withStyles(styleSheet, { name: 'MuiGridListTileBar' })(GridListTileBar);

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -7,7 +7,7 @@ import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 import { capitalizeFirstLetter } from '../utils/helpers';
 
-export const styleSheet = createStyleSheet('MuiIcon', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     userSelect: 'none',
   },
@@ -82,4 +82,4 @@ Icon.defaultProps = {
 
 Icon.muiName = 'Icon';
 
-export default withStyles(styleSheet)(Icon);
+export default withStyles(styleSheet, { name: 'MuiIcon' })(Icon);

--- a/src/Icon/Icon.spec.js
+++ b/src/Icon/Icon.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import Icon, { styleSheet } from './Icon';
+import Icon from './Icon';
 
 describe('<Icon />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<Icon />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Icon />);
   });
 
   it('renders children by default', () => {

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -10,7 +10,7 @@ import { capitalizeFirstLetter } from '../utils/helpers';
 import Icon from '../Icon';
 import { isMuiComponent } from '../utils/reactHelpers';
 
-export const styleSheet = createStyleSheet('MuiIconButton', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     display: 'inline-flex',
     alignItems: 'center',
@@ -138,4 +138,4 @@ IconButton.defaultProps = {
   disableRipple: false,
 };
 
-export default withStyles(styleSheet)(IconButton);
+export default withStyles(styleSheet, { name: 'MuiIconButton' })(IconButton);

--- a/src/IconButton/IconButton.spec.js
+++ b/src/IconButton/IconButton.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
 import Icon from '../Icon';
-import IconButton, { styleSheet } from './IconButton';
+import IconButton from './IconButton';
 
 describe('<IconButton />', () => {
   let shallow;
@@ -12,7 +12,7 @@ describe('<IconButton />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<IconButton />);
   });
 
   it('should render a ButtonBase', () => {

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -15,7 +15,7 @@ export function isDirty(obj, SSR = false) {
   );
 }
 
-export const styleSheet = createStyleSheet('MuiInput', theme => {
+export const styleSheet = createStyleSheet(theme => {
   const placeholder = {
     color: 'currentColor',
     opacity: theme.palette.type === 'light' ? 0.42 : 0.5,
@@ -528,4 +528,4 @@ class Input extends Component<DefaultProps, AllProps, State> {
   }
 }
 
-export default withStyles(styleSheet)(Input);
+export default withStyles(styleSheet, { name: 'MuiInput' })(Input);

--- a/src/Input/Input.spec.js
+++ b/src/Input/Input.spec.js
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 import { spy } from 'sinon';
 import { createShallow, createMount, getClasses } from '../test-utils';
 import Textarea from './Textarea';
-import Input, { styleSheet, isDirty } from './Input';
+import Input, { isDirty } from './Input';
 
 describe('<Input />', () => {
   let shallow;
@@ -15,7 +15,7 @@ describe('<Input />', () => {
   before(() => {
     shallow = createShallow({ dive: true });
     mount = createMount();
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Input />);
   });
 
   after(() => {

--- a/src/Input/InputLabel.js
+++ b/src/Input/InputLabel.js
@@ -8,7 +8,7 @@ import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 import { FormLabel } from '../Form';
 
-export const styleSheet = createStyleSheet('MuiInputLabel', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     transformOrigin: 'top left',
   },
@@ -126,4 +126,4 @@ InputLabel.contextTypes = {
   muiFormControl: PropTypes.object,
 };
 
-export default withStyles(styleSheet)(InputLabel);
+export default withStyles(styleSheet, { name: 'MuiInputLabel' })(InputLabel);

--- a/src/Input/InputLabel.spec.js
+++ b/src/Input/InputLabel.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import InputLabel, { styleSheet } from './InputLabel';
+import InputLabel from './InputLabel';
 
 describe('<InputLabel />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<InputLabel />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<InputLabel />);
   });
 
   it('should render a FormLabel', () => {

--- a/src/Input/Textarea.js
+++ b/src/Input/Textarea.js
@@ -9,7 +9,7 @@ import withStyles from '../styles/withStyles';
 
 const rowsHeight = 24;
 
-export const styleSheet = createStyleSheet('MuiTextarea', {
+export const styleSheet = createStyleSheet({
   root: {
     position: 'relative', // because the shadow has position: 'absolute',
   },
@@ -244,4 +244,4 @@ class Textarea extends Component<DefaultProps, AllProps, State> {
   }
 }
 
-export default withStyles(styleSheet)(Textarea);
+export default withStyles(styleSheet, { name: 'MuiTextarea' })(Textarea);

--- a/src/List/List.js
+++ b/src/List/List.js
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiList', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     flex: '1 1 auto',
     overflow: 'auto',
@@ -125,4 +125,4 @@ List.childContextTypes = {
   dense: PropTypes.bool,
 };
 
-export default withStyles(styleSheet)(List);
+export default withStyles(styleSheet, { name: 'MuiList' })(List);

--- a/src/List/List.spec.js
+++ b/src/List/List.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
 import ListSubheader from './ListSubheader';
-import List, { styleSheet } from './List';
+import List from './List';
 
 describe('<List />', () => {
   let shallow;
@@ -12,7 +12,7 @@ describe('<List />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<List />);
   });
 
   it('should render a div', () => {

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -9,7 +9,7 @@ import withStyles from '../styles/withStyles';
 import ButtonBase from '../ButtonBase';
 import { isMuiComponent } from '../utils/reactHelpers';
 
-export const styleSheet = createStyleSheet('MuiListItem', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     display: 'flex',
     alignItems: 'center',
@@ -194,4 +194,4 @@ ListItem.childContextTypes = {
   dense: PropTypes.bool,
 };
 
-export default withStyles(styleSheet)(ListItem);
+export default withStyles(styleSheet, { name: 'MuiListItem' })(ListItem);

--- a/src/List/ListItem.spec.js
+++ b/src/List/ListItem.spec.js
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
 import ListItemText from './ListItemText';
 import ListItemSecondaryAction from './ListItemSecondaryAction';
-import ListItem, { styleSheet } from './ListItem';
+import ListItem from './ListItem';
 import ListItemAvatar from './ListItemAvatar';
 
 describe('<ListItem />', () => {
@@ -14,7 +14,7 @@ describe('<ListItem />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<ListItem />);
   });
 
   it('should render a div', () => {

--- a/src/List/ListItemAvatar.js
+++ b/src/List/ListItemAvatar.js
@@ -8,7 +8,7 @@ import warning from 'warning';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiListItemAvatar', {
+export const styleSheet = createStyleSheet({
   root: {
     width: 36,
     height: 36,
@@ -77,4 +77,4 @@ ListItemAvatar.contextTypes = {
 
 ListItemAvatar.muiName = 'ListItemAvatar';
 
-export default withStyles(styleSheet)(ListItemAvatar);
+export default withStyles(styleSheet, { name: 'MuiListItemAvatar' })(ListItemAvatar);

--- a/src/List/ListItemAvatar.spec.js
+++ b/src/List/ListItemAvatar.spec.js
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
 import consoleErrorMock from '../../test/utils/consoleErrorMock';
 import Avatar from '../Avatar';
-import ListItemAvatar, { styleSheet } from './ListItemAvatar';
+import ListItemAvatar from './ListItemAvatar';
 
 describe('<ListItemAvatar />', () => {
   let shallow;
@@ -13,7 +13,16 @@ describe('<ListItemAvatar />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(
+      <ListItemAvatar className="foo">
+        <Avatar className="bar" />
+      </ListItemAvatar>,
+      {
+        context: {
+          dense: true,
+        },
+      },
+    );
   });
 
   it('should render with the user and root classes', () => {

--- a/src/List/ListItemIcon.js
+++ b/src/List/ListItemIcon.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiListItemIcon', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     height: 24,
     marginRight: theme.spacing.unit * 2,
@@ -49,4 +49,4 @@ function ListItemIcon(props: AllProps) {
   });
 }
 
-export default withStyles(styleSheet)(ListItemIcon);
+export default withStyles(styleSheet, { name: 'MuiListItemIcon' })(ListItemIcon);

--- a/src/List/ListItemIcon.spec.js
+++ b/src/List/ListItemIcon.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import ListItemIcon, { styleSheet } from './ListItemIcon';
+import ListItemIcon from './ListItemIcon';
 
 describe('<ListItemIcon />', () => {
   let shallow;
@@ -11,7 +11,11 @@ describe('<ListItemIcon />', () => {
 
   before(() => {
     shallow = createShallow();
-    classes = getClasses(styleSheet);
+    classes = getClasses(
+      <ListItemIcon>
+        <span />
+      </ListItemIcon>,
+    );
   });
 
   it('should render a span', () => {

--- a/src/List/ListItemSecondaryAction.js
+++ b/src/List/ListItemSecondaryAction.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiListItemSecondaryAction', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     position: 'absolute',
     right: 4,
@@ -48,4 +48,6 @@ function ListItemSecondaryAction(props: AllProps) {
 
 ListItemSecondaryAction.muiName = 'ListItemSecondaryAction';
 
-export default withStyles(styleSheet)(ListItemSecondaryAction);
+export default withStyles(styleSheet, { name: 'MuiListItemSecondaryAction' })(
+  ListItemSecondaryAction,
+);

--- a/src/List/ListItemSecondaryAction.spec.js
+++ b/src/List/ListItemSecondaryAction.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import ListItemSecondaryAction, { styleSheet } from './ListItemSecondaryAction';
+import ListItemSecondaryAction from './ListItemSecondaryAction';
 
 describe('<ListItemSecondaryAction />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<ListItemSecondaryAction />', () => {
 
   before(() => {
     shallow = createShallow({ untilSelector: 'ListItemSecondaryAction' });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<ListItemSecondaryAction />);
   });
 
   it('should render a div', () => {

--- a/src/List/ListItemText.js
+++ b/src/List/ListItemText.js
@@ -7,7 +7,7 @@ import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 import Typography from '../Typography';
 
-export const styleSheet = createStyleSheet('MuiListItemText', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     flex: '1 1 auto',
     padding: '0 16px',
@@ -108,4 +108,4 @@ ListItemText.contextTypes = {
   dense: PropTypes.bool,
 };
 
-export default withStyles(styleSheet)(ListItemText);
+export default withStyles(styleSheet, { name: 'MuiListItemText' })(ListItemText);

--- a/src/List/ListItemText.spec.js
+++ b/src/List/ListItemText.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import ListItemText, { styleSheet } from './ListItemText';
+import ListItemText from './ListItemText';
 
 describe('<ListItemText />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<ListItemText />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<ListItemText />);
   });
 
   it('should render a div', () => {

--- a/src/List/ListSubheader.js
+++ b/src/List/ListSubheader.js
@@ -7,7 +7,7 @@ import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 import { capitalizeFirstLetter } from '../utils/helpers';
 
-export const styleSheet = createStyleSheet('MuiListSubheader', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     boxSizing: 'border-box',
     lineHeight: '48px',
@@ -76,4 +76,4 @@ ListSubheader.defaultProps = {
 
 ListSubheader.muiName = 'ListSubheader';
 
-export default withStyles(styleSheet)(ListSubheader);
+export default withStyles(styleSheet, { name: 'MuiListSubheader' })(ListSubheader);

--- a/src/List/ListSubheader.spec.js
+++ b/src/List/ListSubheader.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import ListSubheader, { styleSheet } from './ListSubheader';
+import ListSubheader from './ListSubheader';
 
 describe('<ListSubheader />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<ListSubheader />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<ListSubheader />);
   });
 
   it('should render a div', () => {

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -80,7 +80,7 @@ export type Props = {
 
 type AllProps = DefaultProps & Props;
 
-export const styleSheet = createStyleSheet('MuiMenu', {
+export const styleSheet = createStyleSheet({
   root: {
     /**
      * specZ: The maximum height of a simple menu should be one or more rows less than the view
@@ -177,4 +177,4 @@ class Menu extends Component<DefaultProps, AllProps, void> {
   }
 }
 
-export default withStyles(styleSheet)(Menu);
+export default withStyles(styleSheet, { name: 'MuiMenu' })(Menu);

--- a/src/Menu/Menu.spec.js
+++ b/src/Menu/Menu.spec.js
@@ -5,7 +5,7 @@ import { spy, stub } from 'sinon';
 import { assert } from 'chai';
 import ReactDOM from 'react-dom';
 import { createShallow, createMount, getClasses } from '../test-utils';
-import Menu, { styleSheet } from './Menu';
+import Menu from './Menu';
 
 describe('<Menu />', () => {
   let shallow;
@@ -13,7 +13,7 @@ describe('<Menu />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Menu />);
   });
 
   it('should render a Popover', () => {

--- a/src/Menu/MenuItem.js
+++ b/src/Menu/MenuItem.js
@@ -7,7 +7,7 @@ import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 import ListItem from '../List/ListItem';
 
-export const styleSheet = createStyleSheet('MuiMenuItem', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     ...theme.typography.subheading,
     height: 48,
@@ -92,4 +92,4 @@ MenuItem.defaultProps = {
   selected: false,
 };
 
-export default withStyles(styleSheet)(MenuItem);
+export default withStyles(styleSheet, { name: 'MuiMenuItem' })(MenuItem);

--- a/src/Menu/MenuItem.spec.js
+++ b/src/Menu/MenuItem.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
 import { createShallow, getClasses } from '../test-utils';
-import MenuItem, { styleSheet } from './MenuItem';
+import MenuItem from './MenuItem';
 
 describe('<MenuItem />', () => {
   let shallow;
@@ -12,7 +12,7 @@ describe('<MenuItem />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<MenuItem />);
   });
 
   it('should render a button ListItem with with ripple', () => {

--- a/src/MobileStepper/MobileStepper.js
+++ b/src/MobileStepper/MobileStepper.js
@@ -12,7 +12,7 @@ import KeyboardArrowLeft from '../svg-icons/keyboard-arrow-left';
 import KeyboardArrowRight from '../svg-icons/keyboard-arrow-right';
 import { LinearProgress } from '../Progress';
 
-export const styleSheet = createStyleSheet('MuiMobileStepper', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     display: 'flex',
     flexDirection: 'row',
@@ -172,4 +172,4 @@ MobileStepper.defaultProps = {
   type: 'dots',
 };
 
-export default withStyles(styleSheet)(MobileStepper);
+export default withStyles(styleSheet, { name: 'MuiMobileStepper' })(MobileStepper);

--- a/src/MobileStepper/MobileStepper.spec.js
+++ b/src/MobileStepper/MobileStepper.spec.js
@@ -7,7 +7,7 @@ import Button from '../Button/Button';
 import KeyboardArrowLeft from '../svg-icons/keyboard-arrow-left';
 import KeyboardArrowRight from '../svg-icons/keyboard-arrow-right';
 import { LinearProgress } from '../Progress';
-import MobileStepper, { styleSheet } from './MobileStepper';
+import MobileStepper from './MobileStepper';
 
 describe('<MobileStepper />', () => {
   let shallow;
@@ -20,7 +20,7 @@ describe('<MobileStepper />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<MobileStepper {...defaultProps} />);
   });
 
   it('should render a Paper component', () => {

--- a/src/Paper/Paper.js
+++ b/src/Paper/Paper.js
@@ -6,7 +6,7 @@ import warning from 'warning';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiPaper', theme => {
+export const styleSheet = createStyleSheet(theme => {
   const shadows = {};
 
   theme.shadows.forEach((shadow, index) => {
@@ -93,4 +93,4 @@ Paper.defaultProps = {
   square: false,
 };
 
-export default withStyles(styleSheet)(Paper);
+export default withStyles(styleSheet, { name: 'MuiPaper' })(Paper);

--- a/src/Paper/Paper.spec.js
+++ b/src/Paper/Paper.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import Paper, { styleSheet } from './Paper';
+import Paper from './Paper';
 
 describe('<Paper />', () => {
   let shallow;
@@ -13,7 +13,7 @@ describe('<Paper />', () => {
     shallow = createShallow({
       dive: true,
     });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Paper />);
   });
 
   it('should render a div', () => {

--- a/src/Progress/CircularProgress.js
+++ b/src/Progress/CircularProgress.js
@@ -14,7 +14,7 @@ function getRelativeValue(value, min, max) {
   return (clampedValue - min) / (max - min);
 }
 
-export const styleSheet = createStyleSheet('MuiCircularProgress', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     display: 'inline-block',
   },
@@ -167,4 +167,4 @@ CircularProgress.defaultProps = {
   max: 100,
 };
 
-export default withStyles(styleSheet)(CircularProgress);
+export default withStyles(styleSheet, { name: 'MuiCircularProgress' })(CircularProgress);

--- a/src/Progress/CircularProgress.spec.js
+++ b/src/Progress/CircularProgress.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import CircularProgress, { styleSheet } from './CircularProgress';
+import CircularProgress from './CircularProgress';
 
 describe('<CircularProgress />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<CircularProgress />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<CircularProgress />);
   });
 
   it('should render a div with the root class', () => {

--- a/src/Progress/LinearProgress.js
+++ b/src/Progress/LinearProgress.js
@@ -8,7 +8,7 @@ import withStyles from '../styles/withStyles';
 
 const transitionDuration = 4; // 400ms
 
-export const styleSheet = createStyleSheet('MuiLinearProgress', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     position: 'relative',
     overflow: 'hidden',
@@ -221,4 +221,4 @@ LinearProgress.defaultProps = {
   value: 0,
 };
 
-export default withStyles(styleSheet)(LinearProgress);
+export default withStyles(styleSheet, { name: 'MuiLinearProgress' })(LinearProgress);

--- a/src/Progress/LinearProgress.spec.js
+++ b/src/Progress/LinearProgress.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import LinearProgress, { styleSheet } from './LinearProgress';
+import LinearProgress from './LinearProgress';
 
 describe('<LinearProgress />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<LinearProgress />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<LinearProgress />);
   });
 
   it('should render a div with the root class', () => {

--- a/src/Radio/Radio.js
+++ b/src/Radio/Radio.js
@@ -3,11 +3,12 @@
 import React from 'react';
 import type { Element } from 'react';
 import createStyleSheet from '../styles/createStyleSheet';
+import withStyles from '../styles/withStyles';
 import createSwitch from '../internal/SwitchBase';
 import RadioButtonCheckedIcon from '../svg-icons/radio-button-checked';
 import RadioButtonUncheckedIcon from '../svg-icons/radio-button-unchecked';
 
-export const styleSheet = createStyleSheet('MuiRadio', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   default: {
     color: theme.palette.text.secondary,
   },
@@ -19,12 +20,13 @@ export const styleSheet = createStyleSheet('MuiRadio', theme => ({
   },
 }));
 
-const Radio = createSwitch({
-  styleSheet,
-  inputType: 'radio',
-  defaultIcon: <RadioButtonUncheckedIcon />,
-  defaultCheckedIcon: <RadioButtonCheckedIcon />,
-});
+const Radio = withStyles(styleSheet, { name: 'MuiRadio' })(
+  createSwitch({
+    inputType: 'radio',
+    defaultIcon: <RadioButtonUncheckedIcon />,
+    defaultCheckedIcon: <RadioButtonCheckedIcon />,
+  }),
+);
 
 Radio.displayName = 'Radio';
 

--- a/src/Radio/Radio.spec.js
+++ b/src/Radio/Radio.spec.js
@@ -1,14 +1,15 @@
 // @flow
 
+import React from 'react';
 import { assert } from 'chai';
 import { getClasses } from '../test-utils';
-import Radio, { styleSheet } from './Radio';
+import Radio from './Radio';
 
 describe('<Radio />', () => {
   let classes;
 
   before(() => {
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Radio />);
   });
 
   describe('styleSheet', () => {

--- a/src/Radio/RadioGroup.js
+++ b/src/Radio/RadioGroup.js
@@ -8,7 +8,7 @@ import withStyles from '../styles/withStyles';
 import FormGroup from '../Form/FormGroup';
 import { find } from '../utils/helpers';
 
-export const styleSheet = createStyleSheet('MuiRadioGroup', {
+export const styleSheet = createStyleSheet({
   root: {
     flex: '1 1 auto',
     margin: 0,
@@ -128,4 +128,4 @@ class RadioGroup extends PureComponent<void, AllProps, void> {
   }
 }
 
-export default withStyles(styleSheet)(RadioGroup);
+export default withStyles(styleSheet, { name: 'MuiRadioGroup' })(RadioGroup);

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -13,7 +13,7 @@ import Slide from '../transitions/Slide';
 import SnackbarContent from './SnackbarContent';
 import type { TransitionCallback } from '../internal/Transition';
 
-export const styleSheet = createStyleSheet('MuiSnackbar', theme => {
+export const styleSheet = createStyleSheet(theme => {
   const gutter = theme.spacing.unit * 3;
   const top = { top: 0 };
   const bottom = { bottom: 0 };
@@ -365,4 +365,4 @@ class Snackbar extends Component<DefaultProps, AllProps, State> {
   }
 }
 
-export default withStyles(styleSheet)(Snackbar);
+export default withStyles(styleSheet, { name: 'MuiSnackbar' })(Snackbar);

--- a/src/Snackbar/Snackbar.spec.js
+++ b/src/Snackbar/Snackbar.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { createShallow, createMount, getClasses } from '../test-utils';
-import Snackbar, { styleSheet } from './Snackbar';
+import Snackbar from './Snackbar';
 import Slide from '../transitions/Slide';
 
 describe('<Snackbar />', () => {
@@ -14,7 +14,7 @@ describe('<Snackbar />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Snackbar open />);
     mount = createMount();
   });
 

--- a/src/Snackbar/SnackbarContent.js
+++ b/src/Snackbar/SnackbarContent.js
@@ -8,7 +8,7 @@ import withStyles from '../styles/withStyles';
 import Paper from '../Paper';
 import Typography from '../Typography';
 
-export const styleSheet = createStyleSheet('MuiSnackbarContent', theme => {
+export const styleSheet = createStyleSheet(theme => {
   const type = theme.palette.type === 'light' ? 'dark' : 'light';
   const backgroundColor = theme.palette.shades[type].background.default;
 
@@ -95,4 +95,4 @@ function SnackbarContent(props: AllProps) {
   );
 }
 
-export default withStyles(styleSheet)(SnackbarContent);
+export default withStyles(styleSheet, { name: 'MuiSnackbarContent' })(SnackbarContent);

--- a/src/Snackbar/SnackbarContent.spec.js
+++ b/src/Snackbar/SnackbarContent.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import SnackbarContent, { styleSheet } from './SnackbarContent';
+import SnackbarContent from './SnackbarContent';
 
 describe('<SnackbarContent />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<SnackbarContent />', () => {
 
   before(() => {
     shallow = createShallow({ untilSelector: 'withStyles(Paper)' });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<SnackbarContent message="message" />);
   });
 
   it('should render a Paper with classes', () => {

--- a/src/SvgIcon/SvgIcon.js
+++ b/src/SvgIcon/SvgIcon.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiSvgIcon', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     display: 'inline-block',
     fill: 'currentColor',
@@ -74,4 +74,4 @@ SvgIcon.defaultProps = {
 
 SvgIcon.muiName = 'SvgIcon';
 
-export default withStyles(styleSheet)(SvgIcon);
+export default withStyles(styleSheet, { name: 'MuiSvgIcon' })(SvgIcon);

--- a/src/SvgIcon/SvgIcon.spec.js
+++ b/src/SvgIcon/SvgIcon.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import SvgIcon, { styleSheet } from './SvgIcon';
+import SvgIcon from './SvgIcon';
 
 describe('<SvgIcon />', () => {
   let shallow;
@@ -12,7 +12,7 @@ describe('<SvgIcon />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<SvgIcon />);
     path = <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />;
   });
 

--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -7,7 +7,7 @@ import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 import createSwitch from '../internal/SwitchBase';
 
-export const styleSheet = createStyleSheet('MuiSwitch', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     display: 'inline-flex',
     width: 62,
@@ -61,7 +61,7 @@ export const styleSheet = createStyleSheet('MuiSwitch', theme => ({
   },
 }));
 
-const SwitchBase = createSwitch({ styleSheet });
+const SwitchBase = createSwitch();
 
 type DefaultProps = {
   classes: Object,
@@ -142,16 +142,24 @@ export type Props = {
 type AllProps = DefaultProps & Props;
 
 function Switch(props: AllProps) {
-  const { classes: { root, ...classes }, className, ...other } = props;
-
+  const { classes, className, ...other } = props;
   const icon = <div className={classes.icon} />;
 
   return (
-    <div className={classNames(root, className)}>
-      <SwitchBase icon={icon} classes={classes} checkedIcon={icon} {...other} />
+    <div className={classNames(classes.root, className)}>
+      <SwitchBase
+        icon={icon}
+        classes={{
+          default: classes.default,
+          checked: classes.checked,
+          disabled: classes.disabled,
+        }}
+        checkedIcon={icon}
+        {...other}
+      />
       <div className={classes.bar} />
     </div>
   );
 }
 
-export default withStyles(styleSheet)(Switch);
+export default withStyles(styleSheet, { name: 'MuiSwitch' })(Switch);

--- a/src/Switch/Switch.spec.js
+++ b/src/Switch/Switch.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import Switch, { styleSheet } from './Switch';
+import Switch from './Switch';
 
 describe('<Switch />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<Switch />', () => {
 
   before(() => {
     shallow = createShallow({ untilSelector: 'div' });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Switch />);
   });
 
   describe('styleSheet', () => {

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiTable', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     fontFamily: theme.typography.fontFamily,
     width: '100%',
@@ -55,4 +55,4 @@ Table.childContextTypes = {
   table: PropTypes.object,
 };
 
-export default withStyles(styleSheet)(Table);
+export default withStyles(styleSheet, { name: 'MuiTable' })(Table);

--- a/src/Table/Table.spec.js
+++ b/src/Table/Table.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import Table, { styleSheet } from './Table';
+import Table from './Table';
 
 describe('<Table />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<Table />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Table />);
   });
 
   it('should render a table', () => {

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiTableBody', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     fontSize: 13,
     color: theme.palette.text.primary,
@@ -58,4 +58,4 @@ TableBody.childContextTypes = {
   table: PropTypes.object,
 };
 
-export default withStyles(styleSheet)(TableBody);
+export default withStyles(styleSheet, { name: 'MuiTableBody' })(TableBody);

--- a/src/Table/TableBody.spec.js
+++ b/src/Table/TableBody.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import TableBody, { styleSheet } from './TableBody';
+import TableBody from './TableBody';
 
 describe('<TableBody />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<TableBody />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<TableBody />);
   });
 
   it('should render a tbody', () => {

--- a/src/Table/TableCell.js
+++ b/src/Table/TableCell.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiTableCell', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     borderBottom: `1px solid ${theme.palette.text.lightDivider}`,
     whiteSpace: 'nowrap',
@@ -114,4 +114,4 @@ TableCell.contextTypes = {
   table: PropTypes.object,
 };
 
-export default withStyles(styleSheet)(TableCell);
+export default withStyles(styleSheet, { name: 'MuiTableCell' })(TableCell);

--- a/src/Table/TableCell.spec.js
+++ b/src/Table/TableCell.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import TableCell, { styleSheet } from './TableCell';
+import TableCell from './TableCell';
 
 describe('<TableCell />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<TableCell />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<TableCell />);
   });
 
   it('should render a td', () => {

--- a/src/Table/TableHead.js
+++ b/src/Table/TableHead.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiTableHead', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     fontSize: 12,
     fontWeight: theme.typography.fontWeightMedium,
@@ -59,4 +59,4 @@ TableHead.childContextTypes = {
   table: PropTypes.object,
 };
 
-export default withStyles(styleSheet)(TableHead);
+export default withStyles(styleSheet, { name: 'MuiTableHead' })(TableHead);

--- a/src/Table/TableHead.spec.js
+++ b/src/Table/TableHead.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import TableHead, { styleSheet } from './TableHead';
+import TableHead from './TableHead';
 
 describe('<TableHead />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<TableHead />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<TableHead />);
   });
 
   it('should render a thead', () => {

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiTableRow', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     height: 48,
     '&:focus': {
@@ -87,4 +87,4 @@ TableRow.contextTypes = {
   table: PropTypes.object,
 };
 
-export default withStyles(styleSheet)(TableRow);
+export default withStyles(styleSheet, { name: 'MuiTableRow' })(TableRow);

--- a/src/Table/TableRow.spec.js
+++ b/src/Table/TableRow.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import TableRow, { styleSheet } from './TableRow';
+import TableRow from './TableRow';
 
 describe('<TableRow />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<TableRow />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<TableRow />);
   });
 
   it('should render a tr', () => {

--- a/src/Table/TableSortLabel.js
+++ b/src/Table/TableSortLabel.js
@@ -8,7 +8,7 @@ import withStyles from '../styles/withStyles';
 import ButtonBase from '../ButtonBase';
 import ArrowDownwardIcon from '../svg-icons/arrow-downward';
 
-export const styleSheet = createStyleSheet('MuiTableSortLabel', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     cursor: 'pointer',
     display: 'inline-flex',
@@ -101,4 +101,4 @@ TableSortLabel.defaultProps = {
   direction: 'desc',
 };
 
-export default withStyles(styleSheet)(TableSortLabel);
+export default withStyles(styleSheet, { name: 'MuiTableSortLabel' })(TableSortLabel);

--- a/src/Table/TableSortLabel.spec.js
+++ b/src/Table/TableSortLabel.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import TableSortLabel, { styleSheet } from './TableSortLabel';
+import TableSortLabel from './TableSortLabel';
 
 describe('<TableSortLabel />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<TableSortLabel />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<TableSortLabel />);
   });
 
   it('should render TableSortLabel', () => {

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -9,7 +9,7 @@ import ButtonBase from '../ButtonBase';
 import { capitalizeFirstLetter } from '../utils/helpers';
 import Icon from '../Icon';
 
-export const styleSheet = createStyleSheet('MuiTab', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     ...theme.typography.button,
     maxWidth: 264,
@@ -269,4 +269,4 @@ Tab.propTypes = {
   ]),
 };
 
-export default withStyles(styleSheet)(Tab);
+export default withStyles(styleSheet, { name: 'MuiTab' })(Tab);

--- a/src/Tabs/Tab.spec.js
+++ b/src/Tabs/Tab.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy, stub } from 'sinon';
 import { createShallow, createMount, getClasses } from '../test-utils';
-import Tab, { styleSheet } from './Tab';
+import Tab from './Tab';
 import Icon from '../Icon';
 
 describe('<Tab />', () => {
@@ -16,7 +16,7 @@ describe('<Tab />', () => {
   before(() => {
     shallow = createShallow({ dive: true });
     mount = createMount();
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Tab textColor="inherit" />);
   });
 
   after(() => {

--- a/src/Tabs/TabIndicator.js
+++ b/src/Tabs/TabIndicator.js
@@ -7,7 +7,7 @@ import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 import { capitalizeFirstLetter } from '../utils/helpers';
 
-export const styleSheet = createStyleSheet('MuiTabIndicator', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     position: 'relative',
     height: 2,
@@ -71,4 +71,4 @@ TabIndicator.propTypes = {
   }).isRequired,
 };
 
-export default withStyles(styleSheet)(TabIndicator);
+export default withStyles(styleSheet, { name: 'MuiTabIndicator' })(TabIndicator);

--- a/src/Tabs/TabIndicator.spec.js
+++ b/src/Tabs/TabIndicator.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import TabIndicator, { styleSheet } from './TabIndicator';
+import TabIndicator from './TabIndicator';
 
 describe('<TabIndicator />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<TabIndicator />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<TabIndicator color="accent" style={{}} />);
   });
 
   it('should render with the root class', () => {

--- a/src/Tabs/TabScrollButton.js
+++ b/src/Tabs/TabScrollButton.js
@@ -9,7 +9,7 @@ import ButtonBase from '../ButtonBase';
 import KeyboardArrowLeft from '../svg-icons/keyboard-arrow-left';
 import KeyboardArrowRight from '../svg-icons/keyboard-arrow-right';
 
-export const styleSheet = createStyleSheet('MuiTabScrollButton', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     background: 'none',
     color: 'inherit',
@@ -63,4 +63,4 @@ TabScrollButton.defaultProps = {
   visible: true,
 };
 
-export default withStyles(styleSheet)(TabScrollButton);
+export default withStyles(styleSheet, { name: 'MuiTabScrollButton' })(TabScrollButton);

--- a/src/Tabs/TabScrollButton.spec.js
+++ b/src/Tabs/TabScrollButton.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, createMount, getClasses } from '../test-utils';
-import TabScrollButton, { styleSheet } from './TabScrollButton';
+import TabScrollButton from './TabScrollButton';
 import ButtonBase from '../ButtonBase';
 import KeyboardArrowLeft from '../svg-icons/keyboard-arrow-left';
 import KeyboardArrowRight from '../svg-icons/keyboard-arrow-right';
@@ -15,7 +15,7 @@ describe('<TabScrollButton />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<TabScrollButton />);
     mount = createMount();
   });
 

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -15,7 +15,7 @@ import withWidth, { isWidthUp } from '../utils/withWidth';
 import TabIndicator from './TabIndicator';
 import TabScrollButton from './TabScrollButton';
 
-export const styleSheet = createStyleSheet('MuiTabs', {
+export const styleSheet = createStyleSheet({
   root: {
     overflow: 'hidden',
   },
@@ -365,4 +365,4 @@ Tabs.propTypes = {
   width: PropTypes.string,
 };
 
-export default compose(withStyles(styleSheet), withWidth())(Tabs);
+export default compose(withStyles(styleSheet, { name: 'MuiTabs' }), withWidth())(Tabs);

--- a/src/Tabs/Tabs.spec.js
+++ b/src/Tabs/Tabs.spec.js
@@ -6,7 +6,7 @@ import { spy, stub, useFakeTimers } from 'sinon';
 import scroll from 'scroll';
 import { createShallow, createMount, getClasses } from '../test-utils';
 import consoleErrorMock from '../../test/utils/consoleErrorMock';
-import Tabs, { styleSheet } from './Tabs';
+import Tabs from './Tabs';
 import TabScrollButton from './TabScrollButton';
 import TabIndicator from './TabIndicator';
 import Tab from './Tab';
@@ -20,7 +20,7 @@ describe('<Tabs />', () => {
 
   before(() => {
     shallow = createShallow({ untilSelector: 'Tabs' });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Tabs />);
     mount = createMount();
   });
 

--- a/src/Toolbar/Toolbar.js
+++ b/src/Toolbar/Toolbar.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiToolbar', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     position: 'relative',
     display: 'flex',
@@ -63,4 +63,4 @@ Toolbar.defaultProps = {
   disableGutters: false,
 };
 
-export default withStyles(styleSheet)(Toolbar);
+export default withStyles(styleSheet, { name: 'MuiCollapse' })(Toolbar);

--- a/src/Toolbar/Toolbar.spec.js
+++ b/src/Toolbar/Toolbar.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import Toolbar, { styleSheet } from './Toolbar';
+import Toolbar from './Toolbar';
 
 describe('<Toolbar />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<Toolbar />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Toolbar />);
   });
 
   it('should render a div', () => {

--- a/src/Typography/Typography.js
+++ b/src/Typography/Typography.js
@@ -7,7 +7,7 @@ import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 import { capitalizeFirstLetter } from '../utils/helpers';
 
-export const styleSheet = createStyleSheet('MuiTypography', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     display: 'block',
     margin: 0,
@@ -178,4 +178,4 @@ Typography.defaultProps = {
   type: 'body1',
 };
 
-export default withStyles(styleSheet)(Typography);
+export default withStyles(styleSheet, { name: 'MuiTypography' })(Typography);

--- a/src/Typography/Typography.spec.js
+++ b/src/Typography/Typography.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import Typography, { styleSheet } from './Typography';
+import Typography from './Typography';
 
 describe('<Typography />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<Typography />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Typography />);
   });
 
   it('should render the text', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,15 @@ export { default as Paper } from './Paper';
 export { CircularProgress, LinearProgress } from './Progress';
 export { default as Radio, RadioGroup } from './Radio';
 export { default as Snackbar, SnackbarContent } from './Snackbar';
-export { MuiThemeProvider } from './styles';
+export {
+  MuiThemeProvider,
+  withStyles,
+  withTheme,
+  createMuiTheme,
+  createTypography,
+  createBreakpoints,
+  createPalette,
+} from './styles';
 
 // eslint-disable-next-line import/first
 import * as colors from './colors';

--- a/src/internal/Backdrop.js
+++ b/src/internal/Backdrop.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-export const styleSheet = createStyleSheet('MuiBackdrop', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     zIndex: -1,
     width: '100%',
@@ -76,4 +76,4 @@ Backdrop.defaultProps = {
   invisible: false,
 };
 
-export default withStyles(styleSheet)(Backdrop);
+export default withStyles(styleSheet, { name: 'MuiBackdrop' })(Backdrop);

--- a/src/internal/Backdrop.spec.js
+++ b/src/internal/Backdrop.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
-import Backdrop, { styleSheet } from './Backdrop';
+import Backdrop from './Backdrop';
 
 describe('<Backdrop />', () => {
   let shallow;
@@ -11,7 +11,7 @@ describe('<Backdrop />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Backdrop />);
   });
 
   it('should render a backdrop div', () => {

--- a/src/internal/Modal.js
+++ b/src/internal/Modal.js
@@ -26,7 +26,7 @@ import type { TransitionCallback } from './Transition';
  */
 const modalManager = createModalManager();
 
-export const styleSheet = createStyleSheet('MuiModal', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     display: 'flex',
     width: '100%',
@@ -449,4 +449,4 @@ class Modal extends Component<DefaultProps, AllProps, State> {
   }
 }
 
-export default withStyles(styleSheet)(Modal);
+export default withStyles(styleSheet, { name: 'MuiModal' })(Modal);

--- a/src/internal/Modal.spec.js
+++ b/src/internal/Modal.spec.js
@@ -9,7 +9,7 @@ import { createShallow, createMount, getClasses } from '../test-utils';
 import consoleErrorMock from '../../test/utils/consoleErrorMock';
 import Fade from '../transitions/Fade';
 import Backdrop from './Backdrop';
-import Modal, { styleSheet } from './Modal';
+import Modal from './Modal';
 
 describe('<Modal />', () => {
   let shallow;
@@ -18,7 +18,7 @@ describe('<Modal />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Modal />);
     mount = createMount();
   });
 

--- a/src/internal/Popover.js
+++ b/src/internal/Popover.js
@@ -62,7 +62,7 @@ function getScrollParent(parent, child) {
   return scrollTop;
 }
 
-export const styleSheet = createStyleSheet('MuiPopover', {
+export const styleSheet = createStyleSheet({
   paper: {
     position: 'absolute',
     overflowY: 'auto',
@@ -412,4 +412,4 @@ class Popover extends Component<DefaultProps, AllProps, void> {
   }
 }
 
-export default withStyles(styleSheet)(Popover);
+export default withStyles(styleSheet, { name: 'MuiPopover' })(Popover);

--- a/src/internal/Popover.spec.js
+++ b/src/internal/Popover.spec.js
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
 import css from 'dom-helpers/style';
 import { createShallow, createMount, getClasses } from '../test-utils';
-import Popover, { styleSheet } from './Popover';
+import Popover from './Popover';
 
 describe('<Popover />', () => {
   let shallow;
@@ -15,9 +15,7 @@ describe('<Popover />', () => {
   before(() => {
     shallow = createShallow({ dive: true });
     mount = createMount();
-    classes = getClasses(styleSheet, {
-      withTheme: true,
-    });
+    classes = getClasses(<Popover />);
   });
 
   after(() => {

--- a/src/internal/SwitchBase.js
+++ b/src/internal/SwitchBase.js
@@ -10,7 +10,7 @@ import CheckBoxOutlineBlankIcon from '../svg-icons/check-box-outline-blank';
 import CheckBoxIcon from '../svg-icons/check-box';
 import Icon from '../Icon';
 
-export const styleSheet = createStyleSheet('MuiSwitchBase', {
+export const styleSheet = createStyleSheet({
   root: {
     display: 'inline-flex',
     alignItems: 'center',
@@ -27,6 +27,9 @@ export const styleSheet = createStyleSheet('MuiSwitchBase', {
     margin: 0,
     padding: 0,
   },
+  default: {},
+  checked: {},
+  disabled: {},
 });
 
 type DefaultProps = {
@@ -129,7 +132,6 @@ type Options = {
   defaultIcon?: Element<*>,
   defaultCheckedIcon?: Element<*>,
   inputType?: string,
-  styleSheet?: Object,
 };
 
 export default function createSwitch(
@@ -137,7 +139,6 @@ export default function createSwitch(
     defaultIcon = <CheckBoxOutlineBlankIcon />,
     defaultCheckedIcon = <CheckBoxIcon />,
     inputType = 'checkbox',
-    styleSheet: switchStyleSheet,
   }: Options = {},
 ) {
   /**
@@ -260,5 +261,5 @@ export default function createSwitch(
     }
   }
 
-  return withStyles([switchStyleSheet, styleSheet])(SwitchBase);
+  return withStyles(styleSheet, { name: 'MuiSwitchBase' })(SwitchBase);
 }

--- a/src/internal/SwitchBase.spec.js
+++ b/src/internal/SwitchBase.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
 import { createShallow, createMount, getClasses } from '../test-utils';
-import createSwitch, { styleSheet } from './SwitchBase';
+import createSwitch from './SwitchBase';
 import Icon from '../Icon';
 
 function assertIsChecked(wrapper) {
@@ -57,7 +57,7 @@ describe('<SwitchBase />', () => {
       dive: true,
     });
     mount = createMount();
-    classes = getClasses(styleSheet);
+    classes = getClasses(<SwitchBase />);
   });
 
   after(() => {

--- a/src/styles/MuiThemeProvider.spec.js
+++ b/src/styles/MuiThemeProvider.spec.js
@@ -48,7 +48,7 @@ describe('<MuiThemeProvider />', () => {
 
       const markup = renderToString(
         <JssProvider registry={sheetsRegistry} jss={jss}>
-          <MuiThemeProvider theme={theme} sheetsManager={new WeakMap()}>
+          <MuiThemeProvider theme={theme} sheetsManager={new Map()}>
             <Button>Hello World</Button>
           </MuiThemeProvider>
         </JssProvider>,

--- a/src/styles/createStyleSheet.js
+++ b/src/styles/createStyleSheet.js
@@ -5,10 +5,8 @@ import merge from 'deepmerge'; // < 1kb payload overhead when lodash/merge is > 
 
 type GetStyles = Object | ((theme: Object) => Object);
 
-function createStyleSheet(name: string | GetStyles, callback?: GetStyles, options: Object = {}) {
-  const getStyles = typeof name === 'string' ? callback : name;
-
-  function createStyles(theme: Object = {}): Object {
+function createStyleSheet(getStyles?: GetStyles) {
+  function createStyles(theme: Object = {}, name?: String): Object {
     const styles = typeof getStyles === 'function' ? getStyles(theme) : getStyles;
 
     if (!theme.overrides || !theme.overrides[name]) {
@@ -27,12 +25,11 @@ function createStyleSheet(name: string | GetStyles, callback?: GetStyles, option
   }
 
   return {
-    name: typeof name === 'string' ? name : false,
     createStyles,
-    options,
+    options: {},
     // Enable the theme if the getStyles is a function (as we provide the theme as first argument)
     // or if the sheets has a name (as we can use the overrides key of the theme).
-    themingEnabled: typeof getStyles === 'function' || typeof name === 'string',
+    themingEnabled: typeof getStyles === 'function',
   };
 }
 

--- a/src/styles/createStyleSheet.spec.js
+++ b/src/styles/createStyleSheet.spec.js
@@ -5,7 +5,7 @@ import createStyleSheet from './createStyleSheet';
 
 describe('createStyleSheet', () => {
   const name = 'name';
-  const styleSheet = createStyleSheet(name, {
+  const styleSheet = createStyleSheet({
     root: {
       color: 'black',
       '&:hover': {
@@ -43,7 +43,7 @@ describe('createStyleSheet', () => {
           },
         },
       };
-      const styles = styleSheet.createStyles(theme);
+      const styles = styleSheet.createStyles(theme, name);
       assert.deepEqual(styles, {
         root: {
           color: 'white',

--- a/src/styles/withStyles.spec.js
+++ b/src/styles/withStyles.spec.js
@@ -35,13 +35,13 @@ describe('withStyles', () => {
     let classes;
 
     before(() => {
-      const styleSheet = createStyleSheet('MuiTextField', {
+      const styleSheet = createStyleSheet({
         root: {
           display: 'flex',
         },
       });
-      StyledComponent1 = withStyles(styleSheet)(Empty);
-      classes = getClasses(styleSheet);
+      StyledComponent1 = withStyles(styleSheet, { name: 'MuiTextField' })(Empty);
+      classes = getClasses(<StyledComponent1 />);
     });
 
     it('should provide a classes property', () => {
@@ -145,12 +145,12 @@ describe('withStyles', () => {
     });
 
     it('should work when depending on a theme', () => {
-      const styleSheet = createStyleSheet('MuiTextField', theme => ({
+      const styleSheet = createStyleSheet(theme => ({
         root: {
           padding: theme.spacing.unit,
         },
       }));
-      const StyledComponent = withStyles(styleSheet)(Empty);
+      const StyledComponent = withStyles(styleSheet, { name: 'MuiTextField' })(Empty);
 
       const wrapper = mount(
         <MuiThemeProvider theme={createMuiTheme()}>
@@ -173,12 +173,12 @@ describe('withStyles', () => {
     });
 
     it('should support the overrides key', () => {
-      const styleSheet = createStyleSheet('MuiTextField', {
+      const styleSheet = createStyleSheet({
         root: {
           padding: 8,
         },
       });
-      const StyledComponent = withStyles(styleSheet)(Empty);
+      const StyledComponent = withStyles(styleSheet, { name: 'MuiTextField' })(Empty);
 
       mount(
         <MuiThemeProvider

--- a/src/test-utils/createShallow.js
+++ b/src/test-utils/createShallow.js
@@ -6,17 +6,17 @@ import until from './until';
 
 // Generate an enhanced shallow function.
 export default function createShallow(options: Object = {}) {
-  const { shallow = enzymeShallow, otherContext, dive = false, untilSelector = false } = options;
+  const { shallow = enzymeShallow, context, dive = false, untilSelector = false } = options;
 
   const shallowWithContext = function shallowWithContext(node: Element<*>, options2: Object = {}) {
     const { context: context2, ...other } = options2;
 
     const wrapper = shallow(node, {
+      ...other,
       context: {
-        ...otherContext,
+        ...context,
         ...context2,
       },
-      ...other,
     });
 
     if (dive) {

--- a/src/test-utils/getClasses.js
+++ b/src/test-utils/getClasses.js
@@ -1,16 +1,24 @@
 // @flow
 
-import React from 'react';
+import * as ns from 'react-jss/lib/ns';
+import { SheetsRegistry } from 'react-jss';
 import createShallow from './createShallow';
-import withStyles from '../styles/withStyles';
+import { sheetsManager } from '../styles/withStyles';
 
 const shallow = createShallow();
-const Empty = () => <div />;
-Empty.defaultProps = {};
 
 // Helper function to extract the classes from a styleSheet.
-export default function getClasses(styleSheet: Object, options?: Object) {
-  const Extractor = withStyles(styleSheet, options)(Empty);
+export default function getClasses(element: Object, options: Object = {}) {
+  const sheetsRegistry = new SheetsRegistry();
 
-  return shallow(<Extractor />).props().classes;
+  sheetsManager.clear();
+  shallow(element, {
+    ...options,
+    context: {
+      [ns.sheetsRegistry]: sheetsRegistry,
+      ...options.context,
+    },
+  });
+
+  return sheetsRegistry.registry[0].classes;
 }

--- a/src/transitions/Collapse.js
+++ b/src/transitions/Collapse.js
@@ -9,7 +9,7 @@ import type { TransitionCallback } from '../internal/Transition';
 
 const reflow = elem => elem.offsetHeight;
 
-export const styleSheet = createStyleSheet('MuiCollapse', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   container: {
     height: 0,
     overflow: 'hidden',
@@ -193,4 +193,5 @@ class Collapse extends PureComponent<DefaultProps, AllProps, void> {
 
 export default withStyles(styleSheet, {
   withTheme: true,
+  name: 'MuiCollapse',
 })(Collapse);

--- a/src/transitions/Collapse.spec.js
+++ b/src/transitions/Collapse.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy, stub } from 'sinon';
 import { createShallow, createMount, getClasses } from '../test-utils';
-import Collapse, { styleSheet } from './Collapse';
+import Collapse from './Collapse';
 
 describe('<Collapse />', () => {
   let shallow;
@@ -12,7 +12,7 @@ describe('<Collapse />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(styleSheet);
+    classes = getClasses(<Collapse />);
   });
 
   it('should render a Transition', () => {


### PR DESCRIPTION
First step toward #7636.

- Move the `name` option from `createStyleSheet` to `withStyles`.
- Move the `option` argument from `createStyleSheet` to `withStyles`.

Now, we should be able to hide `createStyleSheet` quite easily.