### PR TITLE
[typescript] Remove key prop from Snackbar

### DIFF
--- a/src/Snackbar/Snackbar.d.ts
+++ b/src/Snackbar/Snackbar.d.ts
@@ -12,7 +12,6 @@ export type SnackbarProps = {
   autoHideDuration?: number;
   resumeHideDuration?: number;
   enterTransitionDuration?: number;
-  key?: number;
   leaveTransitionDuration?: number;
   message?: React.ReactElement<any>;
   onMouseEnter?: React.MouseEventHandler<any>;


### PR DESCRIPTION
The prop `key` should not be part of the Snackbar props for the following reasons:
* `key` is a special prop that is automatically declared for every React component
* `key` is defined to be `string | number | null` in general (not `number` as was here – way too restrictive)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->