### PR TITLE
[Select] Fix array mutability flow annotation

### DIFF
--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -109,7 +109,7 @@ export type Props = {
   /**
    * The input value, required for a controlled component.
    */
-  value?: Array<string | number> | string | number,
+  value?: $ReadOnlyArray<string | number> | string | number,
 };
 
 function Select(props: ProvidedProps & Props) {

--- a/src/Select/SelectInput.js
+++ b/src/Select/SelectInput.js
@@ -89,7 +89,7 @@ export type Props = {
   /**
    * The value of the component, required for a controlled component.
    */
-  value?: string | number | Array<string | number>,
+  value?: string | number | $ReadOnlyArray<string | number>,
 };
 
 type State = {


### PR DESCRIPTION
This fixes the following use case:

```js
const value: string[] = ['a', 'b', 'c'];
return <Select value={value} />;
```

See #8868