### PR TITLE
[Typography] Add error option to color prop, update API docs page

### DIFF
--- a/pages/api/typography.md
+++ b/pages/api/typography.md
@@ -10,7 +10,7 @@
 | align | union:&nbsp;'inherit', 'left', 'center', 'right', 'justify'<br> | 'inherit' |  |
 | children | Node |  |  |
 | classes | Object |  | Useful to extend the style applied to components. |
-| color | union:&nbsp;'inherit', 'primary', 'secondary', 'accent', 'default'<br> | 'default' | The color of the component. It's using the theme palette when that makes sense. |
+| color | union:&nbsp;'inherit', 'primary', 'secondary', 'accent', 'error', 'default'<br> | 'default' | The color of the component. It's using the theme palette when that makes sense. |
 | component | ElementType |  | The component used for the root node. Either a string to use a DOM element or a component. By default we map the type to a good default headline component. |
 | gutterBottom | boolean | false | If `true`, the text will have a bottom margin. |
 | headlineMapping | signature | {  display4: 'h1',  display3: 'h1',  display2: 'h1',  display1: 'h1',  headline: 'h1',  title: 'h2',  subheading: 'h3',  body2: 'aside',  body1: 'p',} | We are empirically mapping the type property to a range of different DOM element type. For instance, h1 to h6. If you wish to change that mapping, you can provide your own. Alternatively, you can use the `component` property. |
@@ -47,6 +47,7 @@ This property accepts the following keys:
 - `colorPrimary`
 - `colorSecondary`
 - `colorAccent`
+- `colorError`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes)
 section for more detail.

--- a/src/Typography/Typography.d.ts
+++ b/src/Typography/Typography.d.ts
@@ -5,7 +5,7 @@ import { Style, TextStyle } from '../styles/createTypography';
 export interface TypographyProps extends React.HTMLAttributes<HTMLElement> {
   align?: PropTypes.Alignment;
   component?: React.ReactType;
-  color?: PropTypes.Color | 'secondary';
+  color?: PropTypes.Color | 'secondary' | 'error';
   gutterBottom?: boolean;
   headlineMapping?: { [type in TextStyle]: string };
   noWrap?: boolean;

--- a/src/Typography/Typography.js
+++ b/src/Typography/Typography.js
@@ -57,6 +57,9 @@ export const styles = (theme: Object) => ({
   colorAccent: {
     color: theme.palette.secondary.A400,
   },
+  colorError: {
+    color: theme.palette.error.A400,
+  },
 });
 
 export type Type =
@@ -98,7 +101,7 @@ export type Props = {
   /**
    * The color of the component. It's using the theme palette when that makes sense.
    */
-  color?: 'inherit' | 'primary' | 'secondary' | 'accent' | 'default',
+  color?: 'inherit' | 'primary' | 'secondary' | 'accent' | 'error' | 'default',
   /**
    * If `true`, the text will have a bottom margin.
    */

--- a/src/Typography/Typography.spec.js
+++ b/src/Typography/Typography.spec.js
@@ -69,6 +69,7 @@ describe('<Typography />', () => {
     ['secondary', 'colorSecondary'],
     ['accent', 'colorAccent'],
     ['inherit', 'colorInherit'],
+    ['error', 'colorError'],
   ].forEach(([color, className]) => {
     it(`should render ${color} color`, () => {
       const wrapper = shallow(<Typography color={(color: any)}>Hello</Typography>);


### PR DESCRIPTION
This is a follow-up to #8440, additionally adding the error color (using `A400`, same as FormHelperText errors), and updating the API docs page with the two new options.