### PR TITLE
[DatePicker] Fix bug where 'isSelectedDateDisabled' was returning undefined

### DIFF
--- a/src/DatePicker/Calendar.js
+++ b/src/DatePicker/Calendar.js
@@ -81,6 +81,8 @@ class Calendar extends Component {
     }
   }
 
+  calendarRefs = {};
+
   getMinDate() {
     return this.props.minDate || this.props.utils.addYears(new Date(), -100);
   }
@@ -98,7 +100,11 @@ class Calendar extends Component {
       return false;
     }
 
-    return this.refs.calendar.isSelectedDateDisabled();
+    if (this.calendarRefs.calendar) {
+      return this.calendarRefs.calendar.isSelectedDateDisabled();
+    } else {
+      return false;
+    }
   }
 
   addSelectedDays(days) {
@@ -365,7 +371,7 @@ class Calendar extends Component {
                   minDate={this.getMinDate()}
                   maxDate={this.getMaxDate()}
                   onTouchTapDay={this.handleTouchTapDay}
-                  ref="calendar"
+                  ref={(ref) => this.calendarRefs.calendar = ref}
                   selectedDate={this.state.selectedDate}
                   shouldDisableDate={this.props.shouldDisableDate}
                   utils={utils}


### PR DESCRIPTION
Found that using Date Picker in React v16 Beta was returning with this bug again. (as seen before in https://github.com/callemall/material-ui/issues/1224)

Could be something to do with the way refs are handled. Just changed the ref over from a string ref to the recommended way of using a ref function.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

