### PR TITLE
[Input] should accommodate number and string values

### DIFF
--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -6,11 +6,40 @@ import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import Textarea from './Textarea';
 
+const isString = (value: ?(string | number)) => typeof value === 'string';
+const isNumber = (value: ?(string | number)) => !isNaN(parseFloat(value));
+
+/**
+ * @param value
+ * @returns {boolean} true if string or number (including zero)
+ */
+export function hasValue(value: ?(number | string)) {
+  if (isString(value)) {
+    return true;
+  } else if (isNumber(value)) {
+    return true;
+  }
+  return !!value;
+}
+
+/**
+ *
+ * @param obj
+ * @param SSR
+ * @returns {boolean} false when not present or empty string or zero value
+ */
 export function isDirty(obj, SSR = false) {
+  if (!obj) {
+    return false;
+  }
+
+  if (isNumber(obj.value) || (SSR && isNumber(obj.defaultValue))) {
+    return obj.value !== 0 && obj.defaultValue !== 0;
+  }
+
   return (
-    obj &&
-    ((obj.value && obj.value.toString().length) ||
-      (SSR && obj.defaultValue && obj.defaultValue.toString().length)) > 0
+    (hasValue(obj.value) && obj.value.toString().length > 0) ||
+    (SSR && hasValue(obj.defaultValue) && obj.defaultValue.toString().length > 0)
   );
 }
 
