### PR TITLE
Removing Plugin, Should be left up to implementer

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -31,13 +31,8 @@
         "transform-dev-warning",
         "transform-runtime",
         ["react-remove-properties", {"properties": ["data-mui-test"]}],
-        ["transform-react-remove-prop-types", {
-          "mode": "wrap",
-          "plugins": [
-            ["babel-plugin-flow-react-proptypes", {"omitRuntimeTypeExport": true}],
-            "babel-plugin-transform-flow-strip-types"
-          ]
-        }]
+        ["babel-plugin-flow-react-proptypes", {"omitRuntimeTypeExport": true}],
+        "babel-plugin-transform-flow-strip-types"
       ]
     }
   }


### PR DESCRIPTION
Removing babel-plugin-transform-react-remove-prop-types, for a number of reasons.

1. Some other libraries, such as ngReact rely on the prop-types in the production build.
2. The plugin doesn't actually save bandwidth but actually increases the data transferred by the added bytes needed by the if statement. (although this can be changed by setting the mode to remove rather than wrap, which still doesn't solve the other issues).
3. Performance enhancements that affect the state of the application should be left to the implementer.

