### PR TITLE
[TableCell] Fix font-weight in table head

### DIFF
--- a/src/Table/TableCell.js
+++ b/src/Table/TableCell.js
@@ -19,6 +19,7 @@ export const styles = (theme: Object) => ({
   },
   head: {
     whiteSpace: 'pre',
+    fontWeight: theme.typography.fontWeightMedium,
   },
   padding: {
     padding: `0 ${theme.spacing.unit * 7}px 0 ${theme.spacing.unit * 3}px`,


### PR DESCRIPTION
Sorry for opening a new micro-PR. :sweat_smile:

I just realized that the font-weight in the table header cells is not actually set to medium. While it _is_ set to medium in the parent `<tr>`, it falls back to _bold_ (700) for the `<th>` cell elements at least in latest Chromium and Firefox.
This explicitly sets the font-weight to medium in head cells, resulting in much nicer – and spec-compliant – table headers. :rainbow: 

Before:
![image](https://user-images.githubusercontent.com/5544859/30525252-6d9fccb6-9c03-11e7-933e-e2411d2734b6.png)

After:
![image](https://user-images.githubusercontent.com/5544859/30525235-24dae6c8-9c03-11e7-80f5-c004642dac5c.png)
