### PR TITLE
[docs] Fork JssProvider to release the docs

### DIFF
--- a/docs/src/modules/components/AppWrapper.js
+++ b/docs/src/modules/components/AppWrapper.js
@@ -4,9 +4,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import JssProvider from 'react-jss/lib/JssProvider';
 import { MuiThemeProvider } from 'material-ui/styles';
 import getContext, { getTheme } from 'docs/src/modules/styles/getContext';
+import JssProvider from 'docs/src/modules/components/JssProvider';
 import AppFrame from 'docs/src/modules/components/AppFrame';
 import { lightTheme, darkTheme, setPrismTheme } from 'docs/src/modules/utils/prism';
 import config from 'docs/src/config';
@@ -82,7 +82,11 @@ class AppWrapper extends React.Component<any, any> {
     const { children, sheetsRegistry } = this.props;
 
     return (
-      <JssProvider registry={sheetsRegistry} jss={this.styleContext.jss}>
+      <JssProvider
+        registry={sheetsRegistry}
+        jss={this.styleContext.jss}
+        generateClassName={this.styleContext.generateClassName}
+      >
         <MuiThemeProvider
           theme={this.styleContext.theme}
           sheetsManager={this.styleContext.sheetsManager}

--- a/docs/src/modules/components/JssProvider.js
+++ b/docs/src/modules/components/JssProvider.js
@@ -1,0 +1,65 @@
+// @flow
+// This is a fork of https://github.com/cssinjs/react-jss/blob/master/src/JssProvider.js
+// waiting for the component to be released.
+// Use this version at your own risk.
+
+import { Component } from 'react';
+import type { Node } from 'react';
+import * as ns from 'react-jss/lib/ns';
+import contextTypes from 'react-jss/lib/contextTypes';
+import createGenerateClassNameDefault from 'material-ui/styles/createGenerateClassName';
+
+type Props = {
+  jss?: Object,
+  registry?: Object,
+  generateClassName?: Function,
+  children: Node,
+};
+
+class JssProvider extends Component<Props> {
+  static contextTypes = contextTypes;
+
+  static childContextTypes = contextTypes;
+
+  getChildContext() {
+    const { registry: sheetsRegistry, jss, generateClassName } = this.props;
+    const context = {
+      ...this.context,
+      [ns.sheetOptions]: this.context[ns.sheetOptions] || {},
+    };
+
+    if (sheetsRegistry) {
+      context[ns.sheetsRegistry] = sheetsRegistry;
+    }
+
+    if (jss) {
+      context[ns.jss] = jss;
+    }
+
+    if (generateClassName) {
+      context[ns.sheetOptions].generateClassName = generateClassName;
+    } else if (!context[ns.sheetOptions].generateClassName) {
+      if (!this.generateClassName) {
+        let createGenerateClassName = createGenerateClassNameDefault;
+
+        if (jss && jss.options.createGenerateClassName) {
+          createGenerateClassName = jss.options.createGenerateClassName;
+        }
+
+        this.generateClassName = createGenerateClassName();
+      }
+
+      context[ns.sheetOptions].generateClassName = this.generateClassName;
+    }
+
+    return context;
+  }
+
+  generateClassName = null;
+
+  render() {
+    return this.props.children;
+  }
+}
+
+export default JssProvider;

--- a/docs/src/modules/styles/getContext.js
+++ b/docs/src/modules/styles/getContext.js
@@ -38,6 +38,7 @@ function createContext() {
     sheetsManager: new Map(),
     // This is needed in order to inject the critical CSS.
     sheetsRegistry: new SheetsRegistry(),
+    generateClassName: jss.options.createGenerateClassName(),
   };
 }
 

--- a/src/styles/MuiThemeProvider.js
+++ b/src/styles/MuiThemeProvider.js
@@ -84,9 +84,9 @@ class MuiThemeProvider extends React.Component<Object> {
 
 MuiThemeProvider.propTypes = {
   /**
-   * You can only provide a single element.
+   * You can only provide a single element with react@15, a node with react@16.
    */
-  children: PropTypes.element.isRequired,
+  children: PropTypes.node.isRequired,
   /**
    * You can disable the generation of the styles with this option.
    * It can be useful when traversing the React tree outside of the HTML

--- a/src/styles/zIndex.js
+++ b/src/styles/zIndex.js
@@ -1,7 +1,7 @@
 // @flow
 
 // Needed as the zIndex works with absolute values.
-export default {
+const zIndex = {
   mobileStepper: 900,
   menu: 1000,
   appBar: 1100,
@@ -14,3 +14,5 @@ export default {
   snackbar: 2900,
   tooltip: 3000,
 };
+
+export default zIndex;


### PR DESCRIPTION
The mount/unmount behavior changed between react@15 and react@16.
This is breaking the documentation page transition.

With react@15 the unmount was called first.
With react@16 the mount is called first.

I have used the easy way out: sharing the class name generator.
In the future we might also take the `generateClassName` into account
for our ref counting algo.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
