### PR TITLE
[core] Fix size-limit warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "clean:build": "rimraf build",
     "lint": "eslint . --cache && echo \"eslint: no lint errors\"",
     "prebuild": "npm run clean:build",
-    "size": "size-limit 120KB build/index.js",
+    "size": "size-limit",
     "size:why": "size-limit --why build/index.js",
     "spellcheck": "eslint . --config .eslintrc.spellcheck.js && echo \"eslint: no lint errors\"",
     "start": "cd docs && npm start",
@@ -154,6 +154,12 @@
     "webfontloader": "^1.6.28",
     "webpack": "^3.5.3"
   },
+  "size-limit": [
+    {
+      "path": "build/index.js",
+      "limit": "120 KB"
+    }
+  ],
   "nyc": {
     "include": [
       "src/**/*.js"


### PR DESCRIPTION
Fix:

> WARN Limit argument in Size Limit CLi was deprecated.
Use size-limit section in package.json to specify limit.

Follow https://github.com/ai/size-limit#usage

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

