### PR TITLE
[docs] Fix missing props in css-in-js examples

### DIFF
--- a/docs/src/pages/customization/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js.md
@@ -102,8 +102,7 @@ const styles = {
 
 class MyComponent extends Component {
   render () {
-    {classes} = this.props;
-    return <div className={classes.root} />;
+    return <div className={this.props.classes.root} />;
   }
 }
 
@@ -124,8 +123,7 @@ const styles = {
 @withStyles(styles)
 class MyComponent extends Component {
   render () {
-    {classes} = this.props;  
-    return <div className={classes.root} />;
+    return <div className={this.props.classes.root} />;
   }
 }
 

--- a/docs/src/pages/customization/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js.md
@@ -102,7 +102,8 @@ const styles = {
 
 class MyComponent extends Component {
   render () {
-    return <div className={this.classes.root} />;
+    {classes} = this.props;
+    return <div className={classes.root} />;
   }
 }
 
@@ -123,7 +124,8 @@ const styles = {
 @withStyles(styles)
 class MyComponent extends Component {
   render () {
-    return <div className={this.classes.root} />;
+    {classes} = this.props;  
+    return <div className={classes.root} />;
   }
 }
 


### PR DESCRIPTION
`this.classes.root` wouldn't work - `this.props.classes.root' would.

