### PR TITLE
[RadioGroup] Fix TypeScript definition for value property

### DIFF
--- a/src/Radio/RadioGroup.d.ts
+++ b/src/Radio/RadioGroup.d.ts
@@ -5,7 +5,7 @@ import { FormGroupProps } from '../Form';
 export type RadioGroupProps = {
   name?: string;
   onChange?: (event: React.ChangeEvent<{}>, value: string) => void;
-  selectedValue?: string;
+  value?: string;
 } & Partial<Omit<FormGroupProps, 'onChange'>>;
 
 export default class RadioGroup extends StyledComponent<RadioGroupProps> {}


### PR DESCRIPTION
Fixes #8025 

Updates `RadioGroup` TypeScript definition to match code by renaming the `selectedValue` property to `value`.

- [X] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

