### PR TITLE
[typescript] Improve type definition for withStyles

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export type ClassNameMap<Names extends string> = Record<Names, string>;
+export type ClassNameMap<Names extends string = string> = Record<Names, string>;
 
 /**
  * Component exposed by `material-ui` are usually wrapped

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+export type ClassNameMap<Names extends string> = Record<Names, string>;
+
 /**
  * Component exposed by `material-ui` are usually wrapped
  * with the `withStyles` HOC and allow customization via
@@ -9,13 +11,13 @@ import * as React from 'react';
  * - `classes`
  * - `innerRef`
  */
-export interface StyledComponentProps<StyleClasses> {
+export interface StyledComponentProps<Names extends string = string> {
   className?: string;
-  classes?: StyleClasses;
+  classes?: ClassNameMap<Names>;
   innerRef?: React.Ref<any>;
 }
-export class StyledComponent<P, C = Object> extends React.Component<
-  P & StyledComponentProps<C>
+export class StyledComponent<P = {}, Names extends string = string> extends React.Component<
+  P & StyledComponentProps<Names>
 > {}
 
 export type Contrast = 'light' | 'dark' | 'brown';

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -92,7 +92,7 @@ export { CircularProgress, LinearProgress } from './Progress';
 export { default as Radio, RadioGroup } from './Radio';
 export { default as Select } from './Select';
 export { default as Snackbar, SnackbarContent } from './Snackbar';
-export { MuiThemeProvider, withStyles, withTheme, createMuiTheme } from './styles';
+export { MuiThemeProvider, withStyles, WithStyles, withTheme, createMuiTheme } from './styles';
 
 import * as colors from './colors';
 

--- a/src/styles/index.d.ts
+++ b/src/styles/index.d.ts
@@ -3,6 +3,6 @@ export { default as createBreakpoints } from './createBreakpoints';
 export { default as createMuiTheme, Theme } from './createMuiTheme';
 export { default as createPalette } from './createPalette';
 export { default as createTypography } from './createTypography';
-export { default as withStyles } from './withStyles';
+export { default as withStyles, WithStyles } from './withStyles';
 export { StyleRules, StyleRulesCallback } from './withStyles';
 export { default as withTheme } from './withTheme';

--- a/src/styles/withStyles.d.ts
+++ b/src/styles/withStyles.d.ts
@@ -9,33 +9,22 @@ import { Theme } from './createMuiTheme';
    * - the `keys` are the class (names) that will be created
    * - the `values` are objects that represent CSS rules (`React.CSSProperties`).
    */
-export interface StyleRules {
-  [displayName: string]: Partial<React.CSSProperties>;
+export type StyleRules<Names extends string> = {
+  [Name in Names]: Partial<React.CSSProperties>;
 }
 
-export type StyleRulesCallback = (theme: Theme) => StyleRules;
+export type StyleRulesCallback<Names extends string> = (theme: Theme) => StyleRules<Names>;
 
 export interface WithStylesOptions {
   withTheme?: boolean;
   name?: string;
 }
 
-declare function withStyles(
-  style: StyleRules | StyleRulesCallback,
+declare function withStyles<Names extends string>(
+  style: StyleRules<Names> | StyleRulesCallback<Names>,
   options?: WithStylesOptions
-): <
-  C extends React.ComponentType<P & { classes: ClassNames; theme?: Theme }>,
-  P = {},
-  ClassNames = {}
->(
-  component: C
-) => C & React.ComponentClass<P & StyledComponentProps<ClassNames>>
-
-declare function withStyles<P = {}, ClassNames = {}>(
-  style: StyleRules | StyleRulesCallback,
-  options?: WithStylesOptions
-): (
-  component: React.ComponentType<P & { classes: ClassNames; theme?: Theme }>
-) => React.ComponentClass<P & StyledComponentProps<ClassNames>>
+): <P>(
+  component: React.ComponentType<P & { classes: Record<Names, string>; theme?: Theme }>
+) => React.ComponentType<P & StyledComponentProps<Record<Names, string>>>
 
 export default withStyles;

--- a/src/styles/withStyles.d.ts
+++ b/src/styles/withStyles.d.ts
@@ -20,11 +20,14 @@ export interface WithStylesOptions {
   name?: string;
 }
 
-declare function withStyles<Names extends string>(
+export type WithStyles<P, Names extends string> = P & {
+  classes: Record<Names, string>
+  theme?: Theme
+}
+
+export default function withStyles<Names extends string>(
   style: StyleRules<Names> | StyleRulesCallback<Names>,
   options?: WithStylesOptions
 ): <P>(
-  component: React.ComponentType<P & { classes: Record<Names, string>; theme?: Theme }>
+  component: React.ComponentType<WithStyles<P, Names>>
 ) => React.ComponentType<P & StyledComponentProps<Record<Names, string>>>
-
-export default withStyles;

--- a/src/styles/withStyles.d.ts
+++ b/src/styles/withStyles.d.ts
@@ -9,9 +9,7 @@ import { Theme } from './createMuiTheme';
    * - the `keys` are the class (names) that will be created
    * - the `values` are objects that represent CSS rules (`React.CSSProperties`).
    */
-export type StyleRules<Names extends string = string> = {
-  [Name in Names]: Partial<React.CSSProperties>;
-}
+export type StyleRules<Names extends string = string> = Record<Names, Partial<React.CSSProperties>>;
 
 export type StyleRulesCallback<Names extends string = string> = (theme: Theme) => StyleRules<Names>;
 
@@ -23,11 +21,11 @@ export interface WithStylesOptions {
 export type WithStyles<P, Names extends string = string> = P & {
   classes: ClassNameMap<Names>
   theme?: Theme
-}
+};
 
 export default function withStyles<Names extends string>(
   style: StyleRules<Names> | StyleRulesCallback<Names>,
   options?: WithStylesOptions
 ): <P>(
   component: React.ComponentType<WithStyles<P, Names>>
-) => React.ComponentType<P & StyledComponentProps<Names>>
+) => React.ComponentType<P & StyledComponentProps<Names>>;

--- a/src/styles/withStyles.d.ts
+++ b/src/styles/withStyles.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyledComponentProps } from '..';
+import { ClassNameMap, StyledComponentProps } from '..';
 import { Theme } from './createMuiTheme';
 
 /**
@@ -21,7 +21,7 @@ export interface WithStylesOptions {
 }
 
 export type WithStyles<P, Names extends string = string> = P & {
-  classes: Record<Names, string>
+  classes: ClassNameMap<Names>
   theme?: Theme
 }
 
@@ -30,4 +30,4 @@ export default function withStyles<Names extends string>(
   options?: WithStylesOptions
 ): <P>(
   component: React.ComponentType<WithStyles<P, Names>>
-) => React.ComponentType<P & StyledComponentProps<Record<Names, string>>>
+) => React.ComponentType<P & StyledComponentProps<Names>>

--- a/src/styles/withStyles.d.ts
+++ b/src/styles/withStyles.d.ts
@@ -9,18 +9,18 @@ import { Theme } from './createMuiTheme';
    * - the `keys` are the class (names) that will be created
    * - the `values` are objects that represent CSS rules (`React.CSSProperties`).
    */
-export type StyleRules<Names extends string> = {
+export type StyleRules<Names extends string = string> = {
   [Name in Names]: Partial<React.CSSProperties>;
 }
 
-export type StyleRulesCallback<Names extends string> = (theme: Theme) => StyleRules<Names>;
+export type StyleRulesCallback<Names extends string = string> = (theme: Theme) => StyleRules<Names>;
 
 export interface WithStylesOptions {
   withTheme?: boolean;
   name?: string;
 }
 
-export type WithStyles<P, Names extends string> = P & {
+export type WithStyles<P, Names extends string = string> = P & {
   classes: Record<Names, string>
   theme?: Theme
 }

--- a/test/typescript/components.spec.tsx
+++ b/test/typescript/components.spec.tsx
@@ -632,7 +632,7 @@ const StepperTest = () =>
   };
 
 const TableTest = () => {
-  const styles: StyleRulesCallback = theme => ({
+  const styles: StyleRulesCallback<'paper'> = theme => ({
     paper: {
       width: '100%',
       marginTop: theme.spacing.unit * 3,

--- a/test/typescript/styles.spec.tsx
+++ b/test/typescript/styles.spec.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {
   withStyles,
   WithStyles,
-  StyleRules,
   createMuiTheme,
   MuiThemeProvider,
   Theme,
@@ -38,7 +37,7 @@ const StyledComponent = withStyles(styles)<StyledComponentProps>(
 
 // Also works with a plain object
 
-const stylesAsPojo: StyleRules<'root'> = {
+const stylesAsPojo = {
   root: {
     background: 'hotpink',
   },

--- a/test/typescript/styles.spec.tsx
+++ b/test/typescript/styles.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   withStyles,
+  WithStyles,
   StyleRules,
   createMuiTheme,
   MuiThemeProvider,
@@ -25,29 +26,25 @@ interface StyledComponentProps {
   text: string;
 }
 
-const Component: React.SFC<
-  StyledComponentProps & { classes: StyledComponentClassNames }
-> = ({ classes, text }) =>
-  <div className={classes.root}>
-    {text}
-  </div>;
-
-const StyledComponent = withStyles<
-  StyledComponentProps,
-  StyledComponentClassNames
->(styles)(Component);
+const StyledComponent = withStyles(styles)<StyledComponentProps>(
+  ({ classes, text }) => (
+    <div className={classes.root}>
+      {text}
+    </div>
+  )
+);
 
 <StyledComponent text="I am styled!" />;
 
 // Also works with a plain object
 
-const stylesAsPojo: StyleRules = {
+const stylesAsPojo: StyleRules<'root'> = {
   root: {
     background: 'hotpink',
   },
 };
 
-const AnotherStyledComponent = withStyles<{}, StyledComponentClassNames>({
+const AnotherStyledComponent = withStyles({
   root: { background: 'hotpink' },
 })(({ classes }) => <div className={classes.root}>Stylish!</div>);
 
@@ -107,14 +104,13 @@ const AllTheStyles: React.SFC<AllTheProps> = ({ theme, classes }) =>
   </div>;
 
 const AllTheComposition = withTheme(
-  withStyles<{ theme: Theme }, StyledComponentClassNames>(styles)(AllTheStyles)
+  withStyles(styles)(AllTheStyles)
 );
 
-// As decorator
-@withStyles(styles)
-class DecoratedComponent extends React.Component<
-  StyledComponentProps & { classes: StyledComponentClassNames }
-> {
+// Can't use withStyles effectively as a decorator in TypeScript
+// due to https://github.com/Microsoft/TypeScript/issues/4881
+// @withStyles(styles)
+class DecoratableComponent extends React.Component<WithStyles<StyledComponentProps, 'root'>> {
   render() {
     const { classes, text } = this.props;
     return (
@@ -124,3 +120,8 @@ class DecoratedComponent extends React.Component<
     );
   }
 }
+
+const DecoratedComponent = withStyles(styles)(DecoratableComponent);
+
+// no 'classes' property required at element creation time (#8267)
+<DecoratedComponent text="foo" />

--- a/test/typescript/styles.spec.tsx
+++ b/test/typescript/styles.spec.tsx
@@ -109,18 +109,18 @@ const AllTheComposition = withTheme(
 // Can't use withStyles effectively as a decorator in TypeScript
 // due to https://github.com/Microsoft/TypeScript/issues/4881
 // @withStyles(styles)
-class DecoratableComponent extends React.Component<WithStyles<StyledComponentProps, 'root'>> {
-  render() {
-    const { classes, text } = this.props;
-    return (
-      <div className={classes.root}>
-        {text}
-      </div>
-    );
+const DecoratedComponent = withStyles(styles)(
+  class extends React.Component<WithStyles<StyledComponentProps, 'root'>> {
+    render() {
+      const { classes, text } = this.props;
+      return (
+        <div className={classes.root}>
+          {text}
+        </div>
+      );
+    }
   }
-}
-
-const DecoratedComponent = withStyles(styles)(DecoratableComponent);
+);
 
 // no 'classes' property required at element creation time (#8267)
 <DecoratedComponent text="foo" />


### PR DESCRIPTION
This improves the TypeScript typing for `withStyles` using [mapped types](https://www.typescriptlang.org/docs/handbook/advanced-types.html), rendering it more type safe and requiring fewer explicit type arguments. For example, you can write:

```ts
interface NonStyleProps {
  message: string
}
const Test = withStyles({ foo: { backgroundColor: 'red' } })<NonStyleProps>(props =>
  <div className={props.classes.foo}>{props.message}</div>
)
```

and it is fully type safe. The type of `props` is inferred to be both `NonStyleProps` and `{ classes: { foo: string } }`.