### PR TITLE
Improve warning description

### DIFF
--- a/src/styles/getStylesCreator.js
+++ b/src/styles/getStylesCreator.js
@@ -15,7 +15,7 @@ function getStylesCreator(stylesOrCreator: Object | (Object => Object)) {
     const stylesWithOverrides = { ...styles };
 
     Object.keys(overrides).forEach(key => {
-      warning(stylesWithOverrides[key], 'You are trying to overrides a style that do not exist.');
+      warning(stylesWithOverrides[key], 'You are trying to override a style that does not exist.');
       stylesWithOverrides[key] = deepmerge(stylesWithOverrides[key], overrides[key]);
     });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Issue: #8759

I started with fixing the typos. I'm not sure how to reproduce the warning message. Is it enough to say:
```
warning(stylesWithOverrides[key], 'You are trying to override a style that does not exist: ${key}');
```