### PR TITLE
Update issue template with language about providing a reproduction case

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -23,8 +23,14 @@
 ## Steps to Reproduce (for bugs)
 <!--- 
     Provide a link to a live example (you can use codesandbox.io) and an unambiguous set of steps to reproduce this bug. 
-    Include code to reproduce, if relevant. This codesandbox.io template _may_ be a good starting point: 
+    Include code to reproduce, if relevant (which it most likely is). 
+
+    This codesandbox.io template _may_ be a good starting point: 
     https://codesandbox.io/s/github/callemall/material-ui/tree/v1-beta/examples/create-react-app
+
+
+    If you DO NOT provide a codesandbox.io reproduction, SHOULD the community take time to help you? 
+
 -->
 
 1.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -29,7 +29,7 @@
     https://codesandbox.io/s/github/callemall/material-ui/tree/v1-beta/examples/create-react-app
 
 
-    If YOU DO NOT take time to provide a codesandbox.io reproduction, SHOULD the community take time to help you? 
+    If YOU DO NOT take time to provide a codesandbox.io reproduction, should the COMMUNITY take time to help you? 
 
 -->
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -29,7 +29,7 @@
     https://codesandbox.io/s/github/callemall/material-ui/tree/v1-beta/examples/create-react-app
 
 
-    If you DO NOT provide a codesandbox.io reproduction, SHOULD the community take time to help you? 
+    If YOU DO NOT take time to provide a codesandbox.io reproduction, SHOULD the community take time to help you? 
 
 -->
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
One other thought was to include this at the top

> [ ] I have included a codesandbox.io reproduction; OR
> [ ] I certify that a codesandbox.io reproduction is not relevant to this issue; and I stake my personal reputation on it.

I just can't see how we can make it any easier for people to include reproductions, and I find it really disrespectful when maintainers and collaborators put so much time in, only for a library user to ignore the entire issue template.