### PR TITLE
Fix common colors typings

### DIFF
--- a/src/colors/common.d.ts
+++ b/src/colors/common.d.ts
@@ -1,25 +1,15 @@
-declare const black: string;
-declare const white: string;
-declare const transparent: string;
-declare const fullBlack: string;
-declare const darkBlack: string;
-declare const lightBlack: string;
-declare const minBlack: string;
-declare const faintBlack: string;
-declare const fullWhite: string;
-declare const darkWhite: string;
-declare const lightWhite: string;
-
-export default {
-  black,
-  white,
-  transparent,
-  fullBlack,
-  darkBlack,
-  lightBlack,
-  minBlack,
-  faintBlack,
-  fullWhite,
-  darkWhite,
-  lightWhite
+declare const common: {
+  black: string;
+  white: string;
+  transparent: string;
+  fullBlack: string;
+  darkBlack: string;
+  lightBlack: string;
+  minBlack: string;
+  faintBlack: string;
+  fullWhite: string;
+  darkWhite: string;
+  lightWhite: string;
 };
+
+export default common;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
The file, as it is, is not a valid definitions file. You can't have values in `.d.ts` and default export expression takes a variable or an expression which is the treated as a value. This PR fixes that by declaring a variable which has only a type.