### PR TITLE
[ListSubheader] Use sticky list by default

### DIFF
--- a/docs/src/pages/demos/lists/PinnedSubheaderList.js
+++ b/docs/src/pages/demos/lists/PinnedSubheaderList.js
@@ -1,0 +1,46 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from 'material-ui/styles';
+import ListSubheader from 'material-ui/List/ListSubheader';
+import List, { ListItem, ListItemText } from 'material-ui/List';
+
+const styles = theme => ({
+  root: {
+    width: '100%',
+    maxWidth: 360,
+    background: theme.palette.background.paper,
+    position: 'relative',
+    overflow: 'auto',
+    maxHeight: 300,
+  },
+  listSection: {
+    background: 'inherit',
+  },
+});
+
+function PinnedSubheaderList(props) {
+  const classes = props.classes;
+
+  return (
+    <List className={classes.root} subheader>
+      {[0, 1, 2, 3, 4].map(sectionId => (
+        <div key={`section-${sectionId}`} className={classes.listSection}>
+          <ListSubheader>{`I'm sticky ${sectionId}`}</ListSubheader>
+          {[0, 1, 2].map(item => (
+            <ListItem button key={`item-${sectionId}-${item}`}>
+              <ListItemText primary={`Item ${item}`} />
+            </ListItem>
+          ))}
+        </div>
+      ))}
+    </List>
+  );
+}
+
+PinnedSubheaderList.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(PinnedSubheaderList);

--- a/docs/src/pages/demos/lists/lists.md
+++ b/docs/src/pages/demos/lists/lists.md
@@ -26,6 +26,15 @@ Lists are best suited for similar data types.
 
 {{demo='pages/demos/lists/NestedList.js'}}
 
+### Pinned Subheader List
+
+Upon scrolling, subheaders remain pinned to the top of the screen until pushed off screen by the next subheader.
+
+This feature is relying on the CSS sticky positioning.
+Unfortunately it's [not implemented](https://caniuse.com/#search=sticky) by all the browsers we are supporting. We default to `disableSticky` when not supported.
+
+{{demo='pages/demos/lists/PinnedSubheaderList.js'}}
+
 ## List Controls
 
 ### Checkbox

--- a/pages/api/avatar.md
+++ b/pages/api/avatar.md
@@ -10,7 +10,7 @@
 | alt | string |  | Used in combination with `src` or `srcSet` to provide an alt attribute for the rendered `img` element. |
 | children | Element |  | Used to render icon or text elements inside the Avatar. `src` and `alt` props will not be used and no `img` will be rendered by default.<br>This can be an element, or just a string. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| component | union:&nbsp;string<br>&nbsp;ComponentType<*><br> | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | ElementType | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
 | imgProps | Object |  | Properties applied to the `img` element when the component is used to display an image. |
 | sizes | string |  | The `sizes` attribute for the `img` element. |
 | src | string |  | The `src` attribute for the `img` element. |

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -10,7 +10,7 @@
 | centerRipple | boolean | false | If `true`, the ripples will be centered. They won't start at the cursor interaction position. |
 | children | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| component | union:&nbsp;string<br>&nbsp;ComponentType<*><br> |  | The component used for the root node. Either a string to use a DOM element or a component. The default value is a `button`. |
+| component | ElementType |  | The component used for the root node. Either a string to use a DOM element or a component. The default value is a `button`. |
 | disableRipple | boolean | false | If `true`, the ripple effect will be disabled. |
 | disabled | boolean |  | If `true`, the base button will be disabled. |
 | focusRipple | boolean | false | If `true`, the base button will have a keyboard focus ripple. `disableRipple` must also be `false`. |

--- a/pages/api/button.md
+++ b/pages/api/button.md
@@ -10,7 +10,7 @@
 | <span style="color: #31a148">children *</span> | Node |  | The content of the button. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | color | union:&nbsp;'default', 'inherit', 'primary', 'accent', 'contrast'<br> | 'default' | The color of the component. It's using the theme palette when that makes sense. |
