### PR TITLE
[Table] Add a TableFooter for pagination

### DIFF
--- a/docs/src/pages/demos/tables/EnhancedTable.js
+++ b/docs/src/pages/demos/tables/EnhancedTable.js
@@ -11,6 +11,7 @@ import Table, {
   TableCell,
   TableFooter,
   TableHead,
+  TablePagination,
   TableRow,
   TableSortLabel,
 } from 'material-ui/Table';
@@ -19,12 +20,7 @@ import Typography from 'material-ui/Typography';
 import Paper from 'material-ui/Paper';
 import Checkbox from 'material-ui/Checkbox';
 import IconButton from 'material-ui/IconButton';
-import Select from 'material-ui/Select';
-import { MenuItem } from 'material-ui/Menu';
-import Input from 'material-ui/Input';
 import DeleteIcon from 'material-ui-icons/Delete';
-import ChevronLeftIcon from 'material-ui-icons/ChevronLeft';
-import ChevronRightIcon from 'material-ui-icons/ChevronRight';
 import FilterListIcon from 'material-ui-icons/FilterList';
 
 let counter = 0;
@@ -155,118 +151,6 @@ EnhancedTableToolbar.propTypes = {
 
 EnhancedTableToolbar = withStyles(toolbarStyles)(EnhancedTableToolbar);
 
-const footerStyles = theme => ({
-  cell: {
-    padding: '0 !important',
-  },
-  toolbar: {
-    height: 56,
-    minHeight: 56,
-    paddingRight: 2,
-  },
-  spacer: {
-    flex: '1 1 100%',
-  },
-  select: {
-    marginLeft: theme.spacing.unit,
-    width: 34,
-    textAlign: 'right',
-    paddingRight: 22,
-    color: theme.palette.text.secondary,
-    height: 32,
-    lineHeight: '32px',
-  },
-  selectRoot: {
-    marginRight: theme.spacing.unit * 4,
-  },
-  actions: {
-    color: theme.palette.text.secondary,
-    marginLeft: theme.spacing.unit * 2.5,
-  },
-  title: {
-    flex: '0 0 auto',
-  },
-});
-
-let EnhancedTableFooter = props => {
-  const {
-    rowsPerPage,
-    rowsPerPageOptions,
-    count,
-    page,
-    onChangePage,
-    onChangeRowsPerPage,
-    classes,
-  } = props;
-
-  return (
-    <TableFooter>
-      <TableRow>
-        <TableCell
-          className={classes.cell}
-          colSpan={9001} // col-span over everything
-        >
-          <Toolbar className={classes.toolbar}>
-            <div className={classes.spacer} />
-            <div>
-              <Typography type="caption">Rows per page:</Typography>
-            </div>
-            <Select
-              classes={{ root: classes.selectRoot, select: classes.select }}
-              input={<Input disableUnderline />}
-              value={rowsPerPage}
-              onChange={onChangeRowsPerPage}
-            >
-              {rowsPerPageOptions.map(rowsPerPageOption => (
-                <MenuItem key={rowsPerPageOption} value={rowsPerPageOption}>
-                  {rowsPerPageOption}
-                </MenuItem>
-              ))}
-            </Select>
-            <div>
-              <Typography type="caption">
-                {page * rowsPerPage + 1}-{Math.min(count, (page + 1) * rowsPerPage)} of {count}
-              </Typography>
-            </div>
-            <div className={classes.actions}>
-              <IconButton
-                aria-label="Previous page"
-                onClick={() => onChangePage(page - 1)}
-                disabled={page === 0}
-              >
-                <ChevronLeftIcon />
-              </IconButton>
-              <IconButton
-                aria-label="Next page"
-                onClick={() => onChangePage(page + 1)}
-                disabled={page >= Math.ceil(count / rowsPerPage) - 1}
-              >
-                <ChevronRightIcon />
-              </IconButton>
-            </div>
-          </Toolbar>
-        </TableCell>
-      </TableRow>
-    </TableFooter>
-  );
-};
-
-EnhancedTableFooter.propTypes = {
-  classes: PropTypes.object.isRequired,
-  count: PropTypes.number.isRequired,
-  onChangePage: PropTypes.func.isRequired,
-  onChangeRowsPerPage: PropTypes.func.isRequired,
-  page: PropTypes.number.isRequired,
-  rowsPerPage: PropTypes.number.isRequired,
-  rowsPerPageOptions: PropTypes.arrayOf(PropTypes.number),
-};
-
-EnhancedTableFooter.defaultProps = {
-  rowsPerPageOptions: [5, 10, 25],
-};
-
-EnhancedTableFooter = withStyles(footerStyles)(EnhancedTableFooter);
-
 const styles = theme => ({
   paper: {
     width: '100%',
@@ -307,9 +191,10 @@ class EnhancedTable extends React.Component {
       order = 'asc';
     }
 
-    const data = this.state.data.sort(
-      (a, b) => (order === 'desc' ? (b[orderBy] > a[orderBy] ? -1 : 1) : (a[orderBy] > b[orderBy] ? -1 : 1)),
-    );
+    const data =
+      order === 'desc'
+        ? this.state.data.sort((a, b) => (b[orderBy] < a[orderBy] ? -1 : 1))
+        : this.state.data.sort((a, b) => (a[orderBy] < b[orderBy] ? -1 : 1));
 
     this.setState({ data, order, orderBy });
   };
@@ -349,7 +234,7 @@ class EnhancedTable extends React.Component {
     this.setState({ selected: newSelected });
   };
 
-  handleChangePage = page => {
+  handleChangePage = (e, page) => {
     this.setState({ page });
   };
 
@@ -401,13 +286,15 @@ class EnhancedTable extends React.Component {
               );
             })}
           </TableBody>
-          <EnhancedTableFooter
-            count={data.length}
-            rowsPerPage={rowsPerPage}
-            page={page}
-            onChangePage={this.handleChangePage}
-            onChangeRowsPerPage={this.handleChangeRowsPerPage}
-          />
+          <TableFooter>
+            <TablePagination
+              count={data.length}
+              rowsPerPage={rowsPerPage}
+              page={page}
+              onChangePage={this.handleChangePage}
+              onChangeRowsPerPage={this.handleChangeRowsPerPage}
+            />
+          </TableFooter>
         </Table>
       </Paper>
     );

--- a/docs/src/pages/demos/tables/EnhancedTable.js
+++ b/docs/src/pages/demos/tables/EnhancedTable.js
@@ -180,7 +180,7 @@ class EnhancedTable extends React.Component {
         createData('Marshmallow', 318, 0, 81, 2.0),
         createData('Nougat', 360, 19.0, 9, 37.0),
         createData('Oreo', 437, 18.0, 63, 4.0),
-      ].sort((a, b) => a.calories < b.calories ? -1 : 1),
+      ].sort((a, b) => (a.calories < b.calories ? -1 : 1)),
       page: 0,
       rowsPerPage: 5,
     };

--- a/docs/src/pages/demos/tables/EnhancedTable.js
+++ b/docs/src/pages/demos/tables/EnhancedTable.js
@@ -308,7 +308,7 @@ class EnhancedTable extends React.Component {
     }
 
     const data = this.state.data.sort(
-      (a, b) => (order === 'desc' ? b[orderBy] > a[orderBy] : a[orderBy] > b[orderBy]),
+      (a, b) => (order === 'desc' ? (b[orderBy] > a[orderBy] ? -1 : 1) : (a[orderBy] > b[orderBy] ? -1 : 1)),
     );
 
     this.setState({ data, order, orderBy });