@@ -378,7 +407,7 @@ class Input extends Component<DefaultProps, AllProps, State> {
    */
   isControlled() {
     const { onChange, value } = this.props;
-    return !!onChange && value !== undefined; // null necessary for no number
+    return !!onChange && hasValue(value);
   }
 
   checkDirty(obj) {

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -369,8 +369,16 @@ class Input extends Component<DefaultProps, AllProps, State> {
     }
   };
 
+  /**
+   * A controlled input accepts its current value as a prop, as well as a callback
+   * to change that value.
+   *
+   * @returns {boolean}
+   * @see https://facebook.github.io/react/docs/forms.html#controlled-components
+   */
   isControlled() {
-    return typeof this.props.value === 'string';
+    const { onChange, value } = this.props;
+    return !!onChange && value !== undefined; // null necessary for no number
   }
 
   checkDirty(obj) {

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -6,8 +6,8 @@ import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import Textarea from './Textarea';
 
-const isString = (value: ?(string | number)) => typeof value === 'string';
-const isNumber = (value: ?(string | number)) => !isNaN(parseFloat(value));
+export const isString = (value: ?(string | number)) => typeof value === 'string';
+export const isNumber = (value: ?(string | number)) => !isNaN(parseFloat(value));
 
 /**
  * @param value
@@ -23,10 +23,14 @@ export function hasValue(value: ?(number | string)) {
 }
 
 /**
+ * Determine if field is dirty (a.k.a. filled).
+ *
+ * Response determines if label is presented above field or as placeholder.
  *
  * @param obj
  * @param SSR
- * @returns {boolean} false when not present or empty string or zero value
+ * @returns {boolean} False when not present or empty string.
+ *                    True when number or string with length.
  */
 export function isDirty(obj, SSR = false) {
   if (!obj) {
@@ -34,7 +38,7 @@ export function isDirty(obj, SSR = false) {
   }
 
   if (isNumber(obj.value) || (SSR && isNumber(obj.defaultValue))) {
-    return obj.value !== 0 && obj.defaultValue !== 0;
+    return true;
   }
 
   return (

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -6,20 +6,16 @@ import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import Textarea from './Textarea';
 
-export const isString = (value: ?(string | number)) => typeof value === 'string';
-export const isNumber = (value: ?(string | number)) => !isNaN(parseFloat(value));
-
 /**
+ * Supports determination of isControlled().
+ * Controlled input accepts its current value as a prop.
+ *
+ * @see https://facebook.github.io/react/docs/forms.html#controlled-components
  * @param value
- * @returns {boolean} true if string or number (including zero)
+ * @returns {boolean} true if string (including '') or number (including zero)
  */
 export function hasValue(value: ?(number | string)) {
-  if (isString(value)) {
-    return true;
-  } else if (isNumber(value)) {
-    return true;
-  }
-  return !!value;
+  return value !== undefined && value !== null && !(Array.isArray(value) && value.length === 0);
 }
 
 /**
@@ -30,20 +26,13 @@ export function hasValue(value: ?(number | string)) {
  * @param obj
  * @param SSR
  * @returns {boolean} False when not present or empty string.
- *                    True when number or string with length.
+ *                    True when any number or string with length.
  */
 export function isDirty(obj, SSR = false) {
-  if (!obj) {
-    return false;
-  }
-
-  if (isNumber(obj.value) || (SSR && isNumber(obj.defaultValue))) {
-    return true;
-  }
-
   return (
-    (hasValue(obj.value) && obj.value.toString().length > 0) ||
-    (SSR && hasValue(obj.defaultValue) && obj.defaultValue.toString().length > 0)
+    obj &&
+    ((hasValue(obj.value) && obj.value !== '') ||
+      (SSR && hasValue(obj.defaultValue) && obj.defaultValue !== ''))
   );
 }
 
@@ -403,15 +392,13 @@ class Input extends Component<DefaultProps, AllProps, State> {
   };
 
   /**
-   * A controlled input accepts its current value as a prop, as well as a callback
-   * to change that value.
+   * A controlled input accepts its current value as a prop.
    *
-   * @returns {boolean}
    * @see https://facebook.github.io/react/docs/forms.html#controlled-components
+   * @returns {boolean} true if string (including '') or number (including zero)
    */
   isControlled() {
-    const { onChange, value } = this.props;
-    return !!onChange && hasValue(value);
+    return hasValue(this.props.value);
   }
 
   checkDirty(obj) {

--- a/src/Input/Input.spec.js
+++ b/src/Input/Input.spec.js
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 import { spy } from 'sinon';
 import { createShallow, createMount, getClasses } from '../test-utils';
 import Textarea from './Textarea';
-import Input, { isDirty } from './Input';
+import Input, { hasValue, isDirty } from './Input';
 
 describe('<Input />', () => {
   let shallow;
@@ -95,24 +95,17 @@ describe('<Input />', () => {
   });
 
   describe('controlled', () => {
-    ['', 1].forEach(value => {
+    ['', 0].forEach(value => {
       describe(`${typeof value} value`, () => {
         let wrapper;
         let handleDirty;
         let handleClean;
-        let initialValue;
 
         before(() => {
           handleClean = spy();
           handleDirty = spy();
-          initialValue = typeof value === 'number' ? null : value;
           wrapper = shallow(
-            <Input
-              value={initialValue} // no number is null
-              onChange={() => {}}
-              onDirty={handleDirty}
-              onClean={handleClean}
-            />,
+            <Input value={value} onChange={() => {}} onDirty={handleDirty} onClean={handleClean} />,
           );
         });
 
@@ -137,7 +130,7 @@ describe('<Input />', () => {
             1,
             'should have called the onClean cb once already',
           );
-          wrapper.setProps({ value: initialValue });
+          wrapper.setProps({ value });
           assert.strictEqual(handleClean.callCount, 2, 'should have called the onClean cb again');
         });
       });
@@ -358,14 +351,38 @@ describe('<Input />', () => {
     });
   });
 
+  describe('hasValue', () => {
+    ['', 0].forEach(value => {
+      it(`is true for ${value}`, () => {
+        assert.strictEqual(hasValue(value), true);
+      });
+    });
+
+    [null, undefined].forEach(value => {
+      it(`is false for ${value}`, () => {
+        assert.strictEqual(hasValue(value), false);
+      });
+    });
+  });
+
   describe('isDirty', () => {
-    it('should support integer', () => {
-      assert.strictEqual(
-        isDirty({
-          value: 3,
-        }),
-        true,
-      );
+    // no number is null
+    [' ', 1].forEach(value => {
+      it(`is true for value ${value}`, () => {
+        assert.strictEqual(isDirty({ value }), true);
+      });
+
+      it(`is true for SSR defaultValue ${value}`, () => {
+        assert.strictEqual(isDirty({ defaultValue: value }, true), true);
+      });
+    });
+    [null, undefined, '', 0].forEach(value => {
+      it(`is false for value ${value}`, () => {
+        assert.strictEqual(isDirty({ value }), false);
+      });
+      it(`is false for SSR defaultValue ${value}`, () => {
+        assert.strictEqual(isDirty({ defaultValue: value }, true), false);
+      });
     });
   });
 });

--- a/src/Input/Input.spec.js
+++ b/src/Input/Input.spec.js
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 import { spy } from 'sinon';
 import { createShallow, createMount, getClasses } from '../test-utils';
 import Textarea from './Textarea';
-import Input, { hasValue, isDirty } from './Input';
+import Input, { hasValue, isDirty, isNumber } from './Input';
 
 describe('<Input />', () => {
   let shallow;
@@ -114,25 +114,32 @@ describe('<Input />', () => {
           assert.strictEqual(instance.isControlled(), true, 'isControlled() should return true');
         });
 
-        it('should have called the handleClean callback', () => {
-          assert.strictEqual(handleClean.callCount, 1, 'should have called the onClean cb');
-        });
+        // don't test number because zero is a dirty state, whereas '' is not
+        if (!isNumber(value)) {
+          it('should have called the handleClean callback', () => {
+            assert.strictEqual(handleClean.callCount, 1, 'should have called the onClean cb');
+          });
 
-        it('should fire the onDirty callback when dirtied', () => {
-          assert.strictEqual(handleDirty.callCount, 0, 'should not have called the onDirty cb yet');
-          wrapper.setProps({ value: typeof value === 'number' ? 2 : 'hello' });
-          assert.strictEqual(handleDirty.callCount, 1, 'should have called the onDirty cb');
-        });
+          it('should fire the onDirty callback when dirtied', () => {
+            assert.strictEqual(
+              handleDirty.callCount,
+              0,
+              'should not have called the onDirty cb yet',
+            );
+            wrapper.setProps({ value: typeof value === 'number' ? 2 : 'hello' });
+            assert.strictEqual(handleDirty.callCount, 1, 'should have called the onDirty cb');
+          });
 
-        it('should fire the onClean callback when dirtied', () => {
-          assert.strictEqual(
-            handleClean.callCount,
-            1,
-            'should have called the onClean cb once already',
-          );
-          wrapper.setProps({ value });
-          assert.strictEqual(handleClean.callCount, 2, 'should have called the onClean cb again');
-        });
+          it('should fire the onClean callback when dirtied', () => {
+            assert.strictEqual(
+              handleClean.callCount,
+              1,
+              'should have called the onClean cb once already',
+            );
+            wrapper.setProps({ value });
+            assert.strictEqual(handleClean.callCount, 2, 'should have called the onClean cb again');
+          });
+        }
       });
     });
   });
@@ -366,8 +373,7 @@ describe('<Input />', () => {
   });
 
   describe('isDirty', () => {
-    // no number is null
-    [' ', 1].forEach(value => {
+    [' ', 0].forEach(value => {
       it(`is true for value ${value}`, () => {
         assert.strictEqual(isDirty({ value }), true);
       });
@@ -376,7 +382,7 @@ describe('<Input />', () => {
         assert.strictEqual(isDirty({ defaultValue: value }, true), true);
       });
     });
-    [null, undefined, '', 0].forEach(value => {
+    [null, undefined, ''].forEach(value => {
       it(`is false for value ${value}`, () => {
         assert.strictEqual(isDirty({ value }), false);
       });

--- a/src/Input/Input.spec.js
+++ b/src/Input/Input.spec.js
@@ -95,20 +95,24 @@ describe('<Input />', () => {
   });
 
   describe('controlled', () => {
-    let wrapper;
-    let handleDirty;
-    let handleClean;
-
-    before(() => {
-      handleClean = spy();
-      handleDirty = spy();
-    });
-
     ['', 1].forEach(value => {
       describe(`${typeof value} value`, () => {
+        let wrapper;
+        let handleDirty;
+        let handleClean;
+        let initialValue;
+
         before(() => {
+          handleClean = spy();
+          handleDirty = spy();
+          initialValue = typeof value === 'number' ? null : value;
           wrapper = shallow(
-            <Input value={value} onChange={() => {}} onDirty={handleDirty} onClean={handleClean} />,
+            <Input
+              value={initialValue} // no number is null
+              onChange={() => {}}
+              onDirty={handleDirty}
+              onClean={handleClean}
+            />,
           );
         });
 
@@ -123,7 +127,7 @@ describe('<Input />', () => {
 
         it('should fire the onDirty callback when dirtied', () => {
           assert.strictEqual(handleDirty.callCount, 0, 'should not have called the onDirty cb yet');
-          wrapper.setProps({ value: 'hello' });
+          wrapper.setProps({ value: typeof value === 'number' ? 2 : 'hello' });
           assert.strictEqual(handleDirty.callCount, 1, 'should have called the onDirty cb');
         });
 
@@ -133,7 +137,7 @@ describe('<Input />', () => {
             1,
             'should have called the onClean cb once already',
           );
-          wrapper.setProps({ value: '' });
+          wrapper.setProps({ value: initialValue });
           assert.strictEqual(handleClean.callCount, 2, 'should have called the onClean cb again');
         });
       });

--- a/src/Input/Input.spec.js
+++ b/src/Input/Input.spec.js
@@ -102,32 +102,41 @@ describe('<Input />', () => {
     before(() => {
       handleClean = spy();
       handleDirty = spy();
-      wrapper = shallow(<Input value="" onDirty={handleDirty} onClean={handleClean} />);
     });
 
-    it('should check that the component is controlled', () => {
-      const instance = wrapper.instance();
-      assert.strictEqual(instance.isControlled(), true, 'isControlled() should return true');
-    });
+    ['', 1].forEach(value => {
+      describe(`${typeof value} value`, () => {
+        before(() => {
+          wrapper = shallow(
+            <Input value={value} onChange={() => {}} onDirty={handleDirty} onClean={handleClean} />,
+          );
+        });
 
-    it('should have called the handleClean callback', () => {
-      assert.strictEqual(handleClean.callCount, 1, 'should have called the onClean cb');
-    });
+        it('should check that the component is controlled', () => {
+          const instance = wrapper.instance();
+          assert.strictEqual(instance.isControlled(), true, 'isControlled() should return true');
+        });
 
-    it('should fire the onDirty callback when dirtied', () => {
-      assert.strictEqual(handleDirty.callCount, 0, 'should not have called the onDirty cb yet');
-      wrapper.setProps({ value: 'hello' });
-      assert.strictEqual(handleDirty.callCount, 1, 'should have called the onDirty cb');
-    });
+        it('should have called the handleClean callback', () => {
+          assert.strictEqual(handleClean.callCount, 1, 'should have called the onClean cb');
+        });
 
-    it('should fire the onClean callback when dirtied', () => {
-      assert.strictEqual(
-        handleClean.callCount,
-        1,
-        'should have called the onClean cb once already',
-      );
-      wrapper.setProps({ value: '' });
-      assert.strictEqual(handleClean.callCount, 2, 'should have called the onClean cb again');
+        it('should fire the onDirty callback when dirtied', () => {
+          assert.strictEqual(handleDirty.callCount, 0, 'should not have called the onDirty cb yet');
+          wrapper.setProps({ value: 'hello' });
+          assert.strictEqual(handleDirty.callCount, 1, 'should have called the onDirty cb');
+        });
+
+        it('should fire the onClean callback when dirtied', () => {
+          assert.strictEqual(
+            handleClean.callCount,
+            1,
+            'should have called the onClean cb once already',
+          );
+          wrapper.setProps({ value: '' });
+          assert.strictEqual(handleClean.callCount, 2, 'should have called the onClean cb again');
+        });
+      });
     });
   });
 

--- a/src/Input/Input.spec.js
+++ b/src/Input/Input.spec.js
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 import { spy } from 'sinon';
 import { createShallow, createMount, getClasses } from '../test-utils';
 import Textarea from './Textarea';
-import Input, { hasValue, isDirty, isNumber } from './Input';
+import Input, { hasValue, isDirty } from './Input';
 
 describe('<Input />', () => {
   let shallow;
@@ -104,9 +104,7 @@ describe('<Input />', () => {
         before(() => {
           handleClean = spy();
           handleDirty = spy();
-          wrapper = shallow(
-            <Input value={value} onChange={() => {}} onDirty={handleDirty} onClean={handleClean} />,
-          );
+          wrapper = shallow(<Input value={value} onDirty={handleDirty} onClean={handleClean} />);
         });
 
         it('should check that the component is controlled', () => {
@@ -115,7 +113,7 @@ describe('<Input />', () => {
         });
 
         // don't test number because zero is a dirty state, whereas '' is not
-        if (!isNumber(value)) {
+        if (typeof value !== 'number') {
           it('should have called the handleClean callback', () => {
             assert.strictEqual(handleClean.callCount, 1, 'should have called the onClean cb');
           });


### PR DESCRIPTION
The previous `isControlled()` was too naive and not in-line with the definition of a controlled component as defined by React.  This previous implementation was the root cause of failures to trigger the dirty state on the field.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

