### PR TITLE
[CircularProgress] Add "inherit" color option

### DIFF
--- a/pages/api/circular-progress.md
+++ b/pages/api/circular-progress.md
@@ -13,7 +13,7 @@ filename: /src/Progress/CircularProgress.js
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | classes | Object |  | Useful to extend the style applied to components. |
-| color | union:&nbsp;'primary'<br>&nbsp;'accent'<br> | 'primary' | The color of the component. It's using the theme palette when that makes sense. |
+| color | union:&nbsp;'primary'<br>&nbsp;'accent'<br>&nbsp;'inherit'<br> | 'primary' | The color of the component. It's using the theme palette when that makes sense. |
 | max | number | 100 | The max value of progress in determinate mode. |
 | min | number | 0 | The min value of progress in determinate mode. |
 | mode | union:&nbsp;'determinate'<br>&nbsp;'indeterminate'<br> | 'indeterminate' | The mode of show your progress. Indeterminate for when there is no value for progress. Determinate for controlled progress value. |

--- a/src/Progress/CircularProgress.d.ts
+++ b/src/Progress/CircularProgress.d.ts
@@ -5,7 +5,7 @@ export interface CircularProgressProps extends StandardProps<
   React.HTMLAttributes<HTMLDivElement>,
   CircularProgressClassKey
 > {
-  color?: 'primary' | 'accent';
+  color?: 'primary' | 'accent' | 'inherit';
   max?: number;
   min?: number;
   mode?: 'determinate' | 'indeterminate';

--- a/src/Progress/CircularProgress.js
+++ b/src/Progress/CircularProgress.js
@@ -58,7 +58,7 @@ export const styles = (theme: Object) => ({
   },
 });
 
-export type Color = 'primary' | 'accent';
+export type Color = 'primary' | 'accent' | 'inherit';
 export type Mode = 'determinate' | 'indeterminate';
 
 type ProvidedProps = {
@@ -149,7 +149,11 @@ function CircularProgress(props: ProvidedProps & Props) {
 
   return (
     <div
-      className={classNames(classes.root, classes[`${color}Color`], className)}
+      className={classNames(
+        classes.root,
+        color !== 'inherit' && classes[`${color}Color`],
+        className,
+      )}
       style={{ width: size, height: size, ...style }}
       role="progressbar"
       {...rootProps}


### PR DESCRIPTION
Since most other components that accept a `color` accept `inherit`, I figured why not add this to `CircularProgress` as well. 

My use case is a white progress indicator on a dark background, which I can achieve with `<CircularProgress style={{ color: 'inherit' }} />`, but `color='inherit'` is more in-line with the other components.

I have no idea how to update the docs in `pages/api`, though. Should I update them manually?