### PR TITLE
[Drawer] Add `type` property, remove `docked` property in TypeScript definition

### DIFF
--- a/src/Drawer/Drawer.d.ts
+++ b/src/Drawer/Drawer.d.ts
@@ -6,13 +6,13 @@ import { Theme } from '../styles/createMuiTheme';
 
 export interface DrawerProps extends ModalProps {
   anchor?: 'left' | 'top' | 'right' | 'bottom';
-  docked?: boolean;
   elevation?: number;
   enterTransitionDuration?: number;
   leaveTransitionDuration?: number;
   open?: boolean;
   SlideProps?: SlideProps;
   theme?: Theme;
+  type: 'permanent' | 'persistent' | 'temporary';
 }
 
 export default class Drawer extends StyledComponent<DrawerProps> {}


### PR DESCRIPTION
Beta 7 made changes to the Drawer component, but the `Drawer.d.ts` definition file was not updated. The changes are as follows:

- The `docked` property is no longer used by the underlying JS code. It has already been removed from the flow interface.
- The new `type` property definition was added. It matches the flow definition.

Fixes #7997

- [X] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

