### PR TITLE
[Menu] changed behavior of onEnter to override this.handleEnter. Other misc changes

### DIFF
--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -125,10 +125,6 @@ class Menu extends Component<DefaultProps, AllProps, void> {
       // $FlowFixMe
       menuList.style.width = `calc(100% + ${size})`;
     }
-
-    if (this.props.onEnter) {
-      this.props.onEnter(element);
-    }
   };
 
   handleListKeyDown = (event: SyntheticUIEvent, key: string) => {
@@ -157,7 +153,13 @@ class Menu extends Component<DefaultProps, AllProps, void> {
       <Popover
         getContentAnchorEl={this.getContentAnchorEl}
         className={classNames(classes.root, className)}
-        onEnter={this.handleEnter}
+        onEnter={(...args) => {
+          if (onEnter instanceof Function) {
+            return onEnter.apply(this, args);
+          }
+
+          return this.handleEnter(...args);
+        }}
         {...other}
       >
         <MenuList

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ export {
 export { default as Menu, MenuItem, MenuList } from './Menu';
 export { default as Paper } from './Paper';
 export { CircularProgress, LinearProgress } from './Progress';
+export { default as Popover } from './internal/Popover';
 export { default as Radio, RadioGroup } from './Radio';
 export { default as Snackbar, SnackbarContent } from './Snackbar';
 export {

--- a/src/internal/Modal.js
+++ b/src/internal/Modal.js
@@ -41,6 +41,7 @@ export const styles = (theme: Object) => ({
 });
 
 type DefaultProps = {
+  autoFocus: true,
   backdropComponent: Function,
   backdropTransitionDuration: number,
   backdropInvisible: boolean,
@@ -53,6 +54,10 @@ type DefaultProps = {
 };
 
 export type Props = {
+  /**
+   * If `false`, do not pull the focus off any currently focussed element
+   */
+  autoFocus?: boolean,
   /**
    * The CSS class name of the backdrop element.
    */
@@ -261,7 +266,9 @@ class Modal extends Component<DefaultProps, AllProps, State> {
     this.props.modalManager.add(this);
     this.onDocumentKeyUpListener = addEventListener(doc, 'keyup', this.handleDocumentKeyUp);
     this.onFocusListener = addEventListener(doc, 'focus', this.handleFocusListener, true);
-    this.focus();
+    if (this.props.autoFocus !== false) {
+      this.focus();
+    }
   }
 
   handleHide() {

--- a/src/internal/Popover.js
+++ b/src/internal/Popover.js
@@ -372,12 +372,13 @@ class Popover extends Component<DefaultProps, AllProps, void> {
       onExiting,
       onExited,
       elevation,
+      autoFocus,
       ...other
     } = this.props;
 
     // FIXME: props API consistency problem? - `...other` not spread over the root
     return (
-      <Modal show={open} backdropInvisible onRequestClose={onRequestClose}>
+      <Modal show={open} backdropInvisible onRequestClose={onRequestClose} autoFocus={autoFocus}>
         <Grow
           in={open}
           enteredClassName={enteredClassName}


### PR DESCRIPTION
1. I changed the behavior of Menu `onEnter` prop to **OVERRIDE** the behavior of this.handleEnter (instead of just be triggered fom `this.handleEnter`). I didn't want the focus to be stolen by `this.handleEnter`, and the way I wrote it `onEnter` is called via `onEnter.apply(this, args)`, allowing someone to still call `this.handleEnter` inside `{function onEnter(...args) { /*...do my stuff;*/ return this.handleEnter(...args); } }`, giving the ability to override default functionality, disable it, or add to it.

2. I also exposed the `Popover` component.
3. I also modified Modal to not steal the focus on show by passing the property `autoFocus={false}`. Popover also passes this property to the Modal.

FYI: I am trying to make my own autocomplete field... and I would like to use Menu / Popover to do this. The changes I made shouldn't break anything for current users, and they open up more usage possibilities via a complete Menu/onEnter override, and using Popover and modals for things other than modals... i.e. input field popups