### PR TITLE
[typescript] Correct definition of StyledComponentProps

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,14 +5,12 @@ import * as React from 'react';
  * with the `withStyles` HOC and allow customization via
  * the following props:
  *
- * - `className`
  * - `classes`
- * - `style`
+ * - `innerRef`
  */
 export interface StyledComponentProps<StyleClasses> {
-  className?: string;
   classes?: StyleClasses;
-  style?: Partial<React.CSSProperties>;
+  innerRef?: React.Ref<any>;
 }
 export class StyledComponent<P, C = Object> extends React.Component<
   P & StyledComponentProps<C>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
The type definiton of `StyledComponentProps` seems wrong to me. These are the additional props that are added to the props of a component wrapped into `withStyles`. According to the source code of `withStyles` and to the flow type definitions, only the additional entries

* `classes` and
* `innerRef`

instead of

* `className`,
* `classes` and
* `style`

are added. Moreover, I provide the correct type for `innerRef`, taken from the React type definitions.