### PR TITLE
[Dialog] `fullWidth` property added.

### DIFF
--- a/src/Dialog/Dialog.d.ts
+++ b/src/Dialog/Dialog.d.ts
@@ -9,6 +9,7 @@ export type DialogProps = {
   enterTransitionDuration?: number | string;
   leaveTransitionDuration?: number | string;
   maxWidth?: 'xs' | 'sm' | 'md';
+  fullWidth?: boolean;
   onBackdropClick?: Function;
   onEscapeKeyUp?: Function;
   onRequestClose?: React.EventHandler<any>;

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -36,6 +36,9 @@ export const styles = (theme: Object) => ({
   paperWidthMd: {
     maxWidth: theme.breakpoints.values.md,
   },
+  fullWidth: {
+    width: '100%',
+  },
   fullScreen: {
     margin: 0,
     width: '100%',
@@ -90,6 +93,10 @@ export type Props = {
    * application.
    */
   maxWidth?: 'xs' | 'sm' | 'md',
+  /**
+   * If specified, stretches dialog to max width.
+   */
+  fullWidth?: boolean,
   /**
    * Callback fired when the backdrop is clicked.
    */
@@ -154,6 +161,7 @@ function Dialog(props: AllProps) {
     enterTransitionDuration,
     leaveTransitionDuration,
     maxWidth,
+    fullWidth,
     open,
     onBackdropClick,
     onEscapeKeyUp,
@@ -204,7 +212,10 @@ function Dialog(props: AllProps) {
           className={classNames(
             classes.paper,
             classes[`paperWidth${capitalizeFirstLetter(maxWidth)}`],
-            { [classes.fullScreen]: fullScreen },
+            {
+              [classes.fullScreen]: fullScreen,
+              [classes.fullWidth]: fullWidth,
+            },
           )}
         >
           {children}
@@ -221,6 +232,7 @@ Dialog.defaultProps = {
   enterTransitionDuration: duration.enteringScreen,
   leaveTransitionDuration: duration.leavingScreen,
   maxWidth: 'sm',
+  fullWidth: false,
   open: false,
   transition: Fade,
 };

--- a/src/Dialog/Dialog.spec.js
+++ b/src/Dialog/Dialog.spec.js
@@ -118,6 +118,18 @@ describe('<Dialog />', () => {
     });
   });
 
+  describe('prop: fullWidth', () => {
+    it('should set `fullWidth` class if specified', () => {
+      const wrapper = shallow(<Dialog fullWidth />);
+      assert.strictEqual(wrapper.find(Paper).hasClass(classes.fullWidth), true);
+    });
+
+    it('should not set `fullWidth` class if not specified', () => {
+      const wrapper = shallow(<Dialog />);
+      assert.strictEqual(wrapper.find(Paper).hasClass(classes.fullWidth), false);
+    });
+  });
+
   describe('prop: fullScreen', () => {
     it('true should render fullScreen', () => {
       const wrapper = shallow(<Dialog fullScreen />);


### PR DESCRIPTION
`fullWidth` prop added.

If specified, stretches dialog to max width.

Fixes #8318