### PR TITLE
[CardMedia] Allow styling without breaking image

### DIFF
--- a/src/Card/CardMedia.js
+++ b/src/Card/CardMedia.js
@@ -29,20 +29,19 @@ export type Props = {
    * Note that caller must specify height otherwise the image will not be visible.
    */
   image: string,
+  /**
+   * @ignore
+   */
+  style?: Object,
 };
 
 type AllProps = DefaultProps & Props;
 
 function CardMedia(props: AllProps) {
-  const { classes, className, image, ...other } = props;
+  const { classes, className, image, style, ...other } = props;
+  const composedStyle = { backgroundImage: `url(${image})`, ...style };
 
-  return (
-    <div
-      className={classNames(classes.root, className)}
-      style={{ backgroundImage: `url(${image})` }}
-      {...other}
-    />
-  );
+  return <div className={classNames(classes.root, className)} style={composedStyle} {...other} />;
 }
 
 export default withStyles(styles, { name: 'MuiCardMedia' })(CardMedia);

--- a/src/Card/CardMedia.spec.js
+++ b/src/Card/CardMedia.spec.js
@@ -33,4 +33,17 @@ describe('<CardMedia />', () => {
       'custom prop should be woofCardMedia',
     );
   });
+
+  it('should have backgroundImage specified even though custom styles got passed', () => {
+    const wrapper = shallow(<CardMedia image="/foo.jpg" style={{ height: 200 }} />);
+    assert.strictEqual(wrapper.prop('style').backgroundImage, 'url(/foo.jpg)');
+    assert.strictEqual(wrapper.prop('style').height, 200);
+  });
+
+  it('should be possible to overwrite backgroundImage via custom styles', () => {
+    const wrapper = shallow(
+      <CardMedia image="/foo.jpg" style={{ backgroundImage: 'url(/bar.jpg)' }} />,
+    );
+    assert.strictEqual(wrapper.prop('style').backgroundImage, 'url(/bar.jpg)');
+  });
 });


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

As explained in [Docs](https://material-ui-1dab0.firebaseapp.com/customization/overrides/), MUI should allow [overwriting of styles via inline-styles](https://material-ui-1dab0.firebaseapp.com/customization/overrides/#overriding-with-inline-style).

Therefore I would expect the following snippet to have a height of `200px` and `foo.jpg` as a background image:
```js
<CardMedia image="foo.jpg" style={{ height: 200 }} />
```

Currently the custom inline style attribute overwrites the internal styles for background image.

This PR allows users to set custom inline styles without overwriting the internal behaviour directly. Though it still enables users to consciously overwrite `backgroundImage` in order to stick to the following statement:

> You don't have to worry about CSS specificity as the inline-style takes precedence over the regular CSS.