-| component | union:&nbsp;string<br>&nbsp;ComponentType<*><br> |  | The component used for the root node. Either a string to use a DOM element or a component. The default value is a `button`. |
+| component | ElementType |  | The component used for the root node. Either a string to use a DOM element or a component. The default value is a `button`. |
 | dense | boolean | false | Uses a smaller minWidth, ideal for things like card actions. |
 | disableFocusRipple | boolean | false | If `true`, the  keyboard focus ripple will be disabled. `disableRipple` must also be true. |
 | disableRipple | boolean | false | If `true`, the ripple effect will be disabled. |

--- a/pages/api/card-actions.md
+++ b/pages/api/card-actions.md
@@ -7,7 +7,7 @@
 ## Props
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| children | Node |  | The content of the component. |
+| children | ChildrenArray |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | disableActionSpacing | boolean | false | If `true`, the card actions do not have additional margin. |
 

--- a/pages/api/dialog.md
+++ b/pages/api/dialog.md
@@ -11,6 +11,7 @@ Dialogs are overlaid modal paper based components with a backdrop.
 | classes | Object |  | Useful to extend the style applied to components. |
 | enterTransitionDuration | number | duration.enteringScreen | Duration of the animation when the element is entering. |
 | fullScreen | boolean | false | If `true`, it will be full-screen |
+| fullWidth | boolean | false | If specified, stretches dialog to max width. |
 | ignoreBackdropClick | boolean | false | If `true`, clicking the backdrop will not fire the `onRequestClose` callback. |
 | ignoreEscapeKeyUp | boolean | false | If `true`, hitting escape will not fire the `onRequestClose` callback. |
 | leaveTransitionDuration | number | duration.leavingScreen | Duration of the animation when the element is leaving. |
@@ -38,6 +39,7 @@ This property accepts the following keys:
 - `paperWidthXs`
 - `paperWidthSm`
 - `paperWidthMd`
+- `fullWidth`
 - `fullScreen`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes)

--- a/pages/api/form-control.md
+++ b/pages/api/form-control.md
@@ -16,7 +16,7 @@ This context is used by the following components:
 |:-----|:-----|:--------|:------------|
 | children | $ReadOnlyArray |  | The contents of the form control. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| component | union:&nbsp;string<br>&nbsp;ComponentType<*><br> | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | ElementType | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
 | disabled | boolean | false | If `true`, the label, input and helper text should be displayed in a disabled state. |
 | error | boolean | false | If `true`, the label should be displayed in an error state. |
 | fullWidth | boolean | false | If `true`, the label will take up the full width of its container. |

--- a/pages/api/form-label.md
+++ b/pages/api/form-label.md
@@ -9,7 +9,7 @@
 |:-----|:-----|:--------|:------------|
 | children | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| component | union:&nbsp;string<br>&nbsp;ComponentType<*><br> | 'label' | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | ElementType | 'label' | The component used for the root node. Either a string to use a DOM element or a component. |
 | disabled | boolean |  | If `true`, the label should be displayed in a disabled state. |
 | error | boolean |  | If `true`, the label should be displayed in an error state. |
 | focused | boolean |  | If `true`, the input of this label is focused (used by `FormGroup` components). |

--- a/pages/api/grid-list-tile.md
+++ b/pages/api/grid-list-tile.md
@@ -10,7 +10,7 @@
 | children | $ReadOnlyArray |  | Theoretically you can pass any node as children, but the main use case is to pass an img, in which case GridListTile takes care of making the image "cover" available space (similar to `background-size: cover` or to `object-fit: cover`). |
 | classes | Object |  | Useful to extend the style applied to components. |
 | cols | number | 1 | Width of the tile in number of grid cells. |
-| component | union:&nbsp;string<br>&nbsp;ComponentType<*><br> | 'li' | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | ElementType | 'li' | The component used for the root node. Either a string to use a DOM element or a component. |
 | rows | number | 1 | Height of the tile in number of grid cells. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).

