### PR TITLE
[theme] Use secondary wording over accent

### DIFF
--- a/docs/src/modules/components/Link.js
+++ b/docs/src/modules/components/Link.js
@@ -21,7 +21,7 @@ const styles = theme => ({
     color: theme.palette.primary[500],
   },
   variantAccent: {
-    color: theme.palette.accent.A400,
+    color: theme.palette.secondary.A400,
   },
   variantButton: {
     '&:hover': {

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -174,7 +174,7 @@ const styles = theme => ({
     },
     '& a, & a code': {
       // Style taken from the Link component
-      color: theme.palette.accent.A400,
+      color: theme.palette.secondary.A400,
       textDecoration: 'none',
       '&:hover': {
         textDecoration: 'underline',

--- a/docs/src/pages/customization/Palette.js
+++ b/docs/src/pages/customization/Palette.js
@@ -11,7 +11,7 @@ import Button from 'material-ui/Button';
 const theme = createMuiTheme({
   palette: createPalette({
     primary: purple, // Purple and green play nicely together.
-    accent: {
+    secondary: {
       ...green,
       A400: '#00e677',
     },

--- a/docs/src/pages/customization/themes.md
+++ b/docs/src/pages/customization/themes.md
@@ -28,7 +28,7 @@ A color intention is a mapping of a palette to a given intention within your app
 We expose the following color intentions:
 
 - primary - used to represent primary interface elements for a user.
-- accent - used to represent secondary interface elements for a user.
+- secondary - used to represent secondary interface elements for a user.
 - error - used to represent interface elements that the user should be careful of.
 
 The palette is using the hues prefixed with `A` (`A200`, etc.) for the accent color and the hues unprefixed for the other intentions.

--- a/docs/src/pages/demos/tables/EnhancedTable.js
+++ b/docs/src/pages/demos/tables/EnhancedTable.js
@@ -91,12 +91,12 @@ const toolbarStyles = theme => ({
   highlight:
     theme.palette.type === 'light'
       ? {
-          color: theme.palette.accent.A700,
-          backgroundColor: theme.palette.accent.A100,
+          color: theme.palette.secondary.A700,
+          backgroundColor: theme.palette.secondary.A100,
         }
       : {
-          color: theme.palette.accent.A100,
-          backgroundColor: theme.palette.accent.A700,
+          color: theme.palette.secondary.A100,
+          backgroundColor: theme.palette.secondary.A700,
         },
   spacer: {
     flex: '1 1 100%',

--- a/docs/src/pages/layout/MediaQuery.js
+++ b/docs/src/pages/layout/MediaQuery.js
@@ -14,7 +14,7 @@ const styles = theme => ({
       backgroundColor: theme.palette.primary[500],
     },
     [theme.breakpoints.down('md')]: {
-      backgroundColor: theme.palette.accent.A400,
+      backgroundColor: theme.palette.secondary.A400,
     },
   },
 });

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -40,8 +40,8 @@ export const styles = (theme: Object) => ({
     color: theme.palette.getContrastText(theme.palette.primary[500]),
   },
   colorAccent: {
-    backgroundColor: theme.palette.accent.A200,
-    color: theme.palette.getContrastText(theme.palette.accent.A200),
+    backgroundColor: theme.palette.secondary.A200,
+    color: theme.palette.getContrastText(theme.palette.secondary.A200),
   },
 });
 

--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -37,8 +37,8 @@ export const styles = (theme: Object) => ({
     color: theme.palette.getContrastText(theme.palette.primary[500]),
   },
   colorAccent: {
-    backgroundColor: theme.palette.accent.A200,
-    color: theme.palette.getContrastText(theme.palette.accent.A200),
+    backgroundColor: theme.palette.secondary.A200,
+    color: theme.palette.getContrastText(theme.palette.secondary.A200),
   },
 });
 

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -60,9 +60,9 @@ export const styles = (theme: Object) => ({
     },
   },
   flatAccent: {
-    color: theme.palette.accent.A200,
+    color: theme.palette.secondary.A200,
     '&:hover': {
-      backgroundColor: fade(theme.palette.accent.A200, 0.12),
+      backgroundColor: fade(theme.palette.secondary.A200, 0.12),
       // Reset on mouse devices
       '@media (hover: none)': {
         backgroundColor: 'transparent',
@@ -124,13 +124,13 @@ export const styles = (theme: Object) => ({
     },
   },
   raisedAccent: {
-    color: theme.palette.getContrastText(theme.palette.accent.A200),
-    backgroundColor: theme.palette.accent.A200,
+    color: theme.palette.getContrastText(theme.palette.secondary.A200),
+    backgroundColor: theme.palette.secondary.A200,
     '&:hover': {
-      backgroundColor: theme.palette.accent.A400,
+      backgroundColor: theme.palette.secondary.A400,
       // Reset on mouse devices
       '@media (hover: none)': {
-        backgroundColor: theme.palette.accent.A200,
+        backgroundColor: theme.palette.secondary.A200,
       },
     },
   },

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -11,7 +11,7 @@ export const styles = (theme: Object) => ({
     userSelect: 'none',
   },
   colorAccent: {
-    color: theme.palette.accent.A200,
+    color: theme.palette.secondary.A200,
   },
   colorAction: {
     color: theme.palette.action.active,

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -32,7 +32,7 @@ export const styles = (theme: Object) => ({
     color: theme.palette.action.disabled,
   },
   colorAccent: {
-    color: theme.palette.accent.A200,
+    color: theme.palette.secondary.A200,
   },
   colorContrast: {
     color: theme.palette.getContrastText(theme.palette.primary[500]),

--- a/src/Progress/CircularProgress.js
+++ b/src/Progress/CircularProgress.js
@@ -21,7 +21,7 @@ export const styles = (theme: Object) => ({
     color: theme.palette.primary[500],
   },
   accentColor: {
-    color: theme.palette.accent.A200,
+    color: theme.palette.secondary.A200,
   },
   svg: {
     transform: 'rotate(-90deg)',

--- a/src/Progress/LinearProgress.js
+++ b/src/Progress/LinearProgress.js
@@ -26,13 +26,13 @@ export const styles = (theme: Object) => ({
     backgroundPosition: '0px -23px',
   },
   accentColor: {
-    backgroundColor: theme.palette.accent.A100,
+    backgroundColor: theme.palette.secondary.A100,
   },
   accentColorBar: {
-    backgroundColor: theme.palette.accent.A400,
+    backgroundColor: theme.palette.secondary.A400,
   },
   accentDashed: {
-    background: `radial-gradient(${theme.palette.accent.A100} 0%, ${theme.palette.accent
+    background: `radial-gradient(${theme.palette.secondary.A100} 0%, ${theme.palette.secondary
       .A100} 16%, transparent 42%)`,
     backgroundSize: '10px 10px',
     backgroundPosition: '0px -23px',
@@ -85,7 +85,7 @@ export const styles = (theme: Object) => ({
   },
   bufferBar2Accent: {
     transition: `transform .${transitionDuration}s linear`,
-    backgroundColor: theme.palette.accent.A100,
+    backgroundColor: theme.palette.secondary.A100,
   },
   '@keyframes mui-indeterminate1': {
     '0%': {

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -30,7 +30,7 @@ export const styles = (theme: Object) => ({
     color: theme.palette.text.secondary,
   },
   rootAccentSelected: {
-    color: theme.palette.accent.A200,
+    color: theme.palette.secondary.A200,
   },
   rootAccentDisabled: {
     color: theme.palette.text.disabled,

--- a/src/Tabs/TabIndicator.js
+++ b/src/Tabs/TabIndicator.js
@@ -15,7 +15,7 @@ export const styles = (theme: Object) => ({
     willChange: 'left, width',
   },
   colorAccent: {
-    backgroundColor: theme.palette.accent.A200,
+    backgroundColor: theme.palette.secondary.A200,
   },
   colorPrimary: {
     backgroundColor: theme.palette.primary[500],

--- a/src/Typography/Typography.js
+++ b/src/Typography/Typography.js
@@ -52,7 +52,7 @@ export const styles = (theme: Object) => ({
     color: theme.palette.text.secondary,
   },
   colorAccent: {
-    color: theme.palette.accent.A400,
+    color: theme.palette.secondary.A400,
   },
 });
 

--- a/src/styles/palette.d.ts
+++ b/src/styles/palette.d.ts
@@ -35,7 +35,7 @@ export const dark: Shade;
 
 type PaletteOptions = {
   primary: Color;
-  accent: Color;
+  secondary: Color;
   error: Color;
   type: Contrast;
 };

--- a/src/styles/palette.js
+++ b/src/styles/palette.js
@@ -75,7 +75,7 @@ function getContrastText(color) {
 }
 
 export default function createPalette(options = {}) {
-  const { primary = indigo, accent = pink, error = red, type = 'light' } = options;
+  const { primary = indigo, secondary = pink, error = red, type = 'light' } = options;
 
   if (process.env.NODE_ENV !== 'production') {
     const difference = (base, compare) => {
@@ -103,7 +103,7 @@ export default function createPalette(options = {}) {
     };
 
     paletteColorError('primary', indigo, primary);
-    paletteColorError('accent', pink, accent);
+    paletteColorError('secondary', pink, secondary);
     paletteColorError('error', red, error);
   }
 
@@ -120,7 +120,7 @@ export default function createPalette(options = {}) {
     action: shades[type].action,
     background: shades[type].background,
     primary,
-    accent,
+    secondary,
     error,
     grey,
     getContrastText,

--- a/src/styles/theme.spec.js
+++ b/src/styles/theme.spec.js
@@ -23,7 +23,7 @@ describe('styles/theme', () => {
 
   describe('custom muiTheme', () => {
     const muiTheme = createMuiTheme({
-      palette: createPalette({ primary: deepOrange, accent: green }),
+      palette: createPalette({ primary: deepOrange, secondary: green }),
     });
 
     it('should have the custom palette', () => {
@@ -43,7 +43,7 @@ describe('styles/theme', () => {
     it('should create a material design palette according to spec', () => {
       const palette = createPalette();
       assert.strictEqual(palette.primary, indigo, 'should use indigo as the default primary color');
-      assert.strictEqual(palette.accent, pink, 'should use pink as the default accent color');
+      assert.strictEqual(palette.secondary, pink, 'should use pink as the default secondary color');
       assert.strictEqual(
         palette.text,
         light.text,
@@ -52,16 +52,16 @@ describe('styles/theme', () => {
     });
 
     it('should create a palette with custom colors', () => {
-      const palette = createPalette({ primary: deepOrange, accent: green });
+      const palette = createPalette({ primary: deepOrange, secondary: green });
       assert.strictEqual(palette.primary, deepOrange, 'should use deepOrange as the primary color');
-      assert.strictEqual(palette.accent, green, 'should use green as the accent color');
+      assert.strictEqual(palette.secondary, green, 'should use green as the secondary color');
       assert.strictEqual(palette.text, light.text, 'should use light theme text');
     });
 
     it('should create a dark palette', () => {
       const palette = createPalette({ type: 'dark' });
       assert.strictEqual(palette.primary, indigo, 'should use indigo as the default primary color');
-      assert.strictEqual(palette.accent, pink, 'should use pink as the default accent color');
+      assert.strictEqual(palette.secondary, pink, 'should use pink as the default secondary color');
       assert.strictEqual(palette.text, dark.text, 'should use dark theme text');
       assert.strictEqual(consoleErrorMock.callCount(), 0);
     });
@@ -75,12 +75,12 @@ describe('styles/theme', () => {
       );
     });
 
-    it('should throw an exception when a non-palette accent color is specified', () => {
-      createPalette({ accent: common.fullBlack });
+    it('should throw an exception when a non-palette secondary color is specified', () => {
+      createPalette({ secondary: common.fullBlack });
       assert.strictEqual(consoleErrorMock.callCount(), 2);
       assert.match(
         consoleErrorMock.args()[1][0],
-        /Material-UI: accent color is missing the following hues: 50,100,200,300,400/,
+        /Material-UI: secondary color is missing the following hues: 50,100,200,300,400/,
       );
     });
 


### PR DESCRIPTION
Closes #4150

```diff
     const theme = createMuiTheme({
-      palette: createPalette({ primary: deepOrange, accent: green }),
+      palette: createPalette({ primary: deepOrange, secondary: green }),
     });
```

```diff
   flatAccent: {
-    color: theme.palette.accent.A200,
+    color: theme.palette.secondary.A200,
```

---

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

