### PR TITLE
[TablePagination] Allow using it anywhere

### DIFF
--- a/docs/src/pages/demos/tables/EnhancedTable.js
+++ b/docs/src/pages/demos/tables/EnhancedTable.js
@@ -300,13 +300,15 @@ class EnhancedTable extends React.Component {
               })}
             </TableBody>
             <TableFooter>
-              <TablePagination
-                count={data.length}
-                rowsPerPage={rowsPerPage}
-                page={page}
-                onChangePage={this.handleChangePage}
-                onChangeRowsPerPage={this.handleChangeRowsPerPage}
-              />
+              <TableRow>
+                <TablePagination
+                  count={data.length}
+                  rowsPerPage={rowsPerPage}
+                  page={page}
+                  onChangePage={this.handleChangePage}
+                  onChangeRowsPerPage={this.handleChangeRowsPerPage}
+                />
+              </TableRow>
             </TableFooter>
           </Table>
         </div>

--- a/pages/api/table-pagination.md
+++ b/pages/api/table-pagination.md
@@ -13,6 +13,7 @@ A `TableRow` based component for placing inside `TableFooter` for pagination.
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | classes | Object |  | Useful to extend the style applied to components. |
+| component | ElementType | TableCell | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span style="color: #31a148">count *</span> | number |  | The total number of rows. |
 | labelDisplayedRows | signature | ({ from, to, count }) => `${from}-${to} of ${count}` | Useful to customize the displayed rows label. |
 | labelRowsPerPage | Node | 'Rows per page:' | Useful to customize the rows per page label. Invoked with a `{ from, to, count, page }` object. |
