### PR TITLE
Add witness type for WithStyles<ClassKey> to return value of withStyles()

### DIFF
--- a/src/styles/withStyles.d.ts
+++ b/src/styles/withStyles.d.ts
@@ -33,6 +33,10 @@ export interface StyledComponentProps<ClassKey extends string = string> {
 export default function withStyles<ClassKey extends string>(
   style: StyleRules<ClassKey> | StyleRulesCallback<ClassKey>,
   options?: WithStylesOptions
-): <P>(
-  component: React.ComponentType<P & WithStyles<ClassKey>>
-) => React.ComponentType<P & StyledComponentProps<ClassKey>>;
+): {
+  <P>(
+    component: React.ComponentType<P & WithStyles<ClassKey>>
+  ): React.ComponentType<P & StyledComponentProps<ClassKey>>
+  
+  _StyleProps: WithStyles<ClassKey>
+};


### PR DESCRIPTION
Adds a witness type (a field that only exists in TypeScript typings) to the return value of `withStyles()`, to enable easier typing of React Component props.

Suppose that you have a decorator with many classnames, as returned from `withStyles()`:
```
const decorate = withStyles<'root0' | 'root1' | 'root2' | 'root3' | 'root4' >(theme => ({
  root0: { overflow: 'hidden' },
  root1: { overflow: 'hidden' },
  root2: { overflow: 'hidden' },
  root3: { overflow: 'hidden' },
  root4: { overflow: 'hidden' },
}))
```

In order to decorate a React Component, it is necessary to provide the appropriate generic type parameter for the component's props, which is cumbersome when the number of classnames is large:
```
class Example extends React.Component<MyProps & WithStyles<'root0' | 'root1' | 'root2' | 'root3' | 'root4' >> { ... }
const DecoratedExample = decorate(Example)
```

The witness type on the decorator carries along the typing information needed to augment component props, dramatically simplifying the React Component definition:
```
class Example extends React.Component<MyProps & typeof decorate._StyleProps> { ... }
const DecoratedExample = decorate(Example)
```