### PR TITLE
[typescript] Restore withStyles class decorator

### DIFF
--- a/src/styles/withStyles.d.ts
+++ b/src/styles/withStyles.d.ts
@@ -18,7 +18,7 @@ export interface WithStylesOptions {
   name?: string;
 }
 
-export type WithStyles<P, Names extends string = string> = P & {
+export type WithStyles<Names extends string = string> = {
   classes: ClassNameMap<Names>
   theme?: Theme
 };
@@ -27,5 +27,5 @@ export default function withStyles<Names extends string>(
   style: StyleRules<Names> | StyleRulesCallback<Names>,
   options?: WithStylesOptions
 ): <P>(
-  component: React.ComponentType<WithStyles<P, Names>>
+  component: React.ComponentType<P & WithStyles<Names>>
 ) => React.ComponentType<P & StyledComponentProps<Names>>;

--- a/src/styles/withStyles.d.ts
+++ b/src/styles/withStyles.d.ts
@@ -26,6 +26,11 @@ export type WithStyles<Names extends string = string> = {
 export default function withStyles<Names extends string>(
   style: StyleRules<Names> | StyleRulesCallback<Names>,
   options?: WithStylesOptions
-): <P>(
-  component: React.ComponentType<P & WithStyles<Names>>
-) => React.ComponentType<P & StyledComponentProps<Names>>;
+): {
+  <P>(
+    component: React.StatelessComponent<P & WithStyles<Names>>
+  ): React.ComponentType<P & StyledComponentProps<Names>>;
+  <P, C extends React.ComponentClass<P & StyledComponentProps<Names>>>(
+    component: C
+  ): C;
+};

--- a/test/typescript/styles.spec.tsx
+++ b/test/typescript/styles.spec.tsx
@@ -110,7 +110,7 @@ const AllTheComposition = withTheme(
 // due to https://github.com/Microsoft/TypeScript/issues/4881
 // @withStyles(styles)
 const DecoratedComponent = withStyles(styles)(
-  class extends React.Component<WithStyles<StyledComponentProps, 'root'>> {
+  class extends React.Component<StyledComponentProps & WithStyles<'root'>> {
     render() {
       const { classes, text } = this.props;
       return (

--- a/test/typescript/styles.spec.tsx
+++ b/test/typescript/styles.spec.tsx
@@ -112,7 +112,7 @@ class DecoratedComponent extends StyledComponent<NonStyleProps, 'root'> {
   render() {
     const { classes, text } = this.props;
     return (
-      <div className={classes.root}>
+      <div className={classes!.root}>
         {text}
       </div>
     );

--- a/test/typescript/styles.spec.tsx
+++ b/test/typescript/styles.spec.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { StyledComponent } from '../../src';
 import {
   withStyles,
   WithStyles,
@@ -21,11 +22,11 @@ interface StyledComponentClassNames {
   root: string;
 }
 
-interface StyledComponentProps {
+interface NonStyleProps {
   text: string;
 }
 
-const StyledComponent = withStyles(styles)<StyledComponentProps>(
+const StyledSFC = withStyles(styles)<NonStyleProps>(
   ({ classes, text }) => (
     <div className={classes.root}>
       {text}
@@ -33,7 +34,7 @@ const StyledComponent = withStyles(styles)<StyledComponentProps>(
   )
 );
 
-<StyledComponent text="I am styled!" />;
+<StyledSFC text="I am styled!" />;
 
 // Also works with a plain object
 
@@ -43,7 +44,7 @@ const stylesAsPojo = {
   },
 };
 
-const AnotherStyledComponent = withStyles({
+const AnotherStyledSFC = withStyles({
   root: { background: 'hotpink' },
 })(({ classes }) => <div className={classes.root}>Stylish!</div>);
 
@@ -106,21 +107,17 @@ const AllTheComposition = withTheme(
   withStyles(styles)(AllTheStyles)
 );
 
-// Can't use withStyles effectively as a decorator in TypeScript
-// due to https://github.com/Microsoft/TypeScript/issues/4881
-// @withStyles(styles)
-const DecoratedComponent = withStyles(styles)(
-  class extends React.Component<StyledComponentProps & WithStyles<'root'>> {
-    render() {
-      const { classes, text } = this.props;
-      return (
-        <div className={classes.root}>
-          {text}
-        </div>
-      );
-    }
+@withStyles(styles)
+class DecoratedComponent extends StyledComponent<NonStyleProps, 'root'> {
+  render() {
+    const { classes, text } = this.props;
+    return (
+      <div className={classes.root}>
+        {text}
+      </div>
+    );
   }
-);
+}
 
 // no 'classes' property required at element creation time (#8267)
 <DecoratedComponent text="foo" />


### PR DESCRIPTION
This is a follow-on to #8320 which reenables using `withStyles` as a class decorator in TypeScript, while preserving the fix for #8267:

```ts
@withStyles(styles)
class DecoratedComponent extends StyledComponent<NonStyleProps, 'root'> {
  render() {
    return (
      <div className={this.props.classes!.root}> // <-- `!` required if `strictTypeChecks` is enabled
        {this.props.text}
      </div>
    );
  }
}
```

The only caveat is that with `strictNullChecks` enabled, one needs to use the [non-null assertion operator (`!`)](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html) on accesses of `classes`.