--- a/pages/api/grid.md
+++ b/pages/api/grid.md
@@ -10,7 +10,7 @@
 | align | union:&nbsp;'flex-start', 'center', 'flex-end', 'stretch', 'baseline'<br> | 'stretch' | Defines the `align-items` style property. It's applied for all screen sizes. |
 | children | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| component | union:&nbsp;string<br>&nbsp;ComponentType<*><br> | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | ElementType | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
 | container | boolean | false | If `true`, the component will have the flex *container* behavior. You should be wrapping *items* with a *container*. |
 | direction | union:&nbsp;'row'<br>&nbsp;'row-reverse'<br>&nbsp;'column'<br>&nbsp;'column-reverse'<br> | 'row' | Defines the `flex-direction` style property. It is applied for all screen sizes. |
 | hidden | [HiddenProps](/layout/hidden) | undefined | If provided, will wrap with [Hidden](/api/hidden) component and given properties. |

--- a/pages/api/list-item.md
+++ b/pages/api/list-item.md
@@ -10,7 +10,7 @@
 | button | boolean | false | If `true`, the ListItem will be a button. |
 | children | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| component | union:&nbsp;string<br>&nbsp;ComponentType<*><br> | 'li' | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | ElementType | 'li' | The component used for the root node. Either a string to use a DOM element or a component. |
 | dense | boolean | false | If `true`, compact vertical padding designed for keyboard and mouse input will be used. |
 | disableGutters | boolean | false | If `true`, the left and right padding is removed. |
 | divider | boolean | false | If `true`, a 1px light border is added to the bottom of the list item. |

--- a/pages/api/list-subheader.md
+++ b/pages/api/list-subheader.md
@@ -10,6 +10,7 @@
 | children | node |  | The content of the component. |
 | classes | object |  | Useful to extend the style applied to components. |
 | color | enum:&nbsp;'default'<br>&nbsp;'primary'<br>&nbsp;'inherit'<br> | 'default' | The color of the component. It's using the theme palette when that makes sense. |
+| disableSticky | bool | false | If `true`, the List Subheader will not stick to the top during scroll. |
 | inset | bool | false | If `true`, the List Subheader will be indented. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
@@ -22,6 +23,7 @@ This property accepts the following keys:
 - `colorPrimary`
 - `colorInherit`
 - `inset`
+- `sticky`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes)
 section for more detail.

--- a/pages/api/list.md
+++ b/pages/api/list.md
@@ -9,7 +9,7 @@
 |:-----|:-----|:--------|:------------|
 | children | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| component | union:&nbsp;string<br>&nbsp;ComponentType<*><br> | 'ul' | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | ElementType | 'ul' | The component used for the root node. Either a string to use a DOM element or a component. |
 | dense | boolean | false | If `true`, compact vertical padding designed for keyboard and mouse input will be used for the list and list items. The property is available to descendant components as the `dense` context. |
 | disablePadding | boolean | false | If `true`, vertical padding will be removed from the list. |
 | rootRef | Function |  | Use that property to pass a ref callback to the root component. |

--- a/pages/api/menu-item.md
+++ b/pages/api/menu-item.md
@@ -9,7 +9,7 @@
 |:-----|:-----|:--------|:------------|
 | children | Node |  | Menu item contents. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| component | union:&nbsp;string<br>&nbsp;ComponentType<*><br> |  | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | ElementType |  | The component used for the root node. Either a string to use a DOM element or a component. |
 | selected | boolean | false | Use to apply selected styling. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).

--- a/pages/api/paper.md
+++ b/pages/api/paper.md
@@ -8,7 +8,7 @@
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | classes | Object |  | Useful to extend the style applied to components. |
-| component | union:&nbsp;string<br>&nbsp;ComponentType<*><br> | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | ElementType | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
 | elevation | number | 2 | Shadow depth, corresponds to `dp` in the spec. It's accepting values between 0 and 24 inclusive. |
 | square | boolean | false | If `true`, rounded corners are disabled. |
 

