### PR TITLE
[IntergrationAutosuggest] Docs - Add createStyleSheet

### DIFF
--- a/docs/src/pages/component-demos/autocomplete/IntegrationAutosuggest.js
+++ b/docs/src/pages/component-demos/autocomplete/IntegrationAutosuggest.js
@@ -9,7 +9,7 @@ import Paper from 'material-ui/Paper';
 import { MenuItem } from 'material-ui/Menu';
 import match from 'autosuggest-highlight/match';
 import parse from 'autosuggest-highlight/parse';
-import { withStyles } from 'material-ui/styles';
+import { withStyles,  createStyleSheet } from 'material-ui/styles';
 
 const suggestions = [
   { label: 'Afghanistan' },
@@ -121,7 +121,7 @@ function getSuggestions(value) {
       });
 }
 
-const styles = theme => ({
+const styles =  createStyleSheet(theme => ({
   container: {
     flexGrow: 1,
     position: 'relative',
@@ -145,7 +145,7 @@ const styles = theme => ({
   textField: {
     width: '100%',
   },
-});
+}));
 
 class IntegrationAutosuggest extends Component {
   state = {


### PR DESCRIPTION
Maybe withStyles is supposed to handle this case but I get an error with the current beta and need to add the createStyleSheet.

`TypeError: Cannot read property 'index' of undefined`

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

