### PR TITLE
[typescript] Collapse: Redefine children from Transition

### DIFF
--- a/src/transitions/Collapse.d.ts
+++ b/src/transitions/Collapse.d.ts
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { StyledComponent } from '..';
+import { StyledComponent, Omit } from '..';
 import { Theme } from '../styles/createMuiTheme';
 import { TransitionDuration, TransitionProps } from '../internal/Transition';
 
-export interface CollapseProps extends TransitionProps {
+export interface CollapseProps extends Omit<TransitionProps, 'children'> {
+  children?: React.ReactNode;
   theme?: Theme;
   transitionDuration?: TransitionDuration | 'auto';
 }

--- a/src/transitions/Collapse.d.ts
+++ b/src/transitions/Collapse.d.ts
@@ -3,7 +3,7 @@ import { StyledComponent, Omit } from '..';
 import { Theme } from '../styles/createMuiTheme';
 import { TransitionDuration, TransitionProps } from '../internal/Transition';
 
-export interface CollapseProps extends Omit<TransitionProps, 'children'> {
+export interface CollapseProps extends Partial<Omit<TransitionProps, 'children'>> {
   children?: React.ReactNode;
   theme?: Theme;
   transitionDuration?: TransitionDuration | 'auto';


### PR DESCRIPTION
Collapse children are passed directly to a div and must not be of type ReactElement.
