### PR TITLE
[typescript] Make StyledComponent only a type, not a class

### DIFF
--- a/src/AppBar/AppBar.d.ts
+++ b/src/AppBar/AppBar.d.ts
@@ -5,4 +5,6 @@ export interface AppBarProps extends PaperProps {
   position?: 'static' | 'fixed' | 'absolute';
 }
 
-export default class AppBar extends StyledComponent<AppBarProps> {}
+declare const AppBar: StyledComponent<AppBarProps>;
+
+export default AppBar;

--- a/src/Avatar/Avatar.d.ts
+++ b/src/Avatar/Avatar.d.ts
@@ -11,4 +11,6 @@ export interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
   srcSet?: string;
 }
 
-export default class Avatar extends StyledComponent<AvatarProps> {}
+declare const Avatar: StyledComponent<AvatarProps>;
+
+export default Avatar;

--- a/src/Badge/Badge.d.ts
+++ b/src/Badge/Badge.d.ts
@@ -7,4 +7,6 @@ export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
   color?: PropTypes.Color;
 }
 
-export default class Badge extends StyledComponent<BadgeProps> {}
+declare const Badge: StyledComponent<BadgeProps>;
+
+export default Badge;

--- a/src/BottomNavigation/BottomNavigation.d.ts
+++ b/src/BottomNavigation/BottomNavigation.d.ts
@@ -8,6 +8,6 @@ export type BottomNavigationProps = {
   value?: any;
 } & React.HTMLAttributes<HTMLDivElement>;
 
-export default class BottomNavigation extends StyledComponent<
-  BottomNavigationProps
-> {}
+declare const BottomNavigation: StyledComponent<BottomNavigationProps>;
+
+export default BottomNavigation;

--- a/src/BottomNavigation/BottomNavigationButton.d.ts
+++ b/src/BottomNavigation/BottomNavigationButton.d.ts
@@ -12,6 +12,6 @@ export type BottomNavigationButtonProps = {
   value?: any;
 } & Partial<Omit<ButtonBaseProps, 'onChange'>>;
 
-export default class BottomNavigationButton extends StyledComponent<
-  BottomNavigationButtonProps
-> {}
+declare const BottomNavigationButton: StyledComponent<BottomNavigationButtonProps>;
+
+export default BottomNavigationButton;

--- a/src/Button/Button.d.ts
+++ b/src/Button/Button.d.ts
@@ -15,4 +15,6 @@ export interface ButtonProps extends ButtonBaseProps {
   type?: string;
 }
 
-export default class Button extends StyledComponent<ButtonProps> {}
+declare const Button: StyledComponent<ButtonProps>;
+
+export default Button

--- a/src/ButtonBase/ButtonBase.d.ts
+++ b/src/ButtonBase/ButtonBase.d.ts
@@ -12,4 +12,6 @@ export type ButtonBaseProps = {
 } & React.ButtonHTMLAttributes<HTMLButtonElement> &
   React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
-export default class ButtonBase extends StyledComponent<ButtonBaseProps> {}
+declare const ButtonBase: StyledComponent<ButtonBaseProps>;
+
+export default ButtonBase;

--- a/src/Card/Card.d.ts
+++ b/src/Card/Card.d.ts
@@ -6,4 +6,6 @@ export interface CardProps extends PaperProps {
   raised?: boolean;
 }
 
-export default class Card extends StyledComponent<CardProps> {}
+declare const Card: StyledComponent<CardProps>;
+
+export default Card;

--- a/src/Card/CardActions.d.ts
+++ b/src/Card/CardActions.d.ts
@@ -4,4 +4,6 @@ export interface CardActionsProps extends React.HTMLAttributes<HTMLDivElement> {
   disableActionSpacing?: boolean;
 }
 
-export default class CardActions extends StyledComponent<CardActionsProps> {}
+declare const CardActions: StyledComponent<CardActionsProps>;
+
+export default CardActions;

--- a/src/Card/CardContent.d.ts
+++ b/src/Card/CardContent.d.ts
@@ -4,4 +4,6 @@ import { StyledComponent } from '..';
 export interface CardContentProps
   extends React.HTMLAttributes<HTMLDivElement> {}
 
-export default class CardContent extends StyledComponent<CardContentProps> {}
+declare const CardContent: StyledComponent<CardContentProps>;
+
+export default CardContent;

--- a/src/Card/CardHeader.d.ts
+++ b/src/Card/CardHeader.d.ts
@@ -8,4 +8,6 @@ export type CardHeaderProps = {
   title?: React.ReactNode;
 } & Partial<Omit<CardContentProps, 'title'>>;
 
-export default class CardHeader extends StyledComponent<CardHeaderProps> {}
+declare const CardHeader: StyledComponent<CardHeaderProps>;
+
+export default CardHeader;

