### PR TITLE
[TablePagination] Add the missing TablePagination export in src/index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,7 @@ export {
   TableHead,
   TableRow,
   TableSortLabel,
-  TablePagination
+  TablePagination,
 } from './Table';
 export { default as Tabs, Tab } from './Tabs';
 export { default as Typography } from './Typography';

--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,7 @@ export {
   TableHead,
   TableRow,
   TableSortLabel,
+  TablePagination
 } from './Table';
 export { default as Tabs, Tab } from './Tabs';
 export { default as Typography } from './Typography';

--- a/src/index.js
+++ b/src/index.js
@@ -53,10 +53,11 @@ export {
   default as Table,
   TableBody,
   TableCell,
+  TableFooter,
   TableHead,
+  TablePagination,
   TableRow,
   TableSortLabel,
-  TablePagination,
 } from './Table';
 export { default as Tabs, Tab } from './Tabs';
 export { default as Typography } from './Typography';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Obviously it is missing... and caused issue https://github.com/callemall/material-ui/issues/8424