### PR TITLE
[IconMenu] Close when another IconMenu is tapped

### DIFF
--- a/src/internal/RenderToLayer.js
+++ b/src/internal/RenderToLayer.js
@@ -34,10 +34,6 @@ class RenderToLayer extends Component {
   }
 
   onClickAway = (event) => {
-    if (event.defaultPrevented) {
-      return;
-    }
-
     if (!this.props.componentClickAway) {
       return;
     }
@@ -65,9 +61,11 @@ class RenderToLayer extends Component {
     if (this.props.useLayerForClickAway) {
       this.layer.style.position = 'relative';
       this.layer.removeEventListener('touchstart', this.onClickAway);
+      this.layer.removeEventListener('touchend', this.onClickAway);
       this.layer.removeEventListener('click', this.onClickAway);
     } else {
       window.removeEventListener('touchstart', this.onClickAway);
+      window.removeEventListener('touchend', this.onClickAway);
       window.removeEventListener('click', this.onClickAway);
     }
 
@@ -95,6 +93,7 @@ class RenderToLayer extends Component {
 
         if (this.props.useLayerForClickAway) {
           this.layer.addEventListener('touchstart', this.onClickAway);
+          this.layer.addEventListener('touchend', this.onClickAway);
           this.layer.addEventListener('click', this.onClickAway);
           this.layer.style.position = 'fixed';
           this.layer.style.top = 0;
@@ -105,6 +104,7 @@ class RenderToLayer extends Component {
         } else {
           setTimeout(() => {
             window.addEventListener('touchstart', this.onClickAway);
+            window.addEventListener('touchend', this.onClickAway);
             window.addEventListener('click', this.onClickAway);
           }, 0);
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

PR fixes closed issues #6996 and #7841. [IconMenu] will now close when another is tapped, instead of overlapping.

Before:
![iconmenu before](https://user-images.githubusercontent.com/5944054/29545855-5b300468-86b6-11e7-89dc-e55e40a6a159.gif)

After:
![iconmenu after](https://user-images.githubusercontent.com/5944054/29545859-5f8e4696-86b6-11e7-8e70-b83ddb28bc40.gif)

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved (http://tr.im/vFqem).

