### PR TITLE
[Select] Fix autoWidth regression

### DIFF
--- a/src/transitions/Grow.js
+++ b/src/transitions/Grow.js
@@ -197,7 +197,7 @@ class Grow extends React.Component<ProvidedProps & Props> {
       ...other
     } = this.props;
 
-    const style = { ...styleProp };
+    const style = { ...children.props.style, ...styleProp };
 
     // For server side rendering.
     if (!this.props.in || appear) {


### PR DESCRIPTION
The latest Transition upgrade broke the autoWidth feature (#8286)

I have noticed the regression digging into #8778.