### PR TITLE
Fixed the issue vertical axis shifting too much

### DIFF
--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -256,9 +256,17 @@ class Popover extends React.Component<ProvidedProps & Props> {
       top -= diff;
       transformOrigin.vertical += diff;
     } else if (bottom > heightThreshold) {
-      const diff = bottom - heightThreshold;
-      top -= diff;
-      transformOrigin.vertical += diff;
+      
+      const diff = bottom - heightThreshold;   
+      
+       if (top - _diff < marginThreshold) {
+          transformOrigin.vertical += top - marginThreshold;
+          top = marginThreshold
+        }
+        else {
+          top -= _diff;
+          transformOrigin.vertical += _diff;
+        }
     }
 
     // Check if the horizontal axis needs shifting


### PR DESCRIPTION
If the popover is longer than the viewport, the popover is positioned too high up in the page. With a negative top.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
