### PR TITLE
Fix create react app explicit dependencies

### DIFF
--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -3,11 +3,15 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "jss": "latest",
+    "jss-preset-default": "latest",
     "material-ui": "next",
+    "prop-types": "latest",
     "react": "latest",
     "react-dom": "latest",
     "react-jss": "latest",
-    "react-scripts": "latest"
+    "react-scripts": "latest",
+    "recompose": "latest"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -6,6 +6,7 @@
     "material-ui": "next",
     "react": "latest",
     "react-dom": "latest",
+    "react-jss": "latest",
     "react-scripts": "latest"
   },
   "scripts": {


### PR DESCRIPTION
This was needed to get the `examples/create-react-app` to work with the Codesandbox.io.

https://codesandbox.io/s/github/alienfast/material-ui/tree/5a6b9ea19de5e384b2a6642b3de81020521578f1/examples/create-react-app

Once merged, we can point an issue_template there and start asking users for reproduction cases.

If this would be better as an entirely separate example project, we can consider something as simple as possible to support test cases, but I figured this example was about as simple as it can be and still allow for quite a variety of test cases.

With Codesandbox.io we can point to any github tree, but note that something like `v1-beta` caches the bundle for some time. I'm not sure about recommended strategy for keeping a sample on the tip of a branch.  I just encountered this as I was trying to get it to work, and switched to a commit-specific tree to verify.

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

