### PR TITLE
[Transition] Rich transitionDuration property

### DIFF
--- a/pages/api/collapse.md
+++ b/pages/api/collapse.md
@@ -16,7 +16,7 @@
 | onExit | TransitionCallback |  | Callback fired before the component is exiting. |
 | onExited | TransitionCallback |  | Callback fired when the component has exited. |
 | onExiting | TransitionCallback |  | Callback fired when the component is exiting. |
-| transitionDuration | union:&nbsp;number<br>&nbsp;'auto'<br> | 300 | Set to 'auto' to automatically calculate transition time based on height. |
+| transitionDuration | union:&nbsp;number<br>&nbsp;{ enter?: number, exit?: number }<br>&nbsp;'auto'<br> | duration.standard | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/dialog.md
+++ b/pages/api/dialog.md
@@ -9,12 +9,10 @@ Dialogs are overlaid modal paper based components with a backdrop.
 |:-----|:-----|:--------|:------------|
 | children | Node |  | Dialog children, usually the included sub-components. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| enterTransitionDuration | number | duration.enteringScreen | Duration of the animation when the element is entering. |
 | fullScreen | boolean | false | If `true`, it will be full-screen |
 | fullWidth | boolean | false | If specified, stretches dialog to max width. |
 | ignoreBackdropClick | boolean | false | If `true`, clicking the backdrop will not fire the `onRequestClose` callback. |
 | ignoreEscapeKeyUp | boolean | false | If `true`, hitting escape will not fire the `onRequestClose` callback. |
-| leaveTransitionDuration | number | duration.leavingScreen | Duration of the animation when the element is leaving. |
 | maxWidth | union:&nbsp;'xs'<br>&nbsp;'sm'<br>&nbsp;'md'<br> | 'sm' | Determine the max width of the dialog. The dialog width grows with the size of the screen, this property is useful on the desktop where you might need some coherent different width size across your application. |
 | onBackdropClick | Function |  | Callback fired when the backdrop is clicked. |
 | onEnter | TransitionCallback |  | Callback fired before the dialog enters. |
@@ -27,6 +25,7 @@ Dialogs are overlaid modal paper based components with a backdrop.
 | onRequestClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | open | boolean | false | If `true`, the Dialog is open. |
 | transition | union:&nbsp;ComponentType<*><br>&nbsp;Element<any><br> | Fade | Transition component. |
+| transitionDuration | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/drawer.md
+++ b/pages/api/drawer.md
@@ -13,11 +13,10 @@
 | <span style="color: #31a148">children *</span> | Node |  | The contents of the drawer. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | elevation | number | 16 | The elevation of the drawer. |
-| enterTransitionDuration | number | duration.enteringScreen | Customizes duration of enter animation (ms) |
-| leaveTransitionDuration | number | duration.leavingScreen | Customizes duration of leave animation (ms) |
 | onRequestClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | open | boolean | false | If `true`, the drawer is open. |
 | <span style="color: #31a148">theme *</span> | Object |  |  |
+| transitionDuration | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | type | union:&nbsp;'permanent'<br>&nbsp;'persistent'<br>&nbsp;'temporary'<br> | 'temporary' | The type of drawer. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).

--- a/pages/api/fade.md
+++ b/pages/api/fade.md
@@ -8,15 +8,14 @@
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | children | Element |  | A single child content element. |
-| enterTransitionDuration | number | duration.enteringScreen | Duration of the animation when the element is entering. |
 | in | boolean | false | If `true`, the component will transition in. |
-| leaveTransitionDuration | number | duration.leavingScreen | Duration of the animation when the element is exiting. |
 | onEnter | TransitionCallback |  | Callback fired before the component enters. |
 | onEntered | TransitionCallback |  | Callback fired when the component has entered. |
 | onEntering | TransitionCallback |  | Callback fired when the component is entering. |
 | onExit | TransitionCallback |  | Callback fired before the component exits. |
 | onExited | TransitionCallback |  | Callback fired when the component has exited. |
 | onExiting | TransitionCallback |  | Callback fired when the component is exiting. |
+| transitionDuration | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/grow.md
+++ b/pages/api/grow.md
@@ -15,7 +15,7 @@ Grow transition used by popovers such as Menu.
 | onExited | TransitionCallback |  | Callback fired when the component has exited |
 | onExiting | TransitionCallback |  | Callback fired when the component is exiting |
 | rootRef | Function |  | Use that property to pass a ref callback to the root component. |
-| transitionDuration | union:&nbsp;number<br>&nbsp;'auto'<br> | 'auto' | Set to 'auto' to automatically calculate transition time based on height |
+| transitionDuration | union:&nbsp;number<br>&nbsp;{ enter?: number, exit?: number }<br>&nbsp;'auto'<br> | 'auto' | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/slide.md
+++ b/pages/api/slide.md
@@ -9,15 +9,14 @@
 |:-----|:-----|:--------|:------------|
 | children | Element |  | A single child content element. |
 | direction | union:&nbsp;'left'<br>&nbsp;'right'<br>&nbsp;'up'<br>&nbsp;'down'<br> | 'down' | Direction the child element will enter from. |
-| enterTransitionDuration | number | duration.enteringScreen | Duration of the animation when the element is entering. |
 | in | boolean |  | If `true`, show the component; triggers the enter or exit animation. |
-| leaveTransitionDuration | number | duration.leavingScreen | Duration of the animation when the element is exiting. |
 | onEnter | TransitionCallback |  | Callback fired before the component enters. |
 | onEntered | TransitionCallback |  | Callback fired when the component has entered. |
 | onEntering | TransitionCallback |  | Callback fired when the component is entering. |
 | onExit | TransitionCallback |  | Callback fired before the component exits. |
 | onExited | TransitionCallback |  | Callback fired when the component has exited. |
 | onExiting | TransitionCallback |  | Callback fired when the component is exiting. |
+| transitionDuration | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/snackbar.md
+++ b/pages/api/snackbar.md
@@ -13,9 +13,7 @@
 | autoHideDuration | number |  | The number of milliseconds to wait before automatically dismissing. This behavior is disabled by default with the `null` value. |
 | children | Element |  | If you wish the take control over the children of the component you can use that property. When using it, no `SnackbarContent` component will be rendered. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| enterTransitionDuration | number | duration.enteringScreen | Customizes duration of enter animation (ms) |
 | key | any |  | When displaying multiple consecutive Snackbars from a parent rendering a single <Snackbar/>, add the key property to ensure independent treatment of each message. e.g. <Snackbar key={message} />, otherwise, the message may update-in-place and features such as autoHideDuration may be canceled. |