--- a/src/Card/CardMedia.d.ts
+++ b/src/Card/CardMedia.d.ts
@@ -5,4 +5,6 @@ export interface CardMediaProps extends React.HTMLAttributes<HTMLDivElement> {
   image: string;
 }
 
-export default class CardMedia extends StyledComponent<CardMediaProps> {}
+declare const CardMedia: StyledComponent<CardMediaProps>;
+
+export default CardMedia;

--- a/src/Checkbox/Checkbox.d.ts
+++ b/src/Checkbox/Checkbox.d.ts
@@ -4,4 +4,6 @@ import { SwitchBaseProps } from '../internal/SwitchBase';
 
 export interface CheckboxProps extends SwitchBaseProps {}
 
-export default class Checkbox extends StyledComponent<CheckboxProps> {}
+declare const Checkbox: StyledComponent<CheckboxProps>;
+
+export default Checkbox;

--- a/src/Chip/Chip.d.ts
+++ b/src/Chip/Chip.d.ts
@@ -8,4 +8,6 @@ export interface ChipProps extends React.HTMLAttributes<HTMLDivElement> {
   onRequestDelete?: React.EventHandler<any>;
 }
 
-export default class Chip extends StyledComponent<ChipProps> {}
+declare const Chip: StyledComponent<ChipProps>;
+
+export default Chip;

--- a/src/Dialog/Dialog.d.ts
+++ b/src/Dialog/Dialog.d.ts
@@ -17,4 +17,6 @@ export type DialogProps = {
   transition?: Function | React.ReactElement<any>;
 } & ModalProps;
 
-export default class Dialog extends StyledComponent<DialogProps> {}
+declare const Dialog: StyledComponent<DialogProps>;
+
+export default Dialog;

--- a/src/Dialog/DialogActions.d.ts
+++ b/src/Dialog/DialogActions.d.ts
@@ -4,6 +4,6 @@ import { StyledComponent } from '..';
 export interface DialogActionsProps
   extends React.HTMLAttributes<HTMLDivElement> {}
 
-export default class DialogActions extends StyledComponent<
-  DialogActionsProps
-> {}
+declare const DialogActions: StyledComponent<DialogActionsProps>;
+
+export default DialogActions;

--- a/src/Dialog/DialogContent.d.ts
+++ b/src/Dialog/DialogContent.d.ts
@@ -4,6 +4,6 @@ import { StyledComponent } from '..';
 export interface DialogContentProps
   extends React.HTMLAttributes<HTMLDivElement> {}
 
-export default class DialogContent extends StyledComponent<
-  DialogContentProps
-> {}
+declare const DialogContent: StyledComponent<DialogContentProps>;
+
+export default DialogContent;

--- a/src/Dialog/DialogContentText.d.ts
+++ b/src/Dialog/DialogContentText.d.ts
@@ -4,6 +4,6 @@ import { StyledComponent } from '..';
 export interface DialogContentTextProps
   extends React.HTMLAttributes<HTMLParagraphElement> {}
 
-export default class DialogContentText extends StyledComponent<
-  DialogContentTextProps
-> {}
+declare const DialogContentText: StyledComponent<DialogContentTextProps>;
+
+export default DialogContentText;

--- a/src/Dialog/DialogTitle.d.ts
+++ b/src/Dialog/DialogTitle.d.ts
@@ -5,4 +5,6 @@ export interface DialogTitleProps extends React.HTMLAttributes<HTMLDivElement> {
   disableTypography?: boolean;
 }
 
-export default class DialogTitle extends StyledComponent<DialogTitleProps> {}
+declare const DialogTitle: StyledComponent<DialogTitleProps>;
+
+export default DialogTitle;

--- a/src/Divider/Divider.d.ts
+++ b/src/Divider/Divider.d.ts
@@ -7,4 +7,6 @@ export interface DividerProps extends React.HTMLAttributes<HTMLHRElement> {
   light?: boolean;
 }
 
-export default class Divider extends StyledComponent<DividerProps> {}
+declare const Divider: StyledComponent<DividerProps>;
+
+export default Divider;

--- a/src/Drawer/Drawer.d.ts
+++ b/src/Drawer/Drawer.d.ts
@@ -15,4 +15,6 @@ export interface DrawerProps extends ModalProps {
   type: 'permanent' | 'persistent' | 'temporary';
 }
 
-export default class Drawer extends StyledComponent<DrawerProps> {}
+declare const Drawer: StyledComponent<DrawerProps>;
+
+export default Drawer;

--- a/src/Form/FormControl.d.ts
+++ b/src/Form/FormControl.d.ts
@@ -13,4 +13,6 @@ export interface FormControlProps
   component?: React.ReactType;
 }
 
