### PR TITLE
[Menu] Fix focus issue

### DIFF
--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -242,7 +242,7 @@ class Menu extends Component {
 
     const filteredChildren = this.getFilteredChildren(this.props.children);
     const focusedItem = filteredChildren[focusIndex];
-    if (focusedItem.props.menuItems && focusedItem.props.menuItems.length > 0) {
+    if (!!focusedItem && focusedItem.props.menuItems && focusedItem.props.menuItems.length > 0) {
       return;
     }
 


### PR DESCRIPTION
Fix condition where item is removed from menu before it is attempted to be used in focus calculation.

Clicking a menu item triggers an event which can end up causing that item to be removed from the menu. If that is the last item in that menu then the menu disappears, but this focus event triggers and an exception is thrown since `focusedItem` is null
