### PR TITLE
[styles] Add performance optimization option

### DIFF
--- a/docs/src/pages/customization/themes.md
+++ b/docs/src/pages/customization/themes.md
@@ -114,6 +114,8 @@ This component takes a `theme` property.
 It makes the `theme` available down the React tree thanks to React context.
 This component should preferably be used at **the root of your component tree**.
 
+You can see the full properties API in [this dedicated page](/api/mui-theme-provider).
+
 #### Examples
 
 ```jsx

--- a/pages/api/mui-theme-provider.md
+++ b/pages/api/mui-theme-provider.md
@@ -6,14 +6,17 @@ filename: /src/styles/MuiThemeProvider.js
 
 # MuiThemeProvider
 
-
+This component takes a `theme` property.
+It makes the `theme` available down the React tree thanks to React context.
+This component should preferably be used at **the root of your component tree**.
 
 ## Props
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span style="color: #31a148">children *</span> | element |  | You can only provide a single element. |
-| sheetsManager | object |  | The sheetsManager is used in order to only inject once a style sheet in a page for a given theme object. You should provide on the server. |
+| disableStylesGeneration | bool | false | You can disable the generation of the styles with this option. It can be useful when traversing the React tree outside of the HTML rendering step on the server. Let's say you are using react-apollo to extract all the queries made by the interface server side. You can significantly speed up the traversal with this property. |
+| sheetsManager | object | null | The sheetsManager is used to deduplicate style sheet injection in the page. It's deduplicating using the (theme, styles) couple. On the server, you should provide a new instance for each request. |
 | <span style="color: #31a148">theme *</span> | union:&nbsp;object<br>&nbsp;func<br> |  | A theme object. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).

--- a/src/styles/MuiThemeProvider.spec.js
+++ b/src/styles/MuiThemeProvider.spec.js
@@ -33,7 +33,38 @@ function getThemeSpy() {
   };
 }
 
+function getOptionsSpy() {
+  const optionsSpy = spy();
+  const OptionsSpy = (props, context) => {
+    optionsSpy(context.muiThemeProviderOptions);
+    return props.children;
+  };
+
+  OptionsSpy.propTypes = {
+    children: PropTypes.element.isRequired,
+  };
+
+  OptionsSpy.contextTypes = {
+    muiThemeProviderOptions: PropTypes.object,
+  };
+
+  return {
+    OptionsSpy,
+    optionsSpy,
+  };
+}
+
 describe('<MuiThemeProvider />', () => {
+  let mount;
+
+  before(() => {
+    mount = createMount();
+  });
+
+  after(() => {
+    mount.cleanUp();
+  });
+
   describe('server side', () => {
     // Only run the test on node.
     if (!/jsdom/.test(window.navigator.userAgent)) {
@@ -72,16 +103,6 @@ describe('<MuiThemeProvider />', () => {
   });
 
   describe('mount', () => {
-    let mount;
-
-    before(() => {
-      mount = createMount();
-    });
-
-    after(() => {
-      mount.cleanUp();
-    });
-
     it('should work with nesting theme', () => {
       const { themeSpy: themeSpy1, ThemeSpy: ThemeSpy1 } = getThemeSpy();
       const { themeSpy: themeSpy2, ThemeSpy: ThemeSpy2 } = getThemeSpy();
@@ -127,6 +148,27 @@ describe('<MuiThemeProvider />', () => {
       assert.strictEqual(themeSpy2.args[1][0].status.color, 'green');
       assert.strictEqual(themeSpy3.callCount, 2);
       assert.strictEqual(themeSpy3.args[1][0].status.color, 'yellow');
+    });
+  });
+
+  describe('prop: disableStylesGeneration', () => {
+    it('should provide the property down the context', () => {
+      const { optionsSpy, OptionsSpy } = getOptionsSpy();
+
+      const theme = createMuiTheme();
+      const wrapper = mount(
+        <MuiThemeProvider theme={theme} disableStylesGeneration>
+          <OptionsSpy>
+            <div>Foo</div>
+          </OptionsSpy>
+        </MuiThemeProvider>,
+      );
+
+      assert.strictEqual(optionsSpy.callCount, 1);
+      assert.strictEqual(optionsSpy.args[0][0].disableStylesGeneration, true);
+
+      wrapper.setProps({ disableStylesGeneration: false });
+      assert.strictEqual(optionsSpy.args[1][0].disableStylesGeneration, false);
     });
   });
 });

--- a/src/styles/withStyles.spec.js
+++ b/src/styles/withStyles.spec.js
@@ -181,5 +181,24 @@ describe('withStyles', () => {
       assert.strictEqual(sheetsRegistry.registry.length, 1, 'should only attach once');
       assert.deepEqual(sheetsRegistry.registry[0].rules.raw, { root: { padding: 9 } });
     });
+
+    describe('options: disableStylesGeneration', () => {
+      it('should not generate the styles', () => {
+        const styles = { root: { display: 'flex' } };
+        const StyledComponent = withStyles(styles)(Empty);
+
+        const wrapper = mount(
+          <MuiThemeProvider theme={createMuiTheme()} disableStylesGeneration>
+            <JssProvider registry={sheetsRegistry} jss={jss}>
+              <StyledComponent />
+            </JssProvider>
+          </MuiThemeProvider>,
+        );
+        assert.strictEqual(sheetsRegistry.registry.length, 0);
+        assert.deepEqual(wrapper.find(Empty).props().classes, {});
+        wrapper.unmount();
+        assert.strictEqual(sheetsRegistry.registry.length, 0);
+      });
+    });
   });
 });


### PR DESCRIPTION
You can disable the generation of the styles with this option. It can be useful when traversing the React tree outside of the HTML rendering step on the server. Let's say you are using react-apollo to extract all the queries made by the interface server side. You can significantly speed up the traversal with this property.

I have noticed a 25% speed-up for handling a single request.

cc @kof