### PR TITLE
[InputLabel] Fix transformOrigin when direction=rtl

### DIFF
--- a/src/Input/InputLabel.js
+++ b/src/Input/InputLabel.js
@@ -9,7 +9,7 @@ import { FormLabel } from '../Form';
 
 export const styles = (theme: Object) => ({
   root: {
-    transformOrigin: `top ${theme.direction === 'ltr' ? 'left' : 'right'}`,
+    transformOrigin: 'top left',
   },
   formControl: {
     position: 'absolute',
@@ -24,7 +24,7 @@ export const styles = (theme: Object) => ({
   },
   shrink: {
     transform: 'translate(0, 1.5px) scale(0.75)',
-    transformOrigin: `top ${theme.direction === 'ltr' ? 'left' : 'right'}`,
+    transformOrigin: 'top left',
   },
   animated: {
     transition: theme.transitions.create('transform', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7722,8 +7722,8 @@ rst-selector-parser@^2.2.2:
     nearley "^2.7.10"
 
 rtl-css-js@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.7.0.tgz#0a9b0a5ddcc7181b0b41977264f39647ba705770"
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.8.0.tgz#af8ccdf5944bd8d6a2657fcf2e4a4e9adf62361b"
 
 run-async@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
The package `rtl-css-js` has added support for `transformOrigin` since version [1.8.0](https://github.com/kentcdodds/rtl-css-js/releases/tag/v1.8.0).

That means we should **stop** manually changing it, right now adding `jss-rtl` will cause it to change back. So we should leave it to `rtl-css-js`.