### PR TITLE
Add helper function for styles in TypeScript.

### DIFF
--- a/src/styles/index.d.ts
+++ b/src/styles/index.d.ts
@@ -1,4 +1,4 @@
 export { default as MuiThemeProvider } from './MuiThemeProvider';
-export { default as withStyles, WithStyles, StyleRules, StyleRulesCallback, StyledComponentProps } from './withStyles';
+export { default as withStyles, style, WithStyles, StyleRules, StyleRulesCallback, StyledComponentProps } from './withStyles';
 export { default as withTheme } from './withTheme';
 export { default as createMuiTheme, Theme } from './createMuiTheme';

--- a/src/styles/withStyles.d.ts
+++ b/src/styles/withStyles.d.ts
@@ -18,6 +18,8 @@ export interface WithStylesOptions {
   name?: string;
 }
 
+export function style(cssProps: Partial<React.CSSProperties>): Partial<React.CSSProperties>
+
 export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, string>;
 
 export interface WithStyles<ClassKey extends string = string> {

--- a/src/styles/withStyles.js
+++ b/src/styles/withStyles.js
@@ -50,6 +50,8 @@ function getDefaultTheme() {
   return defaultTheme;
 }
 
+export const style = (cssProps: Object) => cssProps;
+
 type Options = {
   flip?: boolean,
   withTheme?: boolean,


### PR DESCRIPTION
Adds a helper function `style(cssProps: Partial<React.CSSProperties>): Partial<React.CSSProperties>` to make TypeScript typing easier.

For a guide to using TypeScript with Material UI styles, see https://material-ui-next.com/guides/typescript/

With the current set of typings, the compiler is unable to infer appropriate typings for the arguments to `withStyles()`:

```
const decorate = withStyles(theme => ({
  root: {
    overflow: 'hidden', // error
  },
}))

// Error:
// Types of property 'overflow' are incompatible.
// Type 'string' is not assignable to type '"hidden" | "initial" | "inherit" | "unset" | "auto" | "scroll" | "visible" | undefined'.
```

This can be fixed by adding the classname as a generic parameter, like so:
```
const decorate = withStyles<'root'>(theme => ({
  root: {
    overflow: 'hidden', // ok
  },
}))
```

However, this is cumbersome when the number of classnames becomes large, as in:
```
const decorate = withStyles<'root0' | 'root1' | 'root2' | 'root3' | 'root4' >(theme => ({
  root0: { overflow: 'hidden' },
  root1: { overflow: 'hidden' },
  root2: { overflow: 'hidden' },
  root3: { overflow: 'hidden' },
  root4: { overflow: 'hidden' },
}))
```

The addition of the `style()` helper assists with type inference, such that the above example becomes:
```
const decorate = withStyles(theme => ({
  root0: style({ overflow: 'hidden' }),
  root1: style({ overflow: 'hidden' }),
  root2: style({ overflow: 'hidden' }),
  root3: style({ overflow: 'hidden' }),
  root4: style({ overflow: 'hidden' }),
}))
```

This helper also enables the easy declaration of CSS properties outside of the context of `withStyles()`, eg, where a set of constant properties should be reused in multiple places:
```
const overflowHiddenStyle = style({ overflow: 'hidden' })
```
