### PR TITLE
[Picker] Add page section in the documentation

### DIFF
--- a/docs/src/pages/demos/pickers/DateAndTimePickers.js
+++ b/docs/src/pages/demos/pickers/DateAndTimePickers.js
@@ -1,0 +1,44 @@
+// @flow weak
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from 'material-ui/styles';
+import TextField from 'material-ui/TextField';
+
+const styles = theme => ({
+  container: {
+    display: 'flex',
+    flexWrap: 'wrap',
+  },
+  textField: {
+    marginLeft: theme.spacing.unit,
+    marginRight: theme.spacing.unit,
+    width: 200,
+  },
+});
+
+function DateAndTimePickers(props) {
+  const { classes } = props;
+
+  return (
+    <form className={classes.container} noValidate>
+      <TextField
+        id="datetime-local"
+        label="Next appointment"
+        step="300"
+        type="datetime-local"
+        defaultValue="2017-05-24T10:30"
+        className={classes.textField}
+        InputLabelProps={{
+          shrink: true,
+        }}
+      />
+    </form>
+  );
+}
+
+DateAndTimePickers.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(DateAndTimePickers);

--- a/docs/src/pages/demos/pickers/DatePickers.js
+++ b/docs/src/pages/demos/pickers/DatePickers.js
@@ -1,0 +1,43 @@
+// @flow weak
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from 'material-ui/styles';
+import TextField from 'material-ui/TextField';
+
+const styles = theme => ({
+  container: {
+    display: 'flex',
+    flexWrap: 'wrap',
+  },
+  textField: {
+    marginLeft: theme.spacing.unit,
+    marginRight: theme.spacing.unit,
+    width: 200,
+  },
+});
+
+function DatePickers(props) {
+  const { classes } = props;
+
+  return (
+    <form className={classes.container} noValidate>
+      <TextField
+        id="date"
+        label="Birthday"
+        type="date"
+        defaultValue="2017-05-24"
+        className={classes.textField}
+        InputLabelProps={{
+          shrink: true,
+        }}
+      />
+    </form>
+  );
+}
+
+DatePickers.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(DatePickers);

--- a/docs/src/pages/demos/pickers/TimePickers.js
+++ b/docs/src/pages/demos/pickers/TimePickers.js
@@ -1,0 +1,43 @@
+// @flow weak
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from 'material-ui/styles';
+import TextField from 'material-ui/TextField';
+
+const styles = theme => ({
+  container: {
+    display: 'flex',
+    flexWrap: 'wrap',
+  },
+  textField: {
+    marginLeft: theme.spacing.unit,
+    marginRight: theme.spacing.unit,
+    width: 200,
+  },
+});
+
+function TimePickers(props) {
+  const { classes } = props;
+
+  return (
+    <form className={classes.container} noValidate>
+      <TextField
+        id="time"
+        label="Alarm clock"
+        type="time"
+        defaultValue="07:30"
+        className={classes.textField}
+        InputLabelProps={{
+          shrink: true,
+        }}
+      />
+    </form>
+  );
+}
+
+TimePickers.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(TimePickers);

--- a/docs/src/pages/demos/pickers/pickers.md
+++ b/docs/src/pages/demos/pickers/pickers.md
@@ -1,0 +1,27 @@
+---
+components: TextField
+---
+
+# Pickers
+
+[Pickers](https://material.io/guidelines/components/pickers.html) provide a simple way to select a single value from a pre-determined set.
+
+- On mobile, pickers are best suited for display in confirmation dialog.
+- For inline display, such as on a form, consider using compact controls such as segmented dropdown buttons.
+
+#### Notice
+
+We are currently falling back to **native input controls**.
+If you are interested in implementing or have implemented a rich Material Design Picker with an awesome UX, please, let us know on [#4787](https://github.com/callemall/material-ui/issues/4787) and [#4796](https://github.com/callemall/material-ui/issues/4796)! We could add a link to or a demo of your project in the documentation.
+
+## Date pickers
+
+{{demo='pages/demos/pickers/DatePickers.js'}}
+
+## Time pickers
+
+{{demo='pages/demos/pickers/TimePickers.js'}}
+
+## Date & Time pickers
+
+{{demo='pages/demos/pickers/DateAndTimePickers.js'}}

--- a/docs/src/pages/demos/text-fields/TextFields.js
+++ b/docs/src/pages/demos/text-fields/TextFields.js
@@ -30,7 +30,7 @@ class TextFields extends React.Component {
   };
 
   render() {
-    const classes = this.props.classes;
+    const { classes } = this.props;
 
     return (
       <form className={classes.container} noValidate>
@@ -72,17 +72,6 @@ class TextFields extends React.Component {
           type="password"
           autoComplete="current-password"
           margin="normal"
-        />
-        <TextField
-          id="date"
-          label="From date"
-          type="date"
-          defaultValue="2017-05-24"
-          className={classes.textField}
-          margin="normal"
-          InputLabelProps={{
-            shrink: true,
-          }}
         />
         <TextField
           id="multiline-flexible"

--- a/pages/demos/pickers.js
+++ b/pages/demos/pickers.js
@@ -1,0 +1,39 @@
+// @flow
+
+import React from 'react';
+import withRoot from 'docs/src/modules/components/withRoot';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import markdown from 'docs/src/pages/demos/pickers/pickers.md';
+
+function Page() {
+  return (
+    <MarkdownDocs
+      markdown={markdown}
+      demos={{
+        'pages/demos/pickers/DatePickers.js': {
+          js: require('docs/src/pages/demos/pickers/DatePickers').default,
+          raw: preval`
+module.exports = require('fs')
+  .readFileSync(require.resolve('docs/src/pages/demos/pickers/DatePickers'), 'utf8')
+`,
+        },
+        'pages/demos/pickers/TimePickers.js': {
+          js: require('docs/src/pages/demos/pickers/TimePickers').default,
+          raw: preval`
+module.exports = require('fs')
+  .readFileSync(require.resolve('docs/src/pages/demos/pickers/TimePickers'), 'utf8')
+`,
+        },
+        'pages/demos/pickers/DateAndTimePickers.js': {
+          js: require('docs/src/pages/demos/pickers/DateAndTimePickers').default,
+          raw: preval`
+module.exports = require('fs')
+  .readFileSync(require.resolve('docs/src/pages/demos/pickers/DateAndTimePickers'), 'utf8')
+`,
+        },
+      }}
+    />
+  );
+}
+
+export default withRoot(Page);


### PR DESCRIPTION
This is the best tradeoff I can think of:

## Android
![android](https://user-images.githubusercontent.com/3165635/30239417-633b1b8e-955c-11e7-8886-37eb014a1361.gif)

## iOS
![ios](https://user-images.githubusercontent.com/3165635/30239418-6476be72-955c-11e7-961b-8fcd7e3bc197.gif)

## Chrome
![capture d ecran 2017-09-09 a 12 41 58](https://user-images.githubusercontent.com/3165635/30239420-675b6df4-955c-11e7-8679-8de3e70b8a78.png)

Closes #7875