### PR TITLE
Removing Plugin, Should be left up to implementer

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,15 +11,13 @@
     "docs-production": {
       "plugins": [
         ["transform-replace-object-assign", "simple-assign"],
-        "transform-react-remove-prop-types",
         "transform-react-constant-elements",
         "transform-react-inline-elements"
       ]
     },
     "release": {
       "plugins": [
-        "transform-runtime",
-        ["transform-react-remove-prop-types", {"mode": "wrap"}]
+        "transform-runtime"
       ]
     }
   }


### PR DESCRIPTION
Removing babel-plugin-transform-react-remove-prop-types, for a number of reasons.

Some other libraries, such as ngReact rely on the prop-types in the production build.
The plugin doesn't actually save bandwidth but actually increases the data transferred by the added bytes needed by the if statement. (although this can be changed by setting the mode to remove rather than wrap, which still doesn't solve the other issues).
Performance enhancements that affect the state of the application should be left to the implementer.