### PR TITLE
Upgrade and resolve @types/react to 16.0.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "devDependencies": {
     "@types/enzyme": "^3.1.1",
-    "@types/react": "16.0.9",
+    "@types/react": "16.0.19",
     "app-module-path": "^2.2.0",
     "argos-cli": "^0.0.9",
     "autosuggest-highlight": "^3.1.1",
@@ -178,6 +178,9 @@
     "webfontloader": "^1.6.28",
     "webpack": "^3.8.1",
     "webpack-bundle-analyzer": "^2.9.0"
+  },
+  "resolutions": {
+    "@types/react": "16.0.19"
   },
   "side-effects": false,
   "size-limit": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,13 +59,9 @@
   version "6.0.88"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.88.tgz#f618f11a944f6a18d92b5c472028728a3e3d4b66"
 
-"@types/react@*":
-  version "16.0.7"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.7.tgz#f85b6c33c988a1631e2f32fedae71ec6d9718a0d"
-
-"@types/react@16.0.9":
-  version "16.0.9"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.9.tgz#2ad952abbb22617620927694f9a4bce292d7fb2b"
+"@types/react@*", "@types/react@16.0.19":
+  version "16.0.19"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.19.tgz#f804a0fcd6d94c17df92cf2fd46671bbbc862329"
 
 JSONStream@^1.0.4:
   version "1.3.1"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
A manual version of #8914.  Use `"resolutions"` field in `package.json` to force all dependencies to use the same version of `@types/react` (otherwise we have spurious type checking errors).

Closes #8914