### PR TITLE
[SwitchBase] Simplify the implementation

### DIFF
--- a/docs/src/pages/demos/selection-controls/Checkboxes.js
+++ b/docs/src/pages/demos/selection-controls/Checkboxes.js
@@ -21,8 +21,8 @@ class Checkboxes extends React.Component {
     checkedG: true,
   };
 
-  handleChange = name => (event, checked) => {
-    this.setState({ [name]: checked });
+  handleChange = name => event => {
+    this.setState({ [name]: event.target.checked });
   };
 
   render() {

--- a/docs/src/pages/demos/selection-controls/RadioButtons.js
+++ b/docs/src/pages/demos/selection-controls/RadioButtons.js
@@ -9,7 +9,7 @@ class RadioButtons extends React.Component {
   };
 
   handleChange = event => {
-    this.setState({ selectedValue: event.currentTarget.value });
+    this.setState({ selectedValue: event.target.value });
   };
 
   render() {

--- a/src/internal/SwitchBase.js
+++ b/src/internal/SwitchBase.js
@@ -165,20 +165,14 @@ export default function createSwitch(
     isControlled = null;
 
     handleInputChange = event => {
-      let newChecked;
+      const checked = event.target.checked;
 
-      if (this.isControlled) {
-        newChecked = !this.props.checked;
-      } else {
-        newChecked = !this.state.checked;
-        if (this.input && this.input.checked !== newChecked) {
-          this.input.checked = newChecked;
-        }
-        this.setState({ checked: !this.state.checked });
+      if (!this.isControlled) {
+        this.setState({ checked });
       }
 
       if (this.props.onChange) {
-        this.props.onChange(event, newChecked);
+        this.props.onChange(event, checked);
       }
     };
 

--- a/src/internal/SwitchBase.spec.js
+++ b/src/internal/SwitchBase.spec.js
@@ -240,7 +240,11 @@ describe('<SwitchBase />', () => {
     let onChangeSpy;
 
     before(() => {
-      event = 'woofSwitchBase';
+      event = {
+        target: {
+          checked: false,
+        },
+      };
       onChangeSpy = spy();
       // $FlowFixMe - HOC is hoisting of static Naked, not sure how to represent that
       wrapper = mount(<SwitchBase.Naked classes={{}} />);
@@ -274,10 +278,11 @@ describe('<SwitchBase />', () => {
 
       it('should call onChange once', () => {
         assert.strictEqual(onChangeSpy.callCount, 1);
-      });
-
-      it('should call onChange with event and !props.checked', () => {
-        assert.strictEqual(onChangeSpy.calledWith(event, !checked), true);
+        assert.strictEqual(
+          onChangeSpy.calledWith(event, !checked),
+          true,
+          'call onChange with event and !props.checked',
+        );
       });
     });
 


### PR DESCRIPTION
I have realised this point with a recent user feedback. It's safer relying on the `input` state given we also want our form to work without a JavaScript-based submission. You know, like in the old days with a form post or get :).