--- a/pages/api/snackbar.md
+++ b/pages/api/snackbar.md
@@ -25,6 +25,7 @@
 | onExiting | TransitionCallback |  | Callback fired when the transition is exiting. |
 | onRequestClose | signature |  | Callback fired when the component requests to be closed.<br>Typically `onRequestClose` is used to set state in the parent component, which is used to control the `Snackbar` `open` prop.<br>The `reason` parameter can optionally be used to control the response to `onRequestClose`, for example ignoring `clickaway`.<br><br>**Signature:**<br>`function(event: object, reason: string) => void`<br>*event:* The event source of the callback<br>*reason:* Can be:`"timeout"` (`autoHideDuration` expired) or: `"clickaway"` |
 | <span style="color: #31a148">open *</span> | boolean |  | If true, `Snackbar` is open. |
+| resumeHideDuration | number | null | The number of milliseconds to wait before dismissing after user interaction. If `autoHideDuration` property isn't specified, it does nothing. If `autoHideDuration` property is specified but `resumeHideDuration` isn't, we default to `autoHideDuration / 2` ms. |
 | transition | Element |  | Object with Transition component, props & create Fn. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).

--- a/pages/api/table-body.md
+++ b/pages/api/table-body.md
@@ -9,7 +9,7 @@
 |:-----|:-----|:--------|:------------|
 | children | Node |  | The content of the component, normally `TableRow`. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| component | union:&nbsp;string<br>&nbsp;ComponentType<*><br> | 'tbody' | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | ElementType | 'tbody' | The component used for the root node. Either a string to use a DOM element or a component. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/table-footer.md
+++ b/pages/api/table-footer.md
@@ -9,7 +9,7 @@
 |:-----|:-----|:--------|:------------|
 | children | Node |  | The content of the component, normally `TableRow`. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| component | union:&nbsp;string<br>&nbsp;ComponentType<*><br> | 'tfoot' | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | ElementType | 'tfoot' | The component used for the root node. Either a string to use a DOM element or a component. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/table-head.md
+++ b/pages/api/table-head.md
@@ -9,7 +9,7 @@
 |:-----|:-----|:--------|:------------|
 | children | Node |  | The content of the component, normally `TableRow`. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| component | union:&nbsp;string<br>&nbsp;ComponentType<*><br> | 'thead' | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | ElementType | 'thead' | The component used for the root node. Either a string to use a DOM element or a component. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/table.md
+++ b/pages/api/table.md
@@ -9,7 +9,7 @@
 |:-----|:-----|:--------|:------------|
 | children | Node |  | The content of the table, normally `TableHeader` and `TableBody`. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| component | union:&nbsp;string<br>&nbsp;ComponentType<*><br> | 'table' | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | ElementType | 'table' | The component used for the root node. Either a string to use a DOM element or a component. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/tooltip.md
+++ b/pages/api/tooltip.md
@@ -30,6 +30,7 @@ You can override all the class names injected by Material-UI thanks to the `clas
 This property accepts the following keys:
 - `root`
 - `popper`
+- `popperClose`
 - `tooltip`
 - `tooltipLeft`
 - `tooltipRight`

--- a/pages/api/typography.md
+++ b/pages/api/typography.md
@@ -11,7 +11,7 @@
 | children | Node |  |  |
 | classes | Object |  | Useful to extend the style applied to components. |
 | color | union:&nbsp;'inherit'<br>&nbsp;'secondary'<br>&nbsp;'accent'<br>&nbsp;'default'<br> | 'default' | The color of the component. It's using the theme palette when that makes sense. |
-| component | union:&nbsp;string<br>&nbsp;ComponentType<*><br> |  | The component used for the root node. Either a string to use a DOM element or a component. By default we map the type to a good default headline component. |
+| component | ElementType |  | The component used for the root node. Either a string to use a DOM element or a component. By default we map the type to a good default headline component. |
 | gutterBottom | boolean | false | If `true`, the text will have a bottom margin. |
 | headlineMapping | signature | {  display4: 'h1',  display3: 'h1',  display2: 'h1',  display1: 'h1',  headline: 'h1',  title: 'h2',  subheading: 'h3',  body2: 'aside',  body1: 'p',} | We are empirically mapping the type property to a range of different DOM element type. For instance, h1 to h6. If you wish to change that mapping, you can provide your own. Alternatively, you can use the `component` property. |
 | noWrap | boolean | false | If `true`, the text will not wrap, but instead will truncate with an ellipsis. |

--- a/pages/demos/lists.js
+++ b/pages/demos/lists.js
@@ -38,6 +38,13 @@ module.exports = require('fs')
   .readFileSync(require.resolve('docs/src/pages/demos/lists/NestedList'), 'utf8')
 `,
         },
