### PR TITLE
[Docs] Fix typo in floating-action button property of Button

### DIFF
--- a/pages/api/button.md
+++ b/pages/api/button.md
@@ -15,7 +15,7 @@
 | disableFocusRipple | boolean | false | If `true`, the  keyboard focus ripple will be disabled. `disableRipple` must also be true. |
 | disableRipple | boolean | false | If `true`, the ripple effect will be disabled. |
 | disabled | boolean | false | If `true`, the button will be disabled. |
-| fab | boolean | false | If `true`, well use floating action button styling. |
+| fab | boolean | false | If `true`, will use floating action button styling. |
 | href | string |  | The URL to link to when the button is clicked. If defined, an `a` element will be used as the root node. |
 | raised | boolean | false | If `true`, the button will use raised styling. |
 

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -206,7 +206,7 @@ export type Props = {
    */
   disableRipple?: boolean,
   /**
-   * If `true`, well use floating action button styling.
+   * If `true`, will use floating action button styling.
    */
   fab?: boolean,
   /**


### PR DESCRIPTION
- Button property fab 'will use' not 'well use'
- closes issue #7949
