### PR TITLE
Revert removal of style from StyledComponentProps

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,11 +7,13 @@ import * as React from 'react';
  *
  * - `className`
  * - `classes`
+ * - `style`
  * - `innerRef`
  */
 export interface StyledComponentProps<StyleClasses> {
   className?: string;
   classes?: StyleClasses;
+  style?: Partial<React.CSSProperties>;
   innerRef?: React.Ref<any>;
 }
 export class StyledComponent<P, C = Object> extends React.Component<


### PR DESCRIPTION
The `style` prop was removed as part of #8221, for reasons that are unclear. The [current documentation](https://material-ui-1dab0.firebaseapp.com/customization/overrides/#overriding-with-inline-style) states that one should be able to pass an inline `style` prop to any `material-ui` component, and empirically it seems to work, so the typing should reflect that.