### PR TITLE
[Example] Pin nextjs example to react 15

### DIFF
--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -5,8 +5,8 @@
   "dependencies": {
     "material-ui": "next",
     "next": "latest",
-    "react": "latest",
-    "react-dom": "latest"
+    "react": "^15.0.0",
+    "react-dom": "^15.0.0"
   },
   "scripts": {
     "dev": "next",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
NextJS latest does not support React 16 so pin to React 15.  