### PR TITLE
[MuiThemeProvider] Add more constraints for everybody sanity

### DIFF
--- a/src/Grid/Grid.js
+++ b/src/Grid/Grid.js
@@ -334,7 +334,8 @@ Grid.defaultProps = {
 
 // Add a wrapper component to generate some helper messages in the development
 // environment.
-let GridWrapper = Grid; // eslint-disable-line import/no-mutable-exports
+// eslint-disable-next-line import/no-mutable-exports
+let GridWrapper = Grid;
 
 if (process.env.NODE_ENV !== 'production') {
   const requireProp = requirePropFactory('Grid');

--- a/src/styles/MuiThemeProvider.js
+++ b/src/styles/MuiThemeProvider.js
@@ -4,6 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import createBroadcast from 'brcast';
 import themeListener, { CHANNEL } from './themeListener';
+import exactProp from '../utils/exactProp';
 
 class MuiThemeProvider extends React.Component<Object> {
   constructor(props: Object, context: Object) {
@@ -98,4 +99,14 @@ MuiThemeProvider.childContextTypes = {
 
 MuiThemeProvider.contextTypes = themeListener.contextTypes;
 
-export default MuiThemeProvider;
+// Add a wrapper component to generate some helper messages in the development
+// environment.
+// eslint-disable-next-line import/no-mutable-exports
+let MuiThemeProviderWrapper = MuiThemeProvider;
+
+if (process.env.NODE_ENV !== 'production') {
+  MuiThemeProviderWrapper = (props: any) => <MuiThemeProvider {...props} />;
+  MuiThemeProviderWrapper.propTypes = exactProp(MuiThemeProvider.propTypes, 'MuiThemeProvider');
+}
+
+export default MuiThemeProviderWrapper;

--- a/src/utils/exactProp.js
+++ b/src/utils/exactProp.js
@@ -1,0 +1,24 @@
+// @flow
+// This module is based on https://github.com/airbnb/prop-types-exact repository.
+// However, in order to reduce the number of dependencies and to remove some extra safe checks
+// the module was forked.
+
+export const specialProperty = 'exact-prop: \u200b';
+
+export default function exactProp(propTypes: Object, componentNameInError: string) {
+  return {
+    ...propTypes,
+    // eslint-disable-next-line prefer-arrow-callback
+    [specialProperty]: props => {
+      const unknownProps = Object.keys(props).filter(prop => !propTypes.hasOwnProperty(prop));
+      if (unknownProps.length > 0) {
+        return new TypeError(
+          `${componentNameInError}: unknown props found: ${unknownProps.join(
+            ', ',
+          )}. Please remove the unknown properties.`,
+        );
+      }
+      return null;
+    },
+  };
+}

--- a/src/utils/exactProp.spec.js
+++ b/src/utils/exactProp.spec.js
@@ -1,0 +1,43 @@
+// @flow
+
+import { assert } from 'chai';
+import exactProp, { specialProperty } from './exactProp';
+
+describe('exactProp()', () => {
+  const componentNameInError = 'componentNameInError';
+  let exactPropTypes;
+
+  before(() => {
+    exactPropTypes = exactProp(
+      {
+        bar: {},
+      },
+      componentNameInError,
+    );
+  });
+
+  it('should have the right shape', () => {
+    assert.strictEqual(typeof exactProp, 'function', 'should be a function');
+    assert.strictEqual(typeof exactPropTypes, 'object', 'should be a function');
+  });
+
+  describe('exactPropTypes', () => {
+    let props;
+
+    it('should return null for supported properties', () => {
+      props = {
+        bar: false,
+      };
+      const result = exactPropTypes[specialProperty](props);
+      assert.strictEqual(result, null);
+    });
+
+    it('should return an error for unknown properties', () => {
+      props = {
+        foo: true,
+      };
+      const result = exactPropTypes[specialProperty](props);
+      assert.match(result.message, /componentNameInError: unknown props found: foo/);
+    });
+  });
+});

--- a/src/utils/requirePropFactory.js
+++ b/src/utils/requirePropFactory.js
@@ -1,7 +1,13 @@
 // @flow weak
 
-const requirePropFactory = componentNameInError => {
-  const requireProp = requiredProp => (props, propName, componentName, location, propFullName) => {
+const requirePropFactory = (componentNameInError: string) => {
+  const requireProp = (requiredProp: string) => (
+    props: Object,
+    propName: string,
+    componentName?: string,
+    location?: string,
+    propFullName?: string,
+  ) => {
     const propFullNameSafe = propFullName || propName;
 
     if (typeof props[propName] !== 'undefined' && !props[requiredProp]) {

--- a/src/utils/requirePropFactory.spec.js
+++ b/src/utils/requirePropFactory.spec.js
@@ -3,7 +3,7 @@
 import { assert } from 'chai';
 import requirePropFactory from './requirePropFactory';
 
-describe('requirePropFactory()', () => {
+describe('requirePropFactory', () => {
   const componentNameInError = 'componentNameInError';
   let requireProp;
 
@@ -11,12 +11,9 @@ describe('requirePropFactory()', () => {
     requireProp = requirePropFactory(componentNameInError);
   });
 
-  it('should be a function', () => {
-    assert.strictEqual(typeof requirePropFactory, 'function');
-  });
-
-  it('should return a function', () => {
-    assert.strictEqual(typeof requireProp, 'function');
+  it('should have the right shape', () => {
+    assert.strictEqual(typeof requirePropFactory, 'function', 'should be a function');
+    assert.strictEqual(typeof requireProp, 'function', 'should return a function');
   });
 
   describe('requireProp()', () => {
@@ -63,29 +60,26 @@ describe('requirePropFactory()', () => {
           result = requirePropValidator(props, propName, undefined, undefined, undefined);
         });
 
-        it('returned error should have name property', () => {
-          assert.property(result, 'name', 'result should have name property');
-        });
-
         it('should return Error', () => {
           assert.property(result, 'name', 'result should have name property');
+          assert.property(result, 'name', 'result should have name property');
           assert.strictEqual(result.name, 'Error');
-        });
-
-        it('returned error should have message property', () => {
           assert.property(result, 'message', 'result should have message property');
-        });
-
-        it('returned error message should have propName', () => {
-          assert.strictEqual(result.message.indexOf(propName) > -1, true);
-        });
-
-        it('returned error message should have requiredPropName', () => {
-          assert.strictEqual(result.message.indexOf(requiredPropName) > -1, true);
-        });
-
-        it('returned error message should have componentNameInError', () => {
-          assert.strictEqual(result.message.indexOf(componentNameInError) > -1, true);
+          assert.strictEqual(
+            result.message.indexOf(propName) > -1,
+            true,
+            'returned error message should have propName',
+          );
+          assert.strictEqual(
+            result.message.indexOf(requiredPropName) > -1,
+            true,
+            'returned error message should have requiredPropName',
+          );
+          assert.strictEqual(
+            result.message.indexOf(componentNameInError) > -1,
+            true,
+            'returned error message should have componentNameInError',
+          );
         });
 
         describe('propFullName given to validator', () => {


### PR DESCRIPTION
I ended up losing 30 min for providing a wrong property to the component without knowing. Given how critical this piece of the lib is, we can't accept any mistake. Let's save everybody time with this new warning. It will also help with API changes.

I use a fork of https://github.com/airbnb/prop-types-exact.