### PR TITLE
[codemod] Update import paths for svg-icons v1

### DIFF
--- a/packages/material-ui-codemod/README.md
+++ b/packages/material-ui-codemod/README.md
@@ -42,6 +42,22 @@ find src -name '*.js' -print | xargs jscodeshift -t node_modules/material-ui-cod
 jscodeshift -t <color-imports.js> <path> --importPath='mui/styles/colors' --targetPath='mui/colors'
 ```
 
+#### `svg-icon-imports`
+
+Updates the `svg-icons` import paths from `material-ui/svg-icons/<category>/<icon-name>` to `material-ui-icons/<IconName>`, to use the new [`material-ui-icons`](https://github.com/callemall/material-ui/tree/v1-beta/packages/material-ui-icons) package.
+The diff should look like this:
+
+```diff
+-import AccessAlarmIcon from 'material-ui/svg-icons/device/AccessAlarm';
+-import ThreeDRotation from 'material-ui/svg-icons/action/ThreeDRotation';
++import AccessAlarmIcon from 'material-ui-icons/AccessAlarm';
++import ThreeDRotation from 'material-ui-icons/ThreeDRotation';
+```
+
+```sh
+find src -name '*.js' -print | xargs jscodeshift -t node_modules/material-ui-codemod/lib/v1.0.0/svg-icon-imports.js
+```
+
 ### v0.15.0
 
 #### `import-path`

--- a/packages/material-ui-codemod/src/v1.0.0/svg-icon-imports.js
+++ b/packages/material-ui-codemod/src/v1.0.0/svg-icon-imports.js
@@ -3,9 +3,7 @@
  * @param {string} string
  */
 function capitalize(string) {
-  return string
-    ? `${string[0].toUpperCase()}${string.slice(1)}` 
-    : string;
+  return string ? `${string[0].toUpperCase()}${string.slice(1)}` : string;
 }
 
 /**
@@ -14,7 +12,10 @@ function capitalize(string) {
  * @param {string} iconName
  */
 function pascalize(iconName) {
-  return iconName.split('-').map(capitalize).join('');
+  return iconName
+    .split('-')
+    .map(capitalize)
+    .join('');
 }
 
 /**
@@ -27,10 +28,11 @@ function pascalize(iconName) {
  */
 function transformSVGIconImports(j, root) {
   const pathMatchRegex = /^material-ui\/svg-icons\/.+\/(.+)$/;
-  root.find(j.Literal)
-    .filter(path => (pathMatchRegex.test(path.node.value)))
+  root
+    .find(j.Literal)
+    .filter(path => pathMatchRegex.test(path.node.value))
     .forEach(path => {
-      const [,iconName] = path.node.value.match(pathMatchRegex);
+      const [, iconName] = path.node.value.match(pathMatchRegex);
 
       // update to new path
       path.node.value = `material-ui-icons/${pascalize(iconName)}`;

--- a/packages/material-ui-codemod/src/v1.0.0/svg-icon-imports.js
+++ b/packages/material-ui-codemod/src/v1.0.0/svg-icon-imports.js
@@ -1,0 +1,47 @@
+/**
+ * Capitalize a string
+ * @param {string} string
+ */
+function capitalize(string) {
+  return string
+    ? `${string[0].toUpperCase()}${string.slice(1)}` 
+    : string;
+}
+
+/**
+ * Transform kebab-case icon name to PascalCase
+ * e.g. access-alarm => AccessAlarm
+ * @param {string} iconName
+ */
+function pascalize(iconName) {
+  return iconName.split('-').map(capitalize).join('');
+}
+
+/**
+ * Update all `svg-icons` import references to use `material-ui-icons` package.
+ * Find and replace string literal AST nodes to ensure all svg-icon paths get updated, regardless
+ * of being in an import declaration, or a require() call, etc.
+ * https://github.com/callemall/material-ui/tree/v1-beta/packages/material-ui-icons
+ * @param {jscodeshift_api_object} j
+ * @param {jscodeshift_ast_object} root
+ */
+function transformSVGIconImports(j, root) {
+  const pathMatchRegex = /^material-ui\/svg-icons\/.+\/(.+)$/;
+  root.find(j.Literal)
+    .filter(path => (pathMatchRegex.test(path.node.value)))
+    .forEach(path => {
+      const [,iconName] = path.node.value.match(pathMatchRegex);
+
+      // update to new path
+      path.node.value = `material-ui-icons/${pascalize(iconName)}`;
+    });
+}
+
+module.exports = function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  // transforms
+  transformSVGIconImports(j, root);
+  return root.toSource({ quote: 'single' });
+};

--- a/packages/material-ui-codemod/src/v1.0.0/svg-icon-imports.spec.js
+++ b/packages/material-ui-codemod/src/v1.0.0/svg-icon-imports.spec.js
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import path from 'path';
+import { assert } from 'chai';
+import jscodeshift from 'jscodeshift';
+import transform from './svg-icon-imports';
+
+function trim(str) {
+  return str.replace(/^\s+|\s+$/, '');
+}
+
+function read(fileName) {
+  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+}
+
+describe('material-ui-codemod', () => {
+  describe('v1.0.0', () => {
+    describe('svg-icon-imports', () => {
+      it('update svg-icon imports', () => {
+        const actual = transform(
+          {
+            source: read('./svg-icon-imports.spec/actual.js'),
+          },
+          {
+            jscodeshift: jscodeshift,
+          },
+        );
+
+        const expected = read('./svg-icon-imports.spec/expected.js');
+
+        assert.strictEqual(
+          trim(actual),
+          trim(expected),
+          'The transformed version should be correct',
+        );
+      });
+    });
+  });
+});

--- a/packages/material-ui-codemod/src/v1.0.0/svg-icon-imports.spec/actual.js
+++ b/packages/material-ui-codemod/src/v1.0.0/svg-icon-imports.spec/actual.js
@@ -1,0 +1,4 @@
+import CheckCircle from 'material-ui/svg-icons/action/check-circle';
+import Rotation3D from 'material-ui/svg-icons/action/three-d-rotation';
+import Comment from 'material-ui/svg-icons/communication/comment';
+const TransferWithinAStation = require('material-ui/svg-icons/maps/transfer-within-a-station');

--- a/packages/material-ui-codemod/src/v1.0.0/svg-icon-imports.spec/expected.js
+++ b/packages/material-ui-codemod/src/v1.0.0/svg-icon-imports.spec/expected.js
@@ -1,0 +1,4 @@
+import CheckCircle from 'material-ui-icons/CheckCircle';
+import Rotation3D from 'material-ui-icons/ThreeDRotation';
+import Comment from 'material-ui-icons/Comment';
+const TransferWithinAStation = require('material-ui-icons/TransferWithinAStation');

--- a/packages/material-ui-icons/README.md
+++ b/packages/material-ui-icons/README.md
@@ -49,4 +49,4 @@ Note: Importing named exports in this way will result in the code for *every ico
 If you are upgrading an existing project from Material-UI 0.x.x, you will need to revise the import paths
 from `material-ui/svg-icons/<category>/<icon-name>` to `material-ui-icons/<IconName>`.
 
-We may provide a [codemod](https://github.com/facebook/codemod) in a future release.
+[Here](https://github.com/callemall/material-ui/tree/v1-beta/packages/material-ui-codemod#svg-icon-imports)'s a `jscodeshift` [codemod](https://github.com/facebook/codemod) to help you upgrade.


### PR DESCRIPTION
Codemod to switch v0 Material-UI `svg-icons` to `material-ui-icons` package. Updates the import paths from `material-ui/svg-icons/<category>/<icon-name>` to `material-ui-icons/<IconName>`.

- [x] PR has tests
- [x] PR docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).
