### PR TITLE
[icons] Bump recompose version

### DIFF
--- a/packages/material-ui-icons/package.json
+++ b/packages/material-ui-icons/package.json
@@ -41,7 +41,7 @@
     "react-dom": "^15.3.0 || ^16.0.0"
   },
   "dependencies": {
-    "recompose": "^0.25.1"
+    "recompose": "^0.26.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/packages/material-ui-icons/yarn.lock
+++ b/packages/material-ui-icons/yarn.lock
@@ -1537,9 +1537,9 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
-recompose@^0.25.1:
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.25.1.tgz#5eb9d6cf6e25a9ffad73cbbae5658b5b55d6e728"
+recompose@^0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.26.0.tgz#9babff039cb72ba5bd17366d55d7232fbdfb2d30"
   dependencies:
     change-emitter "^0.1.2"
     fbjs "^0.8.1"


### PR DESCRIPTION
@oliviertassinari not sure how the publish flow works, you probably need to also bump the package version and publish a new one or?

fixes: #8606

Btw. is it possible to link: https://www.npmjs.com/package/material-ui-icons to https://github.com/callemall/material-ui/tree/v1-beta/packages/material-ui-icons ? instead of the package root?

Best Regards,
Lukas