### PR TITLE
[ButtonBase] Better warning message

### DIFF
--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -5,6 +5,7 @@ import type { ComponentType, Node } from 'react';
 import { findDOMNode } from 'react-dom';
 import warning from 'warning';
 import classNames from 'classnames';
+import getDisplayName from 'recompose/getDisplayName';
 import keycode from 'keycode';
 import withStyles from '../styles/withStyles';
 import { listenForFocusKeys, detectKeyboardFocus, focusKeyPressed } from '../utils/keyboardFocus';
@@ -161,8 +162,14 @@ class ButtonBase extends React.Component<AllProps, State> {
 
     warning(
       this.button,
-      `Material-UI: please provide a class to the component property.
-      The keyboard focus logic needs a reference to work correctly.`,
+      [
+        'Material-UI: please provide a class to the component property.',
+        // eslint-disable-next-line prefer-template
+        'You need to fix: ' + getDisplayName(this.props.component) === 'component'
+          ? this.props.component
+          : getDisplayName(this.props.component),
+        'The keyboard focus logic needs a reference to work correctly.',
+      ].join('\n'),
     );
   }
 


### PR DESCRIPTION
Warning fix example:

```diff
-<Button component={(props) => <Link {...props} to="/" />}>
+<Button component={Link} to="/">
```

Closes #7710

---

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