-export default class FormControl extends StyledComponent<FormControlProps> {}
+declare const FormControl: StyledComponent<FormControlProps>;
+
+export default FormControl;

--- a/src/Form/FormControlLabel.d.ts
+++ b/src/Form/FormControlLabel.d.ts
@@ -12,6 +12,6 @@ export type FormControlLabelProps = {
   value?: string;
 } & React.LabelHTMLAttributes<HTMLLabelElement>;
 
-export default class FormControlLabel extends StyledComponent<
-  FormControlLabelProps
-> {}
+declare const FormControlLabel: StyledComponent<FormControlLabelProps>;
+
+export default FormControlLabel;

--- a/src/Form/FormGroup.d.ts
+++ b/src/Form/FormGroup.d.ts
@@ -6,4 +6,6 @@ export interface FormGroupProps
   row?: boolean;
 }
 
-export default class FormGroup extends StyledComponent<FormGroupProps> {}
+declare const FormGroup: StyledComponent<FormGroupProps>;
+
+export default FormGroup;

--- a/src/Form/FormHelperText.d.ts
+++ b/src/Form/FormHelperText.d.ts
@@ -8,6 +8,6 @@ export interface FormHelperTextProps
   margin?: 'dense';
 }
 
-export default class FormHelperText extends StyledComponent<
-  FormHelperTextProps
-> {}
+declare const FormHelperText: StyledComponent<FormHelperTextProps>;
+
+export default FormHelperText;

--- a/src/Form/FormLabel.d.ts
+++ b/src/Form/FormLabel.d.ts
@@ -9,4 +9,6 @@ export interface FormLabelProps
   required?: boolean;
 }
 
-export default class FormLabel extends StyledComponent<FormLabelProps> {}
+declare const FormLabel: StyledComponent<FormLabelProps>;
+
+export default FormLabel;

--- a/src/Grid/Grid.d.ts
+++ b/src/Grid/Grid.d.ts
@@ -33,4 +33,6 @@ export type GridProps = {
 } & Partial<{ [key in Breakpoint]: boolean | GridSize }>
   & Partial<Omit<React.HTMLAttributes<HTMLElement>, 'hidden'>>;
 
-export default class Grid extends StyledComponent<GridProps> {}
+declare const Grid: StyledComponent<GridProps>;
+
+export default Grid;

--- a/src/GridList/GridList.d.ts
+++ b/src/GridList/GridList.d.ts
@@ -8,4 +8,6 @@ export interface GridListProps {
   spacing?: number;
 }
 
-export default class GridList extends StyledComponent<GridListProps> {}
+declare const GridList: StyledComponent<GridListProps>;
+
+export default GridList;

--- a/src/GridList/GridListTile.d.ts
+++ b/src/GridList/GridListTile.d.ts
@@ -7,4 +7,6 @@ export interface GridListTileProps {
   row?: number;
 }
 
-export default class GridListTile extends StyledComponent<GridListTileProps> {}
+declare const GridListTile: StyledComponent<GridListTileProps>;
+
+export default GridListTile;

--- a/src/GridList/GridListTileBar.d.ts
+++ b/src/GridList/GridListTileBar.d.ts
@@ -9,6 +9,6 @@ export interface GridListTileBarProps {
   titlePosition?: 'top' | 'bottom';
 }
 
-export default class GridListTileBar extends StyledComponent<
-  GridListTileBarProps
-> {}
+declare const GridListTileBar: StyledComponent<GridListTileBarProps>;
+
+export default GridListTileBar;

--- a/src/Hidden/Hidden.d.ts
+++ b/src/Hidden/Hidden.d.ts
@@ -17,4 +17,6 @@ export interface HiddenProps {
   implementation?: 'js' | 'css';
 }
 
-export default class Hidden extends StyledComponent<HiddenProps> {}
+declare const Hidden: StyledComponent<HiddenProps>;
+
+export default Hidden;

--- a/src/Hidden/HiddenJs.d.ts
+++ b/src/Hidden/HiddenJs.d.ts
@@ -16,4 +16,6 @@ export interface HiddenJsProps {
   xlDown?: boolean;
 }
 
-export default class HiddenJs extends StyledComponent<HiddenJsProps> {}
+declare const HiddenJs: StyledComponent<HiddenJsProps>;
+
+export default HiddenJs;

--- a/src/Icon/Icon.d.ts
+++ b/src/Icon/Icon.d.ts
@@ -5,4 +5,6 @@ export interface IconProps extends React.HTMLAttributes<HTMLSpanElement> {
   color?: PropTypes.Color | 'action' | 'contrast' | 'disabled' | 'error';
 }
 
-export default class Icon extends StyledComponent<IconProps> {}
+declare const Icon: StyledComponent<IconProps>;
+
+export default Icon;

