### PR TITLE
snackbar docs: 6e3 -> 6000; better to be less clever and more clear

### DIFF
--- a/docs/src/pages/demos/snackbars/SimpleSnackbar.js
+++ b/docs/src/pages/demos/snackbars/SimpleSnackbar.js
@@ -44,7 +44,7 @@ class SimpleSnackbar extends React.Component {
             horizontal: 'left',
           }}
           open={this.state.open}
-          autoHideDuration={6e3}
+          autoHideDuration={6000}
           onRequestClose={this.handleRequestClose}
           SnackbarContentProps={{
             'aria-describedby': 'message-id',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Slight tweak in `autoHideDuration` docs to make it more clear that the value is in milliseconds.