### PR TITLE
[Select] Fix popover width and add autoWidth prop

### DIFF
--- a/docs/src/pages/demos/selects/NativeSelect.js
+++ b/docs/src/pages/demos/selects/NativeSelect.js
@@ -103,7 +103,7 @@ class NativeSelect extends React.Component {
         <FormControl className={classes.formControl}>
           <InputLabel htmlFor="name-input">Name</InputLabel>
           <Input id="name-input" />
-          <FormHelperText>Alignement with an input</FormHelperText>
+          <FormHelperText>Alignment with an input</FormHelperText>
         </FormControl>
         <FormControl className={classes.formControl}>
           <InputLabel htmlFor="uncontrolled-native">Name</InputLabel>

--- a/docs/src/pages/demos/selects/SimpleSelect.js
+++ b/docs/src/pages/demos/selects/SimpleSelect.js
@@ -119,6 +119,23 @@ class SimpleSelect extends React.Component {
           </Select>
           <FormHelperText>Read only</FormHelperText>
         </FormControl>
+        <FormControl className={classes.formControl}>
+          <InputLabel htmlFor="age-simple">Age</InputLabel>
+          <Select
+            value={this.state.age}
+            onChange={this.handleChange('age')}
+            input={<Input id="age-simple" />}
+            autoWidth
+          >
+            <MenuItem value="">
+              <em>None</em>
+            </MenuItem>
+            <MenuItem value={10}>Ten</MenuItem>
+            <MenuItem value={20}>Twenty</MenuItem>
+            <MenuItem value={30}>Thirty</MenuItem>
+          </Select>
+          <FormHelperText>Auto width</FormHelperText>
+        </FormControl>
       </form>
     );
   }

--- a/pages/api/select.md
+++ b/pages/api/select.md
@@ -8,6 +8,7 @@
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | MenuProps | Object |  | Properties applied to the `Menu` element. |
+| autoWidth | boolean | false | If true, the width of the popover will automatically be set according to the items inside the menu, otherwise it will be at least the width of the select input. |
 | <span style="color: #31a148">children *</span> | ChildrenArray |  | The option elements to populate the select with. Can be some `MenuItem` when `native` is false and `option` when `native` is true. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | input | Element | &lt;Input /> | An `Input` element. |

