### PR TITLE
[Collapse] Fix handleEntered method

### DIFF
--- a/src/transitions/Collapse.js
+++ b/src/transitions/Collapse.js
@@ -173,6 +173,7 @@ class Collapse extends React.Component<ProvidedProps & Props> {
       classes,
       onEnter,
       onEntering,
+      onEntered,
       onExit,
       onExiting,
       transitionDuration,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Closes https://github.com/callemall/material-ui/issues/8472. Prevents `onEntered` prop from overwriting `handleEntered` method by omitting `onEntered` from `other`.