--- a/src/IconButton/IconButton.d.ts
+++ b/src/IconButton/IconButton.d.ts
@@ -9,4 +9,6 @@ export interface IconButtonProps extends ButtonBaseProps {
   rootRef?: React.Ref<any>;
 }
 
-export default class IconButton extends StyledComponent<IconButtonProps> {}
+declare const IconButton: StyledComponent<IconButtonProps>;
+
+export default IconButton;

--- a/src/Input/Input.d.ts
+++ b/src/Input/Input.d.ts
@@ -45,4 +45,6 @@ export type InputProps = {
   >
 >;
 
-export default class Input extends StyledComponent<InputProps> {}
+declare const Input: StyledComponent<InputProps>;
+
+export default Input;

--- a/src/Input/InputLabel.d.ts
+++ b/src/Input/InputLabel.d.ts
@@ -11,4 +11,6 @@ export interface InputLabelProps extends FormLabelProps {
   shrink?: boolean;
 }
 
-export default class InputLabel extends StyledComponent<InputLabelProps> {}
+declare const InputLabel: StyledComponent<InputLabelProps>;
+
+export default InputLabel;

--- a/src/Input/Textarea.d.ts
+++ b/src/Input/Textarea.d.ts
@@ -10,4 +10,6 @@ export type TextareaProps = {
   value?: string;
 } & React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
-export default class Textarea extends StyledComponent<TextareaProps> {}
+declare const Textarea: StyledComponent<TextareaProps>;
+
+export default Textarea;

--- a/src/List/List.d.ts
+++ b/src/List/List.d.ts
@@ -9,4 +9,6 @@ export interface ListProps extends React.HTMLAttributes<HTMLUListElement> {
   subheader?: React.ReactElement<any>;
 }
 
-export default class List extends StyledComponent<ListProps> {}
+declare const List: StyledComponent<ListProps>;
+
+export default List;

--- a/src/List/ListItem.d.ts
+++ b/src/List/ListItem.d.ts
@@ -12,4 +12,6 @@ export type ListItemProps = {
 } & ButtonBaseProps &
   React.LiHTMLAttributes<HTMLLIElement>;
 
-export default class ListItem extends StyledComponent<ListItemProps> {}
+declare const ListItem: StyledComponent<ListItemProps>;
+
+export default ListItem;

--- a/src/List/ListItemAvatar.d.ts
+++ b/src/List/ListItemAvatar.d.ts
@@ -2,6 +2,6 @@ import { StyledComponent } from '..';
 
 export interface ListItemAvatarProps {}
 
-export default class ListItemAvatar extends StyledComponent<
-  ListItemAvatarProps
-> {}
+declare const ListItemAvatar: StyledComponent<ListItemAvatarProps>;
+
+export default ListItemAvatar;

--- a/src/List/ListItemIcon.d.ts
+++ b/src/List/ListItemIcon.d.ts
@@ -2,4 +2,6 @@ import { StyledComponent } from '..';
 
 export interface ListItemIconProps {}
 
-export default class ListItemIcon extends StyledComponent<ListItemIconProps> {}
+declare const ListItemIcon: StyledComponent<ListItemIconProps>;
+
+export default ListItemIcon;

--- a/src/List/ListItemSecondaryAction.d.ts
+++ b/src/List/ListItemSecondaryAction.d.ts
@@ -2,6 +2,6 @@ import { StyledComponent } from '..';
 
 export interface ListItemSecondaryActionProps {}
 
-export default class ListItemSecondaryAction extends StyledComponent<
-  ListItemSecondaryActionProps
-> {}
+declare const ListItemSecondaryAction: StyledComponent<ListItemSecondaryActionProps>;
+
+export default ListItemSecondaryAction;

--- a/src/List/ListItemText.d.ts
+++ b/src/List/ListItemText.d.ts
@@ -9,4 +9,6 @@ export interface ListItemTextProps
   secondary?: React.ReactNode;
 }
 
-export default class ListItemText extends StyledComponent<ListItemTextProps> {}
+declare const ListItemText: StyledComponent<ListItemTextProps>;
+
+export default ListItemText;

--- a/src/List/ListSubheader.d.ts
+++ b/src/List/ListSubheader.d.ts
@@ -8,6 +8,6 @@ export interface ListSubheaderProps
   disableSticky?: boolean;
 }
 
-export default class ListSubheader extends StyledComponent<
-  ListSubheaderProps
-> {}
+declare const ListSubheader: StyledComponent<ListSubheaderProps>;
+
+export default ListSubheader;

--- a/src/Menu/Menu.d.ts
+++ b/src/Menu/Menu.d.ts
@@ -13,4 +13,6 @@ export type MenuProps = {
 } & Partial<TransitionHandlers> &
   PopoverProps;
 
