### PR TITLE
Fix textarea width

### DIFF
--- a/src/Input/Textarea.js
+++ b/src/Input/Textarea.js
@@ -11,6 +11,7 @@ const rowsHeight = 24;
 export const styles = {
   root: {
     position: 'relative', // because the shadow has position: 'absolute',
+    width: '100%',
   },
   textarea: {
     width: '100%',


### PR DESCRIPTION
This [change](https://github.com/istarkov/material-ui/commit/16b4ec44a8bf1271772d3aa6ab8d1257e2201507#diff-deaeb5c7e253bfa4f497fa8ace0b3607R67) caused multiline Text fields to not fit the width

See the problem:
![textarea](https://user-images.githubusercontent.com/5077042/32214698-c55ceeb2-be30-11e7-8e69-d37a9f267422.gif)
