### PR TITLE
[Input] Made the labels for adorned elements not shrink on end adornment

### DIFF
--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -5,7 +5,7 @@ import type { ElementType, Node } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
-import { isDirty, isAdornedEnd, isAdornedStart } from '../Input/Input';
+import { isDirty, isAdornedStart } from '../Input/Input';
 import { isMuiElement } from '../utils/reactHelpers';
 
 export const styles = (theme: Object) => ({
@@ -94,7 +94,6 @@ export type Props = {
 };
 
 type State = {
-  adornedEnd: boolean,
   adornedStart: boolean,
   dirty: boolean,
   focused: boolean,
@@ -125,7 +124,6 @@ class FormControl extends React.Component<ProvidedProps & Props, State> {
   };
 
   state = {
-    adornedEnd: false,
     adornedStart: false,
     dirty: false,
     focused: false,
@@ -133,11 +131,10 @@ class FormControl extends React.Component<ProvidedProps & Props, State> {
 
   getChildContext() {
     const { disabled, error, required, margin } = this.props;
-    const { adornedEnd, adornedStart, dirty, focused } = this.state;
+    const { adornedStart, dirty, focused } = this.state;
 
     return {
       muiFormControl: {
-        adornedEnd,
         adornedStart,
         dirty,
         disabled,
@@ -162,12 +159,8 @@ class FormControl extends React.Component<ProvidedProps & Props, State> {
         if (isMuiElement(child, ['Input', 'Select']) && isDirty(child.props, true)) {
           this.setState({ dirty: true });
         }
-        if (isMuiElement(child, ['Input'])) {
-          if (isAdornedEnd(child.props)) {
-            this.setState({ adornedEnd: true });
-          } else if (isAdornedStart(child.props)) {
-            this.setState({ adornedStart: true });
-          }
+        if (isMuiElement(child, ['Input']) && isAdornedStart(child.props)) {
+          this.setState({ adornedStart: true });
         }
       });
     }

--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -5,7 +5,7 @@ import type { ElementType, Node } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
-import { isDirty, isAdorned } from '../Input/Input';
+import { isDirty, isAdornedEnd, isAdornedStart } from '../Input/Input';
 import { isMuiElement } from '../utils/reactHelpers';
 
 export const styles = (theme: Object) => ({
@@ -94,7 +94,8 @@ export type Props = {
 };
 
 type State = {
-  adorned: boolean,
+  adornedEnd: boolean,
+  adornedStart: boolean,
   dirty: boolean,
   focused: boolean,
 };
@@ -124,18 +125,20 @@ class FormControl extends React.Component<ProvidedProps & Props, State> {
   };
 
   state = {
-    adorned: false,
+    adornedEnd: false,
+    adornedStart: false,
     dirty: false,
     focused: false,
   };
 
   getChildContext() {
     const { disabled, error, required, margin } = this.props;
-    const { adorned, dirty, focused } = this.state;
+    const { adornedEnd, adornedStart, dirty, focused } = this.state;
 
     return {
       muiFormControl: {
-        adorned,
+        adornedEnd,
+        adornedStart,
         dirty,
         disabled,
         error,
@@ -159,8 +162,12 @@ class FormControl extends React.Component<ProvidedProps & Props, State> {
         if (isMuiElement(child, ['Input', 'Select']) && isDirty(child.props, true)) {
           this.setState({ dirty: true });
         }
-        if (isMuiElement(child, ['Input']) && isAdorned(child.props)) {
-          this.setState({ adorned: true });
+        if (isMuiElement(child, ['Input'])) {
+          if (isAdornedEnd(child.props)) {
+            this.setState({ adornedEnd: true });
+          } else if (isAdornedStart(child.props)) {
+            this.setState({ adornedStart: true });
+          }
         }
       });
     }

--- a/src/Form/FormControl.spec.js
+++ b/src/Form/FormControl.spec.js
@@ -98,7 +98,7 @@ describe('<FormControl />', () => {
           <Input endAdornment={<div />} />
         </FormControl>,
       );
-      assert.strictEqual(wrapper.state().adornedEnd, true);
+      assert.strictEqual(wrapper.state().adornedStart, false);
     });
 
     it('should be adorned with a startAdornment', () => {
@@ -137,13 +137,6 @@ describe('<FormControl />', () => {
         wrapper.setState({ focused: true });
         loadChildContext();
         assert.strictEqual(muiFormControlContext.focused, true);
-      });
-
-      it('should have the adornedEnd state from the instance', () => {
-        assert.strictEqual(muiFormControlContext.adornedEnd, false);
-        wrapper.setState({ adornedEnd: true });
-        loadChildContext();
-        assert.strictEqual(muiFormControlContext.adornedEnd, true);
       });
 
       it('should have the adornedStart state from the instance', () => {

--- a/src/Form/FormControl.spec.js
+++ b/src/Form/FormControl.spec.js
@@ -92,13 +92,22 @@ describe('<FormControl />', () => {
       assert.strictEqual(wrapper.state().dirty, true);
     });
 
+    it('should be adorned with an endAdornment', () => {
+      const wrapper = shallow(
+        <FormControl>
+          <Input endAdornment={<div />} />
+        </FormControl>,
+      );
+      assert.strictEqual(wrapper.state().adornedEnd, true);
+    });
+
     it('should be adorned with a startAdornment', () => {
       const wrapper = shallow(
         <FormControl>
           <Input startAdornment={<div />} />
         </FormControl>,
       );
-      assert.strictEqual(wrapper.state().adorned, true);
+      assert.strictEqual(wrapper.state().adornedStart, true);
     });
   });
 
@@ -130,11 +139,18 @@ describe('<FormControl />', () => {
         assert.strictEqual(muiFormControlContext.focused, true);
       });
 
-      it('should have the adorned state from the instance', () => {
-        assert.strictEqual(muiFormControlContext.adorned, false);
-        wrapper.setState({ adorned: true });
+      it('should have the adornedEnd state from the instance', () => {
+        assert.strictEqual(muiFormControlContext.adornedEnd, false);
+        wrapper.setState({ adornedEnd: true });
         loadChildContext();
-        assert.strictEqual(muiFormControlContext.adorned, true);
+        assert.strictEqual(muiFormControlContext.adornedEnd, true);
+      });
+
+      it('should have the adornedStart state from the instance', () => {
+        assert.strictEqual(muiFormControlContext.adornedStart, false);
+        wrapper.setState({ adornedStart: true });
+        loadChildContext();
+        assert.strictEqual(muiFormControlContext.adornedStart, true);
       });
     });
 

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -34,15 +34,22 @@ export function isDirty(obj, SSR = false) {
   );
 }
 
-// Determine if an Input is adorned
-//
-// Response determines if label is presented above field or as placeholder.
+// Determine if an Input is adorned on the right end.
 //
 // @param obj
 // @returns {boolean} False when no adornments.
-//                    True when adorned.
-export function isAdorned(obj) {
-  return obj.startAdornment || obj.endAdornment;
+//                    True when adorned on the end.
+export function isAdornedEnd(obj) {
+  return obj.endAdornment;
+}
+
+// Determine if an Input is adorned on the left, aka start.
+//
+// @param obj
+// @returns {boolean} False when no adornments.
+//                    True when adorned at the start.
+export function isAdornedStart(obj) {
+  return obj.startAdornment;
 }
 
 export const styles = (theme: Object) => {

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -34,16 +34,8 @@ export function isDirty(obj, SSR = false) {
   );
 }
 
-// Determine if an Input is adorned on the right end.
-//
-// @param obj
-// @returns {boolean} False when no adornments.
-//                    True when adorned on the end.
-export function isAdornedEnd(obj) {
-  return obj.endAdornment;
-}
-
-// Determine if an Input is adorned on the left, aka start.
+// Determine if an Input is adorned on start.
+// It's corresponding to the left with LTR.
 //
 // @param obj
 // @returns {boolean} False when no adornments.

--- a/src/Input/InputLabel.js
+++ b/src/Input/InputLabel.js
@@ -108,7 +108,7 @@ function InputLabel(props: ProvidedProps & Props, context: { muiFormControl: Obj
   let shrink = shrinkProp;
 
   if (typeof shrink === 'undefined' && muiFormControl) {
-    shrink = muiFormControl.dirty || muiFormControl.focused || muiFormControl.adorned;
+    shrink = muiFormControl.dirty || muiFormControl.focused || muiFormControl.adornedStart;
   }
 
   let margin = marginProp;


### PR DESCRIPTION
This provides more consistency.

This was not done with the startAdornment for two reasons:
1) I don't yet know how, and I don't think it's possible to do generically due to indeterminate adornment width.  Could be wrong due to ignorance.
2) "$ Amount" just doesn't feel right.

Thus I'm open to suggestions.

Closes #8881