### PR TITLE
[transition] Improve interoperability with react-transition-group

### DIFF
--- a/pages/api/collapse.md
+++ b/pages/api/collapse.md
@@ -16,7 +16,7 @@ filename: /src/transitions/Collapse.js
 | classes | Object |  | Useful to extend the style applied to components. |
 | collapsedHeight | string | '0px' | The height of the container when collapsed. |
 | <span style="color: #31a148">in *</span> | boolean |  | If `true`, the component will transition in. |
-| transitionDuration | union:&nbsp;number<br>&nbsp;{ enter?: number, exit?: number }<br>&nbsp;'auto'<br> | duration.standard | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
+| timeout | union:&nbsp;number<br>&nbsp;{ enter?: number, exit?: number }<br>&nbsp;'auto'<br> | duration.standard | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/fade.md
+++ b/pages/api/fade.md
@@ -15,7 +15,7 @@ It's using [react-transition-group](https://github.com/reactjs/react-transition-
 |:-----|:-----|:--------|:------------|
 | <span style="color: #31a148">children *</span> | Element |  | A single child content element. |
 | <span style="color: #31a148">in *</span> | boolean |  | If `true`, the component will transition in. |
-| transitionDuration | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| timeout | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/grow.md
+++ b/pages/api/grow.md
@@ -16,8 +16,8 @@ It's using [react-transition-group](https://github.com/reactjs/react-transition-
 | <span style="color: #31a148">children *</span> | Element |  | A single child content element. |
 | <span style="color: #31a148">in *</span> | boolean |  | If `true`, show the component; triggers the enter or exit animation. |
 | rootRef | Function |  | Use that property to pass a ref callback to the root component. |
