### PR TITLE
[CardMedia] Guard against null children and overlays

### DIFF
--- a/src/Card/CardMedia.js
+++ b/src/Card/CardMedia.js
@@ -107,18 +107,24 @@ class CardMedia extends Component {
     const color = this.context.muiTheme.cardMedia.color;
 
     const styledChildren = React.Children.map(children, (child) => {
+      if (!child) {
+        return child;
+      }
+
       return React.cloneElement(child, {
         style: prepareStyles(Object.assign({}, styles.mediaChild, child.props.style)),
       });
     });
 
     const overlayChildren = React.Children.map(overlay, (child) => {
-      if (child.type.muiName === 'CardHeader' || child.type.muiName === 'CardTitle') {
+      const childMuiName = (child && child.type) ? child.type.muiName : null;
+
+      if (childMuiName === 'CardHeader' || childMuiName === 'CardTitle') {
         return React.cloneElement(child, {
           titleColor: titleColor,
           subtitleColor: subtitleColor,
         });
-      } else if (child.type.muiName === 'CardText') {
+      } else if (childMuiName === 'CardText') {
         return React.cloneElement(child, {
           color: color,
         });


### PR DESCRIPTION
CardMedia with `actAsExpander` prop set to true throws an exception here https://github.com/callemall/material-ui/blob/master/src/Card/CardMedia.js#L110 because Card adds an `undefined` child to it if there's no `showExpandableButton`.

This PR fixes the issue by checking whether a child is empty.