-export default class Menu extends StyledComponent<MenuProps> {}
+declare const Menu: StyledComponent<MenuProps>;
+
+export default Menu;

--- a/src/Menu/MenuItem.d.ts
+++ b/src/Menu/MenuItem.d.ts
@@ -8,4 +8,6 @@ export interface MenuItemProps extends ListItemProps {
   selected?: boolean;
 }
 
-export default class MenuItem extends StyledComponent<MenuItemProps> {}
+declare const MenuItem: StyledComponent<MenuItemProps>;
+
+export default MenuItem;

--- a/src/Menu/MenuList.d.ts
+++ b/src/Menu/MenuList.d.ts
@@ -6,4 +6,6 @@ export type MenuListProps = {
   onKeyDown?: React.ReactEventHandler<React.KeyboardEvent<any>>;
 } & ListProps;
 
-export default class MenuList extends StyledComponent<MenuListProps> {}
+declare const MenuList: StyledComponent<MenuListProps>;
+
+export default MenuList;

--- a/src/MobileStepper/MobileStepper.d.ts
+++ b/src/MobileStepper/MobileStepper.d.ts
@@ -12,6 +12,6 @@ export interface MobileStepperProps extends PaperProps {
   type?: 'text' | 'dots' | 'progress';
 }
 
-export default class MobileStepper extends StyledComponent<
-  MobileStepperProps
-> {}
+declare const MobileStepper: StyledComponent<MobileStepperProps>;
+
+export default MobileStepper;

--- a/src/Paper/Paper.d.ts
+++ b/src/Paper/Paper.d.ts
@@ -7,4 +7,6 @@ export interface PaperProps extends React.HTMLAttributes<HTMLDivElement> {
   square?: boolean;
 }
 
-export default class Paper extends StyledComponent<PaperProps> {}
+declare const Paper: StyledComponent<PaperProps>;
+
+export default Paper;

--- a/src/Popover/Popover.d.ts
+++ b/src/Popover/Popover.d.ts
@@ -29,4 +29,6 @@ export type PopoverProps = {
 } & Partial<TransitionHandlers> &
   ModalProps;
 
-export default class Popover extends StyledComponent<PopoverProps> {}
+declare const Popover: StyledComponent<PopoverProps>;
+
+export default Popover;

--- a/src/Progress/CircularProgress.d.ts
+++ b/src/Progress/CircularProgress.d.ts
@@ -11,6 +11,6 @@ export interface CircularProgressProps
   value?: number;
 }
 
-export default class CircularProgress extends StyledComponent<
-  CircularProgressProps
-> {}
+declare const CircularProgress: StyledComponent<CircularProgressProps>;
+
+export default CircularProgress

--- a/src/Progress/LinearProgress.d.ts
+++ b/src/Progress/LinearProgress.d.ts
@@ -9,6 +9,6 @@ export interface LinearProgressProps
   valueBuffer?: number;
 }
 
-export default class LinearProgress extends StyledComponent<
-  LinearProgressProps
-> {}
+declare const LinearProgress: StyledComponent<LinearProgressProps>;
+
+export default LinearProgress;

--- a/src/Radio/Radio.d.ts
+++ b/src/Radio/Radio.d.ts
@@ -19,4 +19,6 @@ export interface RadioProps extends SwitchBaseProps {
   value?: string;
 }
 
-export default class Radio extends StyledComponent<RadioProps> {}
+declare const Radio: StyledComponent<RadioProps>;
+
+export default Radio;

--- a/src/Radio/RadioGroup.d.ts
+++ b/src/Radio/RadioGroup.d.ts
@@ -8,4 +8,6 @@ export type RadioGroupProps = {
   value?: string;
 } & Partial<Omit<FormGroupProps, 'onChange'>>;
 
-export default class RadioGroup extends StyledComponent<RadioGroupProps> {}
+declare const RadioGroup: StyledComponent<RadioGroupProps>;
+
+export default RadioGroup;

--- a/src/Select/Select.d.ts
+++ b/src/Select/Select.d.ts
@@ -11,4 +11,6 @@ export type SelectProps = {
   value?: Array<string | number> | string | number;
 } & Partial<Omit<InputProps, 'value'>>;
 
-export default class Select extends StyledComponent<SelectProps> {}
+declare const Select: StyledComponent<SelectProps>;
+
+export default Select;

--- a/src/Select/SelectInput.d.ts
+++ b/src/Select/SelectInput.d.ts
@@ -16,4 +16,6 @@ export interface SelectInputProps {
   value?: string | number | Array<string | number>,
 }
 
-export default class SelectInput extends StyledComponent<SelectInputProps> {}
+declare const SelectInput: StyledComponent<SelectInputProps>;
+
+export default SelectInput;

