### PR TITLE
Documentation Fix - Fixing up the README documentation

### DIFF
--- a/examples/create-react-app/README.md
+++ b/examples/create-react-app/README.md
@@ -5,7 +5,7 @@
 Download the example [or clone the repo](https://github.com/callemall/material-ui):
 
 ```bash
-curl https://codeload.github.com/callemall/material-ui/tar.gz/v1-beta | tar -xz --strip=2 next.js-master/examples/create-react-app
+curl https://codeload.github.com/callemall/material-ui/tar.gz/v1-beta | tar -xz --strip=2 material-ui-v1-beta/examples/create-react-app
 cd create-react-app
 ```
 

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -6,7 +6,7 @@
 Download the example [or clone the repo](https://github.com/callemall/material-ui):
 
 ```bash
-curl https://codeload.github.com/callemall/material-ui/tar.gz/v1-beta | tar -xz --strip=2 next.js-master/examples/nextjs
+curl https://codeload.github.com/callemall/material-ui/tar.gz/v1-beta | tar -xz --strip=2  material-ui-1-beta/examples/nextjs
 cd nextjs
 ```
 


### PR DESCRIPTION
Fixing up the readme documentation for the examples as it has the old repo name in it. 

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

