### PR TITLE
[MobileStepper] Add nextButton and backButton property

### DIFF
--- a/docs/src/pages/demos/stepper/DotsMobileStepper.js
+++ b/docs/src/pages/demos/stepper/DotsMobileStepper.js
@@ -4,6 +4,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
 import MobileStepper from 'material-ui/MobileStepper';
+import Button from 'material-ui/Button';
+import KeyboardArrowLeft from 'material-ui-icons/KeyboardArrowLeft';
+import KeyboardArrowRight from 'material-ui-icons/KeyboardArrowRight';
 
 const styles = {
   root: {
@@ -38,10 +41,18 @@ class DotsMobileStepper extends React.Component {
         position="static"
         activeStep={this.state.activeStep}
         className={classes.root}
-        onBack={this.handleBack}
-        onNext={this.handleNext}
-        disableBack={this.state.activeStep === 0}
-        disableNext={this.state.activeStep === 5}
+        nextButton={
+          <Button dense onClick={this.handleNext} disabled={this.state.activeStep === 5}>
+            Next
+            <KeyboardArrowRight />
+          </Button>
+        }
+        backButton={
+          <Button dense onClick={this.handleBack} disabled={this.state.activeStep === 0}>
+            <KeyboardArrowLeft />
+            Back
+          </Button>
+        }
       />
     );
   }

--- a/docs/src/pages/demos/stepper/ProgressMobileStepper.js
+++ b/docs/src/pages/demos/stepper/ProgressMobileStepper.js
@@ -4,6 +4,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
 import MobileStepper from 'material-ui/MobileStepper';
+import Button from 'material-ui/Button';
+import KeyboardArrowLeft from 'material-ui-icons/KeyboardArrowLeft';
+import KeyboardArrowRight from 'material-ui-icons/KeyboardArrowRight';
 
 const styles = {
   root: {
@@ -38,10 +41,18 @@ class ProgressMobileStepper extends React.Component {
         position="static"
         activeStep={this.state.activeStep}
         className={classes.root}
-        onBack={this.handleBack}
-        onNext={this.handleNext}
-        disableBack={this.state.activeStep === 0}
-        disableNext={this.state.activeStep === 5}
+        nextButton={
+          <Button dense onClick={this.handleNext} disabled={this.state.activeStep === 5}>
+            Next
+            <KeyboardArrowRight />
+          </Button>
+        }
+        backButton={
+          <Button dense onClick={this.handleBack} disabled={this.state.activeStep === 0}>
+            <KeyboardArrowLeft />
+            Back
+          </Button>
+        }
       />
     );
   }

--- a/docs/src/pages/demos/stepper/TextMobileStepper.js
+++ b/docs/src/pages/demos/stepper/TextMobileStepper.js
@@ -6,6 +6,9 @@ import { withStyles } from 'material-ui/styles';
 import MobileStepper from 'material-ui/MobileStepper';
 import Paper from 'material-ui/Paper';
 import Typography from 'material-ui/Typography';
+import Button from 'material-ui/Button';
+import KeyboardArrowLeft from 'material-ui-icons/KeyboardArrowLeft';
+import KeyboardArrowRight from 'material-ui-icons/KeyboardArrowRight';
 
 const styles = theme => ({
   root: {
@@ -52,10 +55,18 @@ class TextMobileStepper extends React.Component {
           position="static"
           activeStep={this.state.activeStep}
           className={classes.mobileStepper}
-          onBack={this.handleBack}
-          onNext={this.handleNext}
-          disableBack={this.state.activeStep === 0}
-          disableNext={this.state.activeStep === 5}
+          nextButton={
+            <Button dense onClick={this.handleNext} disabled={this.state.activeStep === 5}>
+              Next
+              <KeyboardArrowRight />
+            </Button>
+          }
+          backButton={
+            <Button dense onClick={this.handleBack} disabled={this.state.activeStep === 0}>
+              <KeyboardArrowLeft />
+              Back
+            </Button>
+          }
         />
       </div>
     );

--- a/src/MobileStepper/MobileStepper.d.ts
+++ b/src/MobileStepper/MobileStepper.d.ts
@@ -1,15 +1,12 @@
 import * as React from 'react';
 import { StyledComponent } from '..';
 import { PaperProps } from '../Paper';
+import { ButtonProps } from '../Button';
 
 export interface MobileStepperProps extends PaperProps {
   activeStep?: number;
-  backButtonText?: React.ReactNode;
-  disableBack?: boolean;
-  disableNext?: boolean;
-  nextButtonText?: React.ReactNode;
-  onBack: React.EventHandler<any>;
-  onNext: React.EventHandler<any>;
+  backButton: React.ReactElement<any>;
+  nextButton: React.ReactElement<any>;  
   position?: 'bottom' | 'top' | 'static';
   steps: number;
   type?: 'text' | 'dots' | 'progress';

--- a/src/MobileStepper/MobileStepper.js
+++ b/src/MobileStepper/MobileStepper.js
@@ -6,10 +6,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import Paper from '../Paper';
-import Button from '../Button';
 import { capitalizeFirstLetter } from '../utils/helpers';
-import KeyboardArrowLeft from '../svg-icons/KeyboardArrowLeft';
-import KeyboardArrowRight from '../svg-icons/KeyboardArrowRight';
 import { LinearProgress } from '../Progress';
 
 export const styles = (theme: Object) => ({
@@ -36,7 +33,6 @@ export const styles = (theme: Object) => ({
     zIndex: theme.zIndex.mobileStepper,
   },
   positionStatic: {},
-  button: {},
   dots: {
     display: 'flex',
     flexDirection: 'row',
@@ -59,16 +55,12 @@ export const styles = (theme: Object) => ({
 function MobileStepper(props) {
   const {
     activeStep,
-    backButtonText,
+    backButton,
     classes,
     className: classNameProp,
-    disableBack,
-    disableNext,
     position,
     type,
-    nextButtonText,
-    onBack,
-    onNext,
+    nextButton,
     steps,
     ...other
   } = props;
@@ -81,10 +73,7 @@ function MobileStepper(props) {
 
   return (
     <Paper square elevation={0} className={className} {...other}>
-      <Button className={classes.button} onClick={onBack} disabled={disableBack}>
-        <KeyboardArrowLeft />
-        {backButtonText}
-      </Button>
+      {backButton}
       {type === 'dots' && (
         <div className={classes.dots}>
           {[...new Array(steps)].map((_, step) => {
@@ -104,10 +93,7 @@ function MobileStepper(props) {
           <LinearProgress mode="determinate" value={Math.ceil(activeStep / (steps - 1) * 100)} />
         </div>
       )}
-      <Button className={classes.button} onClick={onNext} disabled={disableNext}>
-        {nextButtonText}
-        <KeyboardArrowRight />
-      </Button>
+      {nextButton}
     </Paper>
   );
 }
@@ -119,9 +105,9 @@ MobileStepper.propTypes = {
    */
   activeStep: PropTypes.number,
   /**
-   * Set the text that appears for the back button.
+   * A back button element. For instance, it can be be a `Button` or a `IconButton`.
    */
-  backButtonText: PropTypes.node,
+  backButton: PropTypes.element.isRequired,
   /**
    * Useful to extend the style applied to components.
    */
@@ -131,25 +117,9 @@ MobileStepper.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * Set to true to disable the back button.
+   * A next button element. For instance, it can be be a `Button` or a `IconButton`.
    */
-  disableBack: PropTypes.bool,
-  /**
-   * Set to true to disable the next button.
-   */
-  disableNext: PropTypes.bool,
-  /**
-   * Set the text that appears for the next button.
-   */
-  nextButtonText: PropTypes.node,
-  /**
-   * Passed into the onClick prop of the Back button.
-   */
-  onBack: PropTypes.func.isRequired,
-  /**
-   * Passed into the onClick prop of the Next button.
-   */
-  onNext: PropTypes.func.isRequired,
+  nextButton: PropTypes.element.isRequired,
   /**
    * Set the positioning type.
    */
@@ -166,10 +136,6 @@ MobileStepper.propTypes = {
 
 MobileStepper.defaultProps = {
   activeStep: 0,
-  backButtonText: 'Back',
-  disableBack: false,
-  disableNext: false,
-  nextButtonText: 'Next',
   position: 'bottom',
   type: 'dots',
 };

--- a/src/MobileStepper/MobileStepper.spec.js
+++ b/src/MobileStepper/MobileStepper.spec.js
@@ -14,8 +14,18 @@ describe('<MobileStepper />', () => {
   let classes;
   const defaultProps = {
     steps: 2,
-    onBack: () => {},
-    onNext: () => {},
+    nextButton: (
+      <Button>
+        Next
+        <KeyboardArrowRight />
+      </Button>
+    ),
+    backButton: (
+      <Button>
+        <KeyboardArrowLeft />
+        Back
+      </Button>
+    ),
   };
 
   before(() => {
@@ -77,8 +87,18 @@ describe('<MobileStepper />', () => {
     );
   });
 
-  it('should set the backButtonText', () => {
-    const wrapper = shallow(<MobileStepper backButtonText="Past" {...defaultProps} />);
+  it('should render backButton custom text', () => {
+    const props = {
+      steps: defaultProps.steps,
+      nextButton: defaultProps.nextButton,
+      backButton: (
+        <Button>
+          <KeyboardArrowLeft />
+          Past
+        </Button>
+      ),
+    };
+    const wrapper = shallow(<MobileStepper {...props} />);
     assert.strictEqual(
       wrapper
         .childAt(0)
@@ -89,8 +109,18 @@ describe('<MobileStepper />', () => {
     );
   });
 
-  it('should set the nextButtonText', () => {
-    const wrapper = shallow(<MobileStepper nextButtonText="Future" {...defaultProps} />);
+  it('should render nextButton custom text', () => {
+    const props = {
+      steps: defaultProps.steps,
+      nextButton: (
+        <Button>
+          Future
+          <KeyboardArrowRight />
+        </Button>
+      ),
+      backButton: defaultProps.backButton,
+    };
+    const wrapper = shallow(<MobileStepper {...props} />);
     assert.strictEqual(
       wrapper
         .childAt(2)
@@ -101,14 +131,24 @@ describe('<MobileStepper />', () => {
     );
   });
 
-  it('should disable the back button if prop disableBack is passed', () => {
-    const wrapper = shallow(<MobileStepper disableBack {...defaultProps} />);
+  it('should render disabled backButton', () => {
+    const props = {
+      steps: defaultProps.steps,
+      nextButton: defaultProps.nextButton,
+      backButton: <Button disabled />,
+    };
+    const wrapper = shallow(<MobileStepper {...props} />);
     const backButton = wrapper.childAt(0);
     assert.strictEqual(backButton.props().disabled, true, 'should disable the back button');
   });
 
-  it('should disable the next button if prop disableNext is passed', () => {
-    const wrapper = shallow(<MobileStepper disableNext {...defaultProps} />);
+  it('should render disabled nextButton', () => {
+    const props = {
+      steps: defaultProps.steps,
+      nextButton: <Button disabled />,
+      backButton: defaultProps.backButton,
+    };
+    const wrapper = shallow(<MobileStepper {...props} />);
     const nextButton = wrapper.childAt(2);
     assert.strictEqual(nextButton.props().disabled, true, 'should disable the next button');
   });
@@ -164,8 +204,8 @@ describe('<MobileStepper />', () => {
 
   it('should calculate the <LinearProgress /> value correctly', () => {
     const props = {
-      onBack: defaultProps.onBack,
-      onNext: defaultProps.onNext,
+      backButton: defaultProps.backButton,
+      nextButton: defaultProps.nextButton,
     };
     let wrapper = shallow(<MobileStepper type="progress" steps={3} {...props} />);
     let linearProgressProps = wrapper.find(LinearProgress).props();


### PR DESCRIPTION
I needed this to pass props to the `MobileStepper` component

#### Breaking change

```diff
+import KeyboardArrowLeft from 'material-ui-icons/KeyboardArrowLeft';
+import KeyboardArrowRight from 'material-ui-icons/KeyboardArrowRight';

     <MobileStepper
-        onBack={this.handleBack}
-        onNext={this.handleNext}
-        disableBack={this.state.activeStep === 0}
-        disableNext={this.state.activeStep === 5}
+        nextButton={
+          <Button dense onClick={this.handleNext} disabled={this.state.activeStep === 5}>
+            Next
+            <KeyboardArrowRight />
+          </Button>
+        }
+        backButton={
+          <Button dense onClick={this.handleBack} disabled={this.state.activeStep === 0}>
+            <KeyboardArrowLeft />
+            Back
+          </Button>
+        }
      />
```