### PR TITLE
`state.hasValue` might be changed regardless of `props.value`

### DIFF
--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -356,9 +356,8 @@ class TextField extends Component {
   };
 
   handleInputChange = (event) => {
-    if (!this.props.hasOwnProperty('value')) {
-      this.setState({hasValue: isValid(event.target.value)});
-    }
+    this.setState({hasValue: isValid(event.target.value)});
+
     if (this.props.onChange) {
       this.props.onChange(event, event.target.value);
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

`props.value` could be `undefined` and so it won't trigger `render()`.