### PR TITLE
[Tabs] Add momentum scrolling 

### DIFF
--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -16,6 +16,7 @@ import type { IndicatorStyle } from './TabIndicator';
 export const styles = (theme: Object) => ({
   root: {
     overflow: 'hidden',
+    WebkitOverflowScrolling: 'touch',
     minHeight: 48,
   },
   flexContainer: {


### PR DESCRIPTION
Same fix as: https://github.com/callemall/material-ui/pull/8050
But on horizontal tab ( overflow:hidden is valid here)
