### PR TITLE
[Badge] Fix vertical alignment inside IconButton

### DIFF
--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -11,7 +11,7 @@ const RADIUS = 12;
 export const styles = (theme: Object) => ({
   root: {
     position: 'relative',
-    display: 'inline-block',
+    display: 'inline-flex',
   },
   badge: {
     display: 'flex',


### PR DESCRIPTION
**The problem:**
![image](https://user-images.githubusercontent.com/5220147/31545039-59710b7e-b026-11e7-8192-8088969abd9e.png)
[Check online demo](https://codesandbox.io/embed/y7pnyjqn7x)
Placing Badge inside IconButton component breaks vertical alignment of item. The reason of this behaviour is well-known problem with empty space between inline elements.
**The solution:**
Change styles of Badge root element to `display: inline-flex`