### PR TITLE
[IconMenu] stop preventing event default on iconmenu open

### DIFF
--- a/src/IconMenu/IconMenu.js
+++ b/src/IconMenu/IconMenu.js
@@ -207,8 +207,6 @@ class IconMenu extends Component {
       menuInitiallyKeyboardFocused: Events.isKeyboard(event),
       anchorEl: event.currentTarget,
     });
-
-    event.preventDefault();
   }
 
   handleItemTouchTap = (event, child) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
PR fixes closed issues #6996 and #7841. [IconMenu] will now close when another is tapped, instead of overlapping.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved

