### PR TITLE
[docs] Make Drawer example pixel perfect

### DIFF
--- a/docs/src/pages/demos/drawers/MiniDrawer.js
+++ b/docs/src/pages/demos/drawers/MiniDrawer.js
@@ -41,7 +41,7 @@ const styles = theme => ({
   },
   appBarShift: {
     marginLeft: drawerWidth,
-    width: `calc(100% - ${drawerWidth}px)`,
+    width: `calc(100% - ${drawerWidth}px - 1px)`,
     transition: theme.transitions.create(['width', 'margin'], {
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.enteringScreen,


### PR DESCRIPTION
It looks like we need to add one pixel because of the border of the drawer. The issue can be seen in the example below.
<img width="928" alt="screenshot 2017-09-14 10 24 06" src="https://user-images.githubusercontent.com/306134/30419522-f3e6e450-9936-11e7-8374-35d3aaa6a136.png">
