### PR TITLE
[TableCell] Fix padding TypeScript definition

### DIFF
--- a/src/Table/TableCell.d.ts
+++ b/src/Table/TableCell.d.ts
@@ -13,7 +13,7 @@ export type TableCellProps = {
   padding?: Padding;
   numeric?: boolean;
 } & React.ThHTMLAttributes<HTMLTableHeaderCellElement> &
-React.TdHTMLAttributes<HTMLTableDataCellElement>;
+  React.TdHTMLAttributes<HTMLTableDataCellElement>;
   
 export type Padding =
   | 'default'

--- a/src/Table/TableCell.d.ts
+++ b/src/Table/TableCell.d.ts
@@ -10,12 +10,17 @@ import { StyledComponent } from '..';
  * here.
  */
 export type TableCellProps = {
-  checkbox?: boolean;
-  compact?: boolean;
-  disablePadding?: boolean;
+  padding?: Padding;
   numeric?: boolean;
 } & React.ThHTMLAttributes<HTMLTableHeaderCellElement> &
-  React.TdHTMLAttributes<HTMLTableDataCellElement>;
+React.TdHTMLAttributes<HTMLTableDataCellElement>;
+  
+export type Padding =
+  | 'default'
+  | 'checkbox'
+  | 'compact'
+  | 'none'
+  ;
 
 export type TableCellClassKey =
   | 'root'


### PR DESCRIPTION
You can't use the new `padding` attribute with typescript in `<TableCell>` component introduced in https://github.com/callemall/material-ui/pull/8362/commits/358c424a19a0cb17ebf6a11e4bc73d822480f920 (`Property 'padding' does not exist on type...`) because the .d.ts file wasn't changed

This request fixed it
