### PR TITLE
[FormControlLabel] Allow for node in the label prop

### DIFF
--- a/pages/api/form-control-label.md
+++ b/pages/api/form-control-label.md
@@ -12,7 +12,7 @@
 | <span style="color: #31a148">control *</span> | Element |  | A control element. For instance, it can be be a `Radio`, a `Switch` or a `Checkbox`. |
 | disabled | boolean | false | If `true`, the control will be disabled. |
 | inputRef | Function |  | Use that property to pass a ref callback to the native input component. |
-| <span style="color: #31a148">label *</span> | string |  | The text to be used in an enclosing label element. |
+| <span style="color: #31a148">label *</span> | node |  | The text to be used in an enclosing label element. |
 | name | string |  |  |
 | onChange | Function |  | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback<br>*checked:* The `checked` value of the switch |
 | value | string |  | The value of the component. |
@@ -25,7 +25,6 @@ You can overrides all the class names injected by Material-UI thanks to the `cla
 This property accepts the following keys:
 - `root`
 - `disabled`
-- `hasLabel`
 - `label`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes)

--- a/src/Form/FormControlLabel.js
+++ b/src/Form/FormControlLabel.js
@@ -2,7 +2,7 @@
 /* eslint-disable jsx-a11y/label-has-for */
 
 import React from 'react';
-import type { Element } from 'react';
+import type { Node, Element } from 'react';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import Typography from '../Typography';
@@ -14,14 +14,12 @@ export const styles = (theme: Object) => ({
     cursor: 'pointer',
     // Remove grey highlight
     WebkitTapHighlightColor: theme.palette.common.transparent,
+    marginLeft: -12,
+    marginRight: theme.spacing.unit * 2, // used for row presentation of radio/checkbox
   },
   disabled: {
     color: theme.palette.text.disabled,
     cursor: 'default',
-  },
-  hasLabel: {
-    marginLeft: -12,
-    marginRight: theme.spacing.unit * 2, // used for row presentation of radio/checkbox
   },
   label: {
     userSelect: 'none',
@@ -60,7 +58,7 @@ export type Props = {
   /**
    * The text to be used in an enclosing label element.
    */
-  label: string,
+  label: Node,
   /*
    * @ignore
    */
@@ -98,7 +96,6 @@ function FormControlLabel(props: AllProps) {
   const className = classNames(
     classes.root,
     {
-      [classes.hasLabel]: label && label.length,
       [classes.disabled]: disabled,
     },
     classNameProp,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
Allow for node in label props of FormControlLabel

- fixes #7879 

--- 

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

