### PR TITLE
[typescript] Fix typings for withTheme

### DIFF
--- a/src/styles/withTheme.d.ts
+++ b/src/styles/withTheme.d.ts
@@ -1,5 +1,5 @@
 import { Theme } from './createMuiTheme';
 
-export default function withTheme<P = {}, T extends Theme = Theme>(
-  component: React.ComponentType<P & { theme: T }>
-): React.ComponentClass<P>;
+export default function withTheme<P = {}, T extends Theme = Theme>():
+  (component: React.ComponentType<P & { theme: T }>
+  ) => React.ComponentClass<P>;

--- a/test/typescript/styles.spec.tsx
+++ b/test/typescript/styles.spec.tsx
@@ -106,7 +106,7 @@ function OverridesTheme() {
 const ThemedComponent: React.SFC<{ theme: Theme }> = ({ theme }) => (
   <div>{theme.spacing.unit}</div>
 );
-const ComponentWithTheme = withTheme(ThemedComponent);
+const ComponentWithTheme = withTheme()(ThemedComponent);
 
 // withStyles + withTheme
 interface AllTheProps {
@@ -118,7 +118,7 @@ const AllTheStyles: React.SFC<AllTheProps> = ({ theme, classes }) => (
   <div className={classes.root}>{theme.palette.text.primary}</div>
 );
 
-const AllTheComposition = withTheme(withStyles(styles)(AllTheStyles));
+const AllTheComposition = withTheme()(withStyles(styles)(AllTheStyles));
 
 // Can't use withStyles effectively as a decorator in TypeScript
 // due to https://github.com/Microsoft/TypeScript/issues/4881


### PR DESCRIPTION
The implementation does not directly take a component as an argument.

See the documentation at https://material-ui-next.com/customization/themes/#withtheme-component-component for details.
