### PR TITLE
[Input] Fix inputProps overwriting className

### DIFF
--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -475,7 +475,7 @@ class Input extends React.Component<ProvidedProps & Props, State> {
       fullWidth,
       id,
       inputComponent,
-      inputProps: { inputPropsClassName, ...inputPropsProp } = {},
+      inputProps: { className: inputPropsClassName, ...inputPropsProp } = {},
       inputRef,
       margin: marginProp,
       multiline,

--- a/src/Input/Input.spec.js
+++ b/src/Input/Input.spec.js
@@ -413,8 +413,10 @@ describe('<Input />', () => {
   describe('prop: inputProps', () => {
     it('should apply the props on the input', () => {
       const wrapper = shallow(<Input inputProps={{ className: 'foo', readOnly: true }} />);
-      assert.strictEqual(wrapper.find('input').props().className, 'foo');
-      assert.strictEqual(wrapper.find('input').props().readOnly, true);
+      const input = wrapper.find('input');
+      assert.strictEqual(input.hasClass('foo'), true, 'should have the foo class');
+      assert.strictEqual(input.hasClass(classes.input), true, 'should still have the input class');
+      assert.strictEqual(input.props().readOnly, true, 'should have the readOnly prop');
     });
   });
 


### PR DESCRIPTION
I tried to fix https://github.com/callemall/material-ui/issues/8064 as the problem still exists.

In [TextField.js](https://github.com/callemall/material-ui/blob/v1-beta/src/TextField/TextField.js#L192) the `inputClassName` prop is assigned to `inputProps.className`:

``` js
inputProps = {
  className: inputClassName,
  ...inputProps,
};
```

But in [Input.js](https://github.com/callemall/material-ui/blob/v1-beta/src/Input/Input.js#L478) it is destructured like this:

`inputProps: { inputPropsClassName, ...inputPropsProp } = {},`

So `inputPropsClassName` remains undefined and in `inputProps` lingers a `className` property that overwrites the default classes a few lines further down:

``` js
<InputComponent
  autoComplete={autoComplete}
  autoFocus={autoFocus}
  className={inputClassName}   <-- className defined here
  ...
  readOnly={readOnly}
  rows={rows}
  {...inputProps}              <-- gets overwritten here
/>
```

I changed the line in Input.js to this:

```diff
-      inputProps: { inputPropsClassName, ...inputPropsProp } = {},
+      inputProps: { className: inputPropsClassName, ...inputPropsProp } = {},
```

But maybe it should be fixed in TextField.js like this:

``` diff
 inputProps = {
-  className: inputClassName,
+  inputPropsClassName: inputClassName,
   ...inputProps,
 };
```

I'd be happy to change the PR accordingly if that makes more sense (if at all ;-). I don't see the implications entirely yet, this is my first attempt to contribute here. :-) 