### PR TITLE
Supports a custom deleteButton component for the <Chip /> component

### DIFF
--- a/docs/src/pages/demos/chips/Chips.js
+++ b/docs/src/pages/demos/chips/Chips.js
@@ -7,6 +7,7 @@ import Avatar from 'material-ui/Avatar';
 import Chip from 'material-ui/Chip';
 import FaceIcon from 'material-ui-icons/Face';
 import grey from 'material-ui/colors/grey';
+import CheckIcon from 'material-ui-icons/Check';
 
 const styles = theme => ({
   chip: {
@@ -29,6 +30,15 @@ function handleRequestDelete() {
 function handleClick() {
   alert('You clicked the Chip.'); // eslint-disable-line no-alert
 }
+
+function CustomDeleteButton({ className, onRequestDelete }) {
+  return <CheckIcon className={className} onClick={onRequestDelete} />;
+}
+
+CustomDeleteButton.propTypes = {
+  className: PropTypes.string.isRequired,
+  onRequestDelete: PropTypes.func.isRequired,
+};
 
 function Chips(props) {
   const classes = props.classes;
@@ -57,6 +67,11 @@ function Chips(props) {
         onClick={handleClick}
         onRequestDelete={handleRequestDelete}
         className={classes.chip}
+      />
+      <Chip
+        label="With Custom Delete Icon"
+        onRequestDelete={handleRequestDelete}
+        deleteButton={CustomDeleteButton}
       />
     </div>
   );

--- a/pages/api/chip.md
+++ b/pages/api/chip.md
@@ -11,7 +11,7 @@ Chips represent complex entities in small blocks, such as a contact.
 | classes | Object |  | Useful to extend the style applied to components. |
 | label | union:&nbsp;string<br>&nbsp;Element<any><br> |  | The content of the label. |
 | onRequestDelete | signature |  | Callback function fired when the delete icon is clicked. If set, the delete icon will be shown. |
-
+| deleteButton | Component | | Component to render instead of the default close button. Receives onRequestDelete as a prop.
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 
 ## CSS API

--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import type { Element } from 'react';
+import type { Element, ComponentType } from 'react';
 import classNames from 'classnames';
 import keycode from 'keycode';
 import withStyles from '../styles/withStyles';
@@ -119,6 +119,15 @@ export type Props = {
    */
   onRequestDelete?: (event: SyntheticEvent<>) => void,
   /**
+   * Component to render instead of the default delete button.
+   * Passed onRequestDelete through as a prop
+   */
+  deleteButton?: ComponentType<{
+    onRequestDelete: (event: SyntheticEvent<>) => void,
+    className: string,
+  }>,
+
+  /**
    * @ignore
    */
   tabIndex?: number | string,
@@ -171,6 +180,7 @@ class Chip extends React.Component<DefaultProps & Props> {
       onKeyDown,
       onRequestDelete,
       tabIndex: tabIndexProp,
+      deleteButton: DeleteButton,
       ...other
     } = this.props;
 
@@ -183,9 +193,15 @@ class Chip extends React.Component<DefaultProps & Props> {
 
     let deleteIcon = null;
     if (onRequestDelete) {
-      deleteIcon = (
-        <CancelIcon className={classes.deleteIcon} onClick={this.handleDeleteIconClick} />
-      );
+      if (DeleteButton) {
+        deleteIcon = (
+          <DeleteButton className={classes.deleteIcon} onRequestDelete={onRequestDelete} />
+        );
+      } else {
+        deleteIcon = (
+          <CancelIcon className={classes.deleteIcon} onClick={this.handleDeleteIconClick} />
+        );
+      }
     }
 
     let avatar = null;

--- a/src/Chip/Chip.spec.js
+++ b/src/Chip/Chip.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 // @flow
 
 import React from 'react';
@@ -149,6 +150,39 @@ describe('<Chip />', () => {
         1,
         'should have called the stopPropagation handler',
       );
+    });
+  });
+  describe('Custom delete button', () => {
+    let mount;
+    before(() => {
+      mount = createMount();
+    });
+    after(() => {
+      mount.cleanUp();
+    });
+    it('should accept a custom delete button via the deleteButton prop', () => {
+      const DeleteButton = props => {
+        return (
+          <button className={props.className} data-button-id="delete">
+            Delete Button
+          </button>
+        );
+      };
+      const wrapper = mount(<Chip deleteButton={DeleteButton} onRequestDelete={() => {}} />);
+      assert.ok(wrapper.find('[data-button-id="delete"]').exists());
+    });
+    it('The deleteButton component should be passed the className and onRequestDelete prop', () => {
+      const onRequestDelete = spy();
+      const DeleteButton = props => {
+        assert.strictEqual(
+          props.onRequestDelete,
+          onRequestDelete,
+          'onRequestDelete is passed through unchanged',
+        );
+        assert.ok(props.className, 'className is passed down as well');
+        return null;
+      };
+      mount(<Chip deleteButton={DeleteButton} onRequestDelete={onRequestDelete} />);
     });
   });
 


### PR DESCRIPTION
Closes #8420

- deleteButton is expected to be ComponentType, not Node, because we
  need to pass the onRequestDelete handler as well as classNames for
  styling
- Adds simple docs to the Chip component demo page
- Adds documentation to the new prop in the Chip component api page

Screenshot: 
![screenshot_20170930_122355](https://user-images.githubusercontent.com/2380692/31048130-8a86c7fc-a5dc-11e7-9928-eb824359a4bc.png)