@@ -28,9 +29,10 @@ Any other properties supplied will be [spread to the root element](/customizatio
 
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
-- `cell`
+- `root`
 - `toolbar`
 - `spacer`
+- `caption`
 - `select`
 - `selectRoot`
 - `actions`
@@ -45,7 +47,7 @@ you need to use the following style sheet name: `MuiTablePagination`.
 
 ## Inheritance
 
-The properties of the [&lt;TableRow /&gt;](/api/table-row) component are also available.
+The properties of the [&lt;TableCell /&gt;](/api/table-cell) component are also available.
 
 ## Demos
 

--- a/src/Table/TablePagination.d.ts
+++ b/src/Table/TablePagination.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { StyledComponent } from '..';
+import { TableCellProps, TableCellClassKey } from './TableCell.d'
 
 interface LabelDisplayedRowsArgs {
   from: number;
@@ -28,6 +29,6 @@ export type TablePaginationClassKey =
   | 'actions'
   ;
 
-declare const TablePagination: StyledComponent<TablePaginationProps, TablePaginationClassKey>;
+declare const TablePagination: StyledComponent<TablePaginationProps & TableCellProps, TablePaginationClassKey & TableCellClassKey>;
 
 export default TablePagination;

--- a/src/Table/TablePagination.js
+++ b/src/Table/TablePagination.js
@@ -1,25 +1,24 @@
 // @flow
-// @inheritedComponent TableRow
+// @inheritedComponent TableCell
 
 import React from 'react';
-import type { Node } from 'react';
+import type { ElementType, Node } from 'react';
 import withStyles from '../styles/withStyles';
 import IconButton from '../IconButton';
 import Input from '../Input';
 import { MenuItem } from '../Menu';
 import Select from '../Select';
 import TableCell from './TableCell';
-import TableRow from './TableRow';
 import Toolbar from '../Toolbar';
 import Typography from '../Typography';
 import KeyboardArrowLeft from '../svg-icons/KeyboardArrowLeft';
 import KeyboardArrowRight from '../svg-icons/KeyboardArrowRight';
 
 export const styles = (theme: Object) => ({
-  cell: {
+  root: {
     // Increase the specificity to override TableCell.
     '&:last-child': {
-      padding: '0',
+      padding: 0,
     },
   },
   toolbar: {
@@ -29,6 +28,9 @@ export const styles = (theme: Object) => ({
   },
   spacer: {
     flex: '1 1 100%',
+  },
+  caption: {
+    flexShrink: 0,
   },
   select: {
     marginLeft: theme.spacing.unit,
@@ -43,6 +45,7 @@ export const styles = (theme: Object) => ({
     marginRight: theme.spacing.unit * 4,
   },
   actions: {
+    flexShrink: 0,
     color: theme.palette.text.secondary,
     marginLeft: theme.spacing.unit * 2.5,
   },
@@ -57,6 +60,7 @@ export type LabelDisplayedRowsArgs = {
 
 type ProvidedProps = {
   classes: Object,
+  component: ElementType,
   labelRowsPerPage: string,
   labelDisplayedRows: (paginationInfo: LabelDisplayedRowsArgs) => string,
   rowsPerPageOptions: number[],
@@ -68,9 +72,14 @@ export type Props = {
    */
   classes?: Object,
   /**
+   * The component used for the root node.
+   * Either a string to use a DOM element or a component.
+   */
+  component?: ElementType,
+  /**
    * @ignore
    */
-  className?: string,
+  colSpan?: number,
   /**
    * The total number of rows.
    */
@@ -113,6 +122,7 @@ export type Props = {
  */
 class TablePagination extends React.Component<ProvidedProps & Props> {
   static defaultProps = {
+    component: TableCell,
     labelRowsPerPage: 'Rows per page:',
     labelDisplayedRows: ({ from, to, count }) => `${from}-${to} of ${count}`,
     rowsPerPageOptions: [5, 10, 25],
@@ -136,6 +146,8 @@ class TablePagination extends React.Component<ProvidedProps & Props> {
   render() {
     const {
       classes,
+      component: Component,
+      colSpan: colSpanProp,
       count,
       labelDisplayedRows,
       labelRowsPerPage,
@@ -147,15 +159,20 @@ class TablePagination extends React.Component<ProvidedProps & Props> {
       ...other
     } = this.props;
 
+    let colSpan;
+
+    if (Component === TableCell || Component === 'td') {
+      colSpan = colSpanProp || 9001; // col-span over everything
+    }
+
     return (
-      <TableRow {...other}>
-        <TableCell
-          className={classes.cell}
-          colSpan={9001} // col-span over everything
-        >
-          <Toolbar className={classes.toolbar}>
-            <div className={classes.spacer} />
-            <Typography type="caption">{labelRowsPerPage}</Typography>
+      <Component className={classes.root} colSpan={colSpan} {...other}>
+        <Toolbar className={classes.toolbar}>
+          <div className={classes.spacer} />
+          <Typography type="caption" className={classes.caption}>
+            {labelRowsPerPage}
+          </Typography>
+          <Typography component="div" type="caption">
             <Select
               classes={{ root: classes.selectRoot, select: classes.select }}
               input={<Input disableUnderline />}
@@ -168,28 +185,28 @@ class TablePagination extends React.Component<ProvidedProps & Props> {
                 </MenuItem>
               ))}
             </Select>
-            <Typography type="caption">
-              {labelDisplayedRows({
-                from: count === 0 ? 0 : page * rowsPerPage + 1,
-                to: Math.min(count, (page + 1) * rowsPerPage),
-                count,
-                page,
-              })}
-            </Typography>
-            <div className={classes.actions}>
-              <IconButton onClick={this.handleBackButtonClick} disabled={page === 0}>
-                <KeyboardArrowLeft />
-              </IconButton>
-              <IconButton
-                onClick={this.handleNextButtonClick}
-                disabled={page >= Math.ceil(count / rowsPerPage) - 1}
-              >
-                <KeyboardArrowRight />
-              </IconButton>
-            </div>
-          </Toolbar>
-        </TableCell>
-      </TableRow>
+          </Typography>
+          <Typography type="caption" className={classes.caption}>
+            {labelDisplayedRows({
+              from: count === 0 ? 0 : page * rowsPerPage + 1,
+              to: Math.min(count, (page + 1) * rowsPerPage),
+              count,
+              page,
+            })}
+          </Typography>
+          <div className={classes.actions}>
+            <IconButton onClick={this.handleBackButtonClick} disabled={page === 0}>
+              <KeyboardArrowLeft />
+            </IconButton>
+            <IconButton
+              onClick={this.handleNextButtonClick}
+              disabled={page >= Math.ceil(count / rowsPerPage) - 1}
+            >
+              <KeyboardArrowRight />
+            </IconButton>
+          </div>
+        </Toolbar>
+      </Component>
     );
   }
 }

--- a/src/Table/TablePagination.spec.js
+++ b/src/Table/TablePagination.spec.js
@@ -5,6 +5,7 @@ import { assert } from 'chai';
 import { createShallow, createMount } from '../test-utils';
 import TableFooter from './TableFooter';
 import TablePagination from './TablePagination';
+import TableRow from './TableRow';
 
 describe('<TablePagination />', () => {
   const noop = () => {};
@@ -20,7 +21,7 @@ describe('<TablePagination />', () => {
     mount.cleanUp();
   });
 
-  it('should render a TableRow', () => {
+  it('should render a TableCell', () => {
     const wrapper = shallow(
       <TablePagination
         count={1}
@@ -30,7 +31,7 @@ describe('<TablePagination />', () => {
         rowsPerPage={5}
       />,
     );
-    assert.strictEqual(wrapper.name(), 'withStyles(TableRow)');
+    assert.strictEqual(wrapper.name(), 'withStyles(TableCell)');
   });
 
   it('should spread custom props on the root node', () => {
@@ -51,6 +52,37 @@ describe('<TablePagination />', () => {
     );
   });
 
+  describe('prop: component', () => {
+    it('should render a TableCell by default', () => {
+      const wrapper = shallow(
+        <TablePagination
+          count={1}
+          page={0}
+          onChangePage={noop}
+          onChangeRowsPerPage={noop}
+          rowsPerPage={5}
+        />,
+      );
+      assert.strictEqual(wrapper.name(), 'withStyles(TableCell)');
+      assert.notStrictEqual(wrapper.props().colSpan, undefined);
+    });
+
+    it('should be able to use outside of the table', () => {
+      const wrapper = shallow(
+        <TablePagination
+          component="div"
+          count={1}
+          page={0}
+          onChangePage={noop}
+          onChangeRowsPerPage={noop}
+          rowsPerPage={5}
+        />,
+      );
+      assert.strictEqual(wrapper.name(), 'div');
+      assert.strictEqual(wrapper.props().colSpan, undefined);
+    });
+  });
+
   describe('mount', () => {
     it('should use the labelDisplayedRows callback', () => {
       let labelDisplayedRowsCalled = false;
@@ -66,14 +98,16 @@ describe('<TablePagination />', () => {
       const wrapper = mount(
         <table>
           <TableFooter>
-            <TablePagination
-              count={42}
-              page={1}
-              onChangePage={noop}
-              onChangeRowsPerPage={noop}
-              rowsPerPage={5}
-              labelDisplayedRows={labelDisplayedRows}
-            />
+            <TableRow>
+              <TablePagination
+                count={42}
+                page={1}
+                onChangePage={noop}
+                onChangeRowsPerPage={noop}
+                rowsPerPage={5}
+                labelDisplayedRows={labelDisplayedRows}
+              />
+            </TableRow>
           </TableFooter>
         </table>,
       );
@@ -85,14 +119,16 @@ describe('<TablePagination />', () => {
       const wrapper = mount(
         <table>
           <TableFooter>
-            <TablePagination
-              count={1}
-              page={0}
-              onChangePage={noop}
-              onChangeRowsPerPage={noop}
-              rowsPerPage={5}
-              labelRowsPerPage="Zeilen pro Seite:"
-            />
+            <TableRow>
+              <TablePagination
+                count={1}
+                page={0}
+                onChangePage={noop}
+                onChangeRowsPerPage={noop}
+                rowsPerPage={5}
+                labelRowsPerPage="Zeilen pro Seite:"
+              />
+            </TableRow>
           </TableFooter>
         </table>,
       );
@@ -103,13 +139,15 @@ describe('<TablePagination />', () => {
       const wrapper = mount(
         <table>
           <TableFooter>
-            <TablePagination
-              count={6}
-              page={0}
-              onChangePage={noop}
-              onChangeRowsPerPage={noop}
-              rowsPerPage={5}
-            />
+            <TableRow>
+              <TablePagination
+                count={6}
+                page={0}
+                onChangePage={noop}
+                onChangeRowsPerPage={noop}
+                rowsPerPage={5}
+              />
+            </TableRow>
           </TableFooter>
         </table>,
       );
@@ -124,13 +162,15 @@ describe('<TablePagination />', () => {
       const wrapper = mount(
         <table>
           <TableFooter>
-            <TablePagination
-              count={6}
-              page={1}
-              onChangePage={noop}
-              onChangeRowsPerPage={noop}
-              rowsPerPage={5}
-            />
+            <TableRow>
+              <TablePagination
+                count={6}
+                page={1}
+                onChangePage={noop}
+                onChangeRowsPerPage={noop}
+                rowsPerPage={5}
+              />
+            </TableRow>
           </TableFooter>
         </table>,
       );
@@ -146,15 +186,17 @@ describe('<TablePagination />', () => {
       const wrapper = mount(
         <table>
           <TableFooter>
-            <TablePagination
-              count={15}
-              page={page}
-              onChangePage={(event, nextPage) => {
-                page = nextPage;
-              }}
-              onChangeRowsPerPage={noop}
-              rowsPerPage={5}
-            />
+            <TableRow>
+              <TablePagination
+                count={15}
+                page={page}
+                onChangePage={(event, nextPage) => {
+                  page = nextPage;
+                }}
+                onChangeRowsPerPage={noop}
+                rowsPerPage={5}
+              />
+            </TableRow>
           </TableFooter>
         </table>,
       );
@@ -169,15 +211,17 @@ describe('<TablePagination />', () => {
       const wrapper = mount(
         <table>
           <TableFooter>
-            <TablePagination
-              count={15}
-              page={page}
-              onChangePage={(event, nextPage) => {
-                page = nextPage;
-              }}
-              onChangeRowsPerPage={noop}
-              rowsPerPage={5}
-            />
+            <TableRow>
+              <TablePagination
+                count={15}
+                page={page}
+                onChangePage={(event, nextPage) => {
+                  page = nextPage;
+                }}
+                onChangeRowsPerPage={noop}
+                rowsPerPage={5}
+              />
+            </TableRow>
           </TableFooter>
         </table>,
       );
@@ -194,15 +238,17 @@ describe('<TablePagination />', () => {
         return (
           <table>
             <TableFooter>
-              <TablePagination
-                count={11}
-                page={page}
-                onChangePage={(event, nextPage) => {
-                  page = nextPage;
-                }}
-                onChangeRowsPerPage={noop}
-                {...props}
-              />
+              <TableRow>
+                <TablePagination
+                  count={11}
+                  page={page}
+                  onChangePage={(event, nextPage) => {
+                    page = nextPage;
+                  }}
+                  onChangeRowsPerPage={noop}
+                  {...props}
+                />
+              </TableRow>
             </TableFooter>
           </table>
         );
@@ -218,20 +264,22 @@ describe('<TablePagination />', () => {
       const wrapper = mount(
         <table>
           <TableFooter>
-            <TablePagination
-              count={0}
-              page={0}
-              rowsPerPage={5}
-              onChangePage={noop}
-              onChangeRowsPerPage={noop}
-            />
+            <TableRow>
+              <TablePagination
+                count={0}
+                page={0}
+                rowsPerPage={5}
+                onChangePage={noop}
+                onChangeRowsPerPage={noop}
+              />
+            </TableRow>
           </TableFooter>
         </table>,
       );
       assert.strictEqual(
         wrapper
           .find('withStyles(Typography)')
-          .at(1)
+          .at(2)
           .text(),
         '0-0 of 0',
       );
@@ -244,15 +292,17 @@ describe('<TablePagination />', () => {
         return (
           <table>
             <TableFooter>
-              <TablePagination
-                page={1}
-                rowsPerPage={5}
-                onChangePage={(event, newPage) => {
-                  page = newPage;
-                }}
-                onChangeRowsPerPage={noop}
-                {...props}
-              />
+              <TableRow>
+                <TablePagination
+                  page={1}
+                  rowsPerPage={5}
+                  onChangePage={(event, newPage) => {
+                    page = newPage;
+                  }}
+                  onChangeRowsPerPage={noop}
+                  {...props}
+                />
+              </TableRow>
             </TableFooter>
           </table>
         );


### PR DESCRIPTION
This PR modifies the `TablePagination` so that it can be used everywhere. I also modified the TypeScript typings to include the `TableCell` props and styles which might become handy for customizing the pagination (especially the `component` prop needs to be changed to `div` when not using the pagination inside a table).

I'm not sure whether the component should be renamed to `Pagination` and `TablePagination` should become a tiny wrapper around that where `component` is set to `td`? :thinking:

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Breaking change

```diff
             <TableFooter>
-              <TablePagination
-                count={data.length}
-                rowsPerPage={rowsPerPage}
-                page={page}
-                onChangePage={this.handleChangePage}
-                onChangeRowsPerPage={this.handleChangeRowsPerPage}
-              />
+              <TableRow>
+                <TablePagination
+                  count={data.length}
+                  rowsPerPage={rowsPerPage}
+                  page={page}
+                  onChangePage={this.handleChangePage}
+                  onChangeRowsPerPage={this.handleChangeRowsPerPage}
+                />
+              </TableRow>
             </TableFooter>
```

Closes #8520