--- a/docs/src/pages/demos/tables/EnhancedTable.js
+++ b/docs/src/pages/demos/tables/EnhancedTable.js
@@ -160,28 +160,31 @@ const styles = theme => ({
 });
 
 class EnhancedTable extends React.Component {
-  state = {
-    order: 'asc',
-    orderBy: 'calories',
-    selected: [],
-    data: [
-      createData('Cupcake', 305, 3.7, 67, 4.3),
-      createData('Donut', 452, 25.0, 51, 4.9),
-      createData('Eclair', 262, 16.0, 24, 6.0),
-      createData('Frozen yoghurt', 159, 6.0, 24, 4.0),
-      createData('Gingerbread', 356, 16.0, 49, 3.9),
-      createData('Honeycomb', 408, 3.2, 87, 6.5),
-      createData('Ice cream sandwich', 237, 9.0, 37, 4.3),
-      createData('Jelly Bean', 375, 0.0, 94, 0.0),
-      createData('KitKat', 518, 26.0, 65, 7.0),
-      createData('Lollipop', 392, 0.2, 98, 0.0),
-      createData('Marshmallow', 318, 0, 81, 2.0),
-      createData('Nougat', 360, 19.0, 9, 37.0),
-      createData('Oreo', 437, 18.0, 63, 4.0),
-    ],
-    page: 0,
-    rowsPerPage: 5,
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      order: 'asc',
+      orderBy: 'calories',
+      selected: [],
+      data: [
+        createData('Cupcake', 305, 3.7, 67, 4.3),
+        createData('Donut', 452, 25.0, 51, 4.9),
+        createData('Eclair', 262, 16.0, 24, 6.0),
+        createData('Frozen yoghurt', 159, 6.0, 24, 4.0),
+        createData('Gingerbread', 356, 16.0, 49, 3.9),
+        createData('Honeycomb', 408, 3.2, 87, 6.5),
+        createData('Ice cream sandwich', 237, 9.0, 37, 4.3),
+        createData('Jelly Bean', 375, 0.0, 94, 0.0),
+        createData('KitKat', 518, 26.0, 65, 7.0),
+        createData('Lollipop', 392, 0.2, 98, 0.0),
+        createData('Marshmallow', 318, 0, 81, 2.0),
+        createData('Nougat', 360, 19.0, 9, 37.0),
+        createData('Oreo', 437, 18.0, 63, 4.0),
+      ].sort((a, b) => a.calories < b.calories ? -1 : 1),
+      page: 0,
+      rowsPerPage: 5,
+    };
+  }
 
   handleRequestSort = (event, property) => {
     const orderBy = property;

--- a/docs/src/pages/demos/tables/EnhancedTable.js
+++ b/docs/src/pages/demos/tables/EnhancedTable.js
@@ -180,7 +180,7 @@ const footerStyles = theme => ({
   },
   actions: {
     color: theme.palette.text.secondary,
-    marginLeft: 20
+    marginLeft: 20,
   },
   title: {
     flex: '0 0 auto',
@@ -211,15 +211,21 @@ let EnhancedTableFooter = props => {
               <Typography type="caption">Rows per page:</Typography>
             </div>
             <Select
-              classes={{ root: classes.selectRoot, select: classes.select, }}
+              classes={{ root: classes.selectRoot, select: classes.select }}
               input={<Input disableUnderline />}
               value={rowsPerPage}
               onChange={onChangeRowsPerPage}
             >
-              {rowsPerPageOptions.map((v) => <MenuItem key={v} value={v}>{v}</MenuItem>)}
+              {rowsPerPageOptions.map(v => (
+                <MenuItem key={v} value={v}>
+                  {v}
+                </MenuItem>
+              ))}
             </Select>
             <div>
-              <Typography type="caption">{page * rowsPerPage + 1}-{Math.min(count, (page + 1) * rowsPerPage)} of {count}</Typography>
+              <Typography type="caption">
+                {page * rowsPerPage + 1}-{Math.min(count, (page + 1) * rowsPerPage)} of {count}
+              </Typography>
             </div>
             <div className={classes.actions}>
               <IconButton
@@ -247,11 +253,11 @@ let EnhancedTableFooter = props => {
 EnhancedTableFooter.propTypes = {
   classes: PropTypes.object.isRequired,
   count: PropTypes.number.isRequired,
-  rowsPerPage: PropTypes.number.isRequired,
-  rowsPerPageOptions: PropTypes.arrayOf(PropTypes.number),
+  onChangePage: PropTypes.func.isRequired,
   onChangeRowsPerPage: PropTypes.func.isRequired,
   page: PropTypes.number.isRequired,
-  onChangePage: PropTypes.func.isRequired,
+  rowsPerPage: PropTypes.number.isRequired,
+  rowsPerPageOptions: PropTypes.arrayOf(PropTypes.number),
 };
 
 EnhancedTableFooter.defaultProps = {
@@ -342,12 +348,12 @@ class EnhancedTable extends React.Component {
     this.setState({ selected: newSelected });
   };
 
-  handleChangePage = (page) => {
-    this.setState({ page })
+  handleChangePage = page => {
+    this.setState({ page });
   };
 
-  handleChangeRowsPerPage = (e) => {
-    this.setState({ rowsPerPage: e.target.value })
+  handleChangeRowsPerPage = e => {
+    this.setState({ rowsPerPage: e.target.value });
   };
 
   isSelected = id => this.state.selected.indexOf(id) !== -1;

--- a/docs/src/pages/demos/tables/EnhancedTable.js
+++ b/docs/src/pages/demos/tables/EnhancedTable.js
@@ -234,12 +234,12 @@ class EnhancedTable extends React.Component {
     this.setState({ selected: newSelected });
   };
 
-  handleChangePage = (e, page) => {
+  handleChangePage = (event, page) => {
     this.setState({ page });
   };
 
-  handleChangeRowsPerPage = e => {
-    this.setState({ rowsPerPage: e.target.value });
+  handleChangeRowsPerPage = event => {
+    this.setState({ rowsPerPage: event.target.value });
   };
 
   isSelected = id => this.state.selected.indexOf(id) !== -1;

--- a/docs/src/pages/demos/tables/EnhancedTable.js
+++ b/docs/src/pages/demos/tables/EnhancedTable.js
@@ -9,6 +9,7 @@ import keycode from 'keycode';
 import Table, {
   TableBody,
   TableCell,
+  TableFooter,
   TableHead,
   TableRow,
   TableSortLabel,
@@ -18,7 +19,12 @@ import Typography from 'material-ui/Typography';
 import Paper from 'material-ui/Paper';
 import Checkbox from 'material-ui/Checkbox';
 import IconButton from 'material-ui/IconButton';
+import Select from 'material-ui/Select';
+import { MenuItem } from 'material-ui/Menu';
+import Input from 'material-ui/Input';
 import DeleteIcon from 'material-ui-icons/Delete';
+import ChevronLeftIcon from 'material-ui-icons/ChevronLeft';
+import ChevronRightIcon from 'material-ui-icons/ChevronRight';
 import FilterListIcon from 'material-ui-icons/FilterList';
 
 let counter = 0;
@@ -148,6 +154,112 @@ EnhancedTableToolbar.propTypes = {
 
 EnhancedTableToolbar = withStyles(toolbarStyles)(EnhancedTableToolbar);
 
+const footerStyles = theme => ({
+  cell: {
+    padding: '0 !important',
+  },
+  toolbar: {
+    height: 56,
+    minHeight: 56,
+    paddingRight: 2,
+  },
+  spacer: {
+    flex: '1 1 100%',
+  },
+  select: {
+    marginLeft: 8,
+    width: 34,
+    textAlign: 'right',
+    paddingRight: 22,
+    color: theme.palette.text.secondary,
+    height: 32,
+    lineHeight: '32px',
+  },
+  selectRoot: {
+    marginRight: 32,
+  },
+  actions: {
+    color: theme.palette.text.secondary,
+    marginLeft: 20
+  },
+  title: {
+    flex: '0 0 auto',
+  },
+});
+
+let EnhancedTableFooter = props => {
+  const {
+    rowsPerPage,
+    rowsPerPageOptions,
+    count,
+    page,
+    onChangePage,
+    onChangeRowsPerPage,
+    classes,
+  } = props;
+
+  return (
+    <TableFooter>
+      <TableRow>
+        <TableCell
+          className={classes.cell}
+          colSpan={9001} // col-span over everything
+        >
+          <Toolbar className={classes.toolbar}>
+            <div className={classes.spacer} />
+            <div>
+              <Typography type="caption">Rows per page:</Typography>
+            </div>
+            <Select
+              classes={{ root: classes.selectRoot, select: classes.select, }}
+              input={<Input disableUnderline />}
+              value={rowsPerPage}
+              onChange={onChangeRowsPerPage}
+            >
+              {rowsPerPageOptions.map((v) => <MenuItem key={v} value={v}>{v}</MenuItem>)}
+            </Select>
+            <div>
+              <Typography type="caption">{page * rowsPerPage + 1}-{Math.min(count, (page + 1) * rowsPerPage)} of {count}</Typography>
+            </div>
+            <div className={classes.actions}>
+              <IconButton
+                aria-label="Previous page"
+                onClick={() => onChangePage(page - 1)}
+                disabled={page === 0}
+              >
+                <ChevronLeftIcon />
+              </IconButton>
+              <IconButton
+                aria-label="Next page"
+                onClick={() => onChangePage(page + 1)}
+                disabled={page >= Math.ceil(count / rowsPerPage) - 1}
+              >
+                <ChevronRightIcon />
+              </IconButton>
+            </div>
+          </Toolbar>
+        </TableCell>
+      </TableRow>
+    </TableFooter>
+  );
+};
+
+EnhancedTableFooter.propTypes = {
+  classes: PropTypes.object.isRequired,
+  count: PropTypes.number.isRequired,
+  rowsPerPage: PropTypes.number.isRequired,
+  rowsPerPageOptions: PropTypes.arrayOf(PropTypes.number),
+  onChangeRowsPerPage: PropTypes.func.isRequired,
+  page: PropTypes.number.isRequired,
+  onChangePage: PropTypes.func.isRequired,
+};
+
+EnhancedTableFooter.defaultProps = {
+  rowsPerPageOptions: [5, 10, 25],
+};
+
+EnhancedTableFooter = withStyles(footerStyles)(EnhancedTableFooter);
+
 const styles = theme => ({
   paper: {
     width: '100%',
@@ -162,12 +274,22 @@ class EnhancedTable extends React.Component {
     orderBy: 'calories',
     selected: [],
     data: [
-      createData('Frozen yoghurt', 159, 6.0, 24, 4.0),
-      createData('Ice cream sandwich', 237, 9.0, 37, 4.3),
-      createData('Eclair', 262, 16.0, 24, 6.0),
       createData('Cupcake', 305, 3.7, 67, 4.3),
+      createData('Donut', 452, 25.0, 51, 4.9),
+      createData('Eclair', 262, 16.0, 24, 6.0),
+      createData('Frozen yoghurt', 159, 6.0, 24, 4.0),
       createData('Gingerbread', 356, 16.0, 49, 3.9),
+      createData('Honeycomb', 408, 3.2, 87, 6.5),
+      createData('Ice cream sandwich', 237, 9.0, 37, 4.3),
+      createData('Jelly Bean', 375, 0.0, 94, 0.0),
+      createData('KitKat', 518, 26.0, 65, 7.0),
+      createData('Lollipop', 392, 0.2, 98, 0.0),
+      createData('Marshmallow', 318, 0, 81, 2.0),
+      createData('Nougat', 360, 19.0, 9, 37.0),
+      createData('Oreo', 437, 18.0, 63, 4.0),
     ],
+    page: 0,
+    rowsPerPage: 5,
   };
 
   handleRequestSort = (event, property) => {
@@ -220,11 +342,19 @@ class EnhancedTable extends React.Component {
     this.setState({ selected: newSelected });
   };
 
+  handleChangePage = (page) => {
+    this.setState({ page })
+  };
+
+  handleChangeRowsPerPage = (e) => {
+    this.setState({ rowsPerPage: e.target.value })
+  };
+
   isSelected = id => this.state.selected.indexOf(id) !== -1;
 
   render() {
     const classes = this.props.classes;
-    const { data, order, orderBy, selected } = this.state;
+    const { data, order, orderBy, selected, rowsPerPage, page } = this.state;
 
     return (
       <Paper className={classes.paper}>
@@ -238,7 +368,7 @@ class EnhancedTable extends React.Component {
             onRequestSort={this.handleRequestSort}
           />
           <TableBody>
-            {data.map(n => {
+            {data.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map(n => {
               const isSelected = this.isSelected(n.id);
               return (
                 <TableRow
@@ -263,6 +393,13 @@ class EnhancedTable extends React.Component {
               );
             })}
           </TableBody>
+          <EnhancedTableFooter
+            count={data.length}
+            rowsPerPage={rowsPerPage}
+            page={page}
+            onChangePage={this.handleChangePage}
+            onChangeRowsPerPage={this.handleChangeRowsPerPage}
+          />
         </Table>
       </Paper>
     );

--- a/docs/src/pages/demos/tables/EnhancedTable.js
+++ b/docs/src/pages/demos/tables/EnhancedTable.js
@@ -48,6 +48,7 @@ class EnhancedTableHead extends React.Component {
     onSelectAllClick: PropTypes.func.isRequired,
     order: PropTypes.string.isRequired,
     orderBy: PropTypes.string.isRequired,
+    rowCount: PropTypes.number.isRequired,
   };
 
   createSortHandler = property => event => {
@@ -55,15 +56,15 @@ class EnhancedTableHead extends React.Component {
   };
 
   render() {
-    const { onSelectAllClick, order, orderBy, numSelected } = this.props;
+    const { onSelectAllClick, order, orderBy, numSelected, rowCount } = this.props;
 
     return (
       <TableHead>
         <TableRow>
           <TableCell checkbox>
             <Checkbox
-              indeterminate={numSelected > 0 && numSelected < 5}
-              checked={numSelected === 5}
+              indeterminate={numSelected > 0 && numSelected < rowCount}
+              checked={numSelected === rowCount}
               onChange={onSelectAllClick}
             />
           </TableCell>
@@ -167,7 +168,7 @@ const footerStyles = theme => ({
     flex: '1 1 100%',
   },
   select: {
-    marginLeft: 8,
+    marginLeft: theme.spacing.unit,
     width: 34,
     textAlign: 'right',
     paddingRight: 22,
@@ -176,11 +177,11 @@ const footerStyles = theme => ({
     lineHeight: '32px',
   },
   selectRoot: {
-    marginRight: 32,
+    marginRight: theme.spacing.unit * 4,
   },
   actions: {
     color: theme.palette.text.secondary,
-    marginLeft: 20,
+    marginLeft: theme.spacing.unit * 2.5,
   },
   title: {
     flex: '0 0 auto',
@@ -216,9 +217,9 @@ let EnhancedTableFooter = props => {
               value={rowsPerPage}
               onChange={onChangeRowsPerPage}
             >
-              {rowsPerPageOptions.map(v => (
-                <MenuItem key={v} value={v}>
-                  {v}
+              {rowsPerPageOptions.map(rowsPerPageOption => (
+                <MenuItem key={rowsPerPageOption} value={rowsPerPageOption}>
+                  {rowsPerPageOption}
                 </MenuItem>
               ))}
             </Select>
@@ -372,6 +373,7 @@ class EnhancedTable extends React.Component {
             orderBy={orderBy}
             onSelectAllClick={this.handleSelectAllClick}
             onRequestSort={this.handleRequestSort}
+            rowCount={data.length}
           />
           <TableBody>
             {data.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map(n => {

--- a/docs/src/pages/demos/tables/tables.md
+++ b/docs/src/pages/demos/tables/tables.md
@@ -1,5 +1,5 @@
 ---
-components: Table, TableBody, TableCell, TableHead, TableRow, TableSortLabel
+components: Table, TableBody, TableCell, TableFooter, TableHead, TableRow, TableSortLabel
 ---
 
 # Tables

--- a/docs/src/pages/demos/tables/tables.md
+++ b/docs/src/pages/demos/tables/tables.md
@@ -1,5 +1,5 @@
 ---
-components: Table, TableBody, TableCell, TableFooter, TableHead, TableRow, TableSortLabel
+components: Table, TableBody, TableCell, TableFooter, TableHead, TablePagination, TableRow, TableSortLabel
 ---
 
 # Tables

--- a/docs/src/pages/getting-started/supported-components.md
+++ b/docs/src/pages/getting-started/supported-components.md
@@ -42,7 +42,7 @@ to discuss the approach before submitting a PR.
 - **[Data tables](https://www.google.com/design/spec/components/data-tables.html) ✓**
   - **Sortable ✓**
   - **Selectable ✓**
-  - Pagination
+  - **Pagination ✓**
 - **[Dialogs](https://www.google.com/design/spec/components/dialogs.html) ✓**
   - **[Alerts](https://www.google.com/design/spec/components/dialogs.html#dialogs-alerts) ✓**
   - **[Simple menus](https://www.google.com/design/spec/components/dialogs.html#dialogs-simple-menus) (Menu) ✓**

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
   "size-limit": [
     {
       "path": "build/index.js",
-      "limit": "90 KB"
+      "limit": "91 KB"
     }
   ],
   "nyc": {

--- a/pages/api/table-footer.js
+++ b/pages/api/table-footer.js
@@ -1,0 +1,12 @@
+// @flow
+
+import React from 'react';
+import withRoot from 'docs/src/modules/components/withRoot';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import markdown from './table-footer.md';
+
+function Page() {
+  return <MarkdownDocs markdown={markdown} />;
+}
+
+export default withRoot(Page);

--- a/pages/api/table-footer.md
+++ b/pages/api/table-footer.md
@@ -1,0 +1,32 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
+# TableFooter
+
+
+
+## Props
+| Name | Type | Default | Description |
+|:-----|:-----|:--------|:------------|
+| children | Node |  | The content of the component, normally `TableRow`. |
+| classes | Object |  | Useful to extend the style applied to components. |
+| component | union:&nbsp;string<br>&nbsp;ComponentType<*><br> | 'tfoot' | The component used for the root node. Either a string to use a DOM element or a component. |
+
+Any other properties supplied will be [spread to the root element](/customization/api#spread).
+
+## CSS API
+
+You can override all the class names injected by Material-UI thanks to the `classes` property.
+This property accepts the following keys:
+- `root`
+
+Have a look at [overriding with classes](/customization/overrides#overriding-with-classes)
+section for more detail.
+
+If using the `overrides` key of the theme as documented
+[here](/customization/themes#customizing-all-instances-of-a-component-type),
+you need to use the following style sheet name: `MuiTableFooter`.
+
+## Demos
+
+- [Tables](/demos/tables)
+

--- a/pages/api/table-pagination.js
+++ b/pages/api/table-pagination.js
@@ -1,0 +1,12 @@
+// @flow
+
+import React from 'react';
+import withRoot from 'docs/src/modules/components/withRoot';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import markdown from './table-pagination.md';
+
+function Page() {
+  return <MarkdownDocs markdown={markdown} />;
+}
+
+export default withRoot(Page);

--- a/pages/api/table-pagination.md
+++ b/pages/api/table-pagination.md
@@ -1,0 +1,43 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
+# TablePagination
+
+A `TableRow` based component for placing inside `TableFooter` for pagination.
+
+## Props
+| Name | Type | Default | Description |
+|:-----|:-----|:--------|:------------|
+| classes | object |  | Useful to extend the style applied to components. |
+| <span style="color: #31a148">count *</span> | number |  | The total number of rows. |
+| labelDisplayedRows | function | ({ from, to, count }) => `${from}-${to} of ${count}` | Useful to customize the displayed rows label. |
+| labelRowsPerPage | node | 'Rows per page:' | Useful to customize the rows per page label. Invoked with a `{ from, to, count, page }` object. |
+| <span style="color: #31a148">onChangePage *</span> | function |  | Callback fired when the page is changed. Invoked with two arguments: the event and the page to show. |
+| <span style="color: #31a148">onChangeRowsPerPage *</span> | function |  | Callback fired when the number of rows per page is changed. Invoked with two arguments: the event. |
+| <span style="color: #31a148">page *</span> | number |  | The zero-based index of the current page. |
+| <span style="color: #31a148">rowsPerPage *</span> | number |  | The number of rows per page. |
+| rowsPerPageOptions | arrayOf | [5, 10, 25] | Customizes the options of the rows per page select field. |
+
+Any other properties supplied will be [spread to the root element](/customization/api#spread).
+
+## CSS API
+
+You can override all the class names injected by Material-UI thanks to the `classes` property.
+This property accepts the following keys:
+- `cell`
+- `toolbar`
+- `spacer`
+- `select`
+- `selectRoot`
+- `actions`
+
+Have a look at [overriding with classes](/customization/overrides#overriding-with-classes)
+section for more detail.
+
+If using the `overrides` key of the theme as documented
+[here](/customization/themes#customizing-all-instances-of-a-component-type),
+you need to use the following style sheet name: `TablePagination`.
+
+## Demos
+
+- [Tables](/demos/tables)
+

--- a/pages/api/table-pagination.md
+++ b/pages/api/table-pagination.md
@@ -7,15 +7,15 @@ A `TableRow` based component for placing inside `TableFooter` for pagination.
 ## Props
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| classes | object |  | Useful to extend the style applied to components. |
+| classes | Object |  | Useful to extend the style applied to components. |
 | <span style="color: #31a148">count *</span> | number |  | The total number of rows. |
-| labelDisplayedRows | function | ({ from, to, count }) => `${from}-${to} of ${count}` | Useful to customize the displayed rows label. |
-| labelRowsPerPage | node | 'Rows per page:' | Useful to customize the rows per page label. Invoked with a `{ from, to, count, page }` object. |
-| <span style="color: #31a148">onChangePage *</span> | function |  | Callback fired when the page is changed. Invoked with two arguments: the event and the page to show. |
-| <span style="color: #31a148">onChangeRowsPerPage *</span> | function |  | Callback fired when the number of rows per page is changed. Invoked with two arguments: the event. |
+| labelDisplayedRows | signature | ({ from, to, count }) => `${from}-${to} of ${count}` | Useful to customize the displayed rows label. |
+| labelRowsPerPage | Node | 'Rows per page:' | Useful to customize the rows per page label. Invoked with a `{ from, to, count, page }` object. |
+| <span style="color: #31a148">onChangePage *</span> | signature |  | Callback fired when the page is changed. Invoked with two arguments: the event and the page to show. |
+| <span style="color: #31a148">onChangeRowsPerPage *</span> | signature |  | Callback fired when the number of rows per page is changed. Invoked with two arguments: the event. |
 | <span style="color: #31a148">page *</span> | number |  | The zero-based index of the current page. |
 | <span style="color: #31a148">rowsPerPage *</span> | number |  | The number of rows per page. |
-| rowsPerPageOptions | arrayOf | [5, 10, 25] | Customizes the options of the rows per page select field. |
+| rowsPerPageOptions | unknown | [5, 10, 25] | Customizes the options of the rows per page select field. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 
@@ -35,7 +35,7 @@ section for more detail.
 
 If using the `overrides` key of the theme as documented
 [here](/customization/themes#customizing-all-instances-of-a-component-type),
-you need to use the following style sheet name: `TablePagination`.
+you need to use the following style sheet name: `MuiTablePagination`.
 
 ## Demos
 

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -74,10 +74,6 @@ class TableBody extends React.Component<AllProps, void> {
   }
 }
 
-TableBody.contextTypes = {
-  table: PropTypes.object,
-};
-
 TableBody.childContextTypes = {
   table: PropTypes.object,
 };

--- a/src/Table/TableCell.js
+++ b/src/Table/TableCell.js
@@ -123,7 +123,7 @@ TableCell.defaultProps = {
 };
 
 TableCell.contextTypes = {
-  table: PropTypes.object,
+  table: PropTypes.object.isRequired,
 };
 
 export default withStyles(styles, { name: 'MuiTableCell' })(TableCell);

--- a/src/Table/TableCell.js
+++ b/src/Table/TableCell.js
@@ -33,7 +33,9 @@ export const styles = (theme: Object) => ({
     paddingLeft: 12,
     paddingRight: 12,
   },
-  footer: {},
+  footer: {
+    borderBottom: 0,
+  },
 });
 
 function TableCell(props, context) {

--- a/src/Table/TableCell.spec.js
+++ b/src/Table/TableCell.spec.js
@@ -60,6 +60,14 @@ describe('<TableCell />', () => {
     assert.strictEqual(wrapper.hasClass(classes.head), true, 'should have the head class');
   });
 
+  it('should render a th with the footer class when in the context of a table footer', () => {
+    const wrapper = shallow(<TableCell />);
+    wrapper.setContext({ ...wrapper.options.context, table: { footer: true } });
+    assert.strictEqual(wrapper.name(), 'td');
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    assert.strictEqual(wrapper.hasClass(classes.footer), true, 'should have the footer class');
+  });
+
   it('should render a div when custom component prop is used', () => {
     const wrapper = shallow(<TableCell component="div" />);
     assert.strictEqual(wrapper.name(), 'div', 'should be a div element');

--- a/src/Table/TableCell.spec.js
+++ b/src/Table/TableCell.spec.js
@@ -10,7 +10,12 @@ describe('<TableCell />', () => {
   let classes;
 
   before(() => {
-    shallow = createShallow({ dive: true });
+    shallow = createShallow({
+      dive: true,
+      context: {
+        table: { footer: true },
+      },
+    });
     classes = getClasses(<TableCell />);
   });
 
@@ -22,7 +27,7 @@ describe('<TableCell />', () => {
   it('should spread custom props on the root node', () => {
     const wrapper = shallow(<TableCell data-my-prop="woofTableCell" />);
     assert.strictEqual(
-      wrapper.prop('data-my-prop'),
+      wrapper.props()['data-my-prop'],
       'woofTableCell',
       'custom prop should be woofTableCell',
     );

--- a/src/Table/TableFooter.d.ts
+++ b/src/Table/TableFooter.d.ts
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import { StyledComponent } from '..';
+
+export interface TableFooterProps
+  extends React.HTMLAttributes<HTMLTableSectionElement> {}
+
+export default class TableFooter extends StyledComponent<TableFooterProps> {}

--- a/src/Table/TableFooter.js
+++ b/src/Table/TableFooter.js
@@ -1,0 +1,85 @@
+// @flow
+
+import React from 'react';
+import type { ComponentType, Node } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import withStyles from '../styles/withStyles';
+
+export const styles = (theme: Object) => ({
+  root: {
+    fontSize: 12,
+    color: theme.palette.text.secondary,
+  },
+});
+
+type DefaultProps = {
+  classes: Object,
+  component: string,
+};
+
+export type Props = {
+  /**
+   * The content of the component, normally `TableRow`.
+   */
+  children?: Node,
+  /**
+   * Useful to extend the style applied to components.
+   */
+  classes?: Object,
+  /**
+   * @ignore
+   */
+  className?: string,
+  /**
+   * The component used for the root node.
+   * Either a string to use a DOM element or a component.
+   */
+  component?: string | ComponentType<*>,
+};
+
+type AllProps = DefaultProps & Props;
+
+class TableFooter extends React.Component<AllProps, void> {
+  props: AllProps;
+
+  static defaultProps = {
+    component: 'tfoot',
+  };
+
+  getChildContext() {
+    // eslint-disable-line class-methods-use-this
+    return {
+      table: {
+        footer: true,
+      },
+    };
+  }
+
+  render() {
+    const {
+      classes,
+      className: classNameProp,
+      children,
+      component: ComponentProp,
+      ...other
+    } = this.props;
+    const className = classNames(classes.root, classNameProp);
+
+    return (
+      <ComponentProp className={className} {...other}>
+        {children}
+      </ComponentProp>
+    );
+  }
+}
+
+TableFooter.contextTypes = {
+  table: PropTypes.object,
+};
+
+TableFooter.childContextTypes = {
+  table: PropTypes.object,
+};
+
+export default withStyles(styles, { name: 'MuiTableFooter' })(TableFooter);

--- a/src/Table/TableFooter.js
+++ b/src/Table/TableFooter.js
@@ -64,19 +64,14 @@ class TableFooter extends React.Component<AllProps, void> {
       component: ComponentProp,
       ...other
     } = this.props;
-    const className = classNames(classes.root, classNameProp);
 
     return (
-      <ComponentProp className={className} {...other}>
+      <ComponentProp className={classNames(classes.root, classNameProp)} {...other}>
         {children}
       </ComponentProp>
     );
   }
 }
-
-TableFooter.contextTypes = {
-  table: PropTypes.object,
-};
 
 TableFooter.childContextTypes = {
   table: PropTypes.object,

--- a/src/Table/TableFooter.spec.js
+++ b/src/Table/TableFooter.spec.js
@@ -1,0 +1,38 @@
+// @flow
+
+import React from 'react';
+import { assert } from 'chai';
+import { createShallow, getClasses } from '../test-utils';
+import TableFooter from './TableFooter';
+
+describe('<TableFooter />', () => {
+  let shallow;
+  let classes;
+
+  before(() => {
+    shallow = createShallow({ dive: true });
+    classes = getClasses(<TableFooter />);
+  });
+
+  it('should render a tfoot', () => {
+    const wrapper = shallow(<TableFooter />);
+    assert.strictEqual(wrapper.name(), 'tfoot');
+  });
+
+  it('should render a div', () => {
+    const wrapper = shallow(<TableFooter component="div" />);
+    assert.strictEqual(wrapper.name(), 'div');
+  });
+
+  it('should render with the user and root classes', () => {
+    const wrapper = shallow(<TableFooter className="woofTableHead" />);
+    assert.strictEqual(wrapper.hasClass('woofTableHead'), true);
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
+  });
+
+  it('should render children', () => {
+    const children = <tr className="test" />;
+    const wrapper = shallow(<TableFooter>{children}</TableFooter>);
+    assert.strictEqual(wrapper.childAt(0).equals(children), true);
+  });
+});

--- a/src/Table/TableHead.js
+++ b/src/Table/TableHead.js
@@ -75,10 +75,6 @@ class TableHead extends React.Component<AllProps, void> {
   }
 }
 
-TableHead.contextTypes = {
-  table: PropTypes.object,
-};
-
 TableHead.childContextTypes = {
   table: PropTypes.object,
 };

--- a/src/Table/TablePagination.d.ts
+++ b/src/Table/TablePagination.d.ts
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { StyledComponent } from '..';
+
+interface LabelDisplayedRowsArgs {
+  from: number;
+  to: number;
+  count: number;
+  page: number;
+}
+
+export interface TablePaginationProps {
+  count: number;
+  labelDisplayedRows?: (paginationInfo: LabelDisplayedRowsArgs) => Node;
+  labelRowsPerPage?: Node;
+  onChangePage: (event: React.MouseEvent<HTMLButtonElement> | null, page: number) => void;
+  onChangeRowsPerPage: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement>;
+  page: number;
+  rowsPerPage: number;
+  rowsPerPageOptions?: number[];
+}
+
+export default class TablePagination extends StyledComponent<TablePaginationProps> {}

--- a/src/Table/TablePagination.js
+++ b/src/Table/TablePagination.js
@@ -73,9 +73,7 @@ function TablePagination(props) {
       >
         <Toolbar className={classes.toolbar}>
           <div className={classes.spacer} />
-          <div>
-            <Typography type="caption">{labelRowsPerPage}</Typography>
-          </div>
+          <Typography type="caption">{labelRowsPerPage}</Typography>
           <Select
             classes={{ root: classes.selectRoot, select: classes.select }}
             input={<Input disableUnderline />}

--- a/src/Table/TablePagination.js
+++ b/src/Table/TablePagination.js
@@ -16,7 +16,10 @@ import KeyboardArrowRight from '../svg-icons/KeyboardArrowRight';
 
 export const styles = (theme: Object) => ({
   cell: {
-    padding: '0 !important',
+    // Increase the specificity to override TableCell.
+    '&:last-child': {
+      padding: '0',
+    },
   },
   toolbar: {
     height: 56,
@@ -85,22 +88,20 @@ function TablePagination(props) {
               </MenuItem>
             ))}
           </Select>
-          <div>
-            <Typography type="caption">
-              {labelDisplayedRows({
-                from: page * rowsPerPage + 1,
-                to: Math.min(count, (page + 1) * rowsPerPage),
-                count,
-                page,
-              })}
-            </Typography>
-          </div>
+          <Typography type="caption">
+            {labelDisplayedRows({
+              from: page * rowsPerPage + 1,
+              to: Math.min(count, (page + 1) * rowsPerPage),
+              count,
+              page,
+            })}
+          </Typography>
           <div className={classes.actions}>
-            <IconButton onClick={e => onChangePage(e, page - 1)} disabled={page === 0}>
+            <IconButton onClick={event => onChangePage(event, page - 1)} disabled={page === 0}>
               <KeyboardArrowLeft />
             </IconButton>
             <IconButton
-              onClick={e => onChangePage(e, page + 1)}
+              onClick={event => onChangePage(event, page + 1)}
               disabled={page >= Math.ceil(count / rowsPerPage) - 1}
             >
               <KeyboardArrowRight />
@@ -164,4 +165,4 @@ TablePagination.defaultProps = {
   rowsPerPageOptions: [5, 10, 25],
 };
 
-export default withStyles(styles, { name: 'TablePagination' })(TablePagination);
+export default withStyles(styles, { name: 'MuiTablePagination' })(TablePagination);

--- a/src/Table/TablePagination.js
+++ b/src/Table/TablePagination.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import PropTypes from 'prop-types';
+import type { Node } from 'react';
 import withStyles from '../styles/withStyles';
 import IconButton from '../IconButton';
 import Input from '../Input';
@@ -47,120 +47,155 @@ export const styles = (theme: Object) => ({
   },
 });
 
-/**
- * A `TableRow` based component for placing inside `TableFooter` for pagination.
- */
-function TablePagination(props) {
-  const {
-    classes,
-    className,
-    count,
-    labelDisplayedRows,
-    labelRowsPerPage,
-    onChangePage,
-    onChangeRowsPerPage,
-    page,
-    rowsPerPage,
-    rowsPerPageOptions,
-    ...other
-  } = props;
+type LabelDisplayedRowsArgs = {
+  from: number,
+  to: number,
+  count: number,
+  page: number,
+};
 
-  return (
-    <TableRow className={className} {...other}>
-      <TableCell
-        className={classes.cell}
-        colSpan={9001} // col-span over everything
-      >
-        <Toolbar className={classes.toolbar}>
-          <div className={classes.spacer} />
-          <Typography type="caption">{labelRowsPerPage}</Typography>
-          <Select
-            classes={{ root: classes.selectRoot, select: classes.select }}
-            input={<Input disableUnderline />}
-            value={rowsPerPage}
-            onChange={onChangeRowsPerPage}
-          >
-            {rowsPerPageOptions.map(rowsPerPageOption => (
-              <MenuItem key={rowsPerPageOption} value={rowsPerPageOption}>
-                {rowsPerPageOption}
-              </MenuItem>
-            ))}
-          </Select>
-          <Typography type="caption">
-            {labelDisplayedRows({
-              from: page * rowsPerPage + 1,
-              to: Math.min(count, (page + 1) * rowsPerPage),
-              count,
-              page,
-            })}
-          </Typography>
-          <div className={classes.actions}>
-            <IconButton onClick={event => onChangePage(event, page - 1)} disabled={page === 0}>
-              <KeyboardArrowLeft />
-            </IconButton>
-            <IconButton
-              onClick={event => onChangePage(event, page + 1)}
-              disabled={page >= Math.ceil(count / rowsPerPage) - 1}
-            >
-              <KeyboardArrowRight />
-            </IconButton>
-          </div>
-        </Toolbar>
-      </TableCell>
-    </TableRow>
-  );
-}
+type DefaultProps = {
+  classes: Object,
+  labelRowsPerPage: string,
+  labelDisplayedRows: (paginationInfo: LabelDisplayedRowsArgs) => string,
+  rowsPerPageOptions: number[],
+};
 
-TablePagination.propTypes = {
+export type Props = {
   /**
    * Useful to extend the style applied to components.
    */
-  classes: PropTypes.object.isRequired,
+  classes?: Object,
   /**
    * @ignore
    */
-  className: PropTypes.string,
+  className?: string,
   /**
    * The total number of rows.
    */
-  count: PropTypes.number.isRequired,
+  count: number,
   /**
    * Useful to customize the displayed rows label.
    */
-  labelDisplayedRows: PropTypes.func,
+  labelDisplayedRows?: (paginationInfo: LabelDisplayedRowsArgs) => Node,
   /**
    * Useful to customize the rows per page label. Invoked with a `{ from, to, count, page }`
    * object.
    */
-  labelRowsPerPage: PropTypes.node,
+  labelRowsPerPage?: Node,
   /**
    * Callback fired when the page is changed. Invoked with two arguments: the event and the
    * page to show.
    */
-  onChangePage: PropTypes.func.isRequired,
+  onChangePage: (event: SyntheticInputEvent<> | null, page: number) => void,
   /**
    * Callback fired when the number of rows per page is changed. Invoked with two arguments: the
    * event.
    */
-  onChangeRowsPerPage: PropTypes.func.isRequired,
+  onChangeRowsPerPage: (event: SyntheticInputEvent<>) => void,
   /**
    * The zero-based index of the current page.
    */
-  page: PropTypes.number.isRequired,
+  page: number,
   /**
    * The number of rows per page.
    */
-  rowsPerPage: PropTypes.number.isRequired,
+  rowsPerPage: number,
   /**
    * Customizes the options of the rows per page select field.
    */
-  rowsPerPageOptions: PropTypes.arrayOf(PropTypes.number),
+  rowsPerPageOptions?: number[],
 };
 
-TablePagination.defaultProps = {
-  labelRowsPerPage: 'Rows per page:',
-  labelDisplayedRows: ({ from, to, count }) => `${from}-${to} of ${count}`,
-  rowsPerPageOptions: [5, 10, 25],
-};
+type AllProps = DefaultProps & Props;
+
+/**
+ * A `TableRow` based component for placing inside `TableFooter` for pagination.
+ */
+class TablePagination extends React.Component<AllProps, void> {
+  props: AllProps;
+
+  static defaultProps = {
+    labelRowsPerPage: 'Rows per page:',
+    labelDisplayedRows: ({ from, to, count }) => `${from}-${to} of ${count}`,
+    rowsPerPageOptions: [5, 10, 25],
+  };
+
+  componentWillReceiveProps({ count, onChangePage, rowsPerPage }) {
+    const newLastPage = Math.ceil(count / rowsPerPage) - 1;
+    if (this.props.page > newLastPage) {
+      onChangePage(null, newLastPage);
+    }
+  }
+
+  handleBackButtonClick = event => {
+    this.props.onChangePage(event, this.props.page - 1);
+  };
+
+  handleNextButtonClick = event => {
+    this.props.onChangePage(event, this.props.page + 1);
+  };
+
+  render() {
+    const {
+      classes,
+      className,
+      count,
+      labelDisplayedRows,
+      labelRowsPerPage,
+      onChangePage,
+      onChangeRowsPerPage,
+      page,
+      rowsPerPage,
+      rowsPerPageOptions,
+      ...other
+    } = this.props;
+
+    return (
+      <TableRow className={className} {...other}>
+        <TableCell
+          className={classes.cell}
+          colSpan={9001} // col-span over everything
+        >
+          <Toolbar className={classes.toolbar}>
+            <div className={classes.spacer} />
+            <Typography type="caption">{labelRowsPerPage}</Typography>
+            <Select
+              classes={{ root: classes.selectRoot, select: classes.select }}
+              input={<Input disableUnderline />}
+              value={rowsPerPage}
+              onChange={onChangeRowsPerPage}
+            >
+              {rowsPerPageOptions.map(rowsPerPageOption => (
+                <MenuItem key={rowsPerPageOption} value={rowsPerPageOption}>
+                  {rowsPerPageOption}
+                </MenuItem>
+              ))}
+            </Select>
+            <Typography type="caption">
+              {labelDisplayedRows({
+                from: page * rowsPerPage + 1,
+                to: Math.min(count, (page + 1) * rowsPerPage),
+                count,
+                page,
+              })}
+            </Typography>
+            <div className={classes.actions}>
+              <IconButton onClick={this.handleBackButtonClick} disabled={page === 0}>
+                <KeyboardArrowLeft />
+              </IconButton>
+              <IconButton
+                onClick={this.handleNextButtonClick}
+                disabled={page >= Math.ceil(count / rowsPerPage) - 1}
+              >
+                <KeyboardArrowRight />
+              </IconButton>
+            </div>
+          </Toolbar>
+        </TableCell>
+      </TableRow>
+    );
+  }
+}
 
 export default withStyles(styles, { name: 'MuiTablePagination' })(TablePagination);

--- a/src/Table/TablePagination.js
+++ b/src/Table/TablePagination.js
@@ -1,0 +1,167 @@
+// @flow
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import withStyles from '../styles/withStyles';
+import IconButton from '../IconButton';
+import Input from '../Input';
+import { MenuItem } from '../Menu';
+import Select from '../Select';
+import TableCell from './TableCell';
+import TableRow from './TableRow';
+import Toolbar from '../Toolbar';
+import Typography from '../Typography';
+import KeyboardArrowLeft from '../svg-icons/KeyboardArrowLeft';
+import KeyboardArrowRight from '../svg-icons/KeyboardArrowRight';
+
+export const styles = (theme: Object) => ({
+  cell: {
+    padding: '0 !important',
+  },
+  toolbar: {
+    height: 56,
+    minHeight: 56,
+    paddingRight: 2,
+  },
+  spacer: {
+    flex: '1 1 100%',
+  },
+  select: {
+    marginLeft: theme.spacing.unit,
+    width: 34,
+    textAlign: 'right',
+    paddingRight: 22,
+    color: theme.palette.text.secondary,
+    height: 32,
+    lineHeight: '32px',
+  },
+  selectRoot: {
+    marginRight: theme.spacing.unit * 4,
+  },
+  actions: {
+    color: theme.palette.text.secondary,
+    marginLeft: theme.spacing.unit * 2.5,
+  },
+});
+
+/**
+ * A `TableRow` based component for placing inside `TableFooter` for pagination.
+ */
+function TablePagination(props) {
+  const {
+    classes,
+    className,
+    count,
+    labelDisplayedRows,
+    labelRowsPerPage,
+    onChangePage,
+    onChangeRowsPerPage,
+    page,
+    rowsPerPage,
+    rowsPerPageOptions,
+    ...other
+  } = props;
+
+  return (
+    <TableRow className={className} {...other}>
+      <TableCell
+        className={classes.cell}
+        colSpan={9001} // col-span over everything
+      >
+        <Toolbar className={classes.toolbar}>
+          <div className={classes.spacer} />
+          <div>
+            <Typography type="caption">{labelRowsPerPage}</Typography>
+          </div>
+          <Select
+            classes={{ root: classes.selectRoot, select: classes.select }}
+            input={<Input disableUnderline />}
+            value={rowsPerPage}
+            onChange={onChangeRowsPerPage}
+          >
+            {rowsPerPageOptions.map(rowsPerPageOption => (
+              <MenuItem key={rowsPerPageOption} value={rowsPerPageOption}>
+                {rowsPerPageOption}
+              </MenuItem>
+            ))}
+          </Select>
+          <div>
+            <Typography type="caption">
+              {labelDisplayedRows({
+                from: page * rowsPerPage + 1,
+                to: Math.min(count, (page + 1) * rowsPerPage),
+                count,
+                page,
+              })}
+            </Typography>
+          </div>
+          <div className={classes.actions}>
+            <IconButton onClick={e => onChangePage(e, page - 1)} disabled={page === 0}>
+              <KeyboardArrowLeft />
+            </IconButton>
+            <IconButton
+              onClick={e => onChangePage(e, page + 1)}
+              disabled={page >= Math.ceil(count / rowsPerPage) - 1}
+            >
+              <KeyboardArrowRight />
+            </IconButton>
+          </div>
+        </Toolbar>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+TablePagination.propTypes = {
+  /**
+   * Useful to extend the style applied to components.
+   */
+  classes: PropTypes.object.isRequired,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The total number of rows.
+   */
+  count: PropTypes.number.isRequired,
+  /**
+   * Useful to customize the displayed rows label.
+   */
+  labelDisplayedRows: PropTypes.func,
+  /**
+   * Useful to customize the rows per page label. Invoked with a `{ from, to, count, page }`
+   * object.
+   */
+  labelRowsPerPage: PropTypes.node,
+  /**
+   * Callback fired when the page is changed. Invoked with two arguments: the event and the
+   * page to show.
+   */
+  onChangePage: PropTypes.func.isRequired,
+  /**
+   * Callback fired when the number of rows per page is changed. Invoked with two arguments: the
+   * event.
+   */
+  onChangeRowsPerPage: PropTypes.func.isRequired,
+  /**
+   * The zero-based index of the current page.
+   */
+  page: PropTypes.number.isRequired,
+  /**
+   * The number of rows per page.
+   */
+  rowsPerPage: PropTypes.number.isRequired,
+  /**
+   * Customizes the options of the rows per page select field.
+   */
+  rowsPerPageOptions: PropTypes.arrayOf(PropTypes.number),
+};
+
+TablePagination.defaultProps = {
+  labelRowsPerPage: 'Rows per page:',
+  labelDisplayedRows: ({ from, to, count }) => `${from}-${to} of ${count}`,
+  rowsPerPageOptions: [5, 10, 25],
+};
+
+export default withStyles(styles, { name: 'TablePagination' })(TablePagination);

--- a/src/Table/TablePagination.spec.js
+++ b/src/Table/TablePagination.spec.js
@@ -1,0 +1,84 @@
+// @flow
+
+import React from 'react';
+import { assert } from 'chai';
+import { createShallow } from '../test-utils';
+import TablePagination from './TablePagination';
+
+describe('<TablePagination />', () => {
+  let shallow;
+
+  before(() => {
+    shallow = createShallow({ dive: true });
+  });
+
+  it('should render a TableRow', () => {
+    const wrapper = shallow(
+      <TablePagination
+        count={1}
+        page={0}
+        onChangePage={() => {}}
+        onChangeRowsPerPage={() => {}}
+        rowsPerPage={5}
+      />,
+    );
+    assert.strictEqual(wrapper.name(), 'withStyles(TableRow)');
+  });
+
+  it('should spread custom props on the root node', () => {
+    const wrapper = shallow(
+      <TablePagination
+        count={1}
+        page={0}
+        onChangePage={() => {}}
+        onChangeRowsPerPage={() => {}}
+        rowsPerPage={5}
+        data-my-prop="woofTablePagination"
+      />,
+    );
+    assert.strictEqual(
+      wrapper.prop('data-my-prop'),
+      'woofTablePagination',
+      'custom prop should be woofTablePagination',
+    );
+  });
+
+  it('should use the labelDisplayedRows callback', () => {
+    let labelDisplayedRowsCalled = false;
+    function labelDisplayedRows({ from, to, count, page }) {
+      labelDisplayedRowsCalled = true;
+      assert.strictEqual(from, 6);
+      assert.strictEqual(to, 10);
+      assert.strictEqual(count, 42);
+      assert.strictEqual(page, 1);
+      return `Page ${page}`;
+    }
+
+    const wrapper = shallow(
+      <TablePagination
+        count={42}
+        page={1}
+        onChangePage={() => {}}
+        onChangeRowsPerPage={() => {}}
+        rowsPerPage={5}
+        labelDisplayedRows={labelDisplayedRows}
+      />,
+    );
+    assert.isTrue(labelDisplayedRowsCalled);
+    assert.isTrue(wrapper.html().includes('Page 1'));
+  });
+
+  it('should use labelRowsPerPage', () => {
+    const wrapper = shallow(
+      <TablePagination
+        count={1}
+        page={0}
+        onChangePage={() => {}}
+        onChangeRowsPerPage={() => {}}
+        rowsPerPage={5}
+        labelRowsPerPage="Zeilen pro Seite:"
+      />,
+    );
+    assert.isTrue(wrapper.html().includes('Zeilen pro Seite:'));
+  });
+});

--- a/src/Table/TablePagination.spec.js
+++ b/src/Table/TablePagination.spec.js
@@ -2,14 +2,22 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from '../test-utils';
+import { createShallow, createMount } from '../test-utils';
+import TableFooter from './TableFooter';
 import TablePagination from './TablePagination';
 
 describe('<TablePagination />', () => {
+  const noop = () => {};
   let shallow;
+  let mount;
 
   before(() => {
     shallow = createShallow({ dive: true });
+    mount = createMount();
+  });
+
+  after(() => {
+    mount.cleanUp();
   });
 
   it('should render a TableRow', () => {
@@ -17,8 +25,8 @@ describe('<TablePagination />', () => {
       <TablePagination
         count={1}
         page={0}
-        onChangePage={() => {}}
-        onChangeRowsPerPage={() => {}}
+        onChangePage={noop}
+        onChangeRowsPerPage={noop}
         rowsPerPage={5}
       />,
     );
@@ -30,55 +38,65 @@ describe('<TablePagination />', () => {
       <TablePagination
         count={1}
         page={0}
-        onChangePage={() => {}}
-        onChangeRowsPerPage={() => {}}
+        onChangePage={noop}
+        onChangeRowsPerPage={noop}
         rowsPerPage={5}
         data-my-prop="woofTablePagination"
       />,
     );
     assert.strictEqual(
-      wrapper.prop('data-my-prop'),
+      wrapper.props()['data-my-prop'],
       'woofTablePagination',
       'custom prop should be woofTablePagination',
     );
   });
 
-  it('should use the labelDisplayedRows callback', () => {
-    let labelDisplayedRowsCalled = false;
-    function labelDisplayedRows({ from, to, count, page }) {
-      labelDisplayedRowsCalled = true;
-      assert.strictEqual(from, 6);
-      assert.strictEqual(to, 10);
-      assert.strictEqual(count, 42);
-      assert.strictEqual(page, 1);
-      return `Page ${page}`;
-    }
+  describe('mount', () => {
+    it('should use the labelDisplayedRows callback', () => {
+      let labelDisplayedRowsCalled = false;
+      function labelDisplayedRows({ from, to, count, page }) {
+        labelDisplayedRowsCalled = true;
+        assert.strictEqual(from, 6);
+        assert.strictEqual(to, 10);
+        assert.strictEqual(count, 42);
+        assert.strictEqual(page, 1);
+        return `Page ${page}`;
+      }
 
-    const wrapper = shallow(
-      <TablePagination
-        count={42}
-        page={1}
-        onChangePage={() => {}}
-        onChangeRowsPerPage={() => {}}
-        rowsPerPage={5}
-        labelDisplayedRows={labelDisplayedRows}
-      />,
-    );
-    assert.isTrue(labelDisplayedRowsCalled);
-    assert.isTrue(wrapper.html().includes('Page 1'));
-  });
+      const wrapper = mount(
+        <table>
+          <TableFooter>
+            <TablePagination
+              count={42}
+              page={1}
+              onChangePage={noop}
+              onChangeRowsPerPage={noop}
+              rowsPerPage={5}
+              labelDisplayedRows={labelDisplayedRows}
+            />
+          </TableFooter>
+        </table>,
+      );
+      assert.strictEqual(labelDisplayedRowsCalled, true);
+      assert.strictEqual(wrapper.html().includes('Page 1'), true);
+    });
 
-  it('should use labelRowsPerPage', () => {
-    const wrapper = shallow(
-      <TablePagination
-        count={1}
-        page={0}
-        onChangePage={() => {}}
-        onChangeRowsPerPage={() => {}}
-        rowsPerPage={5}
-        labelRowsPerPage="Zeilen pro Seite:"
-      />,
-    );
-    assert.isTrue(wrapper.html().includes('Zeilen pro Seite:'));
+    it('should use labelRowsPerPage', () => {
+      const wrapper = mount(
+        <table>
+          <TableFooter>
+            <TablePagination
+              count={1}
+              page={0}
+              onChangePage={noop}
+              onChangeRowsPerPage={noop}
+              rowsPerPage={5}
+              labelRowsPerPage="Zeilen pro Seite:"
+            />
+          </TableFooter>
+        </table>,
+      );
+      assert.strictEqual(wrapper.html().includes('Zeilen pro Seite:'), true);
+    });
   });
 });

--- a/src/Table/TablePagination.spec.js
+++ b/src/Table/TablePagination.spec.js
@@ -98,5 +98,120 @@ describe('<TablePagination />', () => {
       );
       assert.strictEqual(wrapper.html().includes('Zeilen pro Seite:'), true);
     });
+
+    it('should disable the back button on the first page', () => {
+      const wrapper = mount(
+        <table>
+          <TableFooter>
+            <TablePagination
+              count={6}
+              page={0}
+              onChangePage={noop}
+              onChangeRowsPerPage={noop}
+              rowsPerPage={5}
+            />
+          </TableFooter>
+        </table>,
+      );
+
+      const backButton = wrapper.find('withStyles(IconButton)').at(0);
+      const nextButton = wrapper.find('withStyles(IconButton)').at(1);
+      assert.strictEqual(backButton.props().disabled, true);
+      assert.strictEqual(nextButton.props().disabled, false);
+    });
+
+    it('should disable the next button on the last page', () => {
+      const wrapper = mount(
+        <table>
+          <TableFooter>
+            <TablePagination
+              count={6}
+              page={1}
+              onChangePage={noop}
+              onChangeRowsPerPage={noop}
+              rowsPerPage={5}
+            />
+          </TableFooter>
+        </table>,
+      );
+
+      const backButton = wrapper.find('withStyles(IconButton)').at(0);
+      const nextButton = wrapper.find('withStyles(IconButton)').at(1);
+      assert.strictEqual(backButton.props().disabled, false);
+      assert.strictEqual(nextButton.props().disabled, true);
+    });
+
+    it('should handle next button clicks properly', () => {
+      let page = 1;
+      const wrapper = mount(
+        <table>
+          <TableFooter>
+            <TablePagination
+              count={15}
+              page={page}
+              onChangePage={(event, nextPage) => {
+                page = nextPage;
+              }}
+              onChangeRowsPerPage={noop}
+              rowsPerPage={5}
+            />
+          </TableFooter>
+        </table>,
+      );
+
+      const nextButton = wrapper.find('withStyles(IconButton)').at(1);
+      nextButton.simulate('click');
+      assert.strictEqual(page, 2);
+    });
+
+    it('should handle back button clicks properly', () => {
+      let page = 1;
+      const wrapper = mount(
+        <table>
+          <TableFooter>
+            <TablePagination
+              count={15}
+              page={page}
+              onChangePage={(event, nextPage) => {
+                page = nextPage;
+              }}
+              onChangeRowsPerPage={noop}
+              rowsPerPage={5}
+            />
+          </TableFooter>
+        </table>,
+      );
+
+      const nextButton = wrapper.find('withStyles(IconButton)').at(0);
+      nextButton.simulate('click');
+      assert.strictEqual(page, 0);
+    });
+
+    it('should handle too high pages after changing rowsPerPage', () => {
+      let page = 2;
+      function ExampleTable(props) {
+        // setProps only works on the mounted root element, so wrap the table
+        return (
+          <table>
+            <TableFooter>
+              <TablePagination
+                count={11}
+                page={page}
+                onChangePage={(event, nextPage) => {
+                  page = nextPage;
+                }}
+                onChangeRowsPerPage={noop}
+                {...props}
+              />
+            </TableFooter>
+          </table>
+        );
+      }
+
+      const wrapper = mount(<ExampleTable rowsPerPage={5} />);
+      wrapper.setProps({ rowsPerPage: 10 });
+      // now, the third page doesn't exist anymore
+      assert.strictEqual(page, 1);
+    });
   });
 });

--- a/src/Table/index.d.ts
+++ b/src/Table/index.d.ts
@@ -1,14 +1,16 @@
 export { default } from './Table';
 export * from './Table';
+export { default as TableFooter } from './TableFooter';
+export * from './TableFooter';
 export { default as TableHead } from './TableHead';
 export * from './TableHead';
 export { default as TableBody } from './TableBody';
 export * from './TableBody';
+export { default as TablePagination } from './TablePagination';
+export * from './TablePagination';
 export { default as TableRow } from './TableRow';
 export * from './TableRow';
 export { default as TableCell } from './TableCell';
 export * from './TableCell';
 export { default as TableSortLabel } from './TableSortLabel';
 export * from './TableSortLabel';
-export { default as TableFooter } from './TableFooter';
-export * from './TableFooter';

--- a/src/Table/index.d.ts
+++ b/src/Table/index.d.ts
@@ -10,3 +10,5 @@ export { default as TableCell } from './TableCell';
 export * from './TableCell';
 export { default as TableSortLabel } from './TableSortLabel';
 export * from './TableSortLabel';
+export { default as TableFooter } from './TableFooter';
+export * from './TableFooter';

--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -6,3 +6,4 @@ export { default as TableBody } from './TableBody';
 export { default as TableRow } from './TableRow';
 export { default as TableCell } from './TableCell';
 export { default as TableSortLabel } from './TableSortLabel';
+export { default as TableFooter } from './TableFooter';

--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -1,9 +1,10 @@
 // @flow
 
 export { default } from './Table';
-export { default as TableHead } from './TableHead';
 export { default as TableBody } from './TableBody';
-export { default as TableRow } from './TableRow';
 export { default as TableCell } from './TableCell';
-export { default as TableSortLabel } from './TableSortLabel';
 export { default as TableFooter } from './TableFooter';
+export { default as TableHead } from './TableHead';
+export { default as TablePagination } from './TablePagination';
+export { default as TableRow } from './TableRow';
+export { default as TableSortLabel } from './TableSortLabel';


### PR DESCRIPTION
This PR adds a new `TableFooter` component and extends the `EnhancedTable` demo to demonstrate pagination. It also adds the missing Android versions to the nutrition list. :cake: :lollipop:

Specs:
![image](https://user-images.githubusercontent.com/5544859/30526350-90e47184-9c19-11e7-93a3-17b1410a916c.png)

This PR:
![image](https://user-images.githubusercontent.com/5544859/30526354-9bffc92e-9c19-11e7-9b5e-2ba9ee65a630.png)

- [x] Add a `TableFooter`, similar to `TableHead`
- [x] Add pixel-perfect pagination footer for tables
- [x] Add tests for `TableFooter`
- [x] Move the pagination code into a `TablePagination` component as suggested in https://github.com/callemall/material-ui/issues/7746#issue-249846046 and immediately add tests this time
- [x] Refactor `TablePagination` to a class and fix a bug when increasing the rows per page results in displaying pages that don't exist anymore
- [x] Add TypeScript typings

Closes #7746 