### PR TITLE
[ButtonBase] Fix missing keyboard ripple

### DIFF
--- a/docs/src/pages/demos/dialogs/AlertDialog.js
+++ b/docs/src/pages/demos/dialogs/AlertDialog.js
@@ -38,7 +38,7 @@ export default class AlertDialog extends React.Component {
             <Button onClick={this.handleRequestClose} color="primary">
               Disagree
             </Button>
-            <Button onClick={this.handleRequestClose} color="primary">
+            <Button onClick={this.handleRequestClose} color="primary" autoFocus>
               Agree
             </Button>
           </DialogActions>

--- a/docs/src/pages/demos/dialogs/ConfirmationDialog.js
+++ b/docs/src/pages/demos/dialogs/ConfirmationDialog.js
@@ -75,7 +75,7 @@ class ConfirmationDialog extends React.Component {
         <DialogTitle>Phone Ringtone</DialogTitle>
         <DialogContent>
           <RadioGroup
-            innerRef={node => {
+            ref={node => {
               this.radioGroup = node;
             }}
             aria-label="ringtone"

--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -270,11 +270,14 @@ class ButtonBase extends React.Component<ProvidedProps & Props, State> {
       return;
     }
 
-    if (this.button) {
-      event.persist();
-      const keyboardFocusCallback = this.onKeyboardFocusHandler.bind(this, event);
-      detectKeyboardFocus(this, this.button, keyboardFocusCallback);
+    // Fix for https://github.com/facebook/react/issues/7769
+    if (!this.button) {
+      this.button = event.currentTarget;
     }
+
+    event.persist();
+    const keyboardFocusCallback = this.onKeyboardFocusHandler.bind(this, event);
+    detectKeyboardFocus(this, this.button, keyboardFocusCallback);
 
     if (this.props.onFocus) {
       this.props.onFocus(event);


### PR DESCRIPTION
~Hopefully this is the fix for #8438~

#### Olivier edits:

I have changed my mind. I don't think that the pulsation display should be the default behavior for the `autoFocus` property. It feels too opinionated. For instance, it's not how a native input behaves.
I would rather want people to opt-in this behavior with #3008.

Instead, I have found a bug with the display of the ripple. We are good now:

<img src="https://media.giphy.com/media/l1J9A37aoeQPnm3PW/giphy.gif" />

Closes #8438