### PR TITLE
[typescript] Allow `Grid` to accept `HTMLAttributes` props

### DIFF
--- a/src/Grid/Grid.d.ts
+++ b/src/Grid/Grid.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyledComponent, StyledComponentProps } from '..';
+import { Omit, StyledComponent, StyledComponentProps } from '..';
 import { HiddenProps } from '../Hidden/Hidden';
 import { Breakpoint } from '../styles/createBreakpoints';
 
@@ -30,6 +30,7 @@ export type GridProps = {
   hidden?: HiddenProps & StyledComponentProps<any>;
   justify?: GridJustification;
   wrap?: GridWrap;
-} & Partial<{ [key in Breakpoint]: boolean | GridSize }>;
+} & Partial<{ [key in Breakpoint]: boolean | GridSize }>
+  & Partial<Omit<React.HTMLAttributes<HTMLElement>, 'hidden'>>;
 
 export default class Grid extends StyledComponent<GridProps> {}

--- a/test/typescript/components.spec.tsx
+++ b/test/typescript/components.spec.tsx
@@ -338,6 +338,9 @@ const GridTest = () =>
     <Grid item xl={true}>
       ...
     </Grid>
+    <Grid item hidden={{ smDown: true }} style={{ color: 'red' }}>
+      ...
+    </Grid>
   </Grid>;
 
 const GridListTest = () =>


### PR DESCRIPTION
Not a typescript expert, but currently you can't pass any `React.HTMLAttributes` props to `Grid` components.

I added another intersection to the `GridProps` type with `hidden` omitted. I believe that's the only overlap.