### PR TITLE
[typescript] Make `withStyles` usable as decorator

### DIFF
--- a/src/styles/withStyles.d.ts
+++ b/src/styles/withStyles.d.ts
@@ -20,9 +20,22 @@ export interface WithStylesOptions {
   name?: string;
 }
 
-export default function withStyles<P = {}, ClassNames = {}>(
+declare function withStyles(
+  style: StyleRules | StyleRulesCallback,
+  options?: WithStylesOptions
+): <
+  C extends React.ComponentType<P & { classes: ClassNames; theme?: Theme }>,
+  P = {},
+  ClassNames = {}
+>(
+  component: C
+) => C & React.ComponentClass<P & StyledComponentProps<ClassNames>>
+
+declare function withStyles<P = {}, ClassNames = {}>(
   style: StyleRules | StyleRulesCallback,
   options?: WithStylesOptions
 ): (
   component: React.ComponentType<P & { classes: ClassNames; theme?: Theme }>
-) => React.ComponentClass<P & StyledComponentProps<ClassNames>>;
+) => React.ComponentClass<P & StyledComponentProps<ClassNames>>
+
+export default withStyles;

--- a/test/typescript/styles.spec.tsx
+++ b/test/typescript/styles.spec.tsx
@@ -27,7 +27,10 @@ interface StyledComponentProps {
 
 const Component: React.SFC<
   StyledComponentProps & { classes: StyledComponentClassNames }
-> = ({ classes, text }) => <div className={classes.root}>{text}</div>;
+> = ({ classes, text }) =>
+  <div className={classes.root}>
+    {text}
+  </div>;
 
 const StyledComponent = withStyles<
   StyledComponentProps,
@@ -77,16 +80,19 @@ const customTheme = createMuiTheme({
 function OverridesTheme() {
   return (
     <MuiThemeProvider theme={theme}>
-      <Button>{'Overrides'}</Button>
+      <Button>
+        {'Overrides'}
+      </Button>
     </MuiThemeProvider>
   );
 }
 
 // withTheme
 
-const ThemedComponent: React.SFC<{ theme: Theme }> = ({ theme }) => (
-  <div>{theme.spacing.unit}</div>
-);
+const ThemedComponent: React.SFC<{ theme: Theme }> = ({ theme }) =>
+  <div>
+    {theme.spacing.unit}
+  </div>;
 const ComponentWithTheme = withTheme(ThemedComponent);
 
 // withStyles + withTheme
@@ -95,10 +101,25 @@ interface AllTheProps {
   classes: StyledComponentClassNames;
 }
 
-const AllTheStyles: React.SFC<AllTheProps> = ({ theme, classes }) => (
-  <div className={classes.root}>{theme.palette.text.primary}</div>
-);
+const AllTheStyles: React.SFC<AllTheProps> = ({ theme, classes }) =>
+  <div className={classes.root}>
+    {theme.palette.text.primary}
+  </div>;
 
 const AllTheComposition = withTheme(
   withStyles<{ theme: Theme }, StyledComponentClassNames>(styles)(AllTheStyles)
 );
+
+@withStyles(styles)
+class DecoratedComponent extends React.Component<
+  StyledComponentProps & { classes: StyledComponentClassNames }
+> {
+  render() {
+    const { classes, text } = this.props;
+    return (
+      <div className={classes.root}>
+        {text}
+      </div>
+    );
+  }
+}

--- a/test/typescript/styles.spec.tsx
+++ b/test/typescript/styles.spec.tsx
@@ -110,6 +110,7 @@ const AllTheComposition = withTheme(
   withStyles<{ theme: Theme }, StyledComponentClassNames>(styles)(AllTheStyles)
 );
 
+// As decorator
 @withStyles(styles)
 class DecoratedComponent extends React.Component<
   StyledComponentProps & { classes: StyledComponentClassNames }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
     "suppressImplicitAnyIndexErrors": true,
-    "noEmit": true
+    "noEmit": true,
+    "experimentalDecorators": true
   },
   "include": ["src/**/*", "test/typescript/*"]
 }


### PR DESCRIPTION
Use overloading to have multiple signatures for `withStyles`.

Closes #8059 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
