### PR TITLE
[typescript] Fix `withResponsiveFullScreen`, `Input` + `Select`

### DIFF
--- a/src/Dialog/withResponsiveFullScreen.d.ts
+++ b/src/Dialog/withResponsiveFullScreen.d.ts
@@ -5,6 +5,8 @@ export interface WithResponsiveFullScreenOptions {
   breakpoint: Breakpoint;
 }
 
-export default function withResponsiveFullScreen<P>(
+export default function withResponsiveFullScreen<P = {}>(
   options: WithResponsiveFullScreenOptions
-): React.ComponentClass<P & WithWidthProps>;
+): (
+  component: React.ComponentType<P & Partial<WithWidthProps>>
+) => React.ComponentClass<P & Partial<WithWidthProps>>;

--- a/src/Input/Input.d.ts
+++ b/src/Input/Input.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyledComponent } from '..';
+import { StyledComponent, Omit } from '..';
 
 export type InputProps = {
   autoComplete?: string;
@@ -25,6 +25,24 @@ export type InputProps = {
   value?: string | number;
   onClean?: () => void;
   onDirty?: () => void;
-} & React.HTMLAttributes<HTMLDivElement>;
+  /**
+   * `onChange`, `onKeyUp` + `onKeyDown` are applied to the inner `InputComponent`,
+   * which by default is an input or textarea. Since these handlers differ from the
+   * ones inherited by `React.HTMLAttributes<HTMLDivElement>` we need to omit them.
+   *
+   * Note that  `blur` and `focus` event handler are applied to the outter `<div>`.
+   * So these can just be inherited from the native `<div>`.
+   */
+  onChange?: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement>;
+  onKeyUp?: React.KeyboardEventHandler<HTMLTextAreaElement | HTMLInputElement>;
+  onKeyDown?: React.KeyboardEventHandler<
+    HTMLTextAreaElement | HTMLInputElement
+  >;
+} & Partial<
+  Omit<
+    React.HTMLAttributes<HTMLDivElement>,
+    'onChange' | 'onKeyUp' | 'onKeyDown'
+  >
+>;
 
 export default class Input extends StyledComponent<InputProps> {}

--- a/src/Select/Select.d.ts
+++ b/src/Select/Select.d.ts
@@ -3,7 +3,7 @@ import { StyledComponent, Omit } from '..';
 import { InputProps } from '../Input';
 
 export type SelectProps = {
-  input: React.ReactNode;
+  input?: React.ReactNode;
   native?: boolean;
   multiple?: boolean;
   MenuProps?: Object;

--- a/src/Select/Select.d.ts
+++ b/src/Select/Select.d.ts
@@ -1,13 +1,14 @@
 import * as React from 'react';
-import { StyledComponent } from '..';
+import { StyledComponent, Omit } from '..';
+import { InputProps } from '../Input';
 
-export interface SelectProps extends React.HTMLAttributes<HTMLDivElement> {
+export type SelectProps = {
   input: React.ReactNode;
   native?: boolean;
   multiple?: boolean;
   MenuProps?: Object;
   renderValue?: Function;
   value?: Array<string | number> | string | number;
-}
+} & Partial<Omit<InputProps, 'value'>>;
 
 export default class Select extends StyledComponent<SelectProps> {}

--- a/test/typescript/components.spec.tsx
+++ b/test/typescript/components.spec.tsx
@@ -52,6 +52,7 @@ import Table, {
   TableRow,
 } from '../../src/Table';
 import { withStyles, StyleRulesCallback } from '../../src/styles';
+import { withResponsiveFullScreen, DialogProps } from '../../src/Dialog';
 
 const log = console.log;
 const FakeIcon = () => <div>ICON</div>;
@@ -762,8 +763,12 @@ const TextFieldTest = () =>
     />
   </div>;
 
-const SelectTest = () =>
-  <Select input={<Input />} value={10}>
+const SelectTest = () => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    console.log(e.currentTarget.value);
+  };
+
+  <Select input={<Input />} value={10} onChange={handleChange}>
     <MenuItem value="">
       <em>None</em>
     </MenuItem>
@@ -771,3 +776,19 @@ const SelectTest = () =>
     <MenuItem value={20}>Twenty</MenuItem>
     <MenuItem value={30}>Thirty</MenuItem>
   </Select>;
+};
+
+const ResponsiveComponentTest = () => {
+  const ResponsiveComponent = withResponsiveFullScreen({
+    breakpoint: 'sm',
+  })(({ children, width }) =>
+    <div style={{ width }}>
+      {children}
+    </div>
+  );
+  <ResponsiveComponent />;
+
+  const ResponsiveDialogComponent = withResponsiveFullScreen<DialogProps>({
+    breakpoint: 'sm',
+  })(Dialog);
+};


### PR DESCRIPTION
Adjust typings for the following `InputProps`: `onChange`, `onKeyUp` + `onKeyDown`
Handlers were previously inherited from the `HTMLDivElement`, but these handler are actually put on the "inner" `InputComponent` rather than on the outter `<div>`.

This will make the `<Select>` typings better sind they can now just inherit from the `<Input>`.

---

Also includes fixes from #8177
Closes #8197

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
