### PR TITLE
[typescript] Correct TypeScript types of typography definitions

### DIFF
--- a/src/styles/createTypography.d.ts
+++ b/src/styles/createTypography.d.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { Palette } from './createPalette';
 
 export type TextStyle =
@@ -15,20 +16,20 @@ export type TextStyle =
 export type Style = TextStyle | 'button';
 
 export interface FontStyle {
-  fontFamily: string;
-  fontSize: number | string;
+  fontFamily: React.CSSProperties['fontFamily'];
+  fontSize: React.CSSProperties['fontSize'];
   fontWeightLight: number | string;
   fontWeightRegular: number | string;
   fontWeightMedium: number | string;
 }
 
 export interface TypographyStyle {
-  color: string;
-  fontFamily: string;
-  fontSize: number | string;
-  fontWeight: number | string;
-  letterSpacing: string;
-  lineHeight: number | string;
+  color: React.CSSProperties['color'];
+  fontFamily: React.CSSProperties['fontFamily'];
+  fontSize: React.CSSProperties['fontSize'];
+  fontWeight: React.CSSProperties['fontWeight'];
+  letterSpacing: React.CSSProperties['letterSpacing'];
+  lineHeight: React.CSSProperties['lineHeight'];
 }
 
 export type Typography = { [type in Style]: TypographyStyle } & FontStyle;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes #8198.

This changes the TypeScript type definitions of `FontStyle` and `TypographyStyle` to conform with the CSS property types defined in React in order to avoid conflicts with the type `StyleRules`.