### PR TITLE
[Select] Remove IE11 arrow

### DIFF
--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -37,6 +37,10 @@ export const styles = (theme: Object) => ({
       color: 'transparent',
       textShadow: '0 0 0 #000',
     },
+    // Remove IE11 arrow
+    '&::-ms-expand': {
+      display: 'none',
+    },
   },
   selectMenu: {
     textOverflow: 'ellipsis',


### PR DESCRIPTION
The IE11 support of the Select component isn't great 🙈 . It's a first step forward.

Before
![capture d ecran 2017-11-03 a 08 48 12](https://user-images.githubusercontent.com/3165635/32364210-e1b8df04-c073-11e7-954b-65d320aaab9f.png)

After
![capture d ecran 2017-11-03 a 08 48 57](https://user-images.githubusercontent.com/3165635/32364213-e569a408-c073-11e7-8bb5-f8df73087565.png)
