### PR TITLE
[IconButton] Add missing definition

### DIFF
--- a/src/IconButton/IconButton.d.ts
+++ b/src/IconButton/IconButton.d.ts
@@ -6,6 +6,7 @@ export interface IconButtonProps extends StandardProps<
   ButtonBaseProps,
   IconButtonClassKey
 > {
+  buttonRef?: React.Ref<any>;
   color?: PropTypes.Color | 'contrast';
   disabled?: boolean;
   disableRipple?: boolean;


### PR DESCRIPTION
Fix @pelotom concern: https://github.com/callemall/material-ui/pull/8986#issuecomment-341915462.