### PR TITLE
[Input] Better handle type=number

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -7,6 +7,7 @@ import IconButton from 'material-ui/IconButton';
 import Collapse from 'material-ui/transitions/Collapse';
 import CodeIcon from 'material-ui-icons/Code';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
+import NoSSR from 'docs/src/modules/components/NoSSR';
 
 const styles = theme => ({
   root: {
@@ -74,7 +75,9 @@ class Demo extends React.Component<any, any> {
           <CodeIcon />
         </IconButton>
         <Collapse in={this.state.codeOpen}>
-          <MarkdownElement className={classes.code} text={`\`\`\`js\n${raw}\n\`\`\``} />
+          <NoSSR>
+            <MarkdownElement className={classes.code} text={`\`\`\`js\n${raw}\n\`\`\``} />
+          </NoSSR>
         </Collapse>
         <div className={classes.demo} data-mui-demo={name}>
           <DemoComponent />

--- a/docs/src/modules/components/NoSSR.js
+++ b/docs/src/modules/components/NoSSR.js
@@ -1,0 +1,26 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const DefaultOnSSR = () => null;
+
+class NoSSR extends React.Component {
+  state = {
+    canRender: false,
+  };
+
+  componentDidMount() {
+    this.setState({ canRender: true }); // eslint-disable-line react/no-did-mount-set-state
+  }
+
+  render() {
+    return this.state.canRender ? this.props.children : <DefaultOnSSR />;
+  }
+}
+
+NoSSR.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default NoSSR;

--- a/docs/src/pages/demos/text-fields/TextFields.js
+++ b/docs/src/pages/demos/text-fields/TextFields.js
@@ -20,12 +20,19 @@ const styles = theme => ({
 class TextFields extends React.Component {
   state = {
     name: 'Cat in the Hat',
+    age: '',
     multiline: 'Controlled',
   };
 
   handleChangeMultiline = event => {
     this.setState({
       multiline: event.target.value,
+    });
+  };
+
+  handleChange = name => event => {
+    this.setState({
+      [name]: event.target.value,
     });
   };
 
@@ -39,7 +46,7 @@ class TextFields extends React.Component {
           label="Name"
           className={classes.textField}
           value={this.state.name}
-          onChange={event => this.setState({ name: event.target.value })}
+          onChange={this.handleChange('name')}
           margin="normal"
         />
         <TextField
@@ -104,15 +111,36 @@ class TextFields extends React.Component {
           label="With placeholder"
           placeholder="Placeholder"
           className={classes.textField}
+          margin="normal"
         />
         <TextField
           label="With placeholder multiline"
           placeholder="Placeholder"
           multiline
           className={classes.textField}
+          margin="normal"
         />
         <TextField
-          id="placeholder"
+          id="number"
+          label="Number"
+          value={this.state.age}
+          onChange={this.handleChange('age')}
+          type="number"
+          className={classes.textField}
+          InputLabelProps={{
+            shrink: true,
+          }}
+          margin="normal"
+        />
+        <TextField
+          id="search"
+          label="Search field"
+          type="search"
+          className={classes.textField}
+          margin="normal"
+        />
+        <TextField
+          id="full-width"
           label="Label"
           InputProps={{ placeholder: 'Placeholder' }}
           helperText="Full width!"

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -172,6 +172,8 @@ export const styles = (theme: Object) => {
     },
     inputSingleline: {
       height: '1em',
+    },
+    inputSearch: {
       appearance: 'textfield', // Improve type search style.
     },
     inputMultiline: {
@@ -255,7 +257,7 @@ export type Props = {
    * If `dense`, will adjust vertical spacing. This is normally obtained via context from
    * FormControl.
    */
-  margin?: 'dense',
+  margin?: 'dense' | 'none',
   /**
    * If `true`, a textarea element will be rendered.
    */
@@ -378,7 +380,9 @@ class Input extends React.Component<AllProps, State> {
   handleChange = (event: SyntheticInputEvent<>) => {
     if (!this.isControlled()) {
       this.checkDirty(this.input);
-    } // else perform in the willUpdate
+    }
+
+    // Perform in the willUpdate
     if (this.props.onChange) {
       this.props.onChange(event);
     }
@@ -494,6 +498,7 @@ class Input extends React.Component<AllProps, State> {
       {
         [classes.inputDisabled]: disabled,
         [classes.inputSingleline]: !multiline,
+        [classes.inputSearch]: type === 'search',
         [classes.inputMultiline]: multiline,
         [classes.inputDense]: margin === 'dense',
       },


### PR DESCRIPTION
- Fix server-side rendering issue
- Improve type number display on Firefox
- Add a type search example
- I wish I had a better solution for #8155 but I don't, the change event isn't triggered. I have provided reproduction examples on the related react issue: https://github.com/facebook/react/issues/10370#issuecomment-328817403. Of course, we could have been running the dirty check at each key down events, but I don't want to harm 80% of the use cases for 20% of this one. This extra checks could increase the feedback latency to users on an input. This is not something I want to risk.

Closes #8155 