### PR TITLE
[typescript] Change the TextField.label type to the InputLabel.children type

### DIFF
--- a/src/TextField/TextField.d.ts
+++ b/src/TextField/TextField.d.ts
@@ -22,7 +22,7 @@ export type TextFieldProps = {
   inputProps?: Object;
   InputProps?: InputProps & StyledComponentProps<any>;
   inputRef?: React.Ref<any>;
-  label?: React.ReactElement<any> | string;
+  label?: React.ReactNode;
   labelClassName?: string;
   multiline?: boolean;
   name?: string;


### PR DESCRIPTION
This is not really a bug, but I believe it is a best-practice to expose the actually used type.

The label property of the TextField component is passed as the children object to the InputLabel component. The typings of the InputLabel component specify React.ReactNode for their children.
