### PR TITLE
[TableCell] Wrong label: 'compact' should be 'dense'

### DIFF
--- a/src/Table/TableCell.d.ts
+++ b/src/Table/TableCell.d.ts
@@ -18,7 +18,7 @@ export type TableCellProps = {
 export type Padding =
   | 'default'
   | 'checkbox'
-  | 'compact'
+  | 'dense'
   | 'none'
   ;
 


### PR DESCRIPTION
I have looked at the wrong commit which stated that `compact` is a possible padding choice. It's actually `dense`