### PR TITLE
[TypeScript] Make createMuiTheme's ThemeOptions recursively partial

### DIFF
--- a/src/styles/createMuiTheme.d.ts
+++ b/src/styles/createMuiTheme.d.ts
@@ -24,5 +24,7 @@ export type Theme<T = {}> = {
   T;
 
 export default function createMuiTheme<T = {}>(
-  options?: Partial<ThemeOptions> & T
+  options?: {
+    [K in keyof ThemeOptions]?: Partial<ThemeOptions[K]>
+  } & T
 ): Theme<T>;

--- a/test/typescript/styles.spec.tsx
+++ b/test/typescript/styles.spec.tsx
@@ -70,6 +70,12 @@ const theme = createMuiTheme({
   },
 });
 
+const customTheme = createMuiTheme({
+  palette: {
+    type: 'dark'
+  }
+});
+
 function OverridesTheme() {
   return (
     <MuiThemeProvider theme={theme}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

```ts
const theme = createMuiTheme({
    palette: {
        type: 'dark'
    }
})
```

This code won't work because `createMuiTheme` takes `Partial<ThemeOptions>`, but `ThemeOptions.palette` is a complete `Palette`.

This PR iterates over `ThemeOptions` properties and make them all `Partial`.
The thing is I don't know if *all* properties should be `Partial`. If not we can use type unions to make only some properties `Partial`.