### PR TITLE
[BottomNavigation] Allow `null` child

### DIFF
--- a/src/BottomNavigation/BottomNavigation.js
+++ b/src/BottomNavigation/BottomNavigation.js
@@ -35,6 +35,10 @@ const BottomNavigation = (props, context) => {
   const styles = getStyles(props, context);
 
   const preparedChildren = Children.map(children, (child, index) => {
+    if (!child) {
+      return null;
+    }
+
     return cloneElement(child, {
       style: Object.assign({}, styles.item, child.props.style),
       selected: index === selectedIndex,

--- a/src/BottomNavigation/BottomNavigation.spec.js
+++ b/src/BottomNavigation/BottomNavigation.spec.js
@@ -10,6 +10,18 @@ describe('<BottomNavigation />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
 
+  it('renders with a null child', () => {
+    const wrapper = shallowWithContext(
+      <BottomNavigation>
+        <BottomNavigationItem />
+        {null}
+        <BottomNavigationItem />
+      </BottomNavigation>
+    );
+
+    assert.strictEqual(wrapper.find(BottomNavigationItem).length, 2);
+  });
+
   describe('prop: selectedIndex', () => {
     it('determines which BottomNavigationItem is selected', () => {
       const wrapper = shallowWithContext(


### PR DESCRIPTION
Prior to this commit, the `BottomNavigation` component would
fail to render if it contains a `null` child:

	TypeError: Cannot read property 'props' of null

This is because the component tries to 'preprocess' every
child, and expects every child to have `props` (see `preparedChildren`).
There are however, cases where the child is `null`, and an error will
be thrown in such cases.

It may be `null` in cases where a user would like a navigation item
to be 'hidden' if certain conditions are not fulfilled (rather
than being disabled).

This bug is not a problem in the `v1-beta` branch, but the fix
has not been applied to `master` (as of this commit, v0.19.x).

---

Closes #8859

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
