### PR TITLE
[makeSelectable] make it work if value of ListItem is object

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,11 +51,12 @@
     "babel-runtime": "^6.23.0",
     "inline-style-prefixer": "^3.0.2",
     "keycode": "^2.1.8",
+    "lodash.isequal": "^4.5.0",
     "lodash.merge": "^4.6.0",
     "lodash.throttle": "^4.1.1",
     "prop-types": "^15.5.7",
-    "react-transition-group": "^1.1.2",
     "react-event-listener": "^0.4.5",
+    "react-transition-group": "^1.1.2",
     "recompose": "0.24.0",
     "simple-assign": "^0.1.0",
     "warning": "^3.0.0"

--- a/src/List/makeSelectable.js
+++ b/src/List/makeSelectable.js
@@ -1,6 +1,7 @@
 import React, {Component, Children} from 'react';
 import PropTypes from 'prop-types';
 import {fade} from '../utils/colorManipulator';
+import isEqual from 'lodash.isequal';
 
 export const makeSelectable = (MyComponent) => {
   return class extends Component {
@@ -59,13 +60,13 @@ export const makeSelectable = (MyComponent) => {
     };
 
     isChildSelected(child, props) {
-      return props.value === child.props.value;
+      return isEqual(props.value, child.props.value);
     }
 
     handleItemTouchTap = (event, item) => {
       const itemValue = item.props.value;
 
-      if (itemValue !== this.props.value) {
+      if (!isEqual(itemValue, this.props.value)) {
         if (this.props.onChange) {
           this.props.onChange(event, itemValue);
         }

--- a/test/integration/List/selectableList.spec.js
+++ b/test/integration/List/selectableList.spec.js
@@ -36,14 +36,14 @@ describe('makeSelectable', () => {
       key={1}
       value={{
         id: 1,
-        name: "Brendan Lim"
+        name: 'Brendan Lim',
       }}
       primaryText="Brendan Lim"
       nestedItems={[
         <ListItem
           value={{
             id: 2,
-            name: "Grace Ng"
+            name: 'Grace Ng',
           }}
           primaryText="Grace Ng"
         />,
@@ -53,7 +53,7 @@ describe('makeSelectable', () => {
       key={3}
       value={{
         id: 3,
-        name: "Kerem Suer"
+        name: 'Kerem Suer',
       }}
       primaryText="Kerem Suer"
     />,

--- a/test/integration/List/selectableList.spec.js
+++ b/test/integration/List/selectableList.spec.js
@@ -31,6 +31,34 @@ describe('makeSelectable', () => {
     />,
   ];
 
+  const testChildrenWithObjectAsValue = [
+    <ListItem
+      key={1}
+      value={{
+        id: 1,
+        name: "Brendan Lim"
+      }}
+      primaryText="Brendan Lim"
+      nestedItems={[
+        <ListItem
+          value={{
+            id: 2,
+            name: "Grace Ng"
+          }}
+          primaryText="Grace Ng"
+        />,
+      ]}
+    />,
+    <ListItem
+      key={3}
+      value={{
+        id: 3,
+        name: "Kerem Suer"
+      }}
+      primaryText="Kerem Suer"
+    />,
+  ];
+
   it('should display the children', () => {
     const SelectableList = makeSelectable(List);
 
@@ -53,6 +81,23 @@ describe('makeSelectable', () => {
     const render = TestUtils.renderIntoDocument(
       <SelectableList value={2}>
         {testChildren}
+      </SelectableList>
+    );
+
+    const nodeTree = TestUtils.scryRenderedDOMComponentsWithTag(render, 'div');
+    assert.equal(
+      nodeTree[0].firstChild.lastChild.querySelector('span').style.backgroundColor,
+      'rgba(0, 0, 0, 0.2)',
+      'Change the backgroundColor of the selected item'
+    );
+  });
+
+  it('should select the right item has object value', () => {
+    const SelectableList = injectTheme(makeSelectable(List));
+
+    const render = TestUtils.renderIntoDocument(
+      <SelectableList value={{id: 2, name: 'Grace Ng'}}>
+        {testChildrenWithObjectAsValue}
       </SelectableList>
     );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The current makeSelectable HOC won't work well if the value is object, as in function `isChildSelected` the `props.value === child.props.value` will return `false` for same value object.

This PR will make following example use case work
```
<SelectableList value={{id: 2, name: 'Kerem Suer'}}>
    <ListItem
      key={1}
      value={{
        id: 1,
        name: 'Brendan Lim',
      }}
      primaryText="Brendan Lim"
    />,
    <ListItem
      key={2}
      value={{
        id: 2,
        name: 'Kerem Suer',
      }}
      primaryText="Kerem Suer"
    />
</SelectableList>
```