### PR TITLE
[typescript] Make the classes property nullable in withStyles

### DIFF
--- a/src/styles/withStyles.d.ts
+++ b/src/styles/withStyles.d.ts
@@ -24,7 +24,7 @@ declare function withStyles(
   style: StyleRules | StyleRulesCallback,
   options?: WithStylesOptions
 ): <
-  C extends React.ComponentType<P & { classes: ClassNames; theme?: Theme }>,
+  C extends React.ComponentType<P & { classes?: ClassNames; theme?: Theme }>,
   P = {},
   ClassNames = {}
 >(
@@ -35,7 +35,7 @@ declare function withStyles<P = {}, ClassNames = {}>(
   style: StyleRules | StyleRulesCallback,
   options?: WithStylesOptions
 ): (
-  component: React.ComponentType<P & { classes: ClassNames; theme?: Theme }>
+  component: React.ComponentType<P & { classes?: ClassNames; theme?: Theme }>
 ) => React.ComponentClass<P & StyledComponentProps<ClassNames>>
 
 export default withStyles;

--- a/test/typescript/styles.spec.tsx
+++ b/test/typescript/styles.spec.tsx
@@ -124,3 +124,40 @@ class DecoratedComponent extends React.Component<
     );
   }
 }
+
+// Avoid naming conflict with 'StyledComponentProps' used in other tests
+import { StyledComponentProps as MUIStyledComponentProps } from '../../src';
+// Ensure that providing a classes prop is optional for components that use withStyles
+const WithStylesDoesntRequireClassesTest = () => {
+
+  const styles = theme => ({
+    root: {
+      color: "aqua"
+    }
+  });
+
+  interface NoClassesRequiredStyles {
+    root: string
+  }
+
+  type NoClassesRequiredProps = {
+    bestComponentLibrary: string
+  } & MUIStyledComponentProps<NoClassesRequiredStyles>
+
+  class NoClassesRequired extends React.Component<NoClassesRequiredProps> {
+
+    render() {
+      const classes = this.props.classes;
+      return (
+        <div className={classes.root}/>
+      );
+    }
+
+  }
+
+  <NoClassesRequired bestComponentLibrary="MUI"/>
+
+  /* If classes regresses and is no longer nullable for components using
+     withStyles, this will not compile. */
+  return withStyles(styles)(NoClassesRequired);
+};

--- a/test/typescript/styles.spec.tsx
+++ b/test/typescript/styles.spec.tsx
@@ -144,6 +144,9 @@ const WithStylesDoesntRequireClassesTest = () => {
     bestComponentLibrary: string
   } & MUIStyledComponentProps<NoClassesRequiredStyles>
 
+  /* If classes regresses and is no longer nullable for components using
+     withStyles, this will not compile. */
+  @withStyles(styles)
   class NoClassesRequired extends React.Component<NoClassesRequiredProps> {
 
     render() {
@@ -157,7 +160,4 @@ const WithStylesDoesntRequireClassesTest = () => {
 
   <NoClassesRequired bestComponentLibrary="MUI"/>
 
-  /* If classes regresses and is no longer nullable for components using
-     withStyles, this will not compile. */
-  return withStyles(styles)(NoClassesRequired);
 };


### PR DESCRIPTION
Problem:
The classes prop seems to be nullable elsewhere but not yet in withStyles, forcing components that consume withStyles to pass a classes prop.

Solution:
Make classes nullable in  #withStyles.

Resolves #8267 