### PR TITLE
[Hidden] Make the children property required

### DIFF
--- a/pages/api/hidden.md
+++ b/pages/api/hidden.md
@@ -7,7 +7,7 @@ Responsively hides children based on the selected implementation.
 ## Props
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| children | Node |  | The content of the component. |
+| <span style="color: #31a148">children *</span> | Node |  | The content of the component. |
 | implementation | union:&nbsp;'js'<br>&nbsp;'css'<br> | 'js' | Specify which implementation to use.  'js' is the default, 'css' works better for server side rendering. |
 | lgDown | boolean | false | If true, screens this size and down will be hidden. |
 | lgUp | boolean | false | If true, screens this size and up will be hidden. |

--- a/pages/api/tooltip.md
+++ b/pages/api/tooltip.md
@@ -8,7 +8,7 @@
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | PopperProps | Object |  | Properties applied to the `Popper` element. |
-| <span style="color: #31a148">children *</span> | union:&nbsp;string<br>&nbsp;Element<any><br> |  | Tooltip reference component. |
+| <span style="color: #31a148">children *</span> | Element |  | Tooltip reference component. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | disableTriggerFocus | boolean | false | Do not respond to focus events. |
 | disableTriggerHover | boolean | false | Do not respond to hover events. |

--- a/src/Hidden/Hidden.js
+++ b/src/Hidden/Hidden.js
@@ -10,7 +10,7 @@ export type Props = {
   /**
    * The content of the component.
    */
-  children?: Node,
+  children: Node,
   /**
    * @ignore
    */

--- a/src/Hidden/HiddenCss.js
+++ b/src/Hidden/HiddenCss.js
@@ -1,6 +1,7 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 
 import React from 'react';
+import type { Node } from 'react';
 import warning from 'warning';
 import { keys as breakpointKeys } from '../styles/createBreakpoints';
 import { capitalizeFirstLetter } from '../utils/helpers';
@@ -8,6 +9,10 @@ import withStyles from '../styles/withStyles';
 import type { HiddenProps } from './types';
 
 export type Props = HiddenProps & {
+  /**
+   * The content of the component.
+   */
+  children: Node,
   /**
    * Useful to extend the style applied to components.
    */

--- a/src/Hidden/HiddenCss.spec.js
+++ b/src/Hidden/HiddenCss.spec.js
@@ -54,13 +54,6 @@ describe('<HiddenCss />', () => {
   });
 
   describe('prop: children', () => {
-    it('should work when empty', () => {
-      const wrapper = shallow(<HiddenCss mdUp />);
-      assert.strictEqual(wrapper.type(), 'span');
-      assert.strictEqual(wrapper.hasClass(classes.mdUp), true);
-      assert.isNull(wrapper.childAt(0).type());
-    });
-
     it('should work when text Node', () => {
       const wrapper = shallow(<HiddenCss mdUp>foo</HiddenCss>);
       assert.strictEqual(wrapper.type(), 'span');

--- a/src/Hidden/HiddenJs.js
+++ b/src/Hidden/HiddenJs.js
@@ -1,11 +1,16 @@
 // @flow
 
+import type { Node } from 'react';
 import warning from 'warning';
 import { keys as breakpointKeys } from '../styles/createBreakpoints';
 import withWidth, { isWidthDown, isWidthUp } from '../utils/withWidth';
 import type { HiddenProps } from './types';
 
 export type Props = HiddenProps & {
+  /**
+   * The content of the component.
+   */
+  children: Node,
   /**
    * @ignore
    * width prop provided by withWidth decorator

--- a/src/Hidden/types.js
+++ b/src/Hidden/types.js
@@ -1,15 +1,10 @@
 // @flow
 
-import type { Node } from 'react';
 import type { Breakpoint } from '../styles/createBreakpoints';
 
 // IMPORTANT: this must be identical to Hidden.js Props.
 // This is here because docgen can't yet import type definitions across files.
 export type HiddenProps = {
-  /**
-   * The content of the component.
-   */
-  children?: Node,
   /**
    * @ignore
    */


### PR DESCRIPTION
There is no point at using the `Hidden` component without children. So, in order to prevent sneaky issue with the js implementation that can go silent in development and end-up in production, I have been making the children required.

Closes #8500 
