### PR TITLE
[Popover] Add a marginThreshold property

### DIFF
--- a/pages/api/popover.md
+++ b/pages/api/popover.md
@@ -25,11 +25,11 @@ filename: /src/Popover/Popover.js
 | onExit | TransitionCallback |  | Callback fired before the component is exiting. |
 | onExited | TransitionCallback |  | Callback fired when the component has exited. |
 | onExiting | TransitionCallback |  | Callback fired when the component is exiting. |
-| onRequestClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
+| onRequestClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback. |
 | <span style="color: #31a148">open *</span> | boolean |  | If `true`, the popover is visible. |
 | transformOrigin | signature | {  vertical: 'top',  horizontal: 'left',} | This is the point on the popover which will attach to the anchor's origin.<br>Options: vertical: [top, center, bottom, x(px)]; horizontal: [left, center, right, x(px)]. |
 | transitionClasses | TransitionClasses |  | The animation classNames applied to the component as it enters or exits. This property is a direct binding to [`CSSTransition.classNames`](https://reactcommunity.org/react-transition-group/#CSSTransition-prop-classNames). |
-| transitionDuration | union:&nbsp;number<br>&nbsp;'auto'<br> | 'auto' | Set to 'auto' to automatically calculate transition time based on height |
+| transitionDuration | union:&nbsp;number<br>&nbsp;'auto'<br> | 'auto' | Set to 'auto' to automatically calculate transition time based on height. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/popover.md
+++ b/pages/api/popover.md
@@ -18,6 +18,7 @@ filename: /src/Popover/Popover.js
 | <span style="color: #31a148">children *</span> | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | elevation | number | 8 | The elevation of the popover. |
+| marginThreshold | number | 16 | Specifies how close to the edge of the window the popover can appear |
 | onEnter | TransitionCallback |  | Callback fired before the component is entering |
 | onEntered | TransitionCallback |  | Callback fired when the component has entered |
 | onEntering | TransitionCallback |  | Callback fired when the component is entering |

--- a/pages/api/popover.md
+++ b/pages/api/popover.md
@@ -18,13 +18,13 @@ filename: /src/Popover/Popover.js
 | <span style="color: #31a148">children *</span> | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | elevation | number | 8 | The elevation of the popover. |
-| marginThreshold | number | 16 | Specifies how close to the edge of the window the popover can appear |
-| onEnter | TransitionCallback |  | Callback fired before the component is entering |
-| onEntered | TransitionCallback |  | Callback fired when the component has entered |
-| onEntering | TransitionCallback |  | Callback fired when the component is entering |
-| onExit | TransitionCallback |  | Callback fired before the component is exiting |
-| onExited | TransitionCallback |  | Callback fired when the component has exited |
-| onExiting | TransitionCallback |  | Callback fired when the component is exiting |
+| marginThreshold | number | 16 | Specifies how close to the edge of the window the popover can appear. |
+| onEnter | TransitionCallback |  | Callback fired before the component is entering. |
+| onEntered | TransitionCallback |  | Callback fired when the component has entered. |
+| onEntering | TransitionCallback |  | Callback fired when the component is entering. |
+| onExit | TransitionCallback |  | Callback fired before the component is exiting. |
+| onExited | TransitionCallback |  | Callback fired when the component has exited. |
+| onExiting | TransitionCallback |  | Callback fired when the component is exiting. |
 | onRequestClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | <span style="color: #31a148">open *</span> | boolean |  | If `true`, the popover is visible. |
 | transformOrigin | signature | {  vertical: 'top',  horizontal: 'left',} | This is the point on the popover which will attach to the anchor's origin.<br>Options: vertical: [top, center, bottom, x(px)]; horizontal: [left, center, right, x(px)]. |

--- a/src/Popover/Popover.d.ts
+++ b/src/Popover/Popover.d.ts
@@ -22,6 +22,7 @@ export interface PopoverProps extends StandardProps<
   exitedClassName?: string;
   exitingClassName?: string;
   getContentAnchorEl?: Function;
+  marginThreshold?: number;
   modal?: boolean;
   onRequestClose?: Function;
   open?: boolean;

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -81,6 +81,7 @@ type ProvidedProps = {
   anchorOrigin: Origin,
   classes: Object,
   transformOrigin: Origin,
+  marginThreshold: number,
 };
 
 export type Props = {
@@ -114,6 +115,10 @@ export type Props = {
    * @ignore
    */
   getContentAnchorEl?: Function,
+  /**
+   * Specifies how close to the edge of the window the popover can appear
+   */
+  marginThreshold?: number,
   /**
    * Callback fired before the component is entering
    */
@@ -188,6 +193,7 @@ class Popover extends React.Component<ProvidedProps & Props> {
     },
     transitionDuration: 'auto',
     elevation: 8,
+    marginThreshold: 16,
   };
 
   componentWillUnmount = () => {
@@ -219,9 +225,9 @@ class Popover extends React.Component<ProvidedProps & Props> {
     this.setPositioningStyles(element);
   }, 166);
 
-  marginThreshold = 16;
+  getPositioningStyle = element => {
+    const { marginThreshold } = this.props;
 
-  getPositioningStyle(element) {
     // Check if the parent has requested anchoring on an inner content node
     const contentAnchorOffset = this.getContentAnchorOffset(element);
     // Get the offset of of the anchoring element
@@ -241,12 +247,12 @@ class Popover extends React.Component<ProvidedProps & Props> {
     const right = left + elemRect.width;
 
     // Window thresholds taking required margin into account
-    const heightThreshold = window.innerHeight - this.marginThreshold;
-    const widthThreshold = window.innerWidth - this.marginThreshold;
+    const heightThreshold = window.innerHeight - marginThreshold;
+    const widthThreshold = window.innerWidth - marginThreshold;
 
     // Check if the vertical axis needs shifting
-    if (top < this.marginThreshold) {
-      const diff = top - this.marginThreshold;
+    if (top < marginThreshold) {
+      const diff = top - marginThreshold;
       top -= diff;
       transformOrigin.vertical += diff;
     } else if (bottom > heightThreshold) {
@@ -256,8 +262,8 @@ class Popover extends React.Component<ProvidedProps & Props> {
     }
 
     // Check if the horizontal axis needs shifting
-    if (left < this.marginThreshold) {
-      const diff = left - this.marginThreshold;
+    if (left < marginThreshold) {
+      const diff = left - marginThreshold;
       left -= diff;
       transformOrigin.horizontal += diff;
     } else if (right > widthThreshold) {
@@ -271,7 +277,7 @@ class Popover extends React.Component<ProvidedProps & Props> {
       left: `${left}px`,
       transformOrigin: getTransformOriginValue(transformOrigin),
     };
-  }
+  };
 
   handleGetOffsetTop = getOffsetTop;
   handleGetOffsetLeft = getOffsetLeft;
@@ -335,6 +341,7 @@ class Popover extends React.Component<ProvidedProps & Props> {
       classes,
       elevation,
       getContentAnchorEl,
+      marginThreshold,
       onEnter,
       onEntering,
       onEntered,

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -146,7 +146,7 @@ export type Props = {
   /**
    * Callback fired when the component requests to be closed.
    *
-   * @param {object} event The event source of the callback
+   * @param {object} event The event source of the callback.
    */
   onRequestClose?: Function,
   /**
@@ -176,7 +176,7 @@ export type Props = {
    */
   transitionClasses?: TransitionClasses,
   /**
-   * Set to 'auto' to automatically calculate transition time based on height
+   * Set to 'auto' to automatically calculate transition time based on height.
    */
   transitionDuration?: number | 'auto',
 };

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -116,31 +116,31 @@ export type Props = {
    */
   getContentAnchorEl?: Function,
   /**
-   * Specifies how close to the edge of the window the popover can appear
+   * Specifies how close to the edge of the window the popover can appear.
    */
   marginThreshold?: number,
   /**
-   * Callback fired before the component is entering
+   * Callback fired before the component is entering.
    */
   onEnter?: TransitionCallback,
   /**
-   * Callback fired when the component is entering
+   * Callback fired when the component is entering.
    */
   onEntering?: TransitionCallback,
   /**
-   * Callback fired when the component has entered
+   * Callback fired when the component has entered.
    */
   onEntered?: TransitionCallback,
   /**
-   * Callback fired before the component is exiting
+   * Callback fired before the component is exiting.
    */
   onExit?: TransitionCallback,
   /**
-   * Callback fired when the component is exiting
+   * Callback fired when the component is exiting.
    */
   onExiting?: TransitionCallback,
   /**
-   * Callback fired when the component has exited
+   * Callback fired when the component has exited.
    */
   onExited?: TransitionCallback,
   /**

--- a/src/Popover/Popover.spec.js
+++ b/src/Popover/Popover.spec.js
@@ -458,166 +458,168 @@ describe('<Popover />', () => {
     });
   });
 
-  describe('getPositioningStyle(element)', () => {
-    let instance;
-    let element;
-    let anchorOffset;
-    let tempAnchorOffset;
-    let transformOrigin;
-    let positioningStyle;
+  [0, 8, 16].forEach(marginThreshold => {
+    describe('getPositioningStyle(element)', () => {
+      let instance;
+      let element;
+      let anchorOffset;
+      let tempAnchorOffset;
+      let transformOrigin;
+      let positioningStyle;
 
-    let innerHeightContainer;
-    let innerWidthContainer;
+      let innerHeightContainer;
+      let innerWidthContainer;
 
-    before(() => {
-      instance = shallow(
-        <Popover {...props}>
-          <div />
-        </Popover>,
-      ).instance();
-      instance.getContentAnchorOffset = spy();
-
-      innerHeightContainer = global.window.innerHeight;
-      innerWidthContainer = global.window.innerWidth;
-
-      global.window.innerHeight = instance.marginThreshold * 2;
-      global.window.innerWidth = instance.marginThreshold * 2;
-
-      anchorOffset = { top: instance.marginThreshold, left: instance.marginThreshold };
-      instance.getAnchorOffset = stub().returns(anchorOffset);
-
-      transformOrigin = { vertical: 0, horizontal: 0 };
-      instance.getTransformOrigin = stub().returns(transformOrigin);
-
-      instance.getTransformOriginValue = stub().returns(true);
-
-      element = { clientHeight: 0, clientWidth: 0 };
-    });
-
-    after(() => {
-      global.window.innerHeight = innerHeightContainer;
-      global.window.innerWidth = innerWidthContainer;
-    });
-
-    describe('no offsets', () => {
       before(() => {
-        positioningStyle = instance.getPositioningStyle(element);
+        instance = shallow(
+          <Popover {...props} marginThreshold={marginThreshold}>
+            <div />
+          </Popover>,
+        ).instance();
+        instance.getContentAnchorOffset = spy();
+
+        innerHeightContainer = global.window.innerHeight;
+        innerWidthContainer = global.window.innerWidth;
+
+        global.window.innerHeight = marginThreshold * 2;
+        global.window.innerWidth = marginThreshold * 2;
+
+        anchorOffset = { top: marginThreshold, left: marginThreshold };
+        instance.getAnchorOffset = stub().returns(anchorOffset);
+
+        transformOrigin = { vertical: 0, horizontal: 0 };
+        instance.getTransformOrigin = stub().returns(transformOrigin);
+
+        instance.getTransformOriginValue = stub().returns(true);
+
+        element = { clientHeight: 0, clientWidth: 0 };
       });
 
       after(() => {
-        instance.getAnchorOffset = stub().returns(anchorOffset);
+        global.window.innerHeight = innerHeightContainer;
+        global.window.innerWidth = innerWidthContainer;
       });
 
-      it('should set top to marginThreshold', () => {
-        assert.strictEqual(positioningStyle.top, `${instance.marginThreshold}px`);
+      describe('no offsets', () => {
+        before(() => {
+          positioningStyle = instance.getPositioningStyle(element);
+        });
+
+        after(() => {
+          instance.getAnchorOffset = stub().returns(anchorOffset);
+        });
+
+        it('should set top to marginThreshold', () => {
+          assert.strictEqual(positioningStyle.top, `${marginThreshold}px`);
+        });
+
+        it('should set left to marginThreshold', () => {
+          assert.strictEqual(positioningStyle.left, `${marginThreshold}px`);
+        });
+
+        it('should transformOrigin according to marginThreshold', () => {
+          assert.strictEqual(positioningStyle.transformOrigin, '0px 0px');
+        });
       });
 
-      it('should set left to marginThreshold', () => {
-        assert.strictEqual(positioningStyle.left, `${instance.marginThreshold}px`);
+      describe('top < marginThreshold', () => {
+        before(() => {
+          tempAnchorOffset = { top: marginThreshold - 1, left: marginThreshold };
+          instance.getAnchorOffset = stub().returns(tempAnchorOffset);
+
+          positioningStyle = instance.getPositioningStyle(element);
+        });
+
+        after(() => {
+          instance.getAnchorOffset = stub().returns(anchorOffset);
+        });
+
+        it('should set top to marginThreshold', () => {
+          assert.strictEqual(positioningStyle.top, `${marginThreshold}px`);
+        });
+
+        it('should set left to marginThreshold', () => {
+          assert.strictEqual(positioningStyle.left, `${marginThreshold}px`);
+        });
+
+        it('should transformOrigin according to marginThreshold', () => {
+          assert.strictEqual(positioningStyle.transformOrigin, '0px -1px');
+        });
       });
 
-      it('should transformOrigin according to marginThreshold', () => {
-        assert.strictEqual(positioningStyle.transformOrigin, '0px 0px');
-      });
-    });
+      describe('bottom > heightThreshold', () => {
+        before(() => {
+          tempAnchorOffset = { top: marginThreshold + 1, left: marginThreshold };
+          instance.getAnchorOffset = stub().returns(tempAnchorOffset);
 
-    describe('top < marginThreshold', () => {
-      before(() => {
-        tempAnchorOffset = { top: instance.marginThreshold - 1, left: instance.marginThreshold };
-        instance.getAnchorOffset = stub().returns(tempAnchorOffset);
+          positioningStyle = instance.getPositioningStyle(element);
+        });
 
-        positioningStyle = instance.getPositioningStyle(element);
-      });
+        after(() => {
+          instance.getAnchorOffset = stub().returns(anchorOffset);
+        });
 
-      after(() => {
-        instance.getAnchorOffset = stub().returns(anchorOffset);
-      });
+        it('should set top to marginThreshold', () => {
+          assert.strictEqual(positioningStyle.top, `${marginThreshold}px`);
+        });
 
-      it('should set top to marginThreshold', () => {
-        assert.strictEqual(positioningStyle.top, `${instance.marginThreshold}px`);
-      });
+        it('should set left to marginThreshold', () => {
+          assert.strictEqual(positioningStyle.left, `${marginThreshold}px`);
+        });
 
-      it('should set left to marginThreshold', () => {
-        assert.strictEqual(positioningStyle.left, `${instance.marginThreshold}px`);
-      });
-
-      it('should transformOrigin according to marginThreshold', () => {
-        assert.strictEqual(positioningStyle.transformOrigin, '0px -1px');
-      });
-    });
-
-    describe('bottom > heightThreshold', () => {
-      before(() => {
-        tempAnchorOffset = { top: instance.marginThreshold + 1, left: instance.marginThreshold };
-        instance.getAnchorOffset = stub().returns(tempAnchorOffset);
-
-        positioningStyle = instance.getPositioningStyle(element);
+        it('should transformOrigin according to marginThreshold', () => {
+          assert.strictEqual(positioningStyle.transformOrigin, '0px 1px');
+        });
       });
 
-      after(() => {
-        instance.getAnchorOffset = stub().returns(anchorOffset);
+      describe('left < marginThreshold', () => {
+        before(() => {
+          tempAnchorOffset = { top: marginThreshold, left: marginThreshold - 1 };
+          instance.getAnchorOffset = stub().returns(tempAnchorOffset);
+
+          positioningStyle = instance.getPositioningStyle(element);
+        });
+
+        after(() => {
+          instance.getAnchorOffset = stub().returns(anchorOffset);
+        });
+
+        it('should set top to marginThreshold', () => {
+          assert.strictEqual(positioningStyle.top, `${marginThreshold}px`);
+        });
+
+        it('should set left to marginThreshold', () => {
+          assert.strictEqual(positioningStyle.left, `${marginThreshold}px`);
+        });
+
+        it('should transformOrigin according to marginThreshold', () => {
+          assert.strictEqual(positioningStyle.transformOrigin, '-1px 0px');
+        });
       });
 
-      it('should set top to marginThreshold', () => {
-        assert.strictEqual(positioningStyle.top, `${instance.marginThreshold}px`);
-      });
+      describe('right > widthThreshold', () => {
+        before(() => {
+          tempAnchorOffset = { top: marginThreshold, left: marginThreshold + 1 };
+          instance.getAnchorOffset = stub().returns(tempAnchorOffset);
 
-      it('should set left to marginThreshold', () => {
-        assert.strictEqual(positioningStyle.left, `${instance.marginThreshold}px`);
-      });
+          positioningStyle = instance.getPositioningStyle(element);
+        });
 
-      it('should transformOrigin according to marginThreshold', () => {
-        assert.strictEqual(positioningStyle.transformOrigin, '0px 1px');
-      });
-    });
+        after(() => {
+          instance.getAnchorOffset = stub().returns(anchorOffset);
+        });
 
-    describe('left < marginThreshold', () => {
-      before(() => {
-        tempAnchorOffset = { top: instance.marginThreshold, left: instance.marginThreshold - 1 };
-        instance.getAnchorOffset = stub().returns(tempAnchorOffset);
+        it('should set top to marginThreshold', () => {
+          assert.strictEqual(positioningStyle.top, `${marginThreshold}px`);
+        });
 
-        positioningStyle = instance.getPositioningStyle(element);
-      });
+        it('should set left to marginThreshold', () => {
+          assert.strictEqual(positioningStyle.left, `${marginThreshold}px`);
+        });
 
-      after(() => {
-        instance.getAnchorOffset = stub().returns(anchorOffset);
-      });
-
-      it('should set top to marginThreshold', () => {
-        assert.strictEqual(positioningStyle.top, `${instance.marginThreshold}px`);
-      });
-
-      it('should set left to marginThreshold', () => {
-        assert.strictEqual(positioningStyle.left, `${instance.marginThreshold}px`);
-      });
-
-      it('should transformOrigin according to marginThreshold', () => {
-        assert.strictEqual(positioningStyle.transformOrigin, '-1px 0px');
-      });
-    });
-
-    describe('right > widthThreshold', () => {
-      before(() => {
-        tempAnchorOffset = { top: instance.marginThreshold, left: instance.marginThreshold + 1 };
-        instance.getAnchorOffset = stub().returns(tempAnchorOffset);
-
-        positioningStyle = instance.getPositioningStyle(element);
-      });
-
-      after(() => {
-        instance.getAnchorOffset = stub().returns(anchorOffset);
-      });
-
-      it('should set top to marginThreshold', () => {
-        assert.strictEqual(positioningStyle.top, `${instance.marginThreshold}px`);
-      });
-
-      it('should set left to marginThreshold', () => {
-        assert.strictEqual(positioningStyle.left, `${instance.marginThreshold}px`);
-      });
-
-      it('should transformOrigin according to marginThreshold', () => {
-        assert.strictEqual(positioningStyle.transformOrigin, '1px 0px');
+        it('should transformOrigin according to marginThreshold', () => {
+          assert.strictEqual(positioningStyle.transformOrigin, '1px 0px');
+        });
       });
     });
   });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Allows users to choose how large the marginThreshold is and have popovers closer than 16px from the edge of the screen if they so wish.

Should we set default to 2 theme units rather than 16?