-| leaveTransitionDuration | number | duration.leavingScreen | Customizes duration of leave animation (ms) |
 | message | Node |  | The message to display. |
 | onEnter | TransitionCallback |  | Callback fired before the transition is entering. |
 | onEntered | TransitionCallback |  | Callback fired when the transition has entered. |
@@ -27,6 +25,7 @@
 | <span style="color: #31a148">open *</span> | boolean |  | If true, `Snackbar` is open. |
 | resumeHideDuration | number |  | The number of milliseconds to wait before dismissing after user interaction. If `autoHideDuration` property isn't specified, it does nothing. If `autoHideDuration` property is specified but `resumeHideDuration` isn't, we default to `autoHideDuration / 2` ms. |
 | transition | union:&nbsp;ComponentType<*><br>&nbsp;Element<any><br> |  | Object with Transition component, props & create Fn. |
+| transitionDuration | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/src/Dialog/Dialog.d.ts
+++ b/src/Dialog/Dialog.d.ts
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { StyledComponent } from '..';
 import { ModalProps } from '../internal/Modal';
+import { TransitionDuration } from '../internal/Transition';
 
 export type DialogProps = {
   fullScreen?: boolean;
   ignoreBackdropClick?: boolean;
   ignoreEscapeKeyUp?: boolean;
-  enterTransitionDuration?: number | string;
-  leaveTransitionDuration?: number | string;
+  transitionDuration?: TransitionDuration;
   maxWidth?: 'xs' | 'sm' | 'md';
   fullWidth?: boolean;
   onBackdropClick?: Function;

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -9,7 +9,7 @@ import Modal from '../internal/Modal';
 import Fade from '../transitions/Fade';
 import { duration } from '../styles/transitions';
 import Paper from '../Paper';
-import type { TransitionCallback } from '../internal/Transition';
+import type { TransitionDuration, TransitionCallback } from '../internal/Transition';
 
 export const styles = (theme: Object) => ({
   root: {
@@ -79,13 +79,10 @@ export type Props = {
    */
   ignoreEscapeKeyUp?: boolean,
   /**
-   * Duration of the animation when the element is entering.
+   * The duration for the transition, in milliseconds.
+   * You may specify a single timeout for all transitions, or individually with an object.
    */
-  enterTransitionDuration?: number, // eslint-disable-line react/sort-prop-types
-  /**
-   * Duration of the animation when the element is leaving.
-   */
-  leaveTransitionDuration?: number,
+  transitionDuration?: TransitionDuration,
   /**
    * Determine the max width of the dialog.
    * The dialog width grows with the size of the screen, this property is useful
@@ -156,8 +153,7 @@ function Dialog(props: DefaultProps & Props) {
     fullScreen,
     ignoreBackdropClick,
     ignoreEscapeKeyUp,
-    enterTransitionDuration,
-    leaveTransitionDuration,
+    transitionDuration,
     maxWidth,
     fullWidth,
     open,
@@ -180,7 +176,7 @@ function Dialog(props: DefaultProps & Props) {
   return (
     <Modal
       className={classNames(classes.root, className)}
-      backdropTransitionDuration={open ? enterTransitionDuration : leaveTransitionDuration}
+      backdropTransitionDuration={transitionDuration}
       ignoreBackdropClick={ignoreBackdropClick}
       ignoreEscapeKeyUp={ignoreEscapeKeyUp}
       onBackdropClick={onBackdropClick}
@@ -195,8 +191,7 @@ function Dialog(props: DefaultProps & Props) {
         {
           in: open,
           transitionAppear: true,
-          enterTransitionDuration,
-          leaveTransitionDuration,
+          transitionDuration,
           onEnter,
           onEntering,
           onEntered,
@@ -227,8 +222,10 @@ Dialog.defaultProps = {
   fullScreen: false,
   ignoreBackdropClick: false,
   ignoreEscapeKeyUp: false,
-  enterTransitionDuration: duration.enteringScreen,
-  leaveTransitionDuration: duration.leavingScreen,
+  transitionDuration: {
+    enter: duration.enteringScreen,
+    exit: duration.leavingScreen,
+  },
   maxWidth: 'sm',
   fullWidth: false,
   open: false,

--- a/src/Dialog/Dialog.spec.js
+++ b/src/Dialog/Dialog.spec.js
@@ -37,8 +37,7 @@ describe('<Dialog />', () => {
     const wrapper = shallow(
       <Dialog
         open
-        enterTransitionDuration={100}
-        leaveTransitionDuration={100}
+        transitionDuration={100}
         onBackdropClick={onBackdropClick}
         onEscapeKeyUp={onEscapeKeyUp}
         onRequestClose={onRequestClose}

--- a/src/Drawer/Drawer.d.ts
+++ b/src/Drawer/Drawer.d.ts
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { StyledComponent, StyledComponentProps } from '..';
 import { ModalProps } from '../internal/Modal';
+import { TransitionDuration } from '../internal/Transition';
 import { SlideProps } from '../transitions/Slide';
 import { Theme } from '../styles/createMuiTheme';
 
 export interface DrawerProps extends ModalProps {
   anchor?: 'left' | 'top' | 'right' | 'bottom';
   elevation?: number;
-  enterTransitionDuration?: number;
-  leaveTransitionDuration?: number;
+  transitionDuration?: TransitionDuration;
   open?: boolean;
   SlideProps?: SlideProps & StyledComponentProps<any>;
   theme?: Theme;

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -9,6 +9,7 @@ import Slide from '../transitions/Slide';
 import Paper from '../Paper';
 import { capitalizeFirstLetter } from '../utils/helpers';
 import { duration } from '../styles/transitions';
+import type { TransitionDuration } from '../internal/Transition';
 
 function getSlideDirection(anchor) {
   if (anchor === 'left') {
@@ -82,8 +83,7 @@ type DefaultProps = {
   anchor: Anchor,
   classes: Object,
   elevation: number,
-  enterTransitionDuration: number,
-  leaveTransitionDuration: number,
+  transitionDuration: TransitionDuration,
   open: boolean,
   type: Type,
 };
@@ -106,17 +106,14 @@ export type Props = {
    */
   className?: string,
   /**
-   * Customizes duration of enter animation (ms)
-   */
-  enterTransitionDuration?: number,
-  /**
    * The elevation of the drawer.
    */
   elevation?: number,
   /**
-   * Customizes duration of leave animation (ms)
+   * The duration for the transition, in milliseconds.
+   * You may specify a single timeout for all transitions, or individually with an object.
    */
-  leaveTransitionDuration?: number,
+  transitionDuration?: TransitionDuration,
   /**
    * Properties applied to the `Modal` element.
    */
@@ -153,8 +150,10 @@ class Drawer extends React.Component<DefaultProps & Props, State> {
   static defaultProps = {
     anchor: 'left',
     elevation: 16,
-    enterTransitionDuration: duration.enteringScreen,
-    leaveTransitionDuration: duration.leavingScreen,
+    transitionDuration: {
+      enter: duration.enteringScreen,
+      exit: duration.leavingScreen,
+    },
     open: false,
     type: 'temporary', // Mobile first.
   };
@@ -179,8 +178,7 @@ class Drawer extends React.Component<DefaultProps & Props, State> {
       classes,
       className,
       elevation,
-      enterTransitionDuration,
-      leaveTransitionDuration,
+      transitionDuration,
       ModalProps,
       onRequestClose,
       open,
@@ -221,8 +219,7 @@ class Drawer extends React.Component<DefaultProps & Props, State> {
       <Slide
         in={open}
         direction={getSlideDirection(anchor)}
-        enterTransitionDuration={enterTransitionDuration}
-        leaveTransitionDuration={leaveTransitionDuration}
+        transitionDuration={transitionDuration}
         transitionAppear={!this.state.firstMount}
         {...SlideProps}
       >
@@ -241,7 +238,7 @@ class Drawer extends React.Component<DefaultProps & Props, State> {
     // type === temporary
     return (
       <Modal
-        backdropTransitionDuration={open ? enterTransitionDuration : leaveTransitionDuration}
+        backdropTransitionDuration={transitionDuration}
         className={classNames(classes.modal, className)}
         show={open}
         onRequestClose={onRequestClose}

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -51,57 +51,31 @@ describe('<Drawer />', () => {
       assert.strictEqual(paper.hasClass(classes.paper), true, 'should have the paper class');
     });
 
-    describe('enterTransitionDuration property', () => {
-      const enterDuration = 854;
-      const leaveDuration = 2967;
+    describe('transitionDuration property', () => {
+      const transitionDuration = {
+        enter: 854,
+        exit: 2967,
+      };
 
       it('should be passed to Slide', () => {
         const wrapper = shallow(
-          <Drawer enterTransitionDuration={enterDuration}>
+          <Drawer transitionDuration={transitionDuration}>
             <div />
           </Drawer>,
         );
-        assert.strictEqual(wrapper.find(Slide).prop('enterTransitionDuration'), enterDuration);
+        assert.strictEqual(wrapper.find(Slide).props().transitionDuration, transitionDuration);
       });
 
       it("should be passed to to Modal's backdropTransitionDuration when open=true", () => {
         const wrapper = shallow(
-          <Drawer
-            open
-            enterTransitionDuration={enterDuration}
-            leaveTransitionDuration={leaveDuration}
-          >
+          <Drawer open transitionDuration={transitionDuration}>
             <div />
           </Drawer>,
         );
-        assert.strictEqual(wrapper.find(Modal).prop('backdropTransitionDuration'), enterDuration);
-      });
-    });
-
-    describe('leaveTransitionDuration property', () => {
-      const enterDuration = 6577;
-      const leaveDuration = 1889;
-
-      it('should be passed to Slide', () => {
-        const wrapper = shallow(
-          <Drawer leaveTransitionDuration={leaveDuration}>
-            <div />
-          </Drawer>,
+        assert.strictEqual(
+          wrapper.find(Modal).props().backdropTransitionDuration,
+          transitionDuration,
         );
-        assert.strictEqual(wrapper.find(Slide).props().leaveTransitionDuration, leaveDuration);
-      });
-
-      it("should be passed to to Modal's backdropTransitionDuration when open=false", () => {
-        const wrapper = shallow(
-          <Drawer
-            open={false}
-            enterTransitionDuration={enterDuration}
-            leaveTransitionDuration={leaveDuration}
-          >
-            <div />
-          </Drawer>,
-        );
-        assert.strictEqual(wrapper.find(Modal).props().backdropTransitionDuration, leaveDuration);
       });
     });
 

--- a/src/Menu/Menu.d.ts
+++ b/src/Menu/Menu.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { StyledComponent, StyledComponentProps } from '..';
 import { PopoverProps } from '../Popover';
-import { TransitionHandlers } from '../internal/Transition';
+import { TransitionDuration, TransitionHandlers } from '../internal/Transition';
 import { MenuListProps } from './MenuList';
 
 export type MenuProps = {
@@ -9,7 +9,7 @@ export type MenuProps = {
   MenuListProps?: MenuListProps & StyledComponentProps<any>;
   onRequestClose?: React.EventHandler<any>;
   open?: boolean;
-  transitionDuration?: number | 'auto';
+  transitionDuration?: TransitionDuration;
 } & Partial<TransitionHandlers> &
   PopoverProps;
 

--- a/src/Popover/Popover.d.ts
+++ b/src/Popover/Popover.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { StyledComponent } from '..';
 import { PaperProps } from '../Paper';
-import { TransitionHandlers } from '../internal/Transition';
+import { TransitionDuration, TransitionHandlers } from '../internal/Transition';
 import { ModalProps } from '../internal/Modal';
 
 export type Origin = {
@@ -23,7 +23,7 @@ export type PopoverProps = {
   open?: boolean;
   role?: string;
   transformOrigin?: Origin;
-  transitionDuration?: number | 'auto';
+  transitionDuration?: TransitionDuration;
   theme?: Object;
   PaperProps?: Partial<PaperProps>;
 } & Partial<TransitionHandlers> &

--- a/src/Snackbar/Snackbar.d.ts
+++ b/src/Snackbar/Snackbar.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { StyledComponent } from '..';
-import { TransitionHandlers } from '../internal/Transition';
+import { TransitionDuration, TransitionHandlers } from '../internal/Transition';
 export type Origin = {
   horizontal?: 'left' | 'center' | 'right' | number;
   vertical?: 'top' | 'center' | 'bottom' | number;
@@ -11,8 +11,7 @@ export type SnackbarProps = {
   anchorOrigin?: Origin;
   autoHideDuration?: number;
   resumeHideDuration?: number;
-  enterTransitionDuration?: number;
-  leaveTransitionDuration?: number;
+  transitionDuration?: TransitionDuration;
   message?: React.ReactElement<any>;
   onMouseEnter?: React.MouseEventHandler<any>;
   onMouseLeave?: React.MouseEventHandler<any>;

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -10,7 +10,7 @@ import ClickAwayListener from '../internal/ClickAwayListener';
 import { capitalizeFirstLetter, createChainedFunction } from '../utils/helpers';
 import Slide from '../transitions/Slide';
 import SnackbarContent from './SnackbarContent';
-import type { TransitionCallback } from '../internal/Transition';
+import type { TransitionDuration, TransitionCallback } from '../internal/Transition';
 
 export const styles = (theme: Object) => {
   const gutter = theme.spacing.unit * 3;
@@ -120,20 +120,12 @@ export type Props = {
    */
   className?: string,
   /**
-   * Customizes duration of enter animation (ms)
-   */
-  enterTransitionDuration?: number,
-  /**
    * When displaying multiple consecutive Snackbars from a parent rendering a single
    * <Snackbar/>, add the key property to ensure independent treatment of each message.
    * e.g. <Snackbar key={message} />, otherwise, the message may update-in-place and
    * features such as autoHideDuration may be canceled.
    */
   key?: any,
-  /**
-   * Customizes duration of leave animation (ms)
-   */
-  leaveTransitionDuration?: number,
   /**
    * The message to display.
    */
@@ -195,6 +187,11 @@ export type Props = {
    * Object with Transition component, props & create Fn.
    */
   transition?: ComponentType<*> | Element<any>,
+  /**
+   * The duration for the transition, in milliseconds.
+   * You may specify a single timeout for all transitions, or individually with an object.
+   */
+  transitionDuration?: TransitionDuration,
 };
 
 type State = {
@@ -204,8 +201,10 @@ type State = {
 class Snackbar extends React.Component<DefaultProps & Props, State> {
   static defaultProps = {
     anchorOrigin: { vertical: 'bottom', horizontal: 'center' },
-    enterTransitionDuration: duration.enteringScreen,
-    leaveTransitionDuration: duration.leavingScreen,
+    transitionDuration: {
+      enter: duration.enteringScreen,
+      exit: duration.leavingScreen,
+    },
   };
 
   state = {
@@ -249,13 +248,13 @@ class Snackbar extends React.Component<DefaultProps & Props, State> {
 
   // Timer that controls delay before snackbar auto hides
   setAutoHideTimer(autoHideDuration = null) {
-    if (!this.props.onRequestClose || this.props.autoHideDuration === null) {
+    if (!this.props.onRequestClose || this.props.autoHideDuration === undefined) {
       return;
     }
 
     clearTimeout(this.timerAutoHide);
     this.timerAutoHide = setTimeout(() => {
-      if (!this.props.onRequestClose || this.props.autoHideDuration === null) {
+      if (!this.props.onRequestClose || this.props.autoHideDuration === undefined) {
         return;
       }
 
@@ -292,8 +291,8 @@ class Snackbar extends React.Component<DefaultProps & Props, State> {
   // Restart the timer when the user is no longer interacting with the Snackbar
   // or when the window is shown back.
   handleResume = () => {
-    if (this.props.autoHideDuration !== null) {
-      if (this.props.resumeHideDuration !== null) {
+    if (this.props.autoHideDuration !== undefined) {
+      if (this.props.resumeHideDuration !== undefined) {
         this.setAutoHideTimer(this.props.resumeHideDuration);
         return;
       }
@@ -314,8 +313,7 @@ class Snackbar extends React.Component<DefaultProps & Props, State> {
       children,
       classes,
       className,
-      enterTransitionDuration,
-      leaveTransitionDuration,
+      transitionDuration,
       message,
       onEnter,
       onEntering,
@@ -339,8 +337,7 @@ class Snackbar extends React.Component<DefaultProps & Props, State> {
     const transitionProps = {
       in: open,
       transitionAppear: true,
-      enterTransitionDuration,
-      leaveTransitionDuration,
+      transitionDuration,
       onEnter,
       onEntering,
       onEntered,

--- a/src/Snackbar/Snackbar.spec.js
+++ b/src/Snackbar/Snackbar.spec.js
@@ -94,7 +94,7 @@ describe('<Snackbar />', () => {
       wrapper.setProps({ open: true });
       assert.strictEqual(handleRequestClose.callCount, 0);
       clock.tick(autoHideDuration / 2);
-      wrapper.setProps({ autoHideDuration: null });
+      wrapper.setProps({ autoHideDuration: undefined });
       clock.tick(autoHideDuration / 2);
       assert.strictEqual(handleRequestClose.callCount, 0);
     });
@@ -136,7 +136,7 @@ describe('<Snackbar />', () => {
           open
           onRequestClose={handleRequestClose}
           message="message"
-          autoHideDuration={null}
+          autoHideDuration={undefined}
         />,
       );
 

--- a/src/Tabs/Tabs.spec.js
+++ b/src/Tabs/Tabs.spec.js
@@ -465,7 +465,7 @@ describe('<Tabs />', () => {
     let instance;
     let metaStub;
 
-    before(() => {
+    beforeEach(() => {
       scrollStub = stub(scroll, 'left');
       const wrapper = shallow(
         <Tabs width="md" onChange={noop} value={0} scrollable>
@@ -477,7 +477,7 @@ describe('<Tabs />', () => {
       metaStub = stub(instance, 'getTabsMeta');
     });
 
-    after(() => {
+    afterEach(() => {
       scroll.left.restore();
     });
 
@@ -498,7 +498,17 @@ describe('<Tabs />', () => {
       });
 
       instance.scrollSelectedIntoView();
-      assert.strictEqual(scrollStub.args[1][1], 10, 'should scroll to 10 position');
+      assert.strictEqual(scrollStub.args[0][1], 10, 'should scroll to 10 position');
+    });
+
+    it('should support value=false', () => {
+      metaStub.returns({
+        tabsMeta: { left: 0, right: 100, scrollLeft: 0 },
+        tabMeta: undefined,
+      });
+
+      instance.scrollSelectedIntoView();
+      assert.strictEqual(scrollStub.callCount, 0, 'should not scroll');
     });
   });
 });

--- a/src/internal/Modal.d.ts
+++ b/src/internal/Modal.d.ts
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { StyledComponent } from '..';
 import { BackdropProps } from './Backdrop';
-import { TransitionHandlers } from './Transition';
+import { TransitionDuration, TransitionHandlers } from './Transition';
 
 export type ModalProps = {
   backdropClassName?: string;
   backdropComponent?: React.ComponentType<BackdropProps>;
   backdropInvisible?: boolean;
-  backdropTransitionDuration?: number;
+  backdropTransitionDuration?: TransitionDuration;
   keepMounted?: boolean;
   disableBackdrop?: boolean;
   ignoreBackdropClick?: boolean;

--- a/src/internal/Modal.js
+++ b/src/internal/Modal.js
@@ -17,7 +17,7 @@ import withStyles from '../styles/withStyles';
 import createModalManager from './modalManager';
 import Backdrop from './Backdrop';
 import Portal from './Portal';
-import type { TransitionCallback } from './Transition';
+import type { TransitionDuration, TransitionCallback } from '../internal/Transition';
 
 // Modals don't open on the server so this won't break concurrency.
 // Could also put this on context.
@@ -58,9 +58,10 @@ export type Props = {
    */
   backdropInvisible?: boolean,
   /**
-   * Duration in ms for the backdrop transition.
+   * The duration for the backdrop transition, in milliseconds.
+   * You may specify a single timeout for all transitions, or individually with an object.
    */
-  backdropTransitionDuration?: number,
+  backdropTransitionDuration?: TransitionDuration,
   /**
    * A single child content element.
    */
@@ -325,14 +326,7 @@ class Modal extends React.Component<DefaultProps & Props, State> {
     } = this.props;
 
     return (
-      <Fade
-        in={show}
-        transitionAppear
-        enterTransitionDuration={backdropTransitionDuration}
-        leaveTransitionDuration={backdropTransitionDuration}
-        timeout={backdropTransitionDuration + 20}
-        {...other}
-      >
+      <Fade in={show} transitionAppear transitionDuration={backdropTransitionDuration} {...other}>
         <BackdropComponent
           invisible={backdropInvisible}
           className={backdropClassName}

--- a/src/internal/Modal.spec.js
+++ b/src/internal/Modal.spec.js
@@ -149,8 +149,7 @@ describe('<Modal />', () => {
     it('should pass a transitionDuration prop to the transition component', () => {
       wrapper.setProps({ backdropTransitionDuration: 200 });
       const transition = wrapper.childAt(0).childAt(0);
-      assert.strictEqual(transition.props().enterTransitionDuration, 200);
-      assert.strictEqual(transition.props().leaveTransitionDuration, 200);
+      assert.strictEqual(transition.props().transitionDuration, 200);
     });
 
     it('should attach a handler to the backdrop that fires onRequestClose', () => {

--- a/src/internal/Transition.d.ts
+++ b/src/internal/Transition.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+export type TransitionDuration = number | { enter: number, exit: number };
 export type TransitionCallback = (element: HTMLElement) => void;
 export type TransitionRequestTimeout = (element: HTMLElement) => number;
 

--- a/src/styles/transitions.js
+++ b/src/styles/transitions.js
@@ -88,6 +88,7 @@ export default {
 
     const constant = height / 36;
 
+    // https://www.wolframalpha.com/input/?i=(4+%2B+15+*+(x+%2F+36+)+**+0.25+%2B+(x+%2F+36)+%2F+5)+*+10
     return Math.round((4 + 15 * constant ** 0.25 + constant / 5) * 10);
   },
 };

--- a/src/transitions/Collapse.d.ts
+++ b/src/transitions/Collapse.d.ts
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { StyledComponent } from '..';
 import { Theme } from '../styles/createMuiTheme';
-import { TransitionProps } from '../internal/Transition';
+import { TransitionDuration, TransitionProps } from '../internal/Transition';
 
 export interface CollapseProps extends TransitionProps {
   theme?: Theme;
-  transitionDuration?: number | string;
+  transitionDuration?: TransitionDuration | 'auto';
 }
 
 declare const Collapse: StyledComponent<CollapseProps>;

--- a/src/transitions/Collapse.spec.js
+++ b/src/transitions/Collapse.spec.js
@@ -68,6 +68,37 @@ describe('<Collapse />', () => {
     });
   });
 
+  describe('props: transitionDuration', () => {
+    let wrapper;
+    let instance;
+    let element;
+    const enterDuration = 556;
+    const leaveDuration = 446;
+
+    beforeEach(() => {
+      wrapper = shallow(
+        <Collapse
+          transitionDuration={{
+            enter: enterDuration,
+            exit: leaveDuration,
+          }}
+        />,
+      );
+      instance = wrapper.instance();
+      element = { getBoundingClientRect: () => ({}), style: {} };
+    });
+
+    it('should create proper easeOut animation onEntering', () => {
+      instance.handleEntering(element);
+      assert.strictEqual(element.style.transitionDuration, `${enterDuration}ms`);
+    });
+
+    it('should create proper sharp animation onExiting', () => {
+      instance.handleExiting(element);
+      assert.strictEqual(element.style.transitionDuration, `${leaveDuration}ms`);
+    });
+  });
+
   describe('transition lifecycle', () => {
     let wrapper;
     let instance;
@@ -157,15 +188,6 @@ describe('<Collapse />', () => {
           instance.handleEntering(element);
 
           assert.strictEqual(element.style.transitionDuration, `${transitionDurationMock}ms`);
-        });
-
-        it('string should set transitionDuration to string', () => {
-          transitionDurationMock = 'woofCollapseStub';
-          wrapper.setProps({ transitionDuration: transitionDurationMock });
-          instance = wrapper.instance();
-          instance.handleEntering(element);
-
-          assert.strictEqual(element.style.transitionDuration, transitionDurationMock);
         });
 
         it('nothing should not set transitionDuration', () => {
@@ -291,15 +313,6 @@ describe('<Collapse />', () => {
           assert.strictEqual(element.style.transitionDuration, `${transitionDurationMock}ms`);
         });
 
-        it('string should set transitionDuration to string', () => {
-          transitionDurationMock = 'woofCollapseStub2';
-          wrapper.setProps({ transitionDuration: transitionDurationMock });
-          instance = wrapper.instance();
-          instance.handleExiting(element);
-
-          assert.strictEqual(element.style.transitionDuration, transitionDurationMock);
-        });
-
         it('nothing should not set transitionDuration', () => {
           const elementBackup = element;
           wrapper.setProps({ transitionDuration: undefined });
@@ -312,6 +325,32 @@ describe('<Collapse />', () => {
           );
         });
       });
+    });
+  });
+
+  describe('handleRequestTimeout()', () => {
+    let wrapper;
+    let instance;
+
+    beforeEach(() => {
+      wrapper = shallow(<Collapse />);
+    });
+
+    it('should return autoTransitionDuration when transitionDuration is auto', () => {
+      wrapper.setProps({ transitionDuration: 'auto' });
+      instance = wrapper.instance();
+      const autoTransitionDuration = 10;
+      instance.autoTransitionDuration = autoTransitionDuration;
+      assert.strictEqual(instance.handleRequestTimeout(), autoTransitionDuration);
+      instance.autoTransitionDuration = undefined;
+      assert.strictEqual(instance.handleRequestTimeout(), 0);
+    });
+
+    it('should return props.transitionDuration when transitionDuration is number', () => {
+      const transitionDuration = 10;
+      wrapper.setProps({ transitionDuration });
+      instance = wrapper.instance();
+      assert.strictEqual(instance.handleRequestTimeout(), transitionDuration);
     });
   });
 

--- a/src/transitions/Fade.d.ts
+++ b/src/transitions/Fade.d.ts
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { StyledComponent } from '..';
 import { Theme } from '../styles/createMuiTheme';
-import { TransitionProps } from '../internal/Transition';
+import { TransitionDuration, TransitionProps } from '../internal/Transition';
 
 export interface FadeProps extends TransitionProps {
   theme?: Theme;
-  enterTransitionDuration?: number;
-  leaveTransitionDuration?: number;
+  transitionDuration?: TransitionDuration;
 }
 
 declare const Fade: StyledComponent<FadeProps>;

--- a/src/transitions/Fade.js
+++ b/src/transitions/Fade.js
@@ -5,11 +5,10 @@ import type { Element } from 'react';
 import Transition from '../internal/Transition';
 import { duration } from '../styles/transitions';
 import withTheme from '../styles/withTheme';
-import type { TransitionCallback } from '../internal/Transition';
+import type { TransitionDuration, TransitionCallback } from '../internal/Transition';
 
 type DefaultProps = {
-  enterTransitionDuration: number,
-  leaveTransitionDuration: number,
+  transitionDuration: TransitionDuration,
 };
 
 export type Props = {
@@ -21,14 +20,6 @@ export type Props = {
    * If `true`, the component will transition in.
    */
   in?: boolean,
-  /**
-   * Duration of the animation when the element is entering.
-   */
-  enterTransitionDuration?: number, // eslint-disable-line react/sort-prop-types
-  /**
-   * Duration of the animation when the element is exiting.
-   */
-  leaveTransitionDuration?: number,
   /**
    * Callback fired before the component enters.
    */
@@ -57,14 +48,20 @@ export type Props = {
    * @ignore
    */
   theme: Object,
+  /**
+   * The duration for the transition, in milliseconds.
+   * You may specify a single timeout for all transitions, or individually with an object.
+   */
+  transitionDuration?: TransitionDuration,
 };
 
 class Fade extends React.Component<DefaultProps & Props> {
   static defaultProps = {
     in: false,
-    enterTransitionDuration: duration.enteringScreen,
-    leaveTransitionDuration: duration.leavingScreen,
-    theme: {},
+    transitionDuration: {
+      enter: duration.enteringScreen,
+      exit: duration.leavingScreen,
+    },
   };
 
   handleEnter = element => {
@@ -75,12 +72,14 @@ class Fade extends React.Component<DefaultProps & Props> {
   };
 
   handleEntering = element => {
-    const { transitions } = this.props.theme;
-    element.style.transition = transitions.create('opacity', {
-      duration: this.props.enterTransitionDuration,
+    const { theme, transitionDuration } = this.props;
+    element.style.transition = theme.transitions.create('opacity', {
+      duration:
+        typeof transitionDuration === 'number' ? transitionDuration : transitionDuration.enter,
     });
-    element.style.WebkitTransition = transitions.create('opacity', {
-      duration: this.props.enterTransitionDuration,
+    element.style.WebkitTransition = theme.transitions.create('opacity', {
+      duration:
+        typeof transitionDuration === 'number' ? transitionDuration : transitionDuration.enter,
     });
     element.style.opacity = 1;
     if (this.props.onEntering) {
@@ -89,12 +88,14 @@ class Fade extends React.Component<DefaultProps & Props> {
   };
 
   handleExit = element => {
-    const { transitions } = this.props.theme;
-    element.style.transition = transitions.create('opacity', {
-      duration: this.props.leaveTransitionDuration,
+    const { theme, transitionDuration } = this.props;
+    element.style.transition = theme.transitions.create('opacity', {
+      duration:
+        typeof transitionDuration === 'number' ? transitionDuration : transitionDuration.enter,
     });
-    element.style.WebkitTransition = transitions.create('opacity', {
-      duration: this.props.leaveTransitionDuration,
+    element.style.WebkitTransition = theme.transitions.create('opacity', {
+      duration:
+        typeof transitionDuration === 'number' ? transitionDuration : transitionDuration.enter,
     });
     element.style.opacity = 0;
     if (this.props.onExit) {
@@ -105,8 +106,7 @@ class Fade extends React.Component<DefaultProps & Props> {
   render() {
     const {
       children,
-      enterTransitionDuration,
-      leaveTransitionDuration,
+      transitionDuration,
       onEnter,
       onEntering,
       onExit,
@@ -119,7 +119,7 @@ class Fade extends React.Component<DefaultProps & Props> {
         onEnter={this.handleEnter}
         onEntering={this.handleEntering}
         onExit={this.handleExit}
-        timeout={Math.max(enterTransitionDuration, leaveTransitionDuration) + 10}
+        timeout={transitionDuration}
         transitionAppear
         {...other}
       >

--- a/src/transitions/Grow.d.ts
+++ b/src/transitions/Grow.d.ts
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { StyledComponent } from '..';
 import { Theme } from '../styles/createMuiTheme';
-import { TransitionProps } from '../internal/Transition';
+import { TransitionDuration, TransitionProps } from '../internal/Transition';
 
 export interface GrowProps extends TransitionProps {
   theme?: Theme;
-  transitionDuration?: number | string;
+  transitionDuration?: TransitionDuration | 'auto';
 }
 
 declare const Grow: StyledComponent<GrowProps>;

--- a/src/transitions/Grow.spec.js
+++ b/src/transitions/Grow.spec.js
@@ -13,6 +13,11 @@ describe('<Grow />', () => {
     shallow = createShallow({ dive: true });
   });
 
+  it('should render a Transition', () => {
+    const wrapper = shallow(<Grow />);
+    assert.strictEqual(wrapper.name(), 'Transition');
+  });
+
   describe('event callbacks', () => {
     it('should fire event callbacks', () => {
       const events = ['onEnter', 'onEntering', 'onEntered', 'onExit', 'onExiting', 'onExited'];
@@ -30,6 +35,37 @@ describe('<Grow />', () => {
         assert.strictEqual(handlers[n].callCount, 1, `should have called the ${n} handler`);
         assert.strictEqual(handlers[n].args[0].length, 1, 'should forward the element');
       });
+    });
+  });
+
+  describe('props: transitionDuration', () => {
+    let wrapper;
+    let instance;
+    let element;
+    const enterDuration = 556;
+    const leaveDuration = 446;
+
+    beforeEach(() => {
+      wrapper = shallow(
+        <Grow
+          transitionDuration={{
+            enter: enterDuration,
+            exit: leaveDuration,
+          }}
+        />,
+      );
+      instance = wrapper.instance();
+      element = { getBoundingClientRect: () => ({}), style: {} };
+    });
+
+    it('should create proper easeOut animation onEnter', () => {
+      instance.handleEnter(element);
+      assert.match(element.style.transition, new RegExp(`${enterDuration}ms`));
+    });
+
+    it('should create proper sharp animation onExit', () => {
+      instance.handleExit(element);
+      assert.match(element.style.transition, new RegExp(`${leaveDuration}ms`));
     });
   });
 
@@ -120,40 +156,25 @@ describe('<Grow />', () => {
     let wrapper;
     let instance;
 
-    before(() => {
+    beforeEach(() => {
       wrapper = shallow(<Grow />);
     });
 
-    describe('transitionDuration is auto', () => {
-      before(() => {
-        wrapper.setProps({ transitionDuration: 'auto' });
-        instance = wrapper.instance();
-      });
-
-      it('should return autoTransitionDuration + 20', () => {
-        const autoTransitionDuration = 10;
-        instance.autoTransitionDuration = autoTransitionDuration;
-        assert.strictEqual(instance.handleRequestTimeout(), autoTransitionDuration + 20);
-      });
-
-      it('should return 20', () => {
-        instance.autoTransitionDuration = undefined;
-        assert.strictEqual(instance.handleRequestTimeout(), 20);
-      });
+    it('should return autoTransitionDuration when transitionDuration is auto', () => {
+      wrapper.setProps({ transitionDuration: 'auto' });
+      instance = wrapper.instance();
+      const autoTransitionDuration = 10;
+      instance.autoTransitionDuration = autoTransitionDuration;
+      assert.strictEqual(instance.handleRequestTimeout(), autoTransitionDuration);
+      instance.autoTransitionDuration = undefined;
+      assert.strictEqual(instance.handleRequestTimeout(), 0);
     });
 
-    describe('transitionDuration is number', () => {
-      let transitionDuration;
-
-      before(() => {
-        transitionDuration = 10;
-        wrapper.setProps({ transitionDuration });
-        instance = wrapper.instance();
-      });
-
-      it('should return props.transitionDuration + 20', () => {
-        assert.strictEqual(instance.handleRequestTimeout(), transitionDuration + 20);
-      });
+    it('should return props.transitionDuration when transitionDuration is number', () => {
+      const transitionDuration = 10;
+      wrapper.setProps({ transitionDuration });
+      instance = wrapper.instance();
+      assert.strictEqual(instance.handleRequestTimeout(), transitionDuration);
     });
   });
 });

--- a/src/transitions/Slide.d.ts
+++ b/src/transitions/Slide.d.ts
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import { StyledComponent } from '..';
 import { Theme } from '../styles/createMuiTheme';
-import { TransitionProps } from '../internal/Transition';
+import { TransitionDuration, TransitionProps } from '../internal/Transition';
 
 export interface SlideProps extends TransitionProps {
   direction?: 'left' | 'right' | 'up' | 'down';
   offset?: string;
   theme?: Theme;
-  enterTransitionDuration?: number;
-  leaveTransitionDuration?: number;
+  transitionDuration?: TransitionDuration;
 }
 
 declare const Slide: StyledComponent<SlideProps>;

--- a/src/transitions/Slide.js
+++ b/src/transitions/Slide.js
@@ -6,7 +6,7 @@ import { findDOMNode } from 'react-dom';
 import Transition from '../internal/Transition';
 import withTheme from '../styles/withTheme';
 import { duration } from '../styles/transitions';
-import type { TransitionCallback } from '../internal/Transition';
+import type { TransitionDuration, TransitionCallback } from '../internal/Transition';
 
 const GUTTER = 24;
 
@@ -32,9 +32,7 @@ function getTranslateValue(props, element: HTMLElement) {
 export type Direction = 'left' | 'right' | 'up' | 'down';
 
 type DefaultProps = {
-  enterTransitionDuration: number,
-  leaveTransitionDuration: number,
-  theme: Object,
+  transitionDuration: TransitionDuration,
 };
 
 export type Props = {
@@ -47,17 +45,9 @@ export type Props = {
    */
   direction?: Direction,
   /**
-   * Duration of the animation when the element is entering.
-   */
-  enterTransitionDuration?: number,
-  /**
    * If `true`, show the component; triggers the enter or exit animation.
    */
   in?: boolean,
-  /**
-   * Duration of the animation when the element is exiting.
-   */
-  leaveTransitionDuration?: number,
   /**
    * Callback fired before the component enters.
    */
@@ -86,14 +76,20 @@ export type Props = {
    * @ignore
    */
   theme: Object,
+  /**
+   * The duration for the transition, in milliseconds.
+   * You may specify a single timeout for all transitions, or individually with an object.
+   */
+  transitionDuration?: TransitionDuration,
 };
 
 class Slide extends React.Component<DefaultProps & Props> {
   static defaultProps = {
     direction: 'down',
-    enterTransitionDuration: duration.enteringScreen,
-    leaveTransitionDuration: duration.leavingScreen,
-    theme: {},
+    transitionDuration: {
+      enter: duration.enteringScreen,
+      exit: duration.leavingScreen,
+    },
   };
 
   componentDidMount() {
@@ -128,14 +124,16 @@ class Slide extends React.Component<DefaultProps & Props> {
   };
 
   handleEntering = element => {
-    const { transitions } = this.props.theme;
-    element.style.transition = transitions.create('transform', {
-      duration: this.props.enterTransitionDuration,
-      easing: transitions.easing.easeOut,
+    const { theme, transitionDuration } = this.props;
+    element.style.transition = theme.transitions.create('transform', {
+      duration:
+        typeof transitionDuration === 'number' ? transitionDuration : transitionDuration.enter,
+      easing: theme.transitions.easing.easeOut,
     });
-    element.style.webkitTransition = transitions.create('-webkit-transform', {
-      duration: this.props.enterTransitionDuration,
-      easing: transitions.easing.easeOut,
+    element.style.webkitTransition = theme.transitions.create('-webkit-transform', {
+      duration:
+        typeof transitionDuration === 'number' ? transitionDuration : transitionDuration.enter,
+      easing: theme.transitions.easing.easeOut,
     });
     element.style.transform = 'translate3d(0, 0, 0)';
     element.style.webkitTransform = 'translate3d(0, 0, 0)';
@@ -145,14 +143,16 @@ class Slide extends React.Component<DefaultProps & Props> {
   };
 
   handleExit = element => {
-    const { transitions } = this.props.theme;
-    element.style.transition = transitions.create('transform', {
-      duration: this.props.leaveTransitionDuration,
-      easing: transitions.easing.sharp,
+    const { theme, transitionDuration } = this.props;
+    element.style.transition = theme.transitions.create('transform', {
+      duration:
+        typeof transitionDuration === 'number' ? transitionDuration : transitionDuration.exit,
+      easing: theme.transitions.easing.sharp,
     });
-    element.style.webkitTransition = transitions.create('-webkit-transform', {
-      duration: this.props.leaveTransitionDuration,
-      easing: transitions.easing.sharp,
+    element.style.webkitTransition = theme.transitions.create('-webkit-transform', {
+      duration:
+        typeof transitionDuration === 'number' ? transitionDuration : transitionDuration.exit,
+      easing: theme.transitions.easing.sharp,
     });
     const transform = getTranslateValue(this.props, element);
     element.style.transform = transform;
@@ -169,8 +169,7 @@ class Slide extends React.Component<DefaultProps & Props> {
       onEnter,
       onEntering,
       onExit,
-      enterTransitionDuration,
-      leaveTransitionDuration,
+      transitionDuration,
       theme,
       ...other
     } = this.props;
@@ -180,7 +179,7 @@ class Slide extends React.Component<DefaultProps & Props> {
         onEnter={this.handleEnter}
         onEntering={this.handleEntering}
         onExit={this.handleExit}
-        timeout={Math.max(enterTransitionDuration, leaveTransitionDuration) + 10}
+        timeout={transitionDuration}
         transitionAppear
         {...other}
         ref={ref => {

--- a/src/transitions/Slide.spec.js
+++ b/src/transitions/Slide.spec.js
@@ -6,7 +6,7 @@ import { spy } from 'sinon';
 import { findDOMNode } from 'react-dom';
 import { createShallow, createMount } from '../test-utils';
 import Slide from './Slide';
-import transitions, { easing, duration } from '../styles/transitions';
+import transitions, { easing } from '../styles/transitions';
 import createMuiTheme from '../styles/createMuiTheme';
 
 describe('<Slide />', () => {
@@ -19,16 +19,6 @@ describe('<Slide />', () => {
   it('should render a Transition', () => {
     const wrapper = shallow(<Slide />);
     assert.strictEqual(wrapper.name(), 'Transition');
-  });
-
-  it('enterTransitionDuration prop should have default value from standard durations', () => {
-    // $FlowFixMe - HOC is hoisting of static Naked, not sure how to represent that
-    assert.strictEqual(Slide.Naked.defaultProps.enterTransitionDuration, duration.enteringScreen);
-  });
-
-  it('leaveTransitionDuration prop should have default value from standard durations', () => {
-    // $FlowFixMe - HOC is hoisting of static Naked, not sure how to represent that
-    assert.strictEqual(Slide.Naked.defaultProps.leaveTransitionDuration, duration.leavingScreen);
   });
 
   describe('event callbacks', () => {
@@ -50,16 +40,21 @@ describe('<Slide />', () => {
     });
   });
 
-  describe('transition animation', () => {
+  describe('props: transitionDuration', () => {
     let wrapper;
     let instance;
     let element;
     const enterDuration = 556;
     const leaveDuration = 446;
 
-    before(() => {
+    beforeEach(() => {
       wrapper = shallow(
-        <Slide enterTransitionDuration={enterDuration} leaveTransitionDuration={leaveDuration} />,
+        <Slide
+          transitionDuration={{
+            enter: enterDuration,
+            exit: leaveDuration,
+          }}
+        />,
       );
       instance = wrapper.instance();
       element = { getBoundingClientRect: () => ({}), style: {} };


### PR DESCRIPTION
Clean up the transition components API. We use the following definition:
```jsx
type TransitionDuration = number | { enter: number, exit: number };
```

Closes #8391 

### Breaking changes

Drop support for `string`  transition duration type

```diff
      <Dialog
-       enterTransitionDuration={100}
-       leaveTransitionDuration={100}
+       transitionDuration={100}
      </Dialog>
```

```diff
      <Dialog
-       enterTransitionDuration={100}
-       leaveTransitionDuration={200}
+       transitionDuration={{
          enter: 100,
          exit: 200,
        }}
      </Dialog>
```