### PR TITLE
[Tooltip] Redefine title from base typescript

### DIFF
--- a/src/Tooltip/Tooltip.d.ts
+++ b/src/Tooltip/Tooltip.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { StyledComponent } from '..';
+import { StyledComponent, Omit } from '..';
 
-export type TooltipProps = React.HTMLAttributes<HTMLDivElement> & {
+export type TooltipProps = Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> & {
   disableTriggerFocus?: boolean;
   disableTriggerHover?: boolean;
   disableTriggerTouch?: boolean;

--- a/test/typescript/components.spec.tsx
+++ b/test/typescript/components.spec.tsx
@@ -37,6 +37,7 @@ import {
   Tabs,
   TextField,
   Toolbar,
+  Tooltip,
   Typography,
   Grid,
   Select,
@@ -809,3 +810,13 @@ const ResponsiveComponentTest = () => {
     breakpoint: 'sm',
   })(Dialog);
 };
+
+const TooltipComponentTest = () =>
+  <div>
+    <Tooltip id="tooltip-top-start" title="Add" placement="top-start">
+      <Button>top-start</Button>
+    </Tooltip>
+    <Tooltip id="tooltip-top-start" title={<strong>Add</strong>} placement="top-start">
+      <Button>top-start</Button>
+    </Tooltip>
+  </div>


### PR DESCRIPTION
The title property on the tooltip is being passed to a div and thus may be of type ReactNode.  The title on the base type however is of type string, thus cannot be used without casting.

See also https://github.com/callemall/material-ui/blob/v1-beta/src/Tooltip/Tooltip.js