### PR TITLE
Disable text decoration on Toolbar `a` elements

### DIFF
--- a/src/Toolbar/Toolbar.js
+++ b/src/Toolbar/Toolbar.js
@@ -10,6 +10,9 @@ export const styles = (theme: Object) => ({
     position: 'relative',
     display: 'flex',
     alignItems: 'center',
+    '& a': {
+      textDecoration: 'none',
+    },
     ...theme.mixins.toolbar,
   },
   gutters: theme.mixins.gutters({}),


### PR DESCRIPTION
Previously, placing a link Button on a Toolbar could result in an unwanted text underline.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
