### PR TITLE
[Drawers] Height should be set to 100% to allow scrolling

### DIFF
--- a/docs/src/pages/demos/drawers/MiniDrawer.js
+++ b/docs/src/pages/demos/drawers/MiniDrawer.js
@@ -56,7 +56,7 @@ const styles = theme => ({
   },
   drawerPaper: {
     position: 'relative',
-    height: 'auto',
+    height: '100%',
     width: drawerWidth,
     transition: theme.transitions.create('width', {
       easing: theme.transitions.easing.sharp,

--- a/docs/src/pages/demos/drawers/PermanentDrawer.js
+++ b/docs/src/pages/demos/drawers/PermanentDrawer.js
@@ -35,7 +35,7 @@ const styles = theme => ({
   },
   drawerPaper: {
     position: 'relative',
-    height: 'auto',
+    height: '100%',
     width: drawerWidth,
   },
   drawerHeader: theme.mixins.toolbar,

--- a/docs/src/pages/demos/drawers/PersistentDrawer.js
+++ b/docs/src/pages/demos/drawers/PersistentDrawer.js
@@ -55,7 +55,7 @@ const styles = theme => ({
   },
   drawerPaper: {
     position: 'relative',
-    height: 'auto',
+    height: '100%',
     width: drawerWidth,
   },
   drawerHeader: {


### PR DESCRIPTION
It was not possible to scroll in the drawer when you simply copy paste the example and run it on a small screen.

Pre PR:
https://gfycat.com/LargeBothAzurevasesponge

Post PR:
https://gfycat.com/DelayedWeightyLadybug