### PR TITLE
[Popover] Fix PopOver animation origin when targetOrigin.horizontal=middle

### DIFF
--- a/src/Popover/PopoverAnimationVertical.js
+++ b/src/Popover/PopoverAnimationVertical.js
@@ -8,7 +8,7 @@ function getStyles(props, context, state) {
   const {targetOrigin} = props;
   const {open} = state;
   const {muiTheme} = context;
-  const horizontal = targetOrigin.horizontal.replace('middle', 'vertical');
+  const horizontal = targetOrigin.horizontal.replace('middle', 'center');
 
   return {
     root: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

When the `targetOrigin.horizontal` of a popover (in my case a `DropDownMenu`) is set to `middle`,  it replaces it with `vertical` which is an invalid value, causing the `transform-origin` style to be rejected and default to the (horizontal and vertical) center of the menu.

This changes it to transform `middle` to `center`, which is the correct css value for centering horizontally.

- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

