### PR TITLE
[BottomNavigation] Allow null bottom navigation items

### DIFF
--- a/src/BottomNavigation/BottomNavigation.js
+++ b/src/BottomNavigation/BottomNavigation.js
@@ -64,7 +64,7 @@ function BottomNavigation(props: ProvidedProps & Props) {
   const className = classNames(classes.root, classNameProp);
 
   const children = React.Children.map(childrenProp, (child, childIndex) => {
-    if(child === null) return null;
+    if ( child === null ) return null;
     const childValue = child.props.value || childIndex;
     return React.cloneElement(child, {
       selected: childValue === value,

--- a/src/BottomNavigation/BottomNavigation.js
+++ b/src/BottomNavigation/BottomNavigation.js
@@ -64,7 +64,7 @@ function BottomNavigation(props: ProvidedProps & Props) {
   const className = classNames(classes.root, classNameProp);
 
   const children = React.Children.map(childrenProp, (child, childIndex) => {
-    if (child === null) return null;
+    if (!React.isValidElement(child)) return null;
     const childValue = child.props.value || childIndex;
     return React.cloneElement(child, {
       selected: childValue === value,

--- a/src/BottomNavigation/BottomNavigation.js
+++ b/src/BottomNavigation/BottomNavigation.js
@@ -64,7 +64,7 @@ function BottomNavigation(props: ProvidedProps & Props) {
   const className = classNames(classes.root, classNameProp);
 
   const children = React.Children.map(childrenProp, (child, childIndex) => {
-    if ( child === null ) return null;
+    if (child === null) return null;
     const childValue = child.props.value || childIndex;
     return React.cloneElement(child, {
       selected: childValue === value,

--- a/src/BottomNavigation/BottomNavigation.js
+++ b/src/BottomNavigation/BottomNavigation.js
@@ -64,6 +64,7 @@ function BottomNavigation(props: ProvidedProps & Props) {
   const className = classNames(classes.root, classNameProp);
 
   const children = React.Children.map(childrenProp, (child, childIndex) => {
+    if(child === null) return null;
     const childValue = child.props.value || childIndex;
     return React.cloneElement(child, {
       selected: childValue === value,

--- a/src/BottomNavigation/BottomNavigation.spec.js
+++ b/src/BottomNavigation/BottomNavigation.spec.js
@@ -29,7 +29,7 @@ describe('<BottomNavigation />', () => {
   });
   
   it('renders with a null child', () => {
-    const wrapper = shallowWithContext(
+    const wrapper = shallow(
       <BottomNavigation showLabels value={0}>
         <BottomNavigationButton label='One'/>
         {null}
@@ -38,7 +38,8 @@ describe('<BottomNavigation />', () => {
     );
 
     assert.strictEqual(wrapper.find(BottomNavigationButton).length, 2);
-});
+  });
+  
   it('should render with the root class', () => {
     const wrapper = shallow(
       <BottomNavigation showLabels value={0}>

--- a/src/BottomNavigation/BottomNavigation.spec.js
+++ b/src/BottomNavigation/BottomNavigation.spec.js
@@ -31,12 +31,11 @@ describe('<BottomNavigation />', () => {
   it('renders with a null child', () => {
     const wrapper = shallow(
       <BottomNavigation showLabels value={0}>
-        <BottomNavigationButton label='One'/>
+        <BottomNavigationButton label="One" />
         {null}
-        <BottomNavigationButton label='Three'/>
-      </BottomNavigation>
+        <BottomNavigationButton label="Three" />
+      </BottomNavigation>,
     );
-
     assert.strictEqual(wrapper.find(BottomNavigationButton).length, 2);
   });
   

--- a/src/BottomNavigation/BottomNavigation.spec.js
+++ b/src/BottomNavigation/BottomNavigation.spec.js
@@ -27,7 +27,7 @@ describe('<BottomNavigation />', () => {
   after(() => {
     mount.cleanUp();
   });
-  
+
   it('renders with a null child', () => {
     const wrapper = shallow(
       <BottomNavigation showLabels value={0}>
@@ -38,7 +38,7 @@ describe('<BottomNavigation />', () => {
     );
     assert.strictEqual(wrapper.find(BottomNavigationButton).length, 2);
   });
-  
+
   it('should render with the root class', () => {
     const wrapper = shallow(
       <BottomNavigation showLabels value={0}>

--- a/src/BottomNavigation/BottomNavigation.spec.js
+++ b/src/BottomNavigation/BottomNavigation.spec.js
@@ -27,7 +27,18 @@ describe('<BottomNavigation />', () => {
   after(() => {
     mount.cleanUp();
   });
+  
+  it('renders with a null child', () => {
+    const wrapper = shallowWithContext(
+      <BottomNavigation showLabels value={0}>
+        <BottomNavigationButton label='One'/>
+        {null}
+        <BottomNavigationButton label='Three'/>
+      </BottomNavigation>
+    );
 
+    assert.strictEqual(wrapper.find(BottomNavigationButton).length, 2);
+});
   it('should render with the root class', () => {
     const wrapper = shallow(
       <BottomNavigation showLabels value={0}>


### PR DESCRIPTION
There was an issue with rendering null children for BottomNavigation.
For v.0.19x it is fixed by #8925 
But it seems that in v1-beta (v1.0.0-beta20) this issue still exists anyway.

This PR solves this issue.