### PR TITLE
[typescript] Fix for Popover -> PaperProps typing

### DIFF
--- a/src/Popover/Popover.d.ts
+++ b/src/Popover/Popover.d.ts
@@ -24,7 +24,7 @@ export type PopoverProps = {
   transformOrigin?: Origin;
   transitionDuration?: number | 'auto';
   theme?: Object;
-} & Partial<TransitionHandlers> &
-  PaperProps;
+  PaperProps?: Partial<PaperProps>;
+} & Partial<TransitionHandlers>;
 
 export default class Popover extends StyledComponent<PopoverProps> {}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This was failing in ts:
```
 <Popover
  PaperProps={{
    style: {
      backgroundColor: 'rgb(30, 30, 30)'
    }
  }}
  >
    {tooltip}
  </Popover>
```