### PR TITLE
[styles] Refactorisation of the breakpoints

### DIFF
--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -28,13 +28,13 @@ export const styles = (theme: Object) => ({
     },
   },
   paperWidthXs: {
-    maxWidth: theme.breakpoints.getWidth('xs'),
+    maxWidth: theme.breakpoints.values.xs,
   },
   paperWidthSm: {
-    maxWidth: theme.breakpoints.getWidth('sm'),
+    maxWidth: theme.breakpoints.values.sm,
   },
   paperWidthMd: {
-    maxWidth: theme.breakpoints.getWidth('md'),
+    maxWidth: theme.breakpoints.values.md,
   },
   fullScreen: {
     margin: 0,

--- a/src/Grid/Grid.js
+++ b/src/Grid/Grid.js
@@ -14,6 +14,7 @@ import React from 'react';
 import type { ComponentType, Node } from 'react';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
+import { keys as breakpointKeys } from '../styles/createBreakpoints';
 import requirePropFactory from '../utils/requirePropFactory';
 import Hidden from '../Hidden';
 import type { HiddenProps } from '../Hidden/types';
@@ -134,7 +135,7 @@ export const styles = (theme: Object) => ({
     justifyContent: 'space-around',
   },
   ...generateGutter(theme, 'xs'),
-  ...theme.breakpoints.keys.reduce((accumulator, key) => {
+  ...breakpointKeys.reduce((accumulator, key) => {
     // Use side effect over immutability for better performance.
     generateGrid(accumulator, theme, key);
     return accumulator;

--- a/src/Hidden/HiddenCss.js
+++ b/src/Hidden/HiddenCss.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import warning from 'warning';
-import { keys as breakpoints } from '../styles/createBreakpoints';
+import { keys as breakpointKeys } from '../styles/createBreakpoints';
 import { capitalizeFirstLetter } from '../utils/helpers';
 import withStyles from '../styles/withStyles';
 import type { HiddenProps } from './types';
@@ -23,7 +23,7 @@ function generateStyles(theme) {
     display: 'none',
   };
 
-  return theme.breakpoints.keys.reduce((styles, key) => {
+  return breakpointKeys.reduce((styles, key) => {
     styles[`only${capitalizeFirstLetter(key)}`] = {
       [theme.breakpoints.only(key)]: hidden,
     };
@@ -73,8 +73,8 @@ function HiddenCss(props: AllProps) {
 
   const className = [];
 
-  for (let i = 0; i < breakpoints.length; i += 1) {
-    const breakpoint = breakpoints[i];
+  for (let i = 0; i < breakpointKeys.length; i += 1) {
+    const breakpoint = breakpointKeys[i];
     const breakpointUp = props[`${breakpoint}Up`];
     const breakpointDown = props[`${breakpoint}Down`];
 

--- a/src/Hidden/HiddenJs.js
+++ b/src/Hidden/HiddenJs.js
@@ -1,7 +1,7 @@
 // @flow
 
 import warning from 'warning';
-import { keys as breakpoints } from '../styles/createBreakpoints';
+import { keys as breakpointKeys } from '../styles/createBreakpoints';
 import withWidth, { isWidthDown, isWidthUp } from '../utils/withWidth';
 import type { HiddenProps } from './types';
 
@@ -59,8 +59,8 @@ function HiddenJs(props: Props) {
   // Allow `only` to be combined with other props. If already hidden, no need to check others.
   if (visible) {
     // determine visibility based on the smallest size up
-    for (let i = 0; i < breakpoints.length; i += 1) {
-      const breakpoint = breakpoints[i];
+    for (let i = 0; i < breakpointKeys.length; i += 1) {
+      const breakpoint = breakpointKeys[i];
       const breakpointUp = props[`${breakpoint}Up`];
       const breakpointDown = props[`${breakpoint}Down`];
       if (

--- a/src/styles/createBreakpoints.js
+++ b/src/styles/createBreakpoints.js
@@ -3,21 +3,23 @@
 export type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 // Sorted ASC by size. That's important.
+// It can't be configured as it's used statically for propTypes.
 export const keys = ['xs', 'sm', 'md', 'lg', 'xl'];
-
-const defaultBreakpointsMap = {
-  xs: 360,
-  sm: 600,
-  md: 960,
-  lg: 1280,
-  xl: 1920,
-};
 
 // Keep in mind that @media is inclusive by the CSS specification.
 export default function createBreakpoints(breakpoints: Object) {
-  const { breakpointsMap = defaultBreakpointsMap, unit = 'px', step = 1, ...other } = breakpoints;
-
-  const values = keys.map(key => breakpointsMap[key]);
+  const {
+    values = {
+      xs: 360,
+      sm: 600,
+      md: 960,
+      lg: 1280,
+      xl: 1920,
+    },
+    unit = 'px',
+    step = 1,
+    ...other
+  } = breakpoints;
 
   function up(key) {
     let value;
@@ -25,13 +27,13 @@ export default function createBreakpoints(breakpoints: Object) {
     if (key === 'xs') {
       value = 0;
     } else {
-      value = breakpointsMap[key] || key;
+      value = values[key] || key;
     }
     return `@media (min-width:${value}${unit})`;
   }
 
   function down(key) {
-    const value = breakpointsMap[key] || key;
+    const value = values[key] || key;
     return `@media (max-width:${value - step / 100}${unit})`;
   }
 
@@ -39,8 +41,8 @@ export default function createBreakpoints(breakpoints: Object) {
     const startIndex = keys.indexOf(start);
     const endIndex = keys.indexOf(end);
     return (
-      `@media (min-width:${values[startIndex]}${unit}) and ` +
-      `(max-width:${values[endIndex + 1] - step / 100}${unit})`
+      `@media (min-width:${values[keys[startIndex]]}${unit}) and ` +
+      `(max-width:${values[keys[endIndex + 1]] - step / 100}${unit})`
     );
   }
 
@@ -52,10 +54,6 @@ export default function createBreakpoints(breakpoints: Object) {
     return between(key, key);
   }
 
-  function getWidth(key) {
-    return breakpointsMap[key];
-  }
-
   return {
     keys,
     values,
@@ -63,7 +61,6 @@ export default function createBreakpoints(breakpoints: Object) {
     down,
     between,
     only,
-    getWidth,
     ...other,
   };
 }

--- a/src/utils/withWidth.js
+++ b/src/utils/withWidth.js
@@ -7,7 +7,7 @@ import debounce from 'lodash/debounce';
 import createEagerFactory from 'recompose/createEagerFactory';
 import wrapDisplayName from 'recompose/wrapDisplayName';
 import withTheme from '../styles/withTheme';
-import { keys } from '../styles/createBreakpoints';
+import { keys as breakpointKeys } from '../styles/createBreakpoints';
 import type { Breakpoint } from '../styles/createBreakpoints';
 
 /**
@@ -19,9 +19,9 @@ import type { Breakpoint } from '../styles/createBreakpoints';
  */
 export const isWidthUp = (breakpoint, screenWidth, inclusive = true) => {
   if (inclusive) {
-    return keys.indexOf(breakpoint) <= keys.indexOf(screenWidth);
+    return breakpointKeys.indexOf(breakpoint) <= breakpointKeys.indexOf(screenWidth);
   }
-  return keys.indexOf(breakpoint) < keys.indexOf(screenWidth);
+  return breakpointKeys.indexOf(breakpoint) < breakpointKeys.indexOf(screenWidth);
 };
 
 /**
@@ -33,9 +33,9 @@ export const isWidthUp = (breakpoint, screenWidth, inclusive = true) => {
  */
 export const isWidthDown = (breakpoint, screenWidth, inclusive = true) => {
   if (inclusive) {
-    return keys.indexOf(screenWidth) <= keys.indexOf(breakpoint);
+    return breakpointKeys.indexOf(screenWidth) <= breakpointKeys.indexOf(breakpoint);
   }
-  return keys.indexOf(screenWidth) < keys.indexOf(breakpoint);
+  return breakpointKeys.indexOf(screenWidth) < breakpointKeys.indexOf(breakpoint);
 };
 
 function withWidth(options = {}) {
@@ -102,12 +102,12 @@ function withWidth(options = {}) {
          * width      |  xs   |  xs   |  sm   |  md   |  lg   |  xl
          */
         let index = 1;
-        while (width === null && index < breakpoints.keys.length) {
-          const currentWidth = breakpoints.keys[index];
+        while (width === null && index < breakpointKeys.length) {
+          const currentWidth = breakpointKeys[index];
 
           // @media are inclusive, so reproduce the behavior here.
-          if (innerWidth < breakpoints.getWidth(currentWidth)) {
-            width = breakpoints.keys[index - 1];
+          if (innerWidth < breakpoints.values[currentWidth]) {
+            width = breakpointKeys[index - 1];
             break;
           }
 

--- a/src/utils/withWidth.spec.js
+++ b/src/utils/withWidth.spec.js
@@ -12,7 +12,7 @@ Empty.propTypes = {}; // Breaks the referencial transparency for testing purpose
 const EmptyWithWidth = withWidth()(Empty);
 
 const breakpoints = createBreakpoints({});
-const TEST_ENV_WIDTH = window.innerWidth > breakpoints.getWidth('md') ? 'md' : 'sm';
+const TEST_ENV_WIDTH = window.innerWidth > breakpoints.values.md ? 'md' : 'sm';
 
 describe('withWidth', () => {
   let shallow;
@@ -85,7 +85,7 @@ describe('withWidth', () => {
       const updateWidth = instance.updateWidth.bind(instance);
 
       breakpoints.keys.forEach(key => {
-        updateWidth(breakpoints.getWidth(key));
+        updateWidth(breakpoints.values[key]);
         assert.strictEqual(wrapper.state().width, key, 'should return the matching width');
       });
     });


### PR DESCRIPTION
This PR is making explicit that the number as well as the name of the breakpoints can't be customized. We expose the information in the propTypes of the component. There is no way we can make it dynamic.
I have also wanted to clean this theme object for a long time. It should be more intuitive this way.

Closes #8279

### Breaking changes

```diff
const muiTheme = createMuiTheme({
  breakpoints: {
-    breakpointsMap: {
+    values: {
      xs: 360,
      sm: 768,
      md: 992,
      lg: 1200,
      xl: 1440,
    },
  },
});
```

 ```diff
   paperWidthXs: {
-    maxWidth: theme.breakpoints.getWidth('xs'),
+    maxWidth: theme.breakpoints.values.xs,
   },
```