### PR TITLE
[ButtonBase] stop ripple on right click

### DIFF
--- a/src/ButtonBase/createRippleHandler.js
+++ b/src/ButtonBase/createRippleHandler.js
@@ -5,10 +5,11 @@ function createRippleHandler(instance: Object, eventName: string, action: string
     /**
       do not ripple on right clicks
     */
-    const clicks = {left: 1, right: 3}
-    if (event.nativeEvent.which === clicks.right) {
-      instance.ripple['stop'](event);
-      return;
+    const clicks = { left: 1, right: 3 };
+    if (event.nativeEvent && event.nativeEvent.which === clicks.right) {
+      action = 'stop';
+      instance.ripple[action](event);
+      event.preventDefault();
     }
 
     if (cb) {

--- a/src/ButtonBase/createRippleHandler.js
+++ b/src/ButtonBase/createRippleHandler.js
@@ -2,6 +2,15 @@
 
 function createRippleHandler(instance: Object, eventName: string, action: string, cb: ?Function) {
   return function handleEvent(event: SyntheticUIEvent<>) {
+    /**
+      do not ripple on right clicks
+    */
+    const clicks = {left: 1, right: 3}
+    if (event.nativeEvent.which === clicks.right) {
+      instance.ripple['stop'](event);
+      return;
+    }
+
     if (cb) {
       cb.call(instance, event);
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
Closes #7537

`createRippleHandler.handleEvent` will invoke `instance.ripple['stop'](event);` when the event is a right click. This resolved issue #7537 on Chrome Version 60.0.3112.113

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

