### PR TITLE
[docs] Add FormDialog Example

### DIFF
--- a/docs/src/pages/demos/dialogs/FormDialog.js
+++ b/docs/src/pages/demos/dialogs/FormDialog.js
@@ -1,0 +1,56 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+
+import React from 'react';
+import Button from 'material-ui/Button';
+import TextField from 'material-ui/TextField';
+import Dialog, {
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from 'material-ui/Dialog';
+
+export default class AlertDialog extends React.Component {
+  state = {
+    open: false,
+  };
+
+  handleClickOpen = () => {
+    this.setState({ open: true });
+  };
+
+  handleRequestClose = () => {
+    this.setState({ open: false });
+  };
+
+  render() {
+    return (
+      <div>
+        <Button onClick={this.handleClickOpen}>Open form dialog</Button>
+        <Dialog open={this.state.open} onRequestClose={this.handleRequestClose}>
+          <DialogTitle>{"Subscribe"}</DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              To subscribe to this website, please enter your email address here. We will send
+              updates occationally.
+            </DialogContentText>
+            <TextField
+              id="name"
+              label="Email Address"
+              fullWidth
+              type='email'
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={this.handleRequestClose} color="default">
+              Cancel
+            </Button>
+            <Button onClick={this.handleRequestClose} color="primary">
+              Subscribe
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </div>
+    );
+  }
+}

--- a/docs/src/pages/demos/dialogs/FormDialog.js
+++ b/docs/src/pages/demos/dialogs/FormDialog.js
@@ -28,18 +28,13 @@ export default class AlertDialog extends React.Component {
       <div>
         <Button onClick={this.handleClickOpen}>Open form dialog</Button>
         <Dialog open={this.state.open} onRequestClose={this.handleRequestClose}>
-          <DialogTitle>{"Subscribe"}</DialogTitle>
+          <DialogTitle>{'Subscribe'}</DialogTitle>
           <DialogContent>
             <DialogContentText>
               To subscribe to this website, please enter your email address here. We will send
               updates occationally.
             </DialogContentText>
-            <TextField
-              id="name"
-              label="Email Address"
-              fullWidth
-              type='email'
-            />
+            <TextField id="name" label="Email Address" type="email" fullWidth />
           </DialogContent>
           <DialogActions>
             <Button onClick={this.handleRequestClose} color="default">

--- a/docs/src/pages/demos/dialogs/FormDialog.js
+++ b/docs/src/pages/demos/dialogs/FormDialog.js
@@ -10,7 +10,7 @@ import Dialog, {
   DialogTitle,
 } from 'material-ui/Dialog';
 
-export default class AlertDialog extends React.Component {
+export default class FormDialog extends React.Component {
   state = {
     open: false,
   };
@@ -34,10 +34,17 @@ export default class AlertDialog extends React.Component {
               To subscribe to this website, please enter your email address here. We will send
               updates occationally.
             </DialogContentText>
-            <TextField id="name" label="Email Address" type="email" fullWidth />
+            <TextField
+              autoFocus
+              margin="dense"
+              id="name"
+              label="Email Address"
+              type="email"
+              fullWidth
+            />
           </DialogContent>
           <DialogActions>
-            <Button onClick={this.handleRequestClose} color="default">
+            <Button onClick={this.handleRequestClose} color="primary">
               Cancel
             </Button>
             <Button onClick={this.handleRequestClose} color="primary">

--- a/docs/src/pages/demos/dialogs/dialogs.md
+++ b/docs/src/pages/demos/dialogs/dialogs.md
@@ -57,6 +57,13 @@ Touching “Cancel” in a confirmation dialog, or pressing Back, cancels the ac
 
 {{demo='pages/demos/dialogs/FullScreenDialog.js'}}
 
+## Form dialogs
+
+Form dialogs allow users to fill out form fields within a dialog.
+For example, if your site prompts for potential subscribers to fill in their email address, they can fill out the email field and touch 'Submit'
+
+{{demo='pages/demos/dialogs/FormDialog.js'}}
+
 ## Responsive full-screen
 
 You may make a `Dialog` responsively full screen the dialog using `withResponsiveFullScreen`. By default, `withResponsiveFullScreen()(Dialog)` responsively full screens *at or below* the `sm` [screen size](/layout/basics).

--- a/pages/demos/dialogs.js
+++ b/pages/demos/dialogs.js
@@ -50,8 +50,8 @@ module.exports = require('fs')
           raw: preval`
 module.exports = require('fs')
   .readFileSync(require.resolve('docs/src/pages/demos/dialogs/FormDialog'), 'utf8')
-`
-        }
+`,
+        },
       }}
     />
   );

--- a/pages/demos/dialogs.js
+++ b/pages/demos/dialogs.js
@@ -45,6 +45,13 @@ module.exports = require('fs')
   .readFileSync(require.resolve('docs/src/pages/demos/dialogs/FullScreenDialog'), 'utf8')
 `,
         },
+        'pages/demos/dialogs/FormDialog.js': {
+          js: require('docs/src/pages/demos/dialogs/FormDialog').default,
+          raw: preval`
+module.exports = require('fs')
+  .readFileSync(require.resolve('docs/src/pages/demos/dialogs/FormDialog'), 'utf8')
+`
+        }
       }}
     />
   );


### PR DESCRIPTION
When going through the new docs to implement the project in my personal app, I thought that a forms dialog example would be helpful.