### PR TITLE
[ButtonBase] Remove Firefox dotted outline

### DIFF
--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -28,6 +28,9 @@ export const styles = (theme: Object) => ({
     textDecoration: 'none',
     // So we take precedent over the style of a native <a /> element.
     color: 'inherit',
+    '&::-moz-focus-inner': {
+      borderStyle: 'none', // Remove Firefox dotted outline.
+    },
   },
   disabled: {
     pointerEvents: 'none', // Disable link interactions

--- a/src/styles/MuiThemeProvider.spec.js
+++ b/src/styles/MuiThemeProvider.spec.js
@@ -60,7 +60,11 @@ describe('<MuiThemeProvider />', () => {
       assert.strictEqual(sheetsRegistry.registry[0].classes.root, 'MuiTouchRipple-root-17');
       assert.deepEqual(
         sheetsRegistry.registry[1].classes,
-        { disabled: 'MuiButtonBase-disabled-16', root: 'MuiButtonBase-root-15' },
+        {
+          '.MuiButtonBase-root-15::-moz-focus-inner': 'MuiButtonBase-root-15::-moz-focus-inner',
+          disabled: 'MuiButtonBase-disabled-16',
+          root: 'MuiButtonBase-root-15',
+        },
         'the class names should be deterministic',
       );
       assert.strictEqual(sheetsRegistry.registry[2].classes.root, 'MuiButton-root-1');


### PR DESCRIPTION
We already have a keyboard focus visual feedback, no need for two.
Same reset as Bootstrap: https://github.com/twbs/bootstrap/blob/ebc82db8efe129c4e91849373ed018d7e3f0194e/scss/_reboot.scss#L391

Before
![capture d ecran 2017-10-16 a 22 41 35](https://user-images.githubusercontent.com/3165635/31634424-bd2923aa-b2c3-11e7-8d19-1405427bda3d.png)

After
![capture d ecran 2017-10-16 a 22 42 33](https://user-images.githubusercontent.com/3165635/31634431-c6035144-b2c3-11e7-82e8-5601568d0f02.png)
