### PR TITLE
[Input] Better support required field

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,10 @@ If you think you have found a bug, or have a new feature idea, please start by m
 Next, create a new issue that briefly explains the problem, and provides a bit of background as to the circumstances that triggered it, and steps to reproduce it.
 
 For code issues please include:
-* Material-UI version
-* React version
-* Browser version
-* A code example or link to a repo, gist or running site.
+- Material-UI version
+- React version
+- Browser version
+- A code example or link to a repo, gist or running site.
 
 For visual or layout problems, images or animated gifs can help explain your issue.
 
@@ -24,11 +24,9 @@ For feature requests please include a link to the relevant section of Material D
 
 ### Issue Guidelines
 
-Please begin the title with '[ComponentName]' where appropriate, and use a succint description. "doesn't work" doesn't help others find similar issues.
-
-Please don't group multiple topics into one issue, but instead each should be its own issue.
-
-And please don't just '+1' an issue. It spams the maintainers and doesn't help move the issue forward.
+- Please begin the title with '[ComponentName]' where appropriate, and use a succint description. "doesn't work" doesn't help others find similar issues.
+- Please don't group multiple topics into one issue, but instead each should be its own issue.
+- And please don't just comment '+1' on an issue. It spams the maintainers and doesn't help move the issue forward.
 
 ## Submitting a Pull Request
 
@@ -83,11 +81,13 @@ Test coverage is limited at present, but where possible, please add tests for an
 
 Please follow the coding style of the current code base. Material-UI uses eslint, so if possible, enable linting in your editor to get realtime feedback. The linting rules are also run when Webpack recompiles your changes, and can be run manually with `yarn lint`.
 
-You can also run linting on a subset of the codebase with `gulp eslint:src`, `gulp eslint:docs` or `gulp eslint:test`. Finally, when you submit a pull request, they are run again by Travis CI, but hopefully by then your code is already clean!
+You can also run `yarn prettier` to reformat the code.
+
+Finally, when you submit a pull request, they are run again by Circle CI, but hopefully by then your code is already clean!
 
 ## Roadmap
 
-To get a sense of where Material-UI is heading, or for ideas on where you could contribute, take a look at the [roadmap](https://github.com/callemall/material-ui/blob/v1-beta/ROADMAP.md) and the list of [Material Design components](https://github.com/callemall/material-ui/issues/2863).
+To get a sense of where Material-UI is heading, or for ideas on where you could contribute, take a look at the [ROADMAP](https://github.com/callemall/material-ui/blob/v1-beta/ROADMAP.md).
 
 ## License
 

--- a/docs/src/pages/demos/text-fields/TextFields.js
+++ b/docs/src/pages/demos/text-fields/TextFields.js
@@ -33,7 +33,7 @@ class TextFields extends React.Component {
     const classes = this.props.classes;
 
     return (
-      <div className={classes.container}>
+      <form className={classes.container} noValidate>
         <TextField
           id="name"
           label="Name"
@@ -130,7 +130,7 @@ class TextFields extends React.Component {
           fullWidth
           margin="normal"
         />
-      </div>
+      </form>
     );
   }
 }

--- a/docs/src/pages/discover-more/related-projects.md
+++ b/docs/src/pages/discover-more/related-projects.md
@@ -6,9 +6,13 @@
 
 ## Complementary Projects
 
-- [redux-form](http://redux-form.com/6.1.1/examples/material-ui/) Manage your form state in Redux.
+- [react-autosuggest](https://github.com/moroshko/react-autosuggest) WAI-ARIA compliant React autosuggest component.
+- [react-popper](https://github.com/souporserious/react-popper) React wrapper around PopperJS.
 - [react-swipeable-views](https://github.com/oliviertassinari/react-swipeable-views)
 A React component for swipeable views. Plays well with the `Tabs` component.
-- [react-dnd](http://gaearon.github.io/react-dnd/examples-sortable-simple.html) Drag and Drop for React.
+- [redux-form](http://redux-form.com/6.1.1/examples/material-ui/) Manage your form state in Redux.
+
+## Boilerplates
+
 - [UniversalRelayBoilerplate](https://github.com/codefoundries/UniversalRelayBoilerplate)
 Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Material-UI), Relay, GraphQL, JWT, Node.js, Apache Cassandra.

--- a/docs/src/pages/getting-started/examples.md
+++ b/docs/src/pages/getting-started/examples.md
@@ -2,7 +2,9 @@
 
 Are you looking for an example project to get started?
 
-We host some example projects. You can find them in our [GitHub repository](https://github.com/callemall/material-ui) under the [`/examples`](https://github.com/callemall/material-ui/tree/v1-beta/examples) folder.
+We host some example projects. You can find them in our [GitHub repository](https://github.com/callemall/material-ui) under the [`/examples`](https://github.com/callemall/material-ui/tree/v1-beta/examples) folder:
+- [Create React App](https://github.com/callemall/material-ui/tree/v1-beta/examples/create-react-app)
+- [Next.js](https://github.com/callemall/material-ui/tree/v1-beta/examples/nextjs)
 
 The source code for this documentation site is also included in the repository.
 This is a slightly more complex project.

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -111,6 +111,10 @@ export const styles = (theme: Object) => {
       '&:focus': {
         outline: 0,
       },
+      // Reset Firefox invalid required input style
+      '&:invalid': {
+        boxShadow: 'none',
+      },
       '&::-webkit-search-decoration': {
         // Remove the padding when type=search.
         appearance: 'none',
@@ -535,7 +539,7 @@ class Input extends React.Component<AllProps, State> {
           onKeyUp={onKeyUp}
           onKeyDown={onKeyDown}
           disabled={disabled}
-          aria-required={required ? true : undefined}
+          required={required ? true : undefined}
           value={value}
           id={id}
           name={name}

--- a/src/Input/Input.spec.js
+++ b/src/Input/Input.spec.js
@@ -40,7 +40,7 @@ describe('<Input />', () => {
     assert.strictEqual(input.name(), 'input');
     assert.strictEqual(input.props().type, 'text', 'should pass the text type prop');
     assert.strictEqual(input.hasClass(classes.input), true, 'should have the input class');
-    assert.strictEqual(input.prop('aria-required'), undefined);
+    assert.strictEqual(input.props().required, undefined);
   });
 
   it('should render an <Textarea /> when passed the multiline prop', () => {
@@ -292,7 +292,7 @@ describe('<Input />', () => {
       it('should have the aria-required prop with value true', () => {
         setFormControlContext({ required: true });
         const input = wrapper.find('input');
-        assert.strictEqual(input.prop('aria-required'), true);
+        assert.strictEqual(input.props().required, true);
       });
     });
   });

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -192,9 +192,6 @@ export type Props = {
 
 type AllProps = DefaultProps & Props;
 
-/**
- * @ignore - internal component.
- */
 class Popover extends React.Component<AllProps, void> {
   props: AllProps;
   static defaultProps = {


### PR DESCRIPTION
- Closes #7887
- Reset Firefox style
- Fix some docs issues

## Breaking change

Following Bootstrap, we are now forwarding the required property down to the input component. We used to only apply `aria-required`. This move makes us less opinionated and should help with native form handling.

If you want to avoid the default browser required property handling, you can add a `noValidate` property to the parent `form`.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

