### PR TITLE
[Toolbar] Fixes documentation of children property

### DIFF
--- a/src/Toolbar/Toolbar.js
+++ b/src/Toolbar/Toolbar.js
@@ -35,7 +35,7 @@ function Toolbar(props) {
 
 Toolbar.propTypes = {
   /**
-   * Can be a `ToolbarGroup` to render a group of related items.
+   * Toolbar children, usually a mixture of `IconButton`, `Button` and `Typography`.
    */
   children: PropTypes.node,
   /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
`ToolbarGroup` no longer exists in v1 so remove reference in `Toolbar.children` doc comment.