### PR TITLE
[typescript] Change Transition.children to type ReactNode

### DIFF
--- a/src/internal/Transition.d.ts
+++ b/src/internal/Transition.d.ts
@@ -14,7 +14,7 @@ export type TransitionHandlers = {
 };
 
 export interface TransitionProps extends Partial<TransitionHandlers> {
-  children?: React.ReactElement<any>;
+  children?: React.ReactNode;
   className?: string;
   enteredClassName?: string;
   enteringClassName?: string;


### PR DESCRIPTION
Children should be typed as a ReactNode not a ReactElement.