### PR TITLE
[docs] Make code follow the header font

### DIFF
--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -104,6 +104,10 @@ const styles = theme => ({
       fontSize: 14,
       lineHeight: 1.6,
     },
+    '& h1 code, & h2 code, & h3 code, & h4 code': {
+      fontSize: 'inherit',
+      lineHeight: 'inherit',
+    },
     '& h1': {
       ...theme.typography.display2,
       color: theme.palette.text.secondary,

--- a/docs/src/pages/customization/themes.md
+++ b/docs/src/pages/customization/themes.md
@@ -151,8 +151,14 @@ Generate a theme base on the options received.
 
 ```js
 import { createMuiTheme } from 'material-ui/styles';
+import purple from 'material-ui/colors/purple';
+import green from 'material-ui/colors/green';
 
 const theme = createMuiTheme({
+  palette: {
+    primary: purple,
+    secondary: green,
+  },
   status: {
     danger: 'orange',
   },


### PR DESCRIPTION
This way, it's more distinguishable.

Closes #8563