--- a/src/Select/Select.d.ts
+++ b/src/Select/Select.d.ts
@@ -3,6 +3,7 @@ import { StyledComponent, Omit } from '..';
 import { InputProps } from '../Input';
 
 export type SelectProps = {
+  autoWidth?: boolean;
   input?: React.ReactNode;
   native?: boolean;
   multiple?: boolean;

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -64,6 +64,11 @@ export const styles = (theme: Object) => ({
 
 export type Props = {
   /**
+   * If true, the width of the popover will automatically be set according to the items inside the
+   * menu, otherwise it will be at least the width of the select input.
+   */
+  autoWidth?: boolean,
+  /**
    * The option elements to populate the select with.
    * Can be some `MenuItem` when `native` is false and `option` when `native` is true.
    */
@@ -102,7 +107,17 @@ export type Props = {
 type AllProps = DefaultProps & Props;
 
 function Select(props: AllProps) {
-  const { children, classes, input, native, multiple, MenuProps, renderValue, ...other } = props;
+  const {
+    autoWidth,
+    children,
+    classes,
+    input,
+    native,
+    multiple,
+    MenuProps,
+    renderValue,
+    ...other
+  } = props;
 
   // Instead of `Element<typeof Input>` to have more flexibility.
   warning(
@@ -120,6 +135,7 @@ function Select(props: AllProps) {
     ...other,
     inputProps: {
       ...input.props.inputProps,
+      autoWidth,
       children,
       classes,
       native,
@@ -131,6 +147,7 @@ function Select(props: AllProps) {
 }
 
 Select.defaultProps = {
+  autoWidth: false,
   input: <Input />,
   native: false,
   multiple: false,

--- a/src/Select/SelectInput.d.ts
+++ b/src/Select/SelectInput.d.ts
@@ -2,19 +2,19 @@ import * as React from 'react';
 import { StyledComponent } from '..';
 
 export interface SelectInputProps {
-  autoWidth?: boolean,
-  disabled?: boolean,
-  native: boolean,
-  multiple: boolean,
-  MenuProps?: Object,
-  name?: string,
+  autoWidth: boolean;
+  disabled?: boolean;
+  native: boolean;
+  multiple: boolean;
+  MenuProps?: Object;
+  name?: string;
   onBlur?: React.FocusEventHandler<any>;
   onChange?: (event: React.ChangeEvent<{}>, child: React.ReactNode) => void,
   onFocus?: React.FocusEventHandler<any>;
-  readOnly?: boolean,
-  renderValue?: Function,
-  selectRef?: Function,
-  value?: string | number | Array<string | number>,
+  readOnly?: boolean;
+  renderValue?: Function;
+  selectRef?: Function;
+  value?: string | number | Array<string | number>;
 }
 
 declare const SelectInput: StyledComponent<SelectInputProps>;

--- a/src/Select/SelectInput.d.ts
+++ b/src/Select/SelectInput.d.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { StyledComponent } from '..';
 
 export interface SelectInputProps {
+  autoWidth?: boolean,
   disabled?: boolean,
   native: boolean,
   multiple: boolean,

--- a/src/Select/SelectInput.js
+++ b/src/Select/SelectInput.js
@@ -11,6 +11,11 @@ import ArrowDropDownIcon from '../svg-icons/ArrowDropDown';
 
 export type Props = {
   /**
+   * If true, the width of the popover will automatically be set according to the items inside the
+   * menu, otherwise it will be at least the width of the select input.
+   */
+  autoWidth?: boolean,
+  /**
    * The option elements to populate the select with.
    * Can be some `MenuItem` when `native` is false and `option` when `native` is true.
    */
@@ -192,6 +197,7 @@ class SelectInput extends React.Component<AllProps, State> {
 
   render() {
     const {
+      autoWidth,
       children,
       className: classNameProp,
       classes,
@@ -301,6 +307,9 @@ class SelectInput extends React.Component<AllProps, State> {
       display = multiple ? displayMultiple.join(', ') : displaySingle;
     }
 
+    const minimumMenuWidth =
+      this.state.anchorEl != null && !autoWidth ? this.state.anchorEl.clientWidth : 0;
+
     return (
       <div className={classes.root}>
         <div
@@ -343,6 +352,13 @@ class SelectInput extends React.Component<AllProps, State> {
           MenuListProps={{
             ...MenuProps.MenuListProps,
             role: 'listbox',
+          }}
+          PaperProps={{
+            ...MenuProps.PaperProps,
+            style: {
+              minWidth: minimumMenuWidth,
+              ...(MenuProps.PaperProps != null ? MenuProps.PaperProps.style : null),
+            },
           }}
         >
           {items}

--- a/src/Select/SelectInput.js
+++ b/src/Select/SelectInput.js
@@ -14,7 +14,7 @@ export type Props = {
    * If true, the width of the popover will automatically be set according to the items inside the
    * menu, otherwise it will be at least the width of the select input.
    */
-  autoWidth?: boolean,
+  autoWidth: boolean,
   /**
    * The option elements to populate the select with.
    * Can be some `MenuItem` when `native` is false and `option` when `native` is true.
@@ -308,7 +308,7 @@ class SelectInput extends React.Component<AllProps, State> {
     }
 
     const minimumMenuWidth =
-      this.state.anchorEl != null && !autoWidth ? this.state.anchorEl.clientWidth : 0;
+      this.state.anchorEl != null && !autoWidth ? this.state.anchorEl.clientWidth : undefined;
 
     return (
       <div className={classes.root}>

--- a/src/Select/SelectInput.spec.js
+++ b/src/Select/SelectInput.spec.js
@@ -6,7 +6,7 @@ import { spy } from 'sinon';
 import { ReactWrapper } from 'enzyme';
 import keycode from 'keycode';
 import { createShallow, createMount } from '../test-utils';
-import { MenuItem } from '../Menu';
+import Menu, { MenuItem } from '../Menu';
 import consoleErrorMock from '../../test/utils/consoleErrorMock';
 import SelectInput from './SelectInput';
 
@@ -17,6 +17,7 @@ describe('<SelectInput />', () => {
     classes: {
       select: 'select',
     },
+    autoWidth: false,
     value: 10,
     native: false,
     multiple: false,
@@ -66,7 +67,7 @@ describe('<SelectInput />', () => {
 
   describe('prop: MenuProps', () => {
     it('should apply additional properties to the Menu component', () => {
-      const wrapper = mount(
+      const wrapper = shallow(
         <SelectInput
           {...props}
           MenuProps={{
@@ -74,7 +75,23 @@ describe('<SelectInput />', () => {
           }}
         />,
       );
-      assert.strictEqual(wrapper.find('Menu').props().transitionDuration, 100);
+      assert.strictEqual(wrapper.find(Menu).props().transitionDuration, 100);
+    });
+
+    it('should be able to override PaperProps minWidth', () => {
+      const wrapper = shallow(
+        <SelectInput
+          {...props}
+          MenuProps={{
+            PaperProps: {
+              style: {
+                minWidth: 12,
+              },
+            },
+          }}
+        />,
+      );
+      assert.strictEqual(wrapper.find(Menu).props().PaperProps.style.minWidth, 12);
     });
   });
 
@@ -187,6 +204,28 @@ describe('<SelectInput />', () => {
       wrapper.find('select').simulate('change', { target: { value: 20 } });
       assert.strictEqual(handleChange.callCount, 1);
       assert.strictEqual(handleChange.args[0][0].target.value, 20);
+    });
+  });
+
+  describe('prop: autoWidth', () => {
+    it('should take the anchor width into account', () => {
+      const wrapper = shallow(<SelectInput {...props} />);
+      wrapper.setState({
+        anchorEl: {
+          clientWidth: 14,
+        },
+      });
+      assert.strictEqual(wrapper.find(Menu).props().PaperProps.style.minWidth, 14);
+    });
+
+    it('should not take the anchor width into account', () => {
+      const wrapper = shallow(<SelectInput {...props} autoWidth />);
+      wrapper.setState({
+        anchorEl: {
+          clientWidth: 14,
+        },
+      });
+      assert.strictEqual(wrapper.find(Menu).props().PaperProps.style.minWidth, undefined);
     });
   });
 


### PR DESCRIPTION
This sets the minimum width of a Select's popover to the width of the select field and adds an `autoWidth` prop to disable this, similar to v0.x of material-ui.

Closes #8286 