### PR TITLE
[docs] Select API default value for input prop

### DIFF
--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -160,7 +160,7 @@ function generateProps(reactAPI) {
       let defaultValue = '';
 
       if (prop.defaultValue) {
-        defaultValue = prop.defaultValue.value.replace(/\n/g, '');
+        defaultValue = prop.defaultValue.value.replace(/\n/g, '').replace(/</g, '&lt;');
       }
 
       if (prop.required) {

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -16,7 +16,7 @@
 | disabledClassName | string |  | The CSS class name of the root element when disabled. |
 | icon | Node |  | The icon to display when the component is unchecked. If a string is provided, it will be used as a font ligature. |
 | indeterminate | boolean | false | If `true`, the component appears indeterminate. |
-| indeterminateIcon | Node | <IndeterminateCheckBoxIcon /> | The icon to display when the component is indeterminate. If a string is provided, it will be used as a font ligature. |
+| indeterminateIcon | Node | &lt;IndeterminateCheckBoxIcon /> | The icon to display when the component is indeterminate. If a string is provided, it will be used as a font ligature. |
 | inputProps | Object |  | Properties applied to the `input` element. |
 | inputRef | Function |  | Use that property to pass a ref callback to the native input component. |
 | name | string |  |  |

--- a/pages/api/drawer.md
+++ b/pages/api/drawer.md
@@ -25,12 +25,14 @@ Any other properties supplied will be [spread to the root element](/customizatio
 
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
-- `paper`
-- `anchorLeft`
-- `anchorRight`
-- `anchorTop`
-- `anchorBottom`
 - `docked`
+- `paper`
+- `paperAnchorLeft`
+- `paperAnchorRight`
+- `paperAnchorTop`
+- `paperAnchorBottom`
+- `paperAnchorDockedLeft`
+- `paperAnchorDockedRight`
 - `modal`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes)

--- a/pages/api/select.md
+++ b/pages/api/select.md
@@ -10,7 +10,7 @@
 | MenuProps | Object |  | Properties applied to the `Menu` element. |
 | <span style="color: #31a148">children *</span> | ChildrenArray |  | The option elements to populate the select with. Can be some `MenuItem` when `native` is false and `option` when `native` is true. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| input | Element | <Input /> | An `Input` element. |
+| input | Element | &lt;Input /> | An `Input` element. |
 | multiple | boolean | false | If true, `value` must be an array and the menu will support multiple selections. |
 | native | boolean | false | If `true`, the component will be using a native `select` element. |
 | renderValue | Function |  | Render the selected value. It's only useful when the `native` property is not set to `true`. |

--- a/pages/api/table-cell.md
+++ b/pages/api/table-cell.md
@@ -7,13 +7,11 @@
 ## Props
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| checkbox | bool | false | If `true`, the cell padding will be adjusted to accommodate a checkbox. |
-| children | node |  | The table cell contents. |
-| classes | object |  | Useful to extend the style applied to components. |
-| compact | bool | false | If `true`, compact cell padding will be used to accommodate more content. |
-| component | string | null | The component used for the root node. Either a string to use a DOM element or a component. |
-| disablePadding | bool | false | If `true`, left/right cell padding will be disabled. |
-| numeric | bool | false | If `true`, content will align to the right. |
+| children | Node |  | The table cell contents. |
+| classes | Object |  | Useful to extend the style applied to components. |
+| component | ElementType | null | The component used for the root node. Either a string to use a DOM element or a component. |
+| numeric | boolean | false | If `true`, content will align to the right. |
+| padding | union:&nbsp;'default'<br>&nbsp;'checkbox'<br>&nbsp;'dense'<br>&nbsp;'none'<br> | 'default' | Sets the padding applied to the cell. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 
@@ -25,7 +23,7 @@ This property accepts the following keys:
 - `numeric`
 - `head`
 - `padding`
-- `compact`
+- `dense`
 - `checkbox`
 - `footer`
 

--- a/pages/api/table-row.md
+++ b/pages/api/table-row.md
@@ -8,11 +8,11 @@ based on the material table element parent (head, body, etc).
 ## Props
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| children | node |  | Should be valid `<tr>` children such as `TableCell`. |
-| classes | object |  | Useful to extend the style applied to components. |
+| children | Node |  | Should be valid `<tr>` children such as `TableCell`. |
+| classes | Object |  | Useful to extend the style applied to components. |
 | component | string | 'tr' | The component used for the root node. Either a string to use a DOM element or a component. |
-| hover | bool | false | If `true`, the table row will shade on hover. |
-| selected | bool | false | If `true`, the table row will have the selected shading. |
+| hover | boolean | false | If `true`, the table row will shade on hover. |
+| selected | boolean | false | If `true`, the table row will have the selected shading. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/table-sort-label.md
+++ b/pages/api/table-sort-label.md
@@ -7,10 +7,10 @@ A button based label for placing inside `TableCell` for column sorting.
 ## Props
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| active | bool | false | If `true`, the label will have the active styling (should be true for the sorted column). |
-| children | node |  | Label contents, the arrow will be appended automatically. |
-| classes | object |  | Useful to extend the style applied to components. |
-| direction | enum:&nbsp;'asc'<br>&nbsp;'desc'<br> | 'desc' | The current sort direction. |
+| active | boolean | false | If `true`, the label will have the active styling (should be true for the sorted column). |
+| children | Node |  | Label contents, the arrow will be appended automatically. |
+| classes | Object |  | Useful to extend the style applied to components. |
+| direction | union:&nbsp;'asc'<br>&nbsp;'desc'<br> | 'desc' | The current sort direction. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/tabs.md
+++ b/pages/api/tabs.md
@@ -32,6 +32,7 @@ This property accepts the following keys:
 - `fixed`
 - `scrollable`
 - `centered`
+- `buttonAuto`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes)
 section for more detail.


### PR DESCRIPTION
The markdown was being rendered as an actual input field on the doc site and not at all when viewed on github.  Left angle bracket needs to be `&lt;` (as mentioned on [gruber's syntax docs](https://daringfireball.net/projects/markdown/syntax#autoescape))

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
