### PR TITLE
[Popover] Fix incorrect className API and add mouseover demo

### DIFF
--- a/docs/src/pages/demos/lists/lists.md
+++ b/docs/src/pages/demos/lists/lists.md
@@ -1,5 +1,5 @@
 ---
-components: List, ListItem, ListItemAvatar, ListItemIcon, ListItemSecondaryAction, ListItemText, ListSubheader, Divider
+components: Collapse, Divider, List, ListItem, ListItemAvatar, ListItemIcon, ListItemSecondaryAction, ListItemText, ListSubheader
 ---
 
 # Lists

--- a/docs/src/pages/demos/popovers/MouseOverPopover.js
+++ b/docs/src/pages/demos/popovers/MouseOverPopover.js
@@ -1,0 +1,112 @@
+/* eslint-disable flowtype/require-valid-file-annotation, jsx-a11y/mouse-events-have-key-events */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Popover from 'material-ui/Popover';
+import Typography from 'material-ui/Typography';
+import { withStyles } from 'material-ui/styles';
+import Grow from 'material-ui/transitions/Grow';
+import Paper from 'material-ui/Paper';
+import { Manager, Target, Popper } from 'react-popper';
+
+const styles = theme => ({
+  paper: {
+    padding: theme.spacing.unit,
+  },
+  popover: {
+    pointerEvents: 'none',
+  },
+  popperClose: {
+    pointerEvents: 'none',
+  },
+});
+
+class MouseOverPopover extends Component {
+  state = {
+    anchorEl: null,
+    popperOpen: false,
+  };
+
+  handlePopoverOpen = event => {
+    this.setState({ anchorEl: event.target });
+  };
+
+  handlePopoverClose = () => {
+    this.setState({ anchorEl: null });
+  };
+
+  handlePopperOpen = () => {
+    this.setState({ popperOpen: true });
+  };
+
+  handlePopperClose = () => {
+    this.setState({ popperOpen: false });
+  };
+
+  render() {
+    const { classes } = this.props;
+    const { anchorEl, popperOpen } = this.state;
+    const open = !!anchorEl;
+
+    return (
+      <div className="wrapper">
+        <Typography onMouseOver={this.handlePopoverOpen} onMouseOut={this.handlePopoverClose}>
+          Hover with a Popover.
+        </Typography>
+        <Popover
+          className={classes.popover}
+          classes={{
+            paper: classes.paper,
+          }}
+          open={open}
+          anchorEl={anchorEl}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'left',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'left',
+          }}
+          onRequestClose={this.handlePopoverClose}
+        >
+          <Typography>I use Popover.</Typography>
+        </Popover>
+        <Manager>
+          <Target>
+            <Typography
+              aria-describedby="react-popper-tooltip"
+              onMouseOver={this.handlePopperOpen}
+              onMouseOut={this.handlePopperClose}
+            >
+              Hover with react-popper.
+            </Typography>
+          </Target>
+          <Popper
+            placement="bottom-start"
+            eventsEnabled={popperOpen}
+            className={!popperOpen ? classes.popperClose : ''}
+          >
+            <Grow in={popperOpen} style={{ transformOrigin: '0 0 0' }}>
+              <Paper
+                id="react-popper-tooltip"
+                className={classes.paper}
+                role="tooltip"
+                aria-hidden={!popperOpen}
+                elevation={8}
+              >
+                <Typography>I use react-popper.</Typography>
+              </Paper>
+            </Grow>
+          </Popper>
+        </Manager>
+      </div>
+    );
+  }
+}
+
+MouseOverPopover.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(MouseOverPopover);

--- a/docs/src/pages/demos/popovers/popovers.md
+++ b/docs/src/pages/demos/popovers/popovers.md
@@ -11,3 +11,9 @@ A `Popover` can be used to display some content on top of another.
 Use the radio buttons to adjust the `anchorOrigin` and `transformOrigin` positions.
 
 {{demo='pages/demos/popovers/AnchorPlayground.js'}}
+
+## Mouse over interaction
+
+We demonstrate who to use the `Popover` component as well as the [react-popper](https://github.com/souporserious/react-popper) package to implement a popover behavior based on the mouse over event.
+
+{{demo='pages/demos/popovers/MouseOverPopover.js'}}

--- a/pages/api/collapse.md
+++ b/pages/api/collapse.md
@@ -44,4 +44,5 @@ you need to use the following style sheet name: `MuiCollapse`.
 ## Demos
 
 - [Cards](/demos/cards)
+- [Lists](/demos/lists)
 

--- a/pages/demos/popovers.js
+++ b/pages/demos/popovers.js
@@ -17,6 +17,13 @@ module.exports = require('fs')
   .readFileSync(require.resolve('docs/src/pages/demos/popovers/AnchorPlayground'), 'utf8')
 `,
         },
+        'pages/demos/popovers/MouseOverPopover.js': {
+          js: require('docs/src/pages/demos/popovers/MouseOverPopover').default,
+          raw: preval`
+module.exports = require('fs')
+  .readFileSync(require.resolve('docs/src/pages/demos/popovers/MouseOverPopover'), 'utf8')
+`,
+        },
       }}
     />
   );

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -3,7 +3,6 @@
 import React from 'react';
 import type { Node } from 'react';
 import ReactDOM from 'react-dom';
-import classNames from 'classnames';
 import warning from 'warning';
 import contains from 'dom-helpers/query/contains';
 import debounce from 'lodash/debounce';
@@ -107,10 +106,6 @@ export type Props = {
    * Useful to extend the style applied to components.
    */
   classes?: Object,
-  /**
-   * @ignore
-   */
-  className?: string,
   /**
    * The elevation of the popover.
    */
@@ -350,7 +345,6 @@ class Popover extends React.Component<ProvidedProps & Props> {
       anchorOrigin,
       children,
       classes,
-      className,
       elevation,
       enteredClassName,
       enteringClassName,
@@ -394,7 +388,7 @@ class Popover extends React.Component<ProvidedProps & Props> {
         >
           <Paper
             data-mui-test="Popover"
-            className={classNames(classes.paper, className)}
+            className={classes.paper}
             elevation={elevation}
             {...PaperProps}
           >

--- a/src/Popover/Popover.spec.js
+++ b/src/Popover/Popover.spec.js
@@ -219,8 +219,8 @@ describe('<Popover />', () => {
           <div />
         </Popover>,
       );
+      assert.strictEqual(wrapper.hasClass('test-class'), true, 'should have the user class');
       const paper = wrapper.childAt(0).childAt(0);
-      assert.strictEqual(paper.hasClass('test-class'), true, 'should have the user class');
       assert.strictEqual(paper.hasClass(classes.paper), true, 'should have the popover class');
     });
 


### PR DESCRIPTION
### Breaking change

I have noticed one inconsistency with the `className` property. The value should have been applied on the root of the component. We enforce this behavior now.

<img src="https://media.giphy.com/media/3ov9k4NtYguKAPcAj6/giphy.gif" />
 
Closes #8751 
