### PR TITLE
[Snackbar] Fix click-through issue in IE11

### DIFF
--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -32,7 +32,6 @@ export const styles = (theme: Object) => {
       right: 0,
       justifyContent: 'center',
       alignItems: 'center',
-      pointerEvents: 'all',
     },
     anchorTopCenter: {
       extend: [top],

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -32,7 +32,7 @@ export const styles = (theme: Object) => {
       right: 0,
       justifyContent: 'center',
       alignItems: 'center',
-      pointerEvents: 'none',
+      pointerEvents: 'all',
     },
     anchorTopCenter: {
       extend: [top],


### PR DESCRIPTION
set pointer-events to all to fix the behaviour in IE that allows to click through the Snackbar to underlying elements

Closes #8081