### PR TITLE
Adding an app to the v1 showcase

### DIFF
--- a/docs/src/pages/discover-more/showcase.md
+++ b/docs/src/pages/discover-more/showcase.md
@@ -9,3 +9,6 @@ Want to add your app? Found an app that no longer works or no longer uses Materi
 ### 1. Indecision Digest
  A platform meant to bring together professionals and the youth together for career enlightenment
  https://indecision.now.sh/
+
+### 2. Mantic Transparence
+ An Open Data tool showing financial and demographic data for all the towns in France (in french). https://app.mantic.fr/

--- a/docs/src/pages/discover-more/showcase.md
+++ b/docs/src/pages/discover-more/showcase.md
@@ -11,4 +11,5 @@ Want to add your app? Found an app that no longer works or no longer uses Materi
  https://indecision.now.sh/
 
 ### 2. Mantic Transparence
- An Open Data tool showing financial and demographic data for all the towns in France (in french). https://app.mantic.fr/
+ An Open Data tool showing financial and demographic data for all the towns in France (in french)
+ https://app.mantic.fr/


### PR DESCRIPTION
Adding Mantic Transparence, an open data tool, to the v1 showcase. It uses material-ui v1, with a react-autosuggest for the search bar on top.
We are currently in the process of opening the code, hope you like the app !