### PR TITLE
[Snackbar] Add `resumeHideDuration` property

### DIFF
--- a/src/Snackbar/Snackbar.d.ts
+++ b/src/Snackbar/Snackbar.d.ts
@@ -10,6 +10,7 @@ export type SnackbarProps = {
   action?: React.ReactElement<any> | React.ReactElement<any>[];
   anchorOrigin?: Origin;
   autoHideDuration?: number;
+  resumeHideDuration?: number;
   enterTransitionDuration?: number;
   key?: number;
   leaveTransitionDuration?: number;

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -83,6 +83,7 @@ type Origin = {
 type DefaultProps = {
   anchorOrigin: Origin,
   autoHideDuration: ?number,
+  resumeHideDuration: ?number,
   classes: Object,
 };
 
@@ -100,6 +101,10 @@ export type Props = {
    * This behavior is disabled by default with the `null` value.
    */
   autoHideDuration?: number,
+  /**
+   * The number of milliseconds to wait before dismissing after user interaction.
+   */
+  resumeHideDuration?: number,
   /**
    * If you wish the take control over the children of the component you can use that property.
    * When using it, no `SnackbarContent` component will be rendered.
@@ -203,6 +208,7 @@ class Snackbar extends React.Component<AllProps, State> {
   static defaultProps = {
     anchorOrigin: { vertical: 'bottom', horizontal: 'center' },
     autoHideDuration: null,
+    resumeHideDuration: null,
     enterTransitionDuration: duration.enteringScreen,
     leaveTransitionDuration: duration.leavingScreen,
   };
@@ -292,6 +298,10 @@ class Snackbar extends React.Component<AllProps, State> {
   // or when the window is shown back.
   handleResume = () => {
     if (this.props.autoHideDuration !== null) {
+      if (this.props.resumeHideDuration !== null) {
+        this.setAutoHideTimer(this.props.resumeHideDuration);
+        return;
+      }
       this.setAutoHideTimer(this.props.autoHideDuration * 0.5);
     }
   };
@@ -305,6 +315,7 @@ class Snackbar extends React.Component<AllProps, State> {
       action,
       anchorOrigin: { vertical, horizontal },
       autoHideDuration,
+      resumeHideDuration,
       children,
       classes,
       className,

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -103,6 +103,9 @@ export type Props = {
   autoHideDuration?: number,
   /**
    * The number of milliseconds to wait before dismissing after user interaction.
+   * If `autoHideDuration` property isn't specified, it does nothing.
+   * If `autoHideDuration` property is specified but `resumeHideDuration` isn't,
+   * we default to `autoHideDuration / 2` ms.
    */
   resumeHideDuration?: number,
   /**

--- a/src/Snackbar/Snackbar.spec.js
+++ b/src/Snackbar/Snackbar.spec.js
@@ -173,6 +173,65 @@ describe('<Snackbar />', () => {
     });
   });
 
+  describe('prop: resumeHideDuration', () => {
+    let clock;
+
+    before(() => {
+      clock = useFakeTimers();
+    });
+
+    after(() => {
+      clock.restore();
+    });
+
+    it('should not call onRequestClose with not timeout after user interaction', () => {
+      const handleRequestClose = spy();
+      const autoHideDuration = 2e3;
+      const resumeHideDuration = 3e3;
+      const wrapper = mount(
+        <Snackbar
+          open
+          onRequestClose={handleRequestClose}
+          message="message"
+          autoHideDuration={autoHideDuration}
+          resumeHideDuration={resumeHideDuration}
+        />,
+      );
+      assert.strictEqual(handleRequestClose.callCount, 0);
+      clock.tick(autoHideDuration / 2);
+      wrapper.simulate('mouseEnter');
+      clock.tick(autoHideDuration / 2);
+      wrapper.simulate('mouseLeave');
+      assert.strictEqual(handleRequestClose.callCount, 0);
+      clock.tick(2e3);
+      assert.strictEqual(handleRequestClose.callCount, 0);
+    });
+
+    it('should call onRequestClose when timer done after user interaction', () => {
+      const handleRequestClose = spy();
+      const autoHideDuration = 2e3;
+      const resumeHideDuration = 3e3;
+      const wrapper = mount(
+        <Snackbar
+          open
+          onRequestClose={handleRequestClose}
+          message="message"
+          autoHideDuration={autoHideDuration}
+          resumeHideDuration={resumeHideDuration}
+        />,
+      );
+      assert.strictEqual(handleRequestClose.callCount, 0);
+      clock.tick(autoHideDuration / 2);
+      wrapper.simulate('mouseEnter');
+      clock.tick(autoHideDuration / 2);
+      wrapper.simulate('mouseLeave');
+      assert.strictEqual(handleRequestClose.callCount, 0);
+      clock.tick(resumeHideDuration);
+      assert.strictEqual(handleRequestClose.callCount, 1);
+      assert.deepEqual(handleRequestClose.args[0], [null, 'timeout']);
+    });
+  });
+
   describe('prop: open', () => {
     it('should not render anything when closed', () => {
       const wrapper = shallow(<Snackbar open={false} message="" />);


### PR DESCRIPTION
Prop `resumeHideDuration` added. 

If not specified will timeout after `autoHideDuration` / 2 after user interaction.
If specified will timeout after `resumeHideDuration` after user interaction.
If `autoHideDuration` not specified will do nothing.

Fixes: #8204