### PR TITLE
[Grid] Add alignItems & alignContent properties

### DIFF
--- a/docs/src/pages/demos/tooltips/PositionedTooltips.js
+++ b/docs/src/pages/demos/tooltips/PositionedTooltips.js
@@ -44,7 +44,7 @@ function PositionedTooltips(props) {
             <Button>left-end</Button>
           </Tooltip>
         </Grid>
-        <Grid item container xs={6} align="flex-end" direction="column" spacing={0}>
+        <Grid item container xs={6} alignItems="flex-end" direction="column" spacing={0}>
           <Grid item>
             <Tooltip id="tooltip-right-start" title="Add" placement="right-start">
               <Button>right-start</Button>

--- a/docs/src/pages/layout/InteractiveGrid.js
+++ b/docs/src/pages/layout/InteractiveGrid.js
@@ -28,7 +28,6 @@ class InteractiveGrid extends React.Component {
   state = {
     direction: 'row',
     justify: 'center',
-    alignContent: 'stretch',
     alignItems: 'center',
   };
 
@@ -40,7 +39,7 @@ class InteractiveGrid extends React.Component {
 
   render() {
     const { classes } = this.props;
-    const { alignContent, alignItems, direction, justify } = this.state;
+    const { alignItems, direction, justify } = this.state;
     return (
       <Grid container className={classes.root}>
         <Grid item xs={12}>
@@ -48,7 +47,6 @@ class InteractiveGrid extends React.Component {
             container
             className={classes.demo}
             alignItems={alignItems}
-            alignContent={alignContent}
             direction={direction}
             justify={justify}
           >
@@ -67,7 +65,7 @@ class InteractiveGrid extends React.Component {
         <Grid item xs={12}>
           <Paper className={classes.control}>
             <Grid container>
-              <Grid item xs={6} sm={3}>
+              <Grid item xs={6} sm={4}>
                 <FormControl component="fieldset">
                   <FormLabel>direction</FormLabel>
                   <RadioGroup
@@ -87,7 +85,7 @@ class InteractiveGrid extends React.Component {
                   </RadioGroup>
                 </FormControl>
               </Grid>
-              <Grid item xs={6} sm={3}>
+              <Grid item xs={6} sm={4}>
                 <FormControl component="fieldset">
                   <FormLabel>justify</FormLabel>
                   <RadioGroup
@@ -112,7 +110,7 @@ class InteractiveGrid extends React.Component {
                   </RadioGroup>
                 </FormControl>
               </Grid>
-              <Grid item xs={6} sm={3}>
+              <Grid item xs={6} sm={4}>
                 <FormControl component="fieldset">
                   <FormLabel>alignItems</FormLabel>
                   <RadioGroup
@@ -126,32 +124,6 @@ class InteractiveGrid extends React.Component {
                     <FormControlLabel value="flex-end" control={<Radio />} label="flex-end" />
                     <FormControlLabel value="stretch" control={<Radio />} label="stretch" />
                     <FormControlLabel value="baseline" control={<Radio />} label="baseline" />
-                  </RadioGroup>
-                </FormControl>
-              </Grid>
-              <Grid item xs={6} sm={3}>
-                <FormControl component="fieldset">
-                  <FormLabel>alignContent</FormLabel>
-                  <RadioGroup
-                    name="alignContent"
-                    aria-label="alignContent"
-                    value={alignContent}
-                    onChange={this.handleChange('alignContent')}
-                  >
-                    <FormControlLabel value="stretch" control={<Radio />} label="stretch" />
-                    <FormControlLabel value="center" control={<Radio />} label="center" />
-                    <FormControlLabel value="flex-start" control={<Radio />} label="flex-start" />
-                    <FormControlLabel value="flex-end" control={<Radio />} label="flex-end" />
-                    <FormControlLabel
-                      value="space-between"
-                      control={<Radio />}
-                      label="space-between"
-                    />
-                    <FormControlLabel
-                      value="space-around"
-                      control={<Radio />}
-                      label="space-around"
-                    />
                   </RadioGroup>
                 </FormControl>
               </Grid>

--- a/docs/src/pages/layout/InteractiveGrid.js
+++ b/docs/src/pages/layout/InteractiveGrid.js
@@ -28,7 +28,8 @@ class InteractiveGrid extends React.Component {
   state = {
     direction: 'row',
     justify: 'center',
-    align: 'center',
+    alignContent: 'stretch',
+    alignItems: 'center',
   };
 
   handleChange = key => (event, value) => {
@@ -39,14 +40,15 @@ class InteractiveGrid extends React.Component {
 
   render() {
     const { classes } = this.props;
-    const { align, direction, justify } = this.state;
+    const { alignContent, alignItems, direction, justify } = this.state;
     return (
       <Grid container className={classes.root}>
         <Grid item xs={12}>
           <Grid
             container
             className={classes.demo}
-            align={align}
+            alignItems={alignItems}
+            alignContent={alignContent}
             direction={direction}
             justify={justify}
           >
@@ -116,8 +118,8 @@ class InteractiveGrid extends React.Component {
                   <RadioGroup
                     name="align"
                     aria-label="align"
-                    value={align}
-                    onChange={this.handleChange('align')}
+                    value={alignItems}
+                    onChange={this.handleChange('alignItems')}
                   >
                     <FormControlLabel value="flex-start" control={<Radio />} label="flex-start" />
                     <FormControlLabel value="center" control={<Radio />} label="center" />

--- a/docs/src/pages/layout/InteractiveGrid.js
+++ b/docs/src/pages/layout/InteractiveGrid.js
@@ -67,7 +67,7 @@ class InteractiveGrid extends React.Component {
         <Grid item xs={12}>
           <Paper className={classes.control}>
             <Grid container>
-              <Grid item xs={6} sm={4}>
+              <Grid item xs={6} sm={3}>
                 <FormControl component="fieldset">
                   <FormLabel>direction</FormLabel>
                   <RadioGroup
@@ -87,7 +87,7 @@ class InteractiveGrid extends React.Component {
                   </RadioGroup>
                 </FormControl>
               </Grid>
-              <Grid item xs={6} sm={4}>
+              <Grid item xs={6} sm={3}>
                 <FormControl component="fieldset">
                   <FormLabel>justify</FormLabel>
                   <RadioGroup
@@ -112,12 +112,12 @@ class InteractiveGrid extends React.Component {
                   </RadioGroup>
                 </FormControl>
               </Grid>
-              <Grid item xs={6} sm={4}>
+              <Grid item xs={6} sm={3}>
                 <FormControl component="fieldset">
-                  <FormLabel>align</FormLabel>
+                  <FormLabel>alignItems</FormLabel>
                   <RadioGroup
-                    name="align"
-                    aria-label="align"
+                    name="alignItems"
+                    aria-label="alignItems"
                     value={alignItems}
                     onChange={this.handleChange('alignItems')}
                   >
@@ -126,6 +126,32 @@ class InteractiveGrid extends React.Component {
                     <FormControlLabel value="flex-end" control={<Radio />} label="flex-end" />
                     <FormControlLabel value="stretch" control={<Radio />} label="stretch" />
                     <FormControlLabel value="baseline" control={<Radio />} label="baseline" />
+                  </RadioGroup>
+                </FormControl>
+              </Grid>
+              <Grid item xs={6} sm={3}>
+                <FormControl component="fieldset">
+                  <FormLabel>alignContent</FormLabel>
+                  <RadioGroup
+                    name="alignContent"
+                    aria-label="alignContent"
+                    value={alignContent}
+                    onChange={this.handleChange('alignContent')}
+                  >
+                    <FormControlLabel value="stretch" control={<Radio />} label="stretch" />
+                    <FormControlLabel value="center" control={<Radio />} label="center" />
+                    <FormControlLabel value="flex-start" control={<Radio />} label="flex-start" />
+                    <FormControlLabel value="flex-end" control={<Radio />} label="flex-end" />
+                    <FormControlLabel
+                      value="space-between"
+                      control={<Radio />}
+                      label="space-between"
+                    />
+                    <FormControlLabel
+                      value="space-around"
+                      control={<Radio />}
+                      label="space-around"
+                    />
                   </RadioGroup>
                 </FormControl>
               </Grid>

--- a/pages/api/grid.md
+++ b/pages/api/grid.md
@@ -12,7 +12,7 @@ filename: /src/Grid/Grid.js
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| alignContent | union:&nbsp;'stretch', 'center', 'flex-start', 'flex-end', 'space-between', 'space-around' | 'stretch' | Defines the `align-content` style property. It's applied for all screen sizes. |
+| alignContent | union:&nbsp;, 'stretch', 'center', 'flex-start', 'flex-end', 'space-between', 'space-around'<br> | 'stretch' | Defines the `align-content` style property. It's applied for all screen sizes. |
 | alignItems | union:&nbsp;'flex-start', 'center', 'flex-end', 'stretch', 'baseline'<br> | 'stretch' | Defines the `align-items` style property. It's applied for all screen sizes. |
 | children | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
@@ -42,10 +42,15 @@ This property accepts the following keys:
 - `direction-xs-column-reverse`
 - `direction-xs-row-reverse`
 - `wrap-xs-nowrap`
-- `align-xs-center`
-- `align-xs-flex-start`
-- `align-xs-flex-end`
-- `align-xs-baseline`
+- `align-items-xs-center`
+- `align-items-xs-flex-start`
+- `align-items-xs-flex-end`
+- `align-items-xs-baseline`
+- `align-content-xs-center`
+- `align-content-xs-flex-start`
+- `align-content-xs-flex-end`
+- `align-content-xs-space-between`
+- `align-content-xs-space-around`
 - `justify-xs-center`
 - `justify-xs-flex-end`
 - `justify-xs-space-between`

--- a/pages/api/grid.md
+++ b/pages/api/grid.md
@@ -12,7 +12,8 @@ filename: /src/Grid/Grid.js
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| align | union:&nbsp;'flex-start', 'center', 'flex-end', 'stretch', 'baseline'<br> | 'stretch' | Defines the `align-items` style property. It's applied for all screen sizes. |
+| alignContent | union:&nbsp;'stretch', 'center', 'flex-start', 'flex-end', 'space-between', 'space-around' | 'stretch' | Defines the `align-content` style property. It's applied for all screen sizes. |
+| alignItems | union:&nbsp;'flex-start', 'center', 'flex-end', 'stretch', 'baseline'<br> | 'stretch' | Defines the `align-items` style property. It's applied for all screen sizes. |
 | children | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | component | ElementType | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |

--- a/src/Grid/Grid.d.ts
+++ b/src/Grid/Grid.d.ts
@@ -3,7 +3,7 @@ import { Omit, StyledComponent, StyledComponentProps } from '..';
 import { HiddenProps } from '../Hidden/Hidden';
 import { Breakpoint } from '../styles/createBreakpoints';
 
-export type GridAlignment = 'flex-start' | 'center' | 'flex-end' | 'stretch';
+export type GridItemsAlignment = 'flex-start' | 'center' | 'flex-end' | 'stretch';
 
 export type GridDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse';
 
@@ -24,7 +24,7 @@ export type GridProps = {
   component?: React.ReactType;
   container?: boolean;
   item?: boolean;
-  align?: GridAlignment;
+  alignItems?: GridItemsAlignment;
   direction?: GridDirection;
   spacing?: GridSpacing;
   hidden?: HiddenProps & StyledComponentProps<any>;
@@ -40,10 +40,10 @@ export type GridClassKey =
   | 'direction-xs-column-reverse'
   | 'direction-xs-row-reverse'
   | 'wrap-xs-nowrap'
-  | 'align-xs-center'
-  | 'align-xs-flex-start'
-  | 'align-xs-flex-end'
-  | 'align-xs-baseline'
+  | 'align-items-xs-center'
+  | 'align-items-xs-flex-start'
+  | 'align-items-xs-flex-end'
+  | 'align-items-xs-baseline'
   | 'justify-xs-center'
   | 'justify-xs-flex-end'
   | 'justify-xs-space-between'

--- a/src/Grid/Grid.d.ts
+++ b/src/Grid/Grid.d.ts
@@ -5,6 +5,8 @@ import { Breakpoint } from '../styles/createBreakpoints';
 
 export type GridItemsAlignment = 'flex-start' | 'center' | 'flex-end' | 'stretch';
 
+export type GridContentAlignment = 'stretch' | 'center' | 'flex-start' | 'flex-end' |'space-between' | 'space-around';
+
 export type GridDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse';
 
 export type GridSpacing = 0 | 8 | 16 | 24 | 40;
@@ -25,6 +27,7 @@ export type GridProps = {
   container?: boolean;
   item?: boolean;
   alignItems?: GridItemsAlignment;
+  alignContent?: GridContentAlignment;
   direction?: GridDirection;
   spacing?: GridSpacing;
   hidden?: HiddenProps & StyledComponentProps<any>;
@@ -44,6 +47,11 @@ export type GridClassKey =
   | 'align-items-xs-flex-start'
   | 'align-items-xs-flex-end'
   | 'align-items-xs-baseline'
+  | 'align-content-xs-center'
+  | 'align-content-xs-flex-start'
+  | 'align-content-xs-flex-end'
+  | 'align-content-xs-space-between'
+  | 'align-content-xs-space-around'
   | 'justify-xs-center'
   | 'justify-xs-flex-end'
   | 'justify-xs-space-between'

--- a/src/Grid/Grid.js
+++ b/src/Grid/Grid.js
@@ -122,6 +122,21 @@ export const styles = (theme: Object) => ({
   'align-items-xs-baseline': {
     alignItems: 'baseline',
   },
+  'align-content-xs-center': {
+    alignContent: 'center',
+  },
+  'align-content-xs-flex-start': {
+    alignContent: 'flex-start',
+  },
+  'align-content-xs-flex-end': {
+    alignContent: 'flex-end',
+  },
+  'align-content-xs-space-between': {
+    alignContent: 'space-between',
+  },
+  'align-content-xs-space-around': {
+    alignContent: 'space-around',
+  },
   'justify-xs-center': {
     justifyContent: 'center',
   },
@@ -177,6 +192,17 @@ export type Props = {
    * You should be wrapping *items* with a *container*.
    */
   item?: boolean,
+  /**
+   * Defines the `align-content` style property.
+   * It's applied for all screen sizes.
+   */
+  alignContent?:
+    | 'stretch'
+    | 'center'
+    | 'flex-start'
+    | 'flex-end'
+    | 'space-between'
+    | 'space-around',
   /**
    * Defines the `align-items` style property.
    * It's applied for all screen sizes.
@@ -240,6 +266,7 @@ function Grid(props: ProvidedProps & Props) {
     component: ComponentProp,
     container,
     item,
+    alignContent,
     alignItems,
     direction,
     spacing,
@@ -263,6 +290,8 @@ function Grid(props: ProvidedProps & Props) {
       [classes[`wrap-xs-${String(wrap)}`]]: wrap !== Grid.defaultProps.wrap,
       [classes[`align-items-xs-${String(alignItems)}`]]:
         alignItems !== Grid.defaultProps.alignItems,
+      [classes[`align-content-xs-${String(alignContent)}`]]:
+        alignContent !== Grid.defaultProps.alignContent,
       [classes[`justify-xs-${String(justify)}`]]: justify !== Grid.defaultProps.justify,
       [classes['grid-xs']]: xs === true,
       [classes[`grid-xs-${String(xs)}`]]: xs && xs !== true,
@@ -291,6 +320,7 @@ function Grid(props: ProvidedProps & Props) {
 }
 
 Grid.defaultProps = {
+  alignContent: 'stretch',
   alignItems: 'stretch',
   component: 'div',
   container: false,
@@ -313,6 +343,7 @@ if (process.env.NODE_ENV !== 'production') {
 
   // $FlowFixMe - cannot mix legacy propTypes with current HOC pattern - https://github.com/facebook/flow/issues/4644#issuecomment-332530909
   GridWrapper.propTypes = {
+    alignContent: requireProp('container'),
     alignItems: requireProp('container'),
     direction: requireProp('container'),
     justify: requireProp('container'),

--- a/src/Grid/Grid.js
+++ b/src/Grid/Grid.js
@@ -110,16 +110,16 @@ export const styles = (theme: Object) => ({
   'wrap-xs-nowrap': {
     flexWrap: 'nowrap',
   },
-  'align-xs-center': {
+  'align-items-xs-center': {
     alignItems: 'center',
   },
-  'align-xs-flex-start': {
+  'align-items-xs-flex-start': {
     alignItems: 'flex-start',
   },
-  'align-xs-flex-end': {
+  'align-items-xs-flex-end': {
     alignItems: 'flex-end',
   },
-  'align-xs-baseline': {
+  'align-items-xs-baseline': {
     alignItems: 'baseline',
   },
   'justify-xs-center': {
@@ -181,7 +181,7 @@ export type Props = {
    * Defines the `align-items` style property.
    * It's applied for all screen sizes.
    */
-  align?: 'flex-start' | 'center' | 'flex-end' | 'stretch' | 'baseline',
+  alignItems?: 'flex-start' | 'center' | 'flex-end' | 'stretch' | 'baseline',
   /**
    * Defines the `flex-direction` style property.
    * It is applied for all screen sizes.
@@ -240,7 +240,7 @@ function Grid(props: ProvidedProps & Props) {
     component: ComponentProp,
     container,
     item,
-    align,
+    alignItems,
     direction,
     spacing,
     hidden,
@@ -261,7 +261,8 @@ function Grid(props: ProvidedProps & Props) {
       [classes[`spacing-xs-${String(spacing)}`]]: container && spacing !== 0,
       [classes[`direction-xs-${String(direction)}`]]: direction !== Grid.defaultProps.direction,
       [classes[`wrap-xs-${String(wrap)}`]]: wrap !== Grid.defaultProps.wrap,
-      [classes[`align-xs-${String(align)}`]]: align !== Grid.defaultProps.align,
+      [classes[`align-items-xs-${String(alignItems)}`]]:
+        alignItems !== Grid.defaultProps.alignItems,
       [classes[`justify-xs-${String(justify)}`]]: justify !== Grid.defaultProps.justify,
       [classes['grid-xs']]: xs === true,
       [classes[`grid-xs-${String(xs)}`]]: xs && xs !== true,
@@ -290,7 +291,7 @@ function Grid(props: ProvidedProps & Props) {
 }
 
 Grid.defaultProps = {
-  align: 'stretch',
+  alignItems: 'stretch',
   component: 'div',
   container: false,
   direction: 'row',
@@ -312,7 +313,7 @@ if (process.env.NODE_ENV !== 'production') {
 
   // $FlowFixMe - cannot mix legacy propTypes with current HOC pattern - https://github.com/facebook/flow/issues/4644#issuecomment-332530909
   GridWrapper.propTypes = {
-    align: requireProp('container'),
+    alignItems: requireProp('container'),
     direction: requireProp('container'),
     justify: requireProp('container'),
     lg: requireProp('item'),

--- a/src/Grid/Grid.spec.js
+++ b/src/Grid/Grid.spec.js
@@ -67,6 +67,13 @@ describe('<Grid />', () => {
     });
   });
 
+  describe('prop: alignItems', () => {
+    it('should apply the item align class', () => {
+      const wrapper = shallow(<Grid alignItems="center" container />);
+      assert.strictEqual(wrapper.hasClass(classes['align-items-xs-center']), true);
+    });
+  });
+
   describe('prop: other', () => {
     it('should spread the other properties to the root element', () => {
       const handleClick = () => {};

--- a/src/Grid/Grid.spec.js
+++ b/src/Grid/Grid.spec.js
@@ -68,9 +68,16 @@ describe('<Grid />', () => {
   });
 
   describe('prop: alignItems', () => {
-    it('should apply the item align class', () => {
+    it('should apply the align-item class', () => {
       const wrapper = shallow(<Grid alignItems="center" container />);
       assert.strictEqual(wrapper.hasClass(classes['align-items-xs-center']), true);
+    });
+  });
+
+  describe('prop: alignContent', () => {
+    it('should apply the align-content class', () => {
+      const wrapper = shallow(<Grid alignContent="center" container />);
+      assert.strictEqual(wrapper.hasClass(classes['align-content-xs-center']), true);
     });
   });
 

--- a/test/regressions/tests/Grid/StressGrid.js
+++ b/test/regressions/tests/Grid/StressGrid.js
@@ -47,7 +47,7 @@ function StressGrid(props) {
             <Paper className={classes.paper}>between</Paper>
           </Grid>
         </Grid>
-        <Grid container item spacing={8} align="stretch" direction="column-reverse">
+        <Grid container item spacing={8} alignItems="stretch" direction="column-reverse">
           <Grid item>
             <Paper className={classes.paper}>reverse</Paper>
           </Grid>

--- a/test/regressions/tests/Tooltip/PositionedTooltips.js
+++ b/test/regressions/tests/Tooltip/PositionedTooltips.js
@@ -47,7 +47,7 @@ function PositionedTooltips(props) {
             <Button>left-end</Button>
           </Tooltip>
         </Grid>
-        <Grid item container xs={6} align="flex-end" direction="column" spacing={0}>
+        <Grid item container xs={6} alignItems="flex-end" direction="column" spacing={0}>
           <Grid item>
             <Tooltip open className={classes.fab} title="Add" placement="right-start">
               <Button>right-start</Button>


### PR DESCRIPTION
@oliviertassinari not sure if it makes sense to add alignContent to the interactive demo - at least not in the current format, as alignContent won't make any difference.

### Breaking change

```diff
-        <Grid container xs={6} align="flex-end">
+        <Grid container xs={6} alignItems="flex-end">
           <Grid item>
```

Closes #8599 