--- a/src/Snackbar/Snackbar.d.ts
+++ b/src/Snackbar/Snackbar.d.ts
@@ -24,4 +24,6 @@ export type SnackbarProps = {
 } & Partial<TransitionHandlers> &
   React.HTMLAttributes<HTMLDivElement>;
 
-export default class Snackbar extends StyledComponent<SnackbarProps> {}
+declare const Snackbar: StyledComponent<SnackbarProps>;
+
+export default Snackbar;

--- a/src/Snackbar/SnackbarContent.d.ts
+++ b/src/Snackbar/SnackbarContent.d.ts
@@ -7,6 +7,6 @@ export interface SnackbarContentProps extends PaperProps {
   message: React.ReactElement<any> | string;
 }
 
-export default class SnackbarContent extends StyledComponent<
-  SnackbarContentProps
-> {}
+declare const SnackbarContent: StyledComponent<SnackbarContentProps>;
+
+export default SnackbarContent;

--- a/src/SvgIcon/SvgIcon.d.ts
+++ b/src/SvgIcon/SvgIcon.d.ts
@@ -6,4 +6,6 @@ export interface SvgIconProps extends React.SVGProps<SVGSVGElement> {
   viewBox?: string;
 }
 
-export default class SvgIcon extends StyledComponent<SvgIconProps> {}
+declare const SvgIcon: StyledComponent<SvgIconProps>;
+
+export default SvgIcon;

--- a/src/Switch/Switch.d.ts
+++ b/src/Switch/Switch.d.ts
@@ -18,4 +18,6 @@ export interface SwitchProps extends SwitchBaseProps {
   value?: string;
 }
 
-export default class Switch extends StyledComponent<SwitchProps> {}
+declare const Switch: StyledComponent<SwitchProps>;
+
+export default Switch;

--- a/src/Table/Table.d.ts
+++ b/src/Table/Table.d.ts
@@ -4,4 +4,6 @@ import { StyledComponent } from '..';
 export interface TableProps
   extends React.TableHTMLAttributes<HTMLTableElement> {}
 
-export default class Table extends StyledComponent<TableProps> {}
+declare const Table: StyledComponent<TableProps>;
+
+export default Table;

--- a/src/Table/TableBody.d.ts
+++ b/src/Table/TableBody.d.ts
@@ -4,4 +4,6 @@ import { StyledComponent } from '..';
 export interface TableBodyProps
   extends React.HTMLAttributes<HTMLTableSectionElement> {}
 
-export default class TableBody extends StyledComponent<TableBodyProps> {}
+declare const TableBody: StyledComponent<TableBodyProps>;
+
+export default TableBody;

--- a/src/Table/TableCell.d.ts
+++ b/src/Table/TableCell.d.ts
@@ -17,4 +17,6 @@ export type TableCellProps = {
 } & React.ThHTMLAttributes<HTMLTableHeaderCellElement> &
   React.TdHTMLAttributes<HTMLTableDataCellElement>;
 
-export default class TableCell extends StyledComponent<TableCellProps> {}
+declare const TableCell: StyledComponent<TableCellProps>;
+
+export default TableCell;

--- a/src/Table/TableFooter.d.ts
+++ b/src/Table/TableFooter.d.ts
@@ -4,4 +4,6 @@ import { StyledComponent } from '..';
 export interface TableFooterProps
   extends React.HTMLAttributes<HTMLTableSectionElement> {}
 
-export default class TableFooter extends StyledComponent<TableFooterProps> {}
+declare const TableFooter: StyledComponent<TableFooterProps>;
+
+export default TableFooter;

--- a/src/Table/TableHead.d.ts
+++ b/src/Table/TableHead.d.ts
@@ -4,4 +4,6 @@ import { StyledComponent } from '..';
 export interface TableHeadProps
   extends React.HTMLAttributes<HTMLTableSectionElement> {}
 
-export default class TableHead extends StyledComponent<TableHeadProps> {}
+declare const TableHead: StyledComponent<TableHeadProps>;
+
+export default TableHead;

--- a/src/Table/TablePagination.d.ts
+++ b/src/Table/TablePagination.d.ts
@@ -19,4 +19,6 @@ export interface TablePaginationProps {
   rowsPerPageOptions?: number[];
 }
 
-export default class TablePagination extends StyledComponent<TablePaginationProps> {}
+declare const TablePagination: StyledComponent<TablePaginationProps>;
+
+export default TablePagination;

--- a/src/Table/TableRow.d.ts
+++ b/src/Table/TableRow.d.ts
@@ -7,4 +7,6 @@ export interface TableRowProps
   selected?: boolean;
 }
 
-export default class TableRow extends StyledComponent<TableRowProps> {}
+declare const TableRow: StyledComponent<TableRowProps>;
+
+export default TableRow;

