### PR TITLE
[styles] More permissive class name generator warning

### DIFF
--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -323,7 +323,7 @@ class Popover extends React.Component<DefaultProps & Props> {
       warning(
         this.props.anchorOrigin.vertical === 'top',
         [
-          'Material-UI: You can change the `anchorOrigin.vertical` value when also ',
+          'Material-UI: you can change the `anchorOrigin.vertical` value when also ',
           'providing the `getContentAnchorEl` property. Pick one.',
         ].join(),
       );

--- a/src/styles/createGenerateClassName.js
+++ b/src/styles/createGenerateClassName.js
@@ -15,16 +15,19 @@ let generatorCounter = 0;
 export default function createGenerateClassName(): generateClassName {
   let ruleCounter = 0;
 
-  if (process.env.NODE_ENV !== 'test' && typeof window !== 'undefined') {
+  if (process.env.NODE_ENV === 'production' && typeof window !== 'undefined') {
     generatorCounter += 1;
 
-    warning(
-      generatorCounter === 1,
-      [
-        'Material-UI: You can only instantiate one class name generator on the client side.',
-        'If you do otherwise, you take the risk to have conflicting class names in production.',
-      ].join('\n'),
-    );
+    if (generatorCounter > 2) {
+      // eslint-disable-next-line no-console
+      console.error(
+        [
+          'Material-UI: we have detected more than needed creation of the class name generator.',
+          'You should only use one class name generator on the client side.',
+          'If you do otherwise, you take the risk to have conflicting class names in production.',
+        ].join('\n'),
+      );
+    }
   }
 
   return (rule: Rule, sheet?: StyleSheet): string => {

--- a/src/styles/createGenerateClassName.spec.js
+++ b/src/styles/createGenerateClassName.spec.js
@@ -2,6 +2,7 @@
 
 import { assert } from 'chai';
 import createGenerateClassName from './createGenerateClassName';
+import consoleErrorMock from '../../test/utils/consoleErrorMock';
 
 describe('createGenerateClassName', () => {
   describe('counter', () => {
@@ -60,10 +61,12 @@ describe('createGenerateClassName', () => {
       before(() => {
         nodeEnv = env.NODE_ENV;
         env.NODE_ENV = 'production';
+        consoleErrorMock.spy();
       });
 
       after(() => {
         env.NODE_ENV = nodeEnv;
+        consoleErrorMock.reset();
       });
 
       it('should us a short representation', () => {
@@ -72,6 +75,16 @@ describe('createGenerateClassName', () => {
         };
         const generateClassName = createGenerateClassName();
         assert.strictEqual(generateClassName(rule), 'c1');
+      });
+
+      it('should warn', () => {
+        createGenerateClassName();
+        createGenerateClassName();
+        assert.strictEqual(consoleErrorMock.callCount() > 0, true);
+        assert.match(
+          consoleErrorMock.args()[0][0],
+          /Material-UI: we have detected more than needed creation of the/,
+        );
       });
     });
   });


### PR DESCRIPTION
Adding the warning in dev mode is challenging as you might end up in a situation where you hot reload your top component, creating a new class name generator and propagating it down the react tree. This is fine.
I'm gonna narrow the warning to the production env, where people will notice the issue. This should help, a bit.

Closes #8367