### PR TITLE
[Radio] Make number a valid input type

### DIFF
--- a/src/Form/FormControlLabel.d.ts
+++ b/src/Form/FormControlLabel.d.ts
@@ -9,7 +9,7 @@ export type FormControlLabelProps = {
   label: React.ReactNode;
   name?: string;
   onChange?: (event: React.ChangeEvent<{}>, checked: boolean) => void;
-  value?: string;
+  value?: string | number;
 } & React.LabelHTMLAttributes<HTMLLabelElement>;
 
 export default class FormControlLabel extends StyledComponent<

--- a/src/Form/FormControlLabel.js
+++ b/src/Form/FormControlLabel.js
@@ -73,7 +73,7 @@ export type Props = {
   /**
    * The value of the component.
    */
-  value?: string,
+  value?: string | number,
 };
 
 type AllProps = DefaultProps & Props;

--- a/src/Radio/RadioGroup.d.ts
+++ b/src/Radio/RadioGroup.d.ts
@@ -5,7 +5,7 @@ import { FormGroupProps } from '../Form';
 export type RadioGroupProps = {
   name?: string;
   onChange?: (event: React.ChangeEvent<{}>, value: string) => void;
-  value?: string;
+  value?: string | number;
 } & Partial<Omit<FormGroupProps, 'onChange'>>;
 
 export default class RadioGroup extends StyledComponent<RadioGroupProps> {}

--- a/src/Radio/RadioGroup.js
+++ b/src/Radio/RadioGroup.js
@@ -55,7 +55,7 @@ export type Props = {
   /**
    * Value of the selected radio button.
    */
-  value?: string,
+  value?: string | number,
 };
 
 type AllProps = DefaultProps & Props;

--- a/src/internal/SwitchBase.d.ts
+++ b/src/internal/SwitchBase.d.ts
@@ -17,7 +17,7 @@ export interface SwitchBaseProps {
   name?: string;
   onChange?: (event: React.ChangeEvent<{}>, checked: boolean) => void;
   tabIndex?: number;
-  value?: string;
+  value?: string | number;
 }
 
 export class SwitchBase extends StyledComponent<SwitchBaseProps> {}

--- a/src/internal/SwitchBase.js
+++ b/src/internal/SwitchBase.js
@@ -115,7 +115,7 @@ export type Props = {
   /**
    * The value of the component.
    */
-  value?: string,
+  value?: string | number,
 };
 
 type AllProps = DefaultProps & Props;


### PR DESCRIPTION
- [x] console type errors are gone
- [ ] figure out why onChange receives a string instead of number

I happend to notice some strange behavior which i wasn't able to debug - onChange will always receive a string instead of a number. I couldn't find a place where the value gets mutated.
```js
class TestComponent extends React.Component{
	state = {
		value: 1
	}

	handleChange = (e, v) => {
                this.setState({value: v})
	}

	render() {
        const arr = [0,1,2,3];
        return (
			<FormControl component="fieldset" required>
				<FormLabel component="legend">Testradio</FormLabel>
				<RadioGroup
					aria-label="gender"
					name="gender"
					value={this.state.value}
					onChange={this.handleChange}
				>
                    {arr && arr.map(v => <FormControlLabel key={v} value={v} control={<Radio />} label={`label: ${v.toString()}`}
				</RadioGroup>
			</FormControl>
		)
	}
}
```

Closes #8180