--- a/src/Table/TableSortLabel.d.ts
+++ b/src/Table/TableSortLabel.d.ts
@@ -7,6 +7,6 @@ export interface TableSortLabelProps extends ButtonBaseProps {
   direction?: 'asc' | 'desc';
 }
 
-export default class TableSortLabel extends StyledComponent<
-  TableSortLabelProps
-> {}
+declare const TableSortLabel: StyledComponent<TableSortLabelProps>;
+
+export default TableSortLabel;

--- a/src/Tabs/Tab.d.ts
+++ b/src/Tabs/Tab.d.ts
@@ -18,4 +18,6 @@ export type TabProps = {
   textColor?: string | 'accent' | 'primary' | 'inherit';
 } & Partial<Omit<ButtonBaseProps, 'onChange'>>;
 
-export default class Tab extends StyledComponent<TabProps> {}
+declare const Tab: StyledComponent<TabProps>;
+
+export default Tab;

--- a/src/Tabs/TabIndicator.d.ts
+++ b/src/Tabs/TabIndicator.d.ts
@@ -7,4 +7,6 @@ export interface TabIndicatorProps
   style: { left: number; width: number };
 }
 
-export default class TabIndicator extends StyledComponent<TabIndicatorProps> {}
+declare const TabIndicator: StyledComponent<TabIndicatorProps>;
+
+export default TabIndicator;

--- a/src/Tabs/TabScrollButton.d.ts
+++ b/src/Tabs/TabScrollButton.d.ts
@@ -7,6 +7,6 @@ export interface TabScrollButtonProps extends ButtonBaseProps {
   visible?: boolean;
 }
 
-export default class TabScrollButton extends StyledComponent<
-  TabScrollButtonProps
-> {}
+declare const TabScrollButton: StyledComponent<TabScrollButtonProps>;
+
+export default TabScrollButton;

--- a/src/Tabs/Tabs.d.ts
+++ b/src/Tabs/Tabs.d.ts
@@ -17,4 +17,6 @@ export type TabsProps = {
   width?: string;
 } & Partial<Omit<ButtonBaseProps, 'onChange'>>;
 
-export default class Tabs extends StyledComponent<TabsProps> {}
+declare const Tabs: StyledComponent<TabsProps>;
+
+export default Tabs;

--- a/src/TextField/TextField.d.ts
+++ b/src/TextField/TextField.d.ts
@@ -37,4 +37,6 @@ export type TextFieldProps = {
   margin?: PropTypes.Margin;
 } & FormControlProps;
 
-export default class Input extends StyledComponent<TextFieldProps> {}
+declare const Input: StyledComponent<TextFieldProps>;
+
+export default Input;

--- a/src/Toolbar/Toolbar.d.ts
+++ b/src/Toolbar/Toolbar.d.ts
@@ -5,4 +5,6 @@ export interface ToolbarProps extends React.HTMLAttributes<HTMLDivElement> {
   disableGutters?: boolean;
 }
 
-export default class Toolbar extends StyledComponent<ToolbarProps> {}
+declare const Toolbar: StyledComponent<ToolbarProps>;
+
+export default Toolbar;

--- a/src/Tooltip/Tooltip.d.ts
+++ b/src/Tooltip/Tooltip.d.ts
@@ -21,4 +21,6 @@ export type TooltipProps = React.HTMLAttributes<HTMLDivElement> & {
     | 'top';
 }
 
-export default class Tooltip extends StyledComponent<TooltipProps> {}
+declare const Tooltip: StyledComponent<TooltipProps>;
+
+export default Tooltip;

--- a/src/Typography/Typography.d.ts
+++ b/src/Typography/Typography.d.ts
@@ -13,4 +13,6 @@ export interface TypographyProps extends React.HTMLAttributes<HTMLElement> {
   type?: Style | 'caption' | 'button';
 }
 
-export default class Typography extends StyledComponent<TypographyProps> {}
+declare const Typography: StyledComponent<TypographyProps>;
+
+export default Typography;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,9 +18,8 @@ export interface StyledComponentProps<Names extends string = string> {
   style?: Partial<React.CSSProperties>;
   innerRef?: React.Ref<any>;
 }
