### PR TITLE
[Collapse] Implement the ability to set the collapsed height through props

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -7,7 +7,6 @@ import IconButton from 'material-ui/IconButton';
 import Collapse from 'material-ui/transitions/Collapse';
 import CodeIcon from 'material-ui-icons/Code';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
-import NoSSR from 'docs/src/modules/components/NoSSR';
 import Tooltip from 'material-ui/Tooltip';
 
 const styles = theme => ({
@@ -79,10 +78,8 @@ class Demo extends React.Component<any, any> {
             <CodeIcon />
           </IconButton>
         </Tooltip>
-        <Collapse in={this.state.codeOpen}>
-          <NoSSR>
-            <MarkdownElement className={classes.code} text={`\`\`\`js\n${raw}\n\`\`\``} />
-          </NoSSR>
+        <Collapse in={this.state.codeOpen} unmountOnExit>
+          <MarkdownElement className={classes.code} text={`\`\`\`js\n${raw}\n\`\`\``} />
         </Collapse>
         <div className={classes.demo} data-mui-demo={name}>
           <DemoComponent />

--- a/pages/api/collapse.md
+++ b/pages/api/collapse.md
@@ -14,6 +14,7 @@ filename: /src/transitions/Collapse.js
 |:-----|:-----|:--------|:------------|
 | children | Node |  | The content node to be collapsed. |
 | classes | Object |  | Useful to extend the style applied to components. |
+| collapsedHeight | string | '0px' | The height of the container when collapsed. |
 | in | boolean | false | If `true`, the component will transition in. |
 | onEnter | TransitionCallback |  | Callback fired before the component is entering. |
 | onEntered | TransitionCallback |  | Callback fired when the component has entered. |

--- a/src/transitions/Collapse.js
+++ b/src/transitions/Collapse.js
@@ -25,6 +25,7 @@ export type TransitionDuration = number | { enter?: number, exit?: number } | 'a
 
 type ProvidedProps = {
   classes: Object,
+  collapsedHeight: string,
   transitionDuration: TransitionDuration,
   theme: Object,
 };
@@ -38,6 +39,10 @@ export type Props = {
    * Useful to extend the style applied to components.
    */
   classes?: Object,
+  /**
+   * The height of the container when collapsed.
+   */
+  collapsedHeight?: string,
   /**
    * If `true`, the component will transition in.
    */
@@ -81,16 +86,16 @@ export type Props = {
 
 class Collapse extends React.Component<ProvidedProps & Props> {
   static defaultProps = {
+    collapsedHeight: '0px',
     in: false,
     transitionDuration: duration.standard,
   };
 
   wrapper = null;
-
   autoTransitionDuration = undefined;
 
   handleEnter = element => {
-    element.style.height = '0px';
+    element.style.height = this.props.collapsedHeight;
     if (this.props.onEnter) {
       this.props.onEnter(element);
     }
@@ -154,7 +159,7 @@ class Collapse extends React.Component<ProvidedProps & Props> {
       }
     }
 
-    element.style.height = '0px';
+    element.style.height = this.props.collapsedHeight;
     if (this.props.onExiting) {
       this.props.onExiting(element);
     }
@@ -171,6 +176,7 @@ class Collapse extends React.Component<ProvidedProps & Props> {
     const {
       children,
       classes,
+      collapsedHeight,
       onEnter,
       onEntering,
       onEntered,
@@ -190,6 +196,10 @@ class Collapse extends React.Component<ProvidedProps & Props> {
         onExiting={this.handleExiting}
         onExit={this.handleExit}
         onRequestTimeout={this.handleRequestTimeout}
+        style={{
+          // For supporting server side rendering.
+          minHeight: this.props.collapsedHeight,
+        }}
         {...other}
       >
         <div className={classes.container}>

--- a/src/transitions/Collapse.spec.js
+++ b/src/transitions/Collapse.spec.js
@@ -233,15 +233,10 @@ describe('<Collapse />', () => {
     });
 
     describe('handleExit()', () => {
-      let element;
-
-      before(() => {
-        element = { style: { height: 'auto' } };
+      it('should set height to the wrapper height', () => {
+        const element = { style: { height: 'auto' } };
         instance.wrapper = { clientHeight: 666 };
         instance.handleExit(element);
-      });
-
-      it('should set height to the wrapper height', () => {
         assert.strictEqual(element.style.height, '666px', 'should have 666px height');
       });
     });
@@ -370,6 +365,23 @@ describe('<Collapse />', () => {
 
     it('instance should have a wrapper property', () => {
       assert.notStrictEqual(mountInstance.wrapper, undefined);
+    });
+  });
+
+  describe('prop: collapsedHeight', () => {
+    const collapsedHeight = '10px';
+
+    it('should work when closed', () => {
+      const wrapper = shallow(<Collapse collapsedHeight={collapsedHeight} />);
+      assert.strictEqual(wrapper.props().style.minHeight, collapsedHeight);
+    });
+
+    it('should be taken into account in handleExiting', () => {
+      const wrapper = shallow(<Collapse collapsedHeight={collapsedHeight} />);
+      const instance = wrapper.instance();
+      const element = { style: { height: 666, transitionDuration: undefined } };
+      instance.handleExiting(element);
+      assert.strictEqual(element.style.height, collapsedHeight, 'should have 0px height');
     });
   });
 });

--- a/src/transitions/Slide.js
+++ b/src/transitions/Slide.js
@@ -182,10 +182,10 @@ class Slide extends React.Component<ProvidedProps & Props> {
         onExit={this.handleExit}
         timeout={transitionDuration}
         transitionAppear
-        {...other}
-        ref={ref => {
-          this.transition = ref;
+        ref={node => {
+          this.transition = node;
         }}
+        {...other}
       >
         {children}
       </Transition>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

For https://github.com/callemall/material-ui/issues/8235, so that the `Collapse` component takes a `collapsedHeight` prop to allow setting a custom height for the container to collapse to. 

For instance,
<img width="919" alt="screen shot 2017-09-24 at 6 30 06 pm" src="https://user-images.githubusercontent.com/25375401/30788937-a244bf32-a156-11e7-8f11-21642d039371.png">

will do this:

![hddcjohkhp](https://user-images.githubusercontent.com/25375401/30788941-aca82b1c-a156-11e7-86a7-142c801c085c.gif)

This is my first PR, so hopefully, my implementation looks alright. Please let me know if there is any improvement you have in mind. 😄 