### PR TITLE
[Select] Update description for displayEmpty propepty

### DIFF
--- a/pages/api/select.md
+++ b/pages/api/select.md
@@ -16,7 +16,7 @@ filename: /src/Select/Select.js
 | autoWidth | boolean | false | If true, the width of the popover will automatically be set according to the items inside the menu, otherwise it will be at least the width of the select input. |
 | <span style="color: #31a148">children *</span> | $ReadOnlyArray |  | The option elements to populate the select with. Can be some `MenuItem` when `native` is false and `option` when `native` is true. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| displayEmpty | boolean | false | If `true`, the select selected item is display even if his value is empty. You can only use it when the `native` property is `false` (default). |
+| displayEmpty | boolean | false | If `true`, the selected item is displayed even if its value is empty. You can only use it when the `native` property is `false` (default). |
 | input | Element | &lt;Input /> | An `Input` element; does not have to be a material-ui specific `Input`. |
 | multiple | boolean | false | If true, `value` must be an array and the menu will support multiple selections. You can only use it when the `native` property is `false` (default). |
 | native | boolean | false | If `true`, the component will be using a native `select` element. |

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -79,7 +79,7 @@ export type Props = {
    */
   classes?: Object,
   /**
-   * If `true`, the select selected item is display even if his value is empty.
+   * If `true`, the selected item is displayed even if its value is empty.
    * You can only use it when the `native` property is `false` (default).
    */
   displayEmpty?: boolean,

--- a/src/Select/SelectInput.js
+++ b/src/Select/SelectInput.js
@@ -37,7 +37,7 @@ export type Props = {
    */
   disabled?: boolean,
   /**
-   * If `true`, the select selected item is display even if his value is empty.
+   * If `true`, the selected item is displayed even if its value is empty.
    * You can only use it when the `native` property is `false` (default).
    */
   displayEmpty: boolean,

--- a/src/Select/SelectInput.spec.js
+++ b/src/Select/SelectInput.spec.js
@@ -79,7 +79,7 @@ describe('<SelectInput />', () => {
   });
 
   describe('prop: displayEmpty', () => {
-    it('should display the selected item even if his value is empty', () => {
+    it('should display the selected item even if its value is empty', () => {
       const wrapper = shallow(
         <SelectInput {...props} value="" displayEmpty>
           <MenuItem value="">Ten</MenuItem>


### PR DESCRIPTION
Thanks for adding the `displayEmpty` prop, exactly what I was looking for! 
This PR adds a better, less sexist, description for the displayEmpty property on the Select component.