-export class StyledComponent<P = {}, Names extends string = string> extends React.Component<
-  P & StyledComponentProps<Names>
-> {}
+export type StyledComponent<P = {}, Names extends string = string> =
+  React.ComponentType<P & StyledComponentProps<Names>>
 
 export type Contrast = 'light' | 'dark' | 'brown';
 export interface Color {

--- a/src/internal/Backdrop.d.ts
+++ b/src/internal/Backdrop.d.ts
@@ -7,4 +7,6 @@ export interface BackdropProps {
   [prop: string]: any;
 }
 
-export default class Backdrop extends StyledComponent<BackdropProps> {}
+declare const Backdrop: StyledComponent<BackdropProps>;
+
+export default Backdrop;

--- a/src/internal/Modal.d.ts
+++ b/src/internal/Modal.d.ts
@@ -20,4 +20,6 @@ export type ModalProps = {
 } & Partial<TransitionHandlers> &
   React.HtmlHTMLAttributes<HTMLDivElement>;
 
-export default class Modal extends StyledComponent<ModalProps> {}
+declare const Modal: StyledComponent<ModalProps>;
+
+export default Modal;

--- a/src/internal/SwitchBase.d.ts
+++ b/src/internal/SwitchBase.d.ts
@@ -20,7 +20,7 @@ export interface SwitchBaseProps {
   value?: string;
 }
 
-export class SwitchBase extends StyledComponent<SwitchBaseProps> {}
+export type SwitchBase = StyledComponent<SwitchBaseProps>
 
 export interface CreateSwitchBaseOptions {
   defaultIcon?: React.ReactNode;

--- a/src/styles/withStyles.d.ts
+++ b/src/styles/withStyles.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ClassNameMap, StyledComponentProps } from '..';
+import { ClassNameMap, StyledComponentProps, StyledComponent } from '..';
 import { Theme } from './createMuiTheme';
 
 /**
@@ -32,7 +32,7 @@ export default function withStyles<Names extends string>(
    */
   <P>(
     component: React.StatelessComponent<P & WithStyles<Names>>
-  ): React.ComponentType<P & StyledComponentProps<Names>>;
+  ): StyledComponent<P, Names>;
 
   /**
    * Decorating a class component. This is slightly less type safe than the

--- a/src/transitions/Collapse.d.ts
+++ b/src/transitions/Collapse.d.ts
@@ -8,4 +8,6 @@ export interface CollapseProps extends TransitionProps {
   transitionDuration?: number | string;
 }
 
-export default class Collapse extends StyledComponent<CollapseProps> {}
+declare const Collapse: StyledComponent<CollapseProps>;
+
+export default Collapse;

--- a/src/transitions/Fade.d.ts
+++ b/src/transitions/Fade.d.ts
@@ -9,4 +9,6 @@ export interface FadeProps extends TransitionProps {
   leaveTransitionDuration?: number;
 }
 
-export default class Fade extends StyledComponent<FadeProps> {}
+declare const Fade: StyledComponent<FadeProps>;
+
+export default Fade;

--- a/src/transitions/Grow.d.ts
+++ b/src/transitions/Grow.d.ts
@@ -8,4 +8,6 @@ export interface GrowProps extends TransitionProps {
   transitionDuration?: number | string;
 }
 
-export default class Grow extends StyledComponent<GrowProps> {}
+declare const Grow: StyledComponent<GrowProps>;
+
+export default Grow;

--- a/src/transitions/Slide.d.ts
+++ b/src/transitions/Slide.d.ts
@@ -11,4 +11,6 @@ export interface SlideProps extends TransitionProps {
   leaveTransitionDuration?: number;
 }
 
-export default class Slide extends StyledComponent<SlideProps> {}
+declare const Slide: StyledComponent<SlideProps>;
+
+export default Slide;

--- a/test/typescript/styles.spec.tsx
+++ b/test/typescript/styles.spec.tsx
@@ -9,6 +9,7 @@ import {
   withTheme,
 } from '../../src/styles';
 import Button from '../../src/Button/Button';
+import { StyledComponentProps } from '../../src/index'
 
 const styles = ({ palette, spacing }) => ({
   root: {
@@ -108,7 +109,7 @@ const AllTheComposition = withTheme(
 );
 
 @withStyles(styles)
-class DecoratedComponent extends StyledComponent<NonStyleProps, 'root'> {
+class DecoratedComponent extends React.Component<NonStyleProps & StyledComponentProps<'root'>> {
   render() {
     const { classes, text } = this.props;
     return (


### PR DESCRIPTION
In the current TypeScript typings, `StyledComponent` is defined as a class which extends `React.Component`, which doesn't reflect the reality of the underlying JS code. This leads one to believe that one can extend `StyledComponent` as if it were a class, which it's not:

```ts
import { StyledComponent } from 'material-ui'

class Foo extends StyledComponent {
  render() { return <div>hi</div> }
}

<Foo />
```

The above will pass the type checker but lead to a runtime error, because no value `StyledComponent` is actually exported from `material-ui`.

By extension, all the `material-ui` components are defined as being classes which extend this base class, but
1. many of them are just functional components, not classes at all
1. even the ones which are classes directly extend `React.Component`, not `StyledComponent` which is not actually a class.

This PR fixes the typing of `StyledComponent` by declaring it to just be a type, not a class, and changes all components to not _extend_ that type, but simply to _have_ that type.