### PR TITLE
[Backdrop] Standardize the API

### DIFF
--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -176,7 +176,7 @@ function Dialog(props: ProvidedProps & Props) {
   return (
     <Modal
       className={classNames(classes.root, className)}
-      backdropTransitionDuration={transitionDuration}
+      BackdropTransitionDuration={transitionDuration}
       ignoreBackdropClick={ignoreBackdropClick}
       ignoreEscapeKeyUp={ignoreEscapeKeyUp}
       onBackdropClick={onBackdropClick}

--- a/src/Dialog/Dialog.spec.js
+++ b/src/Dialog/Dialog.spec.js
@@ -46,7 +46,7 @@ describe('<Dialog />', () => {
       />,
     );
     assert.strictEqual(wrapper.props().show, true);
-    assert.strictEqual(wrapper.props().backdropTransitionDuration, 100);
+    assert.strictEqual(wrapper.props().BackdropTransitionDuration, 100);
     assert.strictEqual(wrapper.props().onBackdropClick, onBackdropClick);
     assert.strictEqual(wrapper.props().onEscapeKeyUp, onEscapeKeyUp);
     assert.strictEqual(wrapper.props().onRequestClose, onRequestClose);

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -238,7 +238,7 @@ class Drawer extends React.Component<ProvidedProps & Props, State> {
     // type === temporary
     return (
       <Modal
-        backdropTransitionDuration={transitionDuration}
+        BackdropTransitionDuration={transitionDuration}
         className={classNames(classes.modal, className)}
         show={open}
         onRequestClose={onRequestClose}

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -67,27 +67,27 @@ describe('<Drawer />', () => {
         assert.strictEqual(wrapper.find(Slide).props().transitionDuration, transitionDuration);
       });
 
-      it("should be passed to to Modal's backdropTransitionDuration when open=true", () => {
+      it("should be passed to to Modal's BackdropTransitionDuration when open=true", () => {
         const wrapper = shallow(
           <Drawer open transitionDuration={transitionDuration}>
             <div />
           </Drawer>,
         );
         assert.strictEqual(
-          wrapper.find(Modal).props().backdropTransitionDuration,
+          wrapper.find(Modal).props().BackdropTransitionDuration,
           transitionDuration,
         );
       });
     });
 
-    it("should override Modal's backdropTransitionDuration from property when specified", () => {
+    it("should override Modal's BackdropTransitionDuration from property when specified", () => {
       const testDuration = 335;
       const wrapper = shallow(
-        <Drawer backdropTransitionDuration={testDuration}>
+        <Drawer BackdropTransitionDuration={testDuration}>
           <div />
         </Drawer>,
       );
-      assert.strictEqual(wrapper.find(Modal).props().backdropTransitionDuration, testDuration);
+      assert.strictEqual(wrapper.find(Modal).props().BackdropTransitionDuration, testDuration);
     });
 
     it('should set the custom className for Modal when type is temporary', () => {

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -351,7 +351,7 @@ class Popover extends React.Component<ProvidedProps & Props> {
     } = this.props;
 
     return (
-      <Modal show={open} backdropInvisible {...other}>
+      <Modal show={open} BackdropInvisible {...other}>
         <Grow
           appear
           in={open}

--- a/src/Popover/Popover.spec.js
+++ b/src/Popover/Popover.spec.js
@@ -37,7 +37,7 @@ describe('<Popover />', () => {
         </Popover>,
       );
       assert.strictEqual(wrapper.name(), 'withStyles(Modal)');
-      assert.strictEqual(wrapper.props().backdropInvisible, true);
+      assert.strictEqual(wrapper.props().BackdropInvisible, true);
     });
 
     it('should pass onRequestClose prop to Modal', () => {

--- a/src/internal/Modal.d.ts
+++ b/src/internal/Modal.d.ts
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import { StyledComponent } from '..';
-import { BackdropProps } from './Backdrop';
 import { TransitionDuration, TransitionHandlers } from './transition';
 
 export type ModalProps = {
-  backdropClassName?: string;
-  backdropComponent?: React.ComponentType<BackdropProps>;
-  backdropInvisible?: boolean;
-  backdropTransitionDuration?: TransitionDuration;
+  BackdropClassName?: string;
+  BackdropComponent?: React.ReactType;
+  BackdropInvisible?: boolean;
+  BackdropTransitionDuration?: TransitionDuration;
   keepMounted?: boolean;
   disableBackdrop?: boolean;
   ignoreBackdropClick?: boolean;

--- a/src/internal/Modal.js
+++ b/src/internal/Modal.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import type { Element } from 'react';
+import type { Element, ElementType } from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import warning from 'warning';
@@ -39,7 +39,7 @@ export const styles = (theme: Object) => ({
 });
 
 type ProvidedProps = {
-  backdropComponent: Function,
+  BackdropComponent: ElementType,
   classes: Object,
   modalManager: Object,
   show: boolean,
@@ -49,20 +49,20 @@ export type Props = {
   /**
    * The CSS class name of the backdrop element.
    */
-  backdropClassName?: string,
+  BackdropClassName?: string,
   /**
    * Pass a component class to use as the backdrop.
    */
-  backdropComponent?: Function,
+  BackdropComponent?: ElementType,
   /**
    * If `true`, the backdrop is invisible.
    */
-  backdropInvisible?: boolean,
+  BackdropInvisible?: boolean,
   /**
    * The duration for the backdrop transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    */
-  backdropTransitionDuration?: TransitionDuration,
+  BackdropTransitionDuration?: TransitionDuration,
   /**
    * A single child content element.
    */
@@ -150,9 +150,9 @@ type State = {
  */
 class Modal extends React.Component<ProvidedProps & Props, State> {
   static defaultProps = {
-    backdropComponent: Backdrop,
-    backdropTransitionDuration: 300,
-    backdropInvisible: false,
+    BackdropComponent: Backdrop,
+    BackdropTransitionDuration: 300,
+    BackdropInvisible: false,
     keepMounted: false,
     disableBackdrop: false,
     ignoreBackdropClick: false,
@@ -319,18 +319,18 @@ class Modal extends React.Component<ProvidedProps & Props, State> {
 
   renderBackdrop(other: { [key: string]: any } = {}) {
     const {
-      backdropComponent: BackdropComponent,
-      backdropClassName,
-      backdropTransitionDuration,
-      backdropInvisible,
+      BackdropComponent,
+      BackdropClassName,
+      BackdropTransitionDuration,
+      BackdropInvisible,
       show,
     } = this.props;
 
     return (
-      <Fade appear in={show} transitionDuration={backdropTransitionDuration} {...other}>
+      <Fade appear in={show} transitionDuration={BackdropTransitionDuration} {...other}>
         <BackdropComponent
-          invisible={backdropInvisible}
-          className={backdropClassName}
+          invisible={BackdropInvisible}
+          className={BackdropClassName}
           onClick={this.handleBackdropClick}
         />
       </Fade>
@@ -340,10 +340,10 @@ class Modal extends React.Component<ProvidedProps & Props, State> {
   render() {
     const {
       disableBackdrop,
-      backdropComponent,
-      backdropClassName,
-      backdropTransitionDuration,
-      backdropInvisible,
+      BackdropComponent,
+      BackdropClassName,
+      BackdropTransitionDuration,
+      BackdropInvisible,
       ignoreBackdropClick,
       ignoreEscapeKeyUp,
       children,

--- a/src/internal/Modal.spec.js
+++ b/src/internal/Modal.spec.js
@@ -147,7 +147,7 @@ describe('<Modal />', () => {
     });
 
     it('should pass a transitionDuration prop to the transition component', () => {
-      wrapper.setProps({ backdropTransitionDuration: 200 });
+      wrapper.setProps({ BackdropTransitionDuration: 200 });
       const transition = wrapper.childAt(0).childAt(0);
       assert.strictEqual(transition.props().transitionDuration, 200);
     });


### PR DESCRIPTION
Prefix specific properties with the component name. It's changing the API on an internal component. It's not a breaking change.

The properties name on the Modal component changes:
```diff
-  backdropClassName
-  backdropComponent
-  backdropInvisible
-  backdropTransitionDuration
+  BackdropClassName
+  BackdropComponent
+  BackdropInvisible
+  BackdropTransitionDuration
```