### PR TITLE
[List] Fix scrollview performance on iOS devices

### DIFF
--- a/src/List/List.js
+++ b/src/List/List.js
@@ -13,7 +13,6 @@ export const styles = (theme: Object) => ({
     listStyle: 'none',
     margin: 0,
     padding: 0,
-    overflowScrolling: 'touch',
     WebkitOverflowScrolling: 'touch',
   },
   padding: {

--- a/src/List/List.js
+++ b/src/List/List.js
@@ -13,6 +13,8 @@ export const styles = (theme: Object) => ({
     listStyle: 'none',
     margin: 0,
     padding: 0,
+    overflowScrolling: 'touch',
+    WebkitOverflowScrolling: 'touch',
   },
   padding: {
     paddingTop: theme.spacing.unit,


### PR DESCRIPTION
The List scrolls bad on iOS devices, and something it even refreshes the page instead of going up in the list.
It's due the overflow:auto property. https://weblog.west-wind.com/posts/2015/jun/05/ipad-scroll-issues-with-fixed-content

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

