### PR TITLE
[typescript] Create typings for TS when building.

### DIFF
--- a/packages/material-ui-icons/copy-files.js
+++ b/packages/material-ui-icons/copy-files.js
@@ -47,6 +47,7 @@ function createPackageFile() {
         main: './index.js',
         module: './index.es.js',
         'jsnext:main': './index.es.js',
+        typings: './index.d.ts',
         keywords,
         repository,
         license,

--- a/packages/material-ui-icons/create-typings.js
+++ b/packages/material-ui-icons/create-typings.js
@@ -1,0 +1,51 @@
+// @flow weak
+/* eslint-disable no-console */
+
+/**
+ * Generate type definitions for `material-ui-icons`.
+ * The generated contens will be written to
+ * `src/typings/material-ui-icons.d.ts`!
+ */
+const path = require('path');
+const { EOL } = require('os');
+const chalk = require('chalk');
+const { outputFile } = require('fs-extra');
+const glob = require('glob');
+
+const log = console.log;
+
+const SRC_DIR = path.resolve(__dirname, 'src');
+const TARGET_FILE = path.resolve(__dirname, 'build/index.d.ts');
+
+// Helpers
+// ---------------
+const getFiles = dir =>
+  new Promise((resolve, reject) => {
+    glob('!(index)*.js', { cwd: dir }, (err, files) => (err ? reject(err) : resolve(files)));
+  });
+
+const normalizeFileName = name => path.parse(name).name;
+
+const createTypeDefinition = name =>
+  `declare module 'material-ui-icons/${name}' {
+  import SvgIcon from 'material-ui/SvgIcon';
+  export default class ${name} extends SvgIcon {}
+}`;
+
+const convertFilesToTypings = files =>
+  files.map(file => createTypeDefinition(normalizeFileName(file)));
+
+// Script
+// ---------------
+log(`\u{1f52c}  Searching for modules inside "${chalk.dim(SRC_DIR)}".`);
+getFiles(SRC_DIR)
+  .then(convertFilesToTypings)
+  .then(typings => typings.join(`${EOL}${EOL}`))
+  .then(contents => outputFile(TARGET_FILE, contents, { encoding: 'utf8' }))
+  .then(() => log(`\u{1F5C4}  Written typings to ${chalk.dim(TARGET_FILE)}.`))
+  .catch(err => {
+    if (err) {
+      log(err);
+    }
+    process.exit(1);
+  });

--- a/packages/material-ui-icons/package.json
+++ b/packages/material-ui-icons/package.json
@@ -22,11 +22,12 @@
     "react-component"
   ],
   "scripts": {
-    "build": "npm run build:icons && npm run build:es2015 && npm run build:es2015modules && npm run build:copy-files",
+    "build": "npm run build:icons && npm run build:es2015 && npm run build:es2015modules && npm run build:copy-files && npm run build:typings",
     "build:es2015": "cross-env NODE_ENV=production babel ./src --out-dir ./build",
     "build:es2015modules": "cross-env NODE_ENV=production BABEL_ENV=modules babel ./src/index.js --out-file ./build/index.es.js",
     "build:copy-files": "babel-node ./copy-files.js",
     "build:icons": "babel-node ./builder.js --output-dir ./src --svg-dir ./node_modules/material-design-icons --glob '/**/production/*_24px.svg' --renameFilter ./filters/rename/material-design-icons.js",
+    "build:typings": "babel-node ./create-typings.js",
     "clean": "rimraf build",
     "prebuild": "npm run clean",
     "test": "mocha",


### PR DESCRIPTION
Added a script that runs when the packages is build and creates typings for all the icons.
Note that there is currently no `index` created, you have to import things the tree-shakable way (`import Apps from 'material-ui-icons/Apps';`).

Closes #7816

---

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

