### PR TITLE
[TableRow] Adjust CSS for components other than <tr>

### DIFF
--- a/docs/src/pages/demos/tables/BasicTable.js
+++ b/docs/src/pages/demos/tables/BasicTable.js
@@ -58,6 +58,13 @@ function BasicTable(props) {
               </TableRow>
             );
           })}
+          <TableRow component="a" href="#basic-table">
+            <TableCell>Oreo</TableCell>
+            <TableCell numeric>109</TableCell>
+            <TableCell numeric>7.9</TableCell>
+            <TableCell numeric>5.9</TableCell>
+            <TableCell numeric>2.6</TableCell>
+          </TableRow>
         </TableBody>
       </Table>
     </Paper>

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -8,10 +8,13 @@ import withStyles from '../styles/withStyles';
 
 export const styles = (theme: Object) => ({
   root: {
+    color: 'inherit',
+    display: 'table-row',
     height: 48,
     '&:focus': {
       outline: 'none',
     },
+    verticalAlign: 'middle',
   },
   head: {
     height: 56,


### PR DESCRIPTION
TableRow has `component` prop similar to ListItem. This allows us to use components such as `a` tag and react-router's `Link`, as can be seen in [ListItem's simple list example](https://material-ui-next.com/demos/lists/). But the same does not work as expected in case of `TableRow`. Check the images below for clarity. Here the `TableRow` with Oreo has `component="a"`.

## Before

![screenshot from 2017-10-19 13-40-54](https://user-images.githubusercontent.com/3336879/31761244-e4486834-b4d4-11e7-80d7-290d78326e42.png)

## After
![screenshot from 2017-10-19 13-41-23](https://user-images.githubusercontent.com/3336879/31761250-e9dc1890-b4d4-11e7-9f98-23bbe3bac0a4.png)

The fix is quite simple, however, please feel free to point out if I missed anything.
Hope this will get merged, as it will be very useful to our team! :smile: 
