### PR TITLE
[Tooltip] fix typescript typings

### DIFF
--- a/src/Tooltip/Tooltip.d.ts
+++ b/src/Tooltip/Tooltip.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { StyledComponent } from '..';
 
-export interface TooltipProps extends React.HTMLAttributes<HTMLDivElement> {
+export type TooltipProps = React.HTMLAttributes<HTMLDivElement> & {
   title: React.ReactNode;
   onRequestClose?: (event: React.ChangeEvent<{}>) => void;
   onRequestOpen?: (event: React.ChangeEvent<{}>) => void;


### PR DESCRIPTION
Update typescript typings for `Tooltip`, Props were changed in https://github.com/callemall/material-ui/pull/8234