### PR TITLE
[Tabs] Fix InkBar location for controlled Tabs (non-v1)

### DIFF
--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -215,9 +215,11 @@ class Tabs extends Component {
       });
     });
 
-    const inkBar = this.state.selectedIndex !== -1 ? (
+    const realSelectedIndex = valueLink.value ? this.getSelectedIndex(this.props) : this.state.selectedIndex;
+
+    const inkBar = realSelectedIndex !== -1 ? (
       <InkBar
-        left={`${width * this.state.selectedIndex}%`}
+        left={`${width * realSelectedIndex}%`}
         width={`${width}%`}
         style={inkBarStyle}
       />

--- a/src/Tabs/Tabs.spec.js
+++ b/src/Tabs/Tabs.spec.js
@@ -21,6 +21,9 @@ describe('<Tabs />', () => {
       );
 
       assert.strictEqual(wrapper.state().selectedIndex, 0);
+      assert.strictEqual(wrapper.find('Tab').at(0).prop('selected'), true);
+      assert.strictEqual(wrapper.find('Tab').at(1).prop('selected'), false);
+      assert.strictEqual(wrapper.find('InkBar').prop('left'), '0%');
     });
   });
 
@@ -34,6 +37,25 @@ describe('<Tabs />', () => {
       );
 
       assert.strictEqual(wrapper.state().selectedIndex, 1);
+      assert.strictEqual(wrapper.find('Tab').at(0).prop('selected'), false);
+      assert.strictEqual(wrapper.find('Tab').at(1).prop('selected'), true);
+      assert.strictEqual(wrapper.find('InkBar').prop('left'), '50%');
+    });
+
+    it('should still use the value prop even after another tab is selected if value stays the same', () => {
+      const wrapper = shallowWithContext(
+        <Tabs value="2">
+          <Tab value="1" />
+          <Tab value="2" />
+        </Tabs>
+      );
+
+      wrapper.setState({selectedIndex: 0});
+
+      assert.strictEqual(wrapper.state().selectedIndex, 0);
+      assert.strictEqual(wrapper.find('Tab').at(0).prop('selected'), false);
+      assert.strictEqual(wrapper.find('Tab').at(1).prop('selected'), true);
+      assert.strictEqual(wrapper.find('InkBar').prop('left'), '50%');
     });
 
     it('should set the right tab active when the children change', () => {
@@ -52,6 +74,9 @@ describe('<Tabs />', () => {
       });
 
       assert.strictEqual(wrapper.state().selectedIndex, 0);
+      assert.strictEqual(wrapper.find('Tab').at(0).prop('selected'), true);
+      assert.strictEqual(wrapper.find('Tab').at(1).prop('selected'), false);
+      assert.strictEqual(wrapper.find('InkBar').prop('left'), '0%');
     });
   });
 });


### PR DESCRIPTION
The InkBar was not checking to see if the controlled `value` was set before using the uncontrolled internal state of `selectedIndex`.  `selectedIndex` gets updated on every click, but it should be ignored when tabs is setup in a controlled way.

My use case was setting my tabs as hyperlink (`<a/>` tags), and if a user opened the link in another browser tab, it would keep the correct tab highlighted (text color wise) but the inkbar would move to the tab that was just clicked. 

I also updated the tests and added one for my case to test the highlighted tab and inkbar location instead of just the internal state.