### PR TITLE
[TypeScript] Fix GridListTitle `rows` property

### DIFF
--- a/src/GridList/GridListTile.d.ts
+++ b/src/GridList/GridListTile.d.ts
@@ -4,7 +4,7 @@ import { StyledComponent } from '..';
 export interface GridListTileProps {
   cols?: number;
   component?: React.ReactType;
-  row?: number;
+  rows?: number;
 }
 
 export type GridListTileClassKey =

--- a/test/typescript/components.spec.tsx
+++ b/test/typescript/components.spec.tsx
@@ -347,7 +347,7 @@ const GridTest = () =>
 
 const GridListTest = () =>
   <GridList cellHeight={160} cols={3}>
-    <GridListTile cols={1}>
+    <GridListTile cols={1} rows={4}>
       <img src="img.png" alt="alt text" />
     </GridListTile>,
   </GridList>;


### PR DESCRIPTION
Currently this prop is defined as `row`, I renamed it to `rows` and I added a TypeScript test case.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