+        'pages/demos/lists/PinnedSubheaderList.js': {
+          js: require('docs/src/pages/demos/lists/PinnedSubheaderList').default,
+          raw: preval`
+module.exports = require('fs')
+  .readFileSync(require.resolve('docs/src/pages/demos/lists/PinnedSubheaderList'), 'utf8')
+`,
+        },
         'pages/demos/lists/CheckboxList.js': {
           js: require('docs/src/pages/demos/lists/CheckboxList').default,
           raw: preval`

--- a/src/List/List.js
+++ b/src/List/List.js
@@ -12,6 +12,7 @@ export const styles = (theme: Object) => ({
     listStyle: 'none',
     margin: 0,
     padding: 0,
+    position: 'relative',
   },
   padding: {
     paddingTop: theme.spacing.unit,

--- a/src/List/ListSubheader.d.ts
+++ b/src/List/ListSubheader.d.ts
@@ -5,6 +5,7 @@ export interface ListSubheaderProps
   extends React.HTMLAttributes<HTMLDivElement> {
   color?: 'default' | 'primary' | 'inherit';
   inset?: boolean;
+  disableSticky?: boolean;
 }
 
 export default class ListSubheader extends StyledComponent<

--- a/src/List/ListSubheader.js
+++ b/src/List/ListSubheader.js
@@ -26,15 +26,30 @@ export const styles = (theme: Object) => ({
   inset: {
     paddingLeft: theme.spacing.unit * 9,
   },
+  sticky: {
+    position: 'sticky',
+    top: 0,
+    zIndex: 1,
+    backgroundColor: 'inherit',
+  },
 });
 
 function ListSubheader(props) {
-  const { classes, className: classNameProp, color, inset, children, ...other } = props;
+  const {
+    children,
+    classes,
+    className: classNameProp,
+    color,
+    disableSticky,
+    inset,
+    ...other
+  } = props;
   const className = classNames(
     classes.root,
     {
       [classes[`color${capitalizeFirstLetter(color)}`]]: color !== 'default',
       [classes.inset]: inset,
+      [classes.sticky]: !disableSticky,
     },
     classNameProp,
   );
@@ -64,6 +79,10 @@ ListSubheader.propTypes = {
    */
   color: PropTypes.oneOf(['default', 'primary', 'inherit']),
   /**
+   * If `true`, the List Subheader will not stick to the top during scroll.
+   */
+  disableSticky: PropTypes.bool,
+  /**
    * If `true`, the List Subheader will be indented.
    */
   inset: PropTypes.bool,
@@ -71,6 +90,7 @@ ListSubheader.propTypes = {
 
 ListSubheader.defaultProps = {
   color: 'default',
+  disableSticky: false,
   inset: false,
 };
 

--- a/src/List/ListSubheader.spec.js
+++ b/src/List/ListSubheader.spec.js
@@ -40,4 +40,16 @@ describe('<ListSubheader />', () => {
     assert.strictEqual(wrapper.hasClass(classes.inset), true, 'should have the primary class');
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
+
+  describe('prop: disableSticky', () => {
+    it('should display sticky class', () => {
+      const wrapper = shallow(<ListSubheader />);
+      assert.strictEqual(wrapper.hasClass(classes.sticky), true);
+    });
+
+    it('should not display sticky class', () => {
+      const wrapper = shallow(<ListSubheader disableSticky />);
+      assert.strictEqual(wrapper.hasClass(classes.sticky), false);
+    });
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/callemall/material-ui/issues/7413

Please let me know what you think or if i should change anything 😄 

BTW, i was able to only run tests. `flow` failed on some package in `node_modules`(not sure why it ran it) and `eslint` just hangs indefinitely

p.s Sticky is supported in all recent version browsers but not in all
https://caniuse.com/#search=sticky
Is it good enough?