### PR TITLE
[Switch] Styling bug fix on long labels

### DIFF
--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -9,7 +9,7 @@ import createSwitch from '../internal/SwitchBase';
 export const styles = (theme: Object) => ({
   root: {
     display: 'inline-flex',
-    width: 62,
+    minWidth: 62,
     position: 'relative',
   },
   bar: {

--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -9,8 +9,9 @@ import createSwitch from '../internal/SwitchBase';
 export const styles = (theme: Object) => ({
   root: {
     display: 'inline-flex',
-    minWidth: 62,
+    width: 62,
     position: 'relative',
+    flexShrink: 0,
   },
   bar: {
     borderRadius: 7,


### PR DESCRIPTION
When the label is too long and wraps it cause the width of the switch to become `48px` which causing the circle to rest in the center of the element during `false`

```jsx
<FormControlLabel
                label="really really looooooong text"
                control={
                    <Switch
                        checked={false}
                    />
                }
            />
```
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
