### PR TITLE
[Palette] Allow Customization of grey

### DIFF
--- a/src/styles/palette.js
+++ b/src/styles/palette.js
@@ -75,7 +75,7 @@ function getContrastText(color) {
 }
 
 export default function createPalette(options = {}) {
-  const { primary = indigo, accent = pink, error = red, type = 'light' } = options;
+  const { primary = indigo, accent = pink, error = red, grey = grey, type = 'light' } = options;
 
   if (process.env.NODE_ENV !== 'production') {
     const difference = (base, compare) => {
@@ -97,7 +97,7 @@ export default function createPalette(options = {}) {
         false,
         [
           `Material-UI: ${name} color is missing the following hues: ${missing.join(',')}`,
-          'See the default colors, indigo, or pink, as exported from material-ui/colors.',
+          'See the default colors, indigo, pink, or grey, as exported from material-ui/colors.',
         ].join('\n'),
       );
     };
@@ -105,6 +105,7 @@ export default function createPalette(options = {}) {
     paletteColorError('primary', indigo, primary);
     paletteColorError('accent', pink, accent);
     paletteColorError('error', red, error);
+    paletteColorError('grey', grey, grey);
   }
 
   const shades = { dark, light };


### PR DESCRIPTION
I've always preferred the `bluegrey` over `grey`, so was a little disappointed when I found that it was impossible to override the default.

This is a quick fix for my issue. The color will fall back on the default (like all the others), but allows for the use of other colors for `grey`.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