+| timeout | union:&nbsp;number<br>&nbsp;{ enter?: number, exit?: number }<br>&nbsp;'auto'<br> | 'auto' | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
 | transitionClasses | TransitionClasses | {} | The animation classNames applied to the component as it enters or exits. This property is a direct binding to [`CSSTransition.classNames`](https://reactcommunity.org/react-transition-group/#CSSTransition-prop-classNames). |
-| transitionDuration | union:&nbsp;number<br>&nbsp;{ enter?: number, exit?: number }<br>&nbsp;'auto'<br> | 'auto' | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/menu.md
+++ b/pages/api/menu.md
@@ -24,7 +24,7 @@ filename: /src/Menu/Menu.js
 | onExiting | TransitionCallback |  | Callback fired when the Menu is exiting. |
 | onRequestClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | open | boolean | false | If `true`, the menu is visible. |
-| transitionDuration | union:&nbsp;number<br>&nbsp;'auto'<br> | 'auto' | The length of the transition in `ms`, or 'auto' |
+| transitionDuration | union:&nbsp;number<br>&nbsp;{ enter?: number, exit?: number }<br>&nbsp;'auto'<br> | 'auto' | The length of the transition in `ms`, or 'auto' |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/popover.md
+++ b/pages/api/popover.md
@@ -29,7 +29,7 @@ filename: /src/Popover/Popover.js
 | <span style="color: #31a148">open *</span> | boolean |  | If `true`, the popover is visible. |
 | transformOrigin | signature | {  vertical: 'top',  horizontal: 'left',} | This is the point on the popover which will attach to the anchor's origin.<br>Options: vertical: [top, center, bottom, x(px)]; horizontal: [left, center, right, x(px)]. |
 | transitionClasses | TransitionClasses |  | The animation classNames applied to the component as it enters or exits. This property is a direct binding to [`CSSTransition.classNames`](https://reactcommunity.org/react-transition-group/#CSSTransition-prop-classNames). |
-| transitionDuration | union:&nbsp;number<br>&nbsp;'auto'<br> | 'auto' | Set to 'auto' to automatically calculate transition time based on height. |
+| transitionDuration | union:&nbsp;number<br>&nbsp;{ enter?: number, exit?: number }<br>&nbsp;'auto'<br> | 'auto' | Set to 'auto' to automatically calculate transition time based on height. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/slide.md
+++ b/pages/api/slide.md
@@ -15,7 +15,7 @@ filename: /src/transitions/Slide.js
 | <span style="color: #31a148">children *</span> | Element |  | A single child content element. |
 | direction | union:&nbsp;'left'<br>&nbsp;'right'<br>&nbsp;'up'<br>&nbsp;'down'<br> | 'down' | Direction the child node will enter from. |
 | <span style="color: #31a148">in *</span> | boolean |  | If `true`, show the component; triggers the enter or exit animation. |
-| transitionDuration | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| timeout | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -191,7 +191,7 @@ function Dialog(props: ProvidedProps & Props) {
         {
           appear: true,
           in: open,
-          transitionDuration,
+          timeout: transitionDuration,
           onEnter,
           onEntering,
           onEntered,

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -219,7 +219,7 @@ class Drawer extends React.Component<ProvidedProps & Props, State> {
       <Slide
         in={open}
         direction={getSlideDirection(anchor)}
-        transitionDuration={transitionDuration}
+        timeout={transitionDuration}
         appear={!this.state.firstMount}
         {...SlideProps}
       >

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -64,7 +64,7 @@ describe('<Drawer />', () => {
             <div />
           </Drawer>,
         );
-        assert.strictEqual(wrapper.find(Slide).props().transitionDuration, transitionDuration);
+        assert.strictEqual(wrapper.find(Slide).props().timeout, transitionDuration);
       });
 
       it("should be passed to to Modal's BackdropTransitionDuration when open=true", () => {

--- a/src/Input/InputLabel.spec.js
+++ b/src/Input/InputLabel.spec.js
@@ -36,7 +36,7 @@ describe('<InputLabel />', () => {
     assert.strictEqual(wrapper.hasClass(classes.disabled), true);
   });
 
-  describe('props: FormControlClasses', () => {
+  describe('prop: FormControlClasses', () => {
     it('should be able to change the FormLabel style', () => {
       const wrapper = shallow(<InputLabel FormControlClasses={{ foo: 'bar' }}>Foo</InputLabel>);
       assert.strictEqual(wrapper.props().classes.foo, 'bar');

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -78,7 +78,7 @@ export type Props = {
   /**
    * The length of the transition in `ms`, or 'auto'
    */
-  transitionDuration?: number | 'auto',
+  transitionDuration?: number | { enter?: number, exit?: number } | 'auto',
 };
 
 const rtlOrigin = {

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -178,7 +178,7 @@ export type Props = {
   /**
    * Set to 'auto' to automatically calculate transition time based on height.
    */
-  transitionDuration?: number | 'auto',
+  transitionDuration?: number | { enter?: number, exit?: number } | 'auto',
 };
 
 class Popover extends React.Component<ProvidedProps & Props> {
@@ -370,7 +370,7 @@ class Popover extends React.Component<ProvidedProps & Props> {
           onExited={onExited}
           role={role}
           transitionClasses={transitionClasses}
-          transitionDuration={transitionDuration}
+          timeout={transitionDuration}
           rootRef={node => {
             this.transitionEl = node;
           }}

--- a/src/Progress/LinearProgress.js
+++ b/src/Progress/LinearProgress.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import warning from 'warning';
 import withStyles from '../styles/withStyles';
 
-const transitionDuration = 4; // 400ms
+const TRANSITION_DURATION = 4; // 400ms
 
 export const styles = (theme: Object) => ({
   root: {
@@ -54,7 +54,7 @@ export const styles = (theme: Object) => ({
     animation: 'buffer 3s infinite linear',
   },
   bufferBar2: {
-    transition: `transform .${transitionDuration}s linear`,
+    transition: `transform .${TRANSITION_DURATION}s linear`,
   },
   rootBuffer: {
     backgroundColor: 'transparent',
@@ -75,18 +75,18 @@ export const styles = (theme: Object) => ({
   },
   determinateBar1: {
     willChange: 'transform',
-    transition: `transform .${transitionDuration}s linear`,
+    transition: `transform .${TRANSITION_DURATION}s linear`,
   },
   bufferBar1: {
     zIndex: 1,
-    transition: `transform .${transitionDuration}s linear`,
+    transition: `transform .${TRANSITION_DURATION}s linear`,
   },
   bufferBar2Primary: {
-    transition: `transform .${transitionDuration}s linear`,
+    transition: `transform .${TRANSITION_DURATION}s linear`,
     backgroundColor: theme.palette.primary[100],
   },
   bufferBar2Accent: {
-    transition: `transform .${transitionDuration}s linear`,
+    transition: `transform .${TRANSITION_DURATION}s linear`,
     backgroundColor: theme.palette.secondary.A100,
   },
   // Legends:

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -343,7 +343,7 @@ class Snackbar extends React.Component<ProvidedProps & Props, State> {
     const transitionProps = {
       in: open,
       appear: true,
-      transitionDuration,
+      timeout: transitionDuration,
       onEnter,
       onEntering,
       onEntered,

--- a/src/internal/Modal.js
+++ b/src/internal/Modal.js
@@ -327,7 +327,7 @@ class Modal extends React.Component<ProvidedProps & Props, State> {
     } = this.props;
 
     return (
-      <Fade appear in={show} transitionDuration={BackdropTransitionDuration} {...other}>
+      <Fade appear in={show} timeout={BackdropTransitionDuration} {...other}>
         <BackdropComponent
           invisible={BackdropInvisible}
           className={BackdropClassName}

--- a/src/internal/Modal.spec.js
+++ b/src/internal/Modal.spec.js
@@ -149,7 +149,7 @@ describe('<Modal />', () => {
     it('should pass a transitionDuration prop to the transition component', () => {
       wrapper.setProps({ BackdropTransitionDuration: 200 });
       const transition = wrapper.childAt(0).childAt(0);
-      assert.strictEqual(transition.props().transitionDuration, 200);
+      assert.strictEqual(transition.props().timeout, 200);
     });
 
     it('should attach a handler to the backdrop that fires onRequestClose', () => {

--- a/src/internal/transition.d.ts
+++ b/src/internal/transition.d.ts
@@ -3,8 +3,6 @@ import * as React from 'react';
 export type TransitionDuration = number | { enter: number, exit: number };
 export type TransitionCallback = (element: HTMLElement) => void;
 
-// export type TransitionRequestTimeout = (element: HTMLElement) => number;
-
 export type TransitionHandlers = {
   onEnter: TransitionCallback;
   onEntering: TransitionCallback;
@@ -18,9 +16,6 @@ export interface TransitionProps extends Partial<TransitionHandlers> {
   children: React.ReactElement<any>;
   className?: string;
   in: boolean;
-  timeout?: number;
   appear?: boolean;
   unmountOnExit?: boolean;
 }
-
-// export default class Transition extends React.Component<TransitionProps> {}

--- a/src/transitions/Collapse.d.ts
+++ b/src/transitions/Collapse.d.ts
@@ -10,7 +10,7 @@ export interface CollapseProps extends StandardProps<
 > {
   children?: React.ReactNode;
   theme?: Theme;
-  transitionDuration?: TransitionDuration | 'auto';
+  timeout?: TransitionDuration | 'auto';
 }
 
 export type CollapseClassKey =

--- a/src/transitions/Collapse.js
+++ b/src/transitions/Collapse.js
@@ -26,7 +26,7 @@ type ProvidedProps = {
   appear: boolean,
   classes: Object,
   collapsedHeight: string,
-  transitionDuration: TransitionDuration,
+  timeout: TransitionDuration,
   theme: Object,
 };
 
@@ -85,7 +85,7 @@ export type Props = {
    *
    * Set to 'auto' to automatically calculate transition time based on height.
    */
-  transitionDuration?: TransitionDuration,
+  timeout?: TransitionDuration,
 };
 
 const reflow = node => node.scrollTop;
@@ -94,7 +94,7 @@ class Collapse extends React.Component<ProvidedProps & Props> {
   static defaultProps = {
     appear: false,
     collapsedHeight: '0px',
-    transitionDuration: duration.standard,
+    timeout: duration.standard,
   };
 
   wrapper = null;
@@ -109,17 +109,17 @@ class Collapse extends React.Component<ProvidedProps & Props> {
   };
 
   handleEntering = (node: HTMLElement) => {
-    const { transitionDuration, theme } = this.props;
+    const { timeout, theme } = this.props;
     const wrapperHeight = this.wrapper ? this.wrapper.clientHeight : 0;
 
-    if (transitionDuration === 'auto') {
+    if (timeout === 'auto') {
       const duration2 = theme.transitions.getAutoHeightDuration(wrapperHeight);
       node.style.transitionDuration = `${duration2}ms`;
       this.autoTransitionDuration = duration2;
-    } else if (typeof transitionDuration === 'number') {
-      node.style.transitionDuration = `${transitionDuration}ms`;
-    } else if (transitionDuration) {
-      node.style.transitionDuration = `${transitionDuration.enter}ms`;
+    } else if (typeof timeout === 'number') {
+      node.style.transitionDuration = `${timeout}ms`;
+    } else if (timeout) {
+      node.style.transitionDuration = `${timeout.enter}ms`;
     } else {
       // The propType will warn in this case.
     }
@@ -151,19 +151,19 @@ class Collapse extends React.Component<ProvidedProps & Props> {
   };
 
   handleExiting = (node: HTMLElement) => {
-    const { transitionDuration, theme } = this.props;
+    const { timeout, theme } = this.props;
     const wrapperHeight = this.wrapper ? this.wrapper.clientHeight : 0;
 
     reflow(node);
 
-    if (transitionDuration === 'auto') {
+    if (timeout === 'auto') {
       const duration2 = theme.transitions.getAutoHeightDuration(wrapperHeight);
       node.style.transitionDuration = `${duration2}ms`;
       this.autoTransitionDuration = duration2;
-    } else if (typeof transitionDuration === 'number') {
-      node.style.transitionDuration = `${transitionDuration}ms`;
-    } else if (transitionDuration) {
-      node.style.transitionDuration = `${transitionDuration.exit}ms`;
+    } else if (typeof timeout === 'number') {
+      node.style.transitionDuration = `${timeout}ms`;
+    } else if (timeout) {
+      node.style.transitionDuration = `${timeout.exit}ms`;
     } else {
       // The propType will warn in this case.
     }
@@ -182,10 +182,10 @@ class Collapse extends React.Component<ProvidedProps & Props> {
   addEndListener = (node, next: Function) => {
     let timeout;
 
-    if (this.props.transitionDuration === 'auto') {
+    if (this.props.timeout === 'auto') {
       timeout = this.autoTransitionDuration || 0;
     } else {
-      timeout = this.props.transitionDuration;
+      timeout = this.props.timeout;
     }
 
     setTimeout(next, timeout);
@@ -203,7 +203,7 @@ class Collapse extends React.Component<ProvidedProps & Props> {
       onExit,
       onExiting,
       style,
-      transitionDuration,
+      timeout,
       theme,
       ...other
     } = this.props;

--- a/src/transitions/Collapse.spec.js
+++ b/src/transitions/Collapse.spec.js
@@ -67,7 +67,7 @@ describe('<Collapse />', () => {
     });
   });
 
-  describe('props: transitionDuration', () => {
+  describe('prop: timeout', () => {
     let wrapper;
     let instance;
     let element;
@@ -78,7 +78,7 @@ describe('<Collapse />', () => {
       wrapper = shallow(
         <Collapse
           {...props}
-          transitionDuration={{
+          timeout={{
             enter: enterDuration,
             exit: leaveDuration,
           }}
@@ -145,16 +145,16 @@ describe('<Collapse />', () => {
         assert.strictEqual(onEnteringStub.calledWith(element), true);
       });
 
-      describe('transitionDuration', () => {
+      describe('timeout', () => {
         let theme;
-        let transitionDurationMock;
+        let timeoutMock;
         let restore;
 
         before(() => {
           theme = instance.props.theme;
           restore = theme.transitions.getAutoHeightDuration;
           theme.transitions.getAutoHeightDuration = stub().returns('woofCollapseStub');
-          wrapper.setProps({ transitionDuration: 'auto' });
+          wrapper.setProps({ timeout: 'auto' });
           instance = wrapper.instance();
         });
 
@@ -181,18 +181,18 @@ describe('<Collapse />', () => {
           );
         });
 
-        it('number should set transitionDuration to ms', () => {
-          transitionDurationMock = 3;
-          wrapper.setProps({ transitionDuration: transitionDurationMock });
+        it('number should set timeout to ms', () => {
+          timeoutMock = 3;
+          wrapper.setProps({ timeout: timeoutMock });
           instance = wrapper.instance();
           instance.handleEntering(element);
 
-          assert.strictEqual(element.style.transitionDuration, `${transitionDurationMock}ms`);
+          assert.strictEqual(element.style.transitionDuration, `${timeoutMock}ms`);
         });
 
-        it('nothing should not set transitionDuration', () => {
+        it('nothing should not set timeout', () => {
           const elementBackup = element;
-          wrapper.setProps({ transitionDuration: undefined });
+          wrapper.setProps({ timeout: undefined });
           instance = wrapper.instance();
           instance.handleEntering(element);
 
@@ -259,16 +259,16 @@ describe('<Collapse />', () => {
         assert.strictEqual(onExitingStub.calledWith(element), true);
       });
 
-      describe('transitionDuration', () => {
+      describe('timeout', () => {
         let theme;
-        let transitionDurationMock;
+        let timeoutMock;
         let restore;
 
         before(() => {
           theme = instance.props.theme;
           restore = theme.transitions.getAutoHeightDuration;
           theme.transitions.getAutoHeightDuration = stub().returns('woofCollapseStub2');
-          wrapper.setProps({ transitionDuration: 'auto' });
+          wrapper.setProps({ timeout: 'auto' });
           instance = wrapper.instance();
         });
 
@@ -295,18 +295,18 @@ describe('<Collapse />', () => {
           );
         });
 
-        it('number should set transitionDuration to ms', () => {
-          transitionDurationMock = 3;
-          wrapper.setProps({ transitionDuration: transitionDurationMock });
+        it('number should set timeout to ms', () => {
+          timeoutMock = 3;
+          wrapper.setProps({ timeout: timeoutMock });
           instance = wrapper.instance();
           instance.handleExiting(element);
 
-          assert.strictEqual(element.style.transitionDuration, `${transitionDurationMock}ms`);
+          assert.strictEqual(element.style.transitionDuration, `${timeoutMock}ms`);
         });
 
-        it('nothing should not set transitionDuration', () => {
+        it('nothing should not set timeout', () => {
           const elementBackup = element;
-          wrapper.setProps({ transitionDuration: undefined });
+          wrapper.setProps({ timeout: undefined });
           instance = wrapper.instance();
           instance.handleExiting(element);
 
@@ -331,8 +331,8 @@ describe('<Collapse />', () => {
       clock.restore();
     });
 
-    it('should return autoTransitionDuration when transitionDuration is auto', () => {
-      const wrapper = shallow(<Collapse {...props} transitionDuration="auto" />);
+    it('should return autoTransitionDuration when timeout is auto', () => {
+      const wrapper = shallow(<Collapse {...props} timeout="auto" />);
       instance = wrapper.instance();
       const next = spy();
 
@@ -350,15 +350,15 @@ describe('<Collapse />', () => {
       assert.strictEqual(next.callCount, 2);
     });
 
-    it('should return props.transitionDuration when transitionDuration is number', () => {
-      const transitionDuration = 10;
-      const wrapper = shallow(<Collapse {...props} transitionDuration={transitionDuration} />);
+    it('should return props.timeout when timeout is number', () => {
+      const timeout = 10;
+      const wrapper = shallow(<Collapse {...props} timeout={timeout} />);
       instance = wrapper.instance();
 
       const next = spy();
       instance.addEndListener(null, next);
       assert.strictEqual(next.callCount, 0);
-      clock.tick(transitionDuration);
+      clock.tick(timeout);
       assert.strictEqual(next.callCount, 1);
     });
   });

--- a/src/transitions/Fade.d.ts
+++ b/src/transitions/Fade.d.ts
@@ -4,7 +4,7 @@ import { TransitionDuration, TransitionProps } from '../internal/transition';
 
 export interface FadeProps extends TransitionProps {
   theme?: Theme;
-  transitionDuration?: TransitionDuration;
+  timeout?: TransitionDuration;
 }
 
 declare const Fade: React.ComponentType<FadeProps>;

--- a/src/transitions/Fade.js
+++ b/src/transitions/Fade.js
@@ -10,7 +10,7 @@ import type { TransitionDuration, TransitionCallback } from '../internal/transit
 
 type ProvidedProps = {
   appear: boolean,
-  transitionDuration: TransitionDuration,
+  timeout: TransitionDuration,
   theme: Object,
 };
 
@@ -51,7 +51,7 @@ export type Props = {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    */
-  transitionDuration?: TransitionDuration,
+  timeout?: TransitionDuration,
 };
 
 const reflow = node => node.scrollTop;
@@ -63,7 +63,7 @@ const reflow = node => node.scrollTop;
 class Fade extends React.Component<ProvidedProps & Props> {
   static defaultProps = {
     appear: true,
-    transitionDuration: {
+    timeout: {
       enter: duration.enteringScreen,
       exit: duration.leavingScreen,
     },
@@ -79,15 +79,13 @@ class Fade extends React.Component<ProvidedProps & Props> {
   };
 
   handleEntering = (node: HTMLElement) => {
-    const { theme, transitionDuration } = this.props;
+    const { theme, timeout } = this.props;
     node.style.transition = theme.transitions.create('opacity', {
-      duration:
-        typeof transitionDuration === 'number' ? transitionDuration : transitionDuration.enter,
+      duration: typeof timeout === 'number' ? timeout : timeout.enter,
     });
     // $FlowFixMe - https://github.com/facebook/flow/pull/5161
     node.style.webkitTransition = theme.transitions.create('opacity', {
-      duration:
-        typeof transitionDuration === 'number' ? transitionDuration : transitionDuration.enter,
+      duration: typeof timeout === 'number' ? timeout : timeout.enter,
     });
     node.style.opacity = '1';
 
@@ -97,15 +95,13 @@ class Fade extends React.Component<ProvidedProps & Props> {
   };
 
   handleExit = (node: HTMLElement) => {
-    const { theme, transitionDuration } = this.props;
+    const { theme, timeout } = this.props;
     node.style.transition = theme.transitions.create('opacity', {
-      duration:
-        typeof transitionDuration === 'number' ? transitionDuration : transitionDuration.exit,
+      duration: typeof timeout === 'number' ? timeout : timeout.exit,
     });
     // $FlowFixMe - https://github.com/facebook/flow/pull/5161
     node.style.webkitTransition = theme.transitions.create('opacity', {
-      duration:
-        typeof transitionDuration === 'number' ? transitionDuration : transitionDuration.exit,
+      duration: typeof timeout === 'number' ? timeout : timeout.exit,
     });
     node.style.opacity = '0';
 
@@ -118,7 +114,6 @@ class Fade extends React.Component<ProvidedProps & Props> {
     const {
       appear,
       children,
-      transitionDuration,
       onEnter,
       onEntering,
       onExit,
@@ -141,7 +136,6 @@ class Fade extends React.Component<ProvidedProps & Props> {
         onEnter={this.handleEnter}
         onEntering={this.handleEntering}
         onExit={this.handleExit}
-        timeout={transitionDuration}
         {...other}
       >
         {children}

--- a/src/transitions/Grow.d.ts
+++ b/src/transitions/Grow.d.ts
@@ -4,7 +4,7 @@ import { TransitionDuration, TransitionProps } from '../internal/transition';
 
 export interface GrowProps extends TransitionProps {
   theme?: Theme;
-  transitionDuration?: TransitionDuration | 'auto';
+  timeout?: TransitionDuration | 'auto';
 }
 
 declare const Grow: React.ComponentType<GrowProps>;

--- a/src/transitions/Grow.js
+++ b/src/transitions/Grow.js
@@ -16,7 +16,7 @@ export type TransitionDuration = number | { enter?: number, exit?: number } | 'a
 
 type ProvidedProps = {
   appear: boolean,
-  transitionDuration: TransitionDuration,
+  timeout: TransitionDuration,
   theme: Object,
 };
 
@@ -80,7 +80,7 @@ export type Props = {
    *
    * Set to 'auto' to automatically calculate transition time based on height.
    */
-  transitionDuration?: TransitionDuration,
+  timeout?: TransitionDuration,
 };
 
 /**
@@ -90,11 +90,11 @@ export type Props = {
 class Grow extends React.Component<ProvidedProps & Props> {
   static defaultProps = {
     appear: true,
-    transitionDuration: 'auto',
+    timeout: 'auto',
     transitionClasses: {},
   };
 
-  autoTransitionDuration = undefined;
+  autoTimeout = undefined;
 
   handleEnter = (node: HTMLElement) => {
     node.style.opacity = '0';
@@ -106,16 +106,16 @@ class Grow extends React.Component<ProvidedProps & Props> {
   };
 
   handleEntering = (node: HTMLElement) => {
-    const { theme, transitionDuration } = this.props;
+    const { theme, timeout } = this.props;
     let duration = 0;
 
-    if (transitionDuration === 'auto') {
+    if (timeout === 'auto') {
       duration = theme.transitions.getAutoHeightDuration(node.clientHeight);
-      this.autoTransitionDuration = duration;
-    } else if (typeof transitionDuration === 'number') {
-      duration = transitionDuration;
-    } else if (transitionDuration) {
-      duration = transitionDuration.enter;
+      this.autoTimeout = duration;
+    } else if (typeof timeout === 'number') {
+      duration = timeout;
+    } else if (timeout) {
+      duration = timeout.enter;
     } else {
       // The propType will warn in this case.
     }
@@ -138,16 +138,16 @@ class Grow extends React.Component<ProvidedProps & Props> {
   };
 
   handleExit = (node: HTMLElement) => {
-    const { theme, transitionDuration } = this.props;
+    const { theme, timeout } = this.props;
     let duration = 0;
 
-    if (transitionDuration === 'auto') {
+    if (timeout === 'auto') {
       duration = theme.transitions.getAutoHeightDuration(node.clientHeight);
-      this.autoTransitionDuration = duration;
-    } else if (typeof transitionDuration === 'number') {
-      duration = transitionDuration;
-    } else if (transitionDuration) {
-      duration = transitionDuration.exit;
+      this.autoTimeout = duration;
+    } else if (typeof timeout === 'number') {
+      duration = timeout;
+    } else if (timeout) {
+      duration = timeout.exit;
     } else {
       // The propType will warn in this case.
     }
@@ -173,10 +173,10 @@ class Grow extends React.Component<ProvidedProps & Props> {
   addEndListener = (node, next: Function) => {
     let timeout;
 
-    if (this.props.transitionDuration === 'auto') {
-      timeout = this.autoTransitionDuration || 0;
+    if (this.props.timeout === 'auto') {
+      timeout = this.autoTimeout || 0;
     } else {
-      timeout = this.props.transitionDuration;
+      timeout = this.props.timeout;
     }
 
     setTimeout(next, timeout);
@@ -192,7 +192,7 @@ class Grow extends React.Component<ProvidedProps & Props> {
       rootRef,
       style: styleProp,
       transitionClasses,
-      transitionDuration,
+      timeout,
       theme,
       ...other
     } = this.props;

--- a/src/transitions/Grow.spec.js
+++ b/src/transitions/Grow.spec.js
@@ -42,7 +42,7 @@ describe('<Grow />', () => {
     });
   });
 
-  describe('props: transitionDuration', () => {
+  describe('prop: timeout', () => {
     let wrapper;
     let instance;
     let element;
@@ -53,7 +53,7 @@ describe('<Grow />', () => {
       wrapper = shallow(
         <Grow
           {...props}
-          transitionDuration={{
+          timeout={{
             enter: enterDuration,
             exit: leaveDuration,
           }}
@@ -169,8 +169,8 @@ describe('<Grow />', () => {
       clock.restore();
     });
 
-    it('should return autoTransitionDuration when transitionDuration is auto', () => {
-      const wrapper = shallow(<Grow {...props} transitionDuration="auto" />);
+    it('should return autoTransitionDuration when timeout is auto', () => {
+      const wrapper = shallow(<Grow {...props} timeout="auto" />);
       instance = wrapper.instance();
       const next = spy();
 
@@ -188,14 +188,14 @@ describe('<Grow />', () => {
       assert.strictEqual(next.callCount, 2);
     });
 
-    it('should return props.transitionDuration when transitionDuration is number', () => {
-      const transitionDuration = 10;
-      const wrapper = shallow(<Grow {...props} transitionDuration={transitionDuration} />);
+    it('should return props.timeout when timeout is number', () => {
+      const timeout = 10;
+      const wrapper = shallow(<Grow {...props} timeout={timeout} />);
       instance = wrapper.instance();
       const next = spy();
       instance.addEndListener(null, next);
       assert.strictEqual(next.callCount, 0);
-      clock.tick(transitionDuration);
+      clock.tick(timeout);
       assert.strictEqual(next.callCount, 1);
     });
   });

--- a/src/transitions/Slide.d.ts
+++ b/src/transitions/Slide.d.ts
@@ -4,9 +4,8 @@ import { TransitionDuration, TransitionProps } from '../internal/transition';
 
 export interface SlideProps extends TransitionProps {
   direction?: 'left' | 'right' | 'up' | 'down';
-  offset?: string;
   theme?: Theme;
-  transitionDuration?: TransitionDuration;
+  timeout?: TransitionDuration;
 }
 
 declare const Slide: React.ComponentType<SlideProps>;

--- a/src/transitions/Slide.js
+++ b/src/transitions/Slide.js
@@ -67,7 +67,7 @@ export function setTranslateValue(props: Object, node: HTMLElement | Object) {
 export type Direction = 'left' | 'right' | 'up' | 'down';
 
 type ProvidedProps = {
-  transitionDuration: TransitionDuration,
+  timeout: TransitionDuration,
   theme: Object,
 };
 
@@ -116,7 +116,7 @@ export type Props = {
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    */
-  transitionDuration?: TransitionDuration,
+  timeout?: TransitionDuration,
   /**
    * @ignore
    */
@@ -132,7 +132,7 @@ const reflow = node => node.scrollTop;
 class Slide extends React.Component<ProvidedProps & Props, State> {
   static defaultProps = {
     direction: 'down',
-    transitionDuration: {
+    timeout: {
       enter: duration.enteringScreen,
       exit: duration.leavingScreen,
     },
@@ -190,16 +190,14 @@ class Slide extends React.Component<ProvidedProps & Props, State> {
   };
 
   handleEntering = (node: HTMLElement) => {
-    const { theme, transitionDuration } = this.props;
+    const { theme, timeout } = this.props;
     node.style.transition = theme.transitions.create('transform', {
-      duration:
-        typeof transitionDuration === 'number' ? transitionDuration : transitionDuration.enter,
+      duration: typeof timeout === 'number' ? timeout : timeout.enter,
       easing: theme.transitions.easing.easeOut,
     });
     // $FlowFixMe - https://github.com/facebook/flow/pull/5161
     node.style.webkitTransition = theme.transitions.create('-webkit-transform', {
-      duration:
-        typeof transitionDuration === 'number' ? transitionDuration : transitionDuration.enter,
+      duration: typeof timeout === 'number' ? timeout : timeout.enter,
       easing: theme.transitions.easing.easeOut,
     });
     node.style.transform = 'translate3d(0, 0, 0)';
@@ -210,16 +208,14 @@ class Slide extends React.Component<ProvidedProps & Props, State> {
   };
 
   handleExit = (node: HTMLElement) => {
-    const { theme, transitionDuration } = this.props;
+    const { theme, timeout } = this.props;
     node.style.transition = theme.transitions.create('transform', {
-      duration:
-        typeof transitionDuration === 'number' ? transitionDuration : transitionDuration.exit,
+      duration: typeof timeout === 'number' ? timeout : timeout.exit,
       easing: theme.transitions.easing.sharp,
     });
     // $FlowFixMe - https://github.com/facebook/flow/pull/5161
     node.style.webkitTransition = theme.transitions.create('-webkit-transform', {
-      duration:
-        typeof transitionDuration === 'number' ? transitionDuration : transitionDuration.exit,
+      duration: typeof timeout === 'number' ? timeout : timeout.exit,
       easing: theme.transitions.easing.sharp,
     });
     setTranslateValue(this.props, node);
@@ -230,16 +226,7 @@ class Slide extends React.Component<ProvidedProps & Props, State> {
   };
 
   render() {
-    const {
-      children,
-      onEnter,
-      onEntering,
-      onExit,
-      style: styleProp,
-      transitionDuration,
-      theme,
-      ...other
-    } = this.props;
+    const { children, onEnter, onEntering, onExit, style: styleProp, theme, ...other } = this.props;
 
     const style = { ...styleProp };
 
@@ -253,7 +240,6 @@ class Slide extends React.Component<ProvidedProps & Props, State> {
           onEnter={this.handleEnter}
           onEntering={this.handleEntering}
           onExit={this.handleExit}
-          timeout={transitionDuration}
           appear
           style={style}
           {...other}

--- a/src/transitions/Slide.spec.js
+++ b/src/transitions/Slide.spec.js
@@ -57,7 +57,7 @@ describe('<Slide />', () => {
     });
   });
 
-  describe('props: transitionDuration', () => {
+  describe('prop: timeout', () => {
     let wrapper;
     let instance;
     let element;
@@ -68,7 +68,7 @@ describe('<Slide />', () => {
       wrapper = shallow(
         <Slide
           {...props}
-          transitionDuration={{
+          timeout={{
             enter: enterDuration,
             exit: leaveDuration,
           }}

--- a/test/typescript/components.spec.tsx
+++ b/test/typescript/components.spec.tsx
@@ -181,7 +181,7 @@ const CardMediaTest = () =>
         <FakeIcon />
       </IconButton>
     </CardActions>
-    <Collapse in={true} transitionDuration="auto" unmountOnExit>
+    <Collapse in={true} timeout="auto" unmountOnExit>
       <CardContent>
         <Typography paragraph type="body2">
           Method:


### PR DESCRIPTION
This change is making our transition component API closer to the react-transition-group API. It should help with interoperability. The issue was raised in https://github.com/callemall/material-ui/issues/7297#issuecomment-338826249.

### Breaking changes

```diff
         <Grow
-          transitionDuration={{
+          timeout={{
             enter: enterDuration,
             exit: leaveDuration,
           }}
         />
```