### PR TITLE
[TableRow] Adjust head row height according to the specs

### DIFF
--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -13,7 +13,7 @@ export const styles = (theme: Object) => ({
     },
   },
   head: {
-    height: 64,
+    height: 56,
   },
   footer: {
     height: 56,


### PR DESCRIPTION
According to [the specs](https://material.io/guidelines/components/data-tables.html#data-tables-tables-within-cards), the table header's height is supposed to be 56dp, just as the footer.