### PR TITLE
[Tabs] Move updateIndicatorState after render lifecycle

### DIFF
--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -161,13 +161,10 @@ class Tabs extends React.Component<AllProps, State> {
     this.updateScrollButtonState();
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.value !== nextProps.value) {
-      this.updateIndicatorState(nextProps);
-    }
-  }
-
   componentDidUpdate(prevProps, prevState) {
+    if (prevProps.value !== this.props.value) {
+      this.updateIndicatorState(this.props);
+    }
     this.updateScrollButtonState();
     if (
       this.props.width !== prevProps.width ||


### PR DESCRIPTION
Fix: https://github.com/callemall/material-ui/issues/7902