### PR TITLE
[typescript] Correct export for InputAdornment

### DIFF
--- a/src/Input/index.d.ts
+++ b/src/Input/index.d.ts
@@ -2,4 +2,6 @@ export { default } from './Input';
 export * from './Input';
 export { default as InputLabel } from './InputLabel';
 export * from './InputLabel';
+export { default as InputAdornment } from './InputAdornment';
+export * from './InputAdornment';
 // NOTE: Textarea is missing from exports (intentional?)


### PR DESCRIPTION
Input/index should export new component "InputAdornment".

**Before:** ![Img](https://i.imgur.com/RAL8U94.png)

**After:** ![Img](https://i.imgur.com/2m3BSu6.png)



