### PR TITLE
Include lineHeight in default theme button style

### DIFF
--- a/src/styles/createTypography.d.ts
+++ b/src/styles/createTypography.d.ts
@@ -30,7 +30,7 @@ export interface TypographyStyle {
   fontSize: React.CSSProperties['fontSize'];
   fontWeight: React.CSSProperties['fontWeight'];
   letterSpacing?: React.CSSProperties['letterSpacing'];
-  lineHeight: React.CSSProperties['lineHeight'];
+  lineHeight?: React.CSSProperties['lineHeight'];
   textTransform?: React.CSSProperties['textTransform'];
 }
 

--- a/src/styles/createTypography.js
+++ b/src/styles/createTypography.js
@@ -110,6 +110,7 @@ export default function createTypography(palette: Object, typography: Object | F
         fontSize: pxToRem(fontSize),
         textTransform: 'uppercase',
         fontWeight: fontWeightMedium,
+        lineHeight: "inherit",
         fontFamily,
       },
     },

--- a/src/styles/createTypography.js
+++ b/src/styles/createTypography.js
@@ -110,7 +110,6 @@ export default function createTypography(palette: Object, typography: Object | F
         fontSize: pxToRem(fontSize),
         textTransform: 'uppercase',
         fontWeight: fontWeightMedium,
-        lineHeight: "inherit",
         fontFamily,
       },
     },


### PR DESCRIPTION
While working with material-ui in a typescript context, I noticed that the default theme does not include a rule for buttons' `lineHeight`. The TypeScript types defined in `createTypography.d.ts` define `lineHeight` as a required property for a `TypographyStyle`. The outcome is that if someone tries to use the default theme button style as a jumping off point, TypeScript throws an error since the default style is missing a required property.

Other ways to solve this might be:

- make `lineHeight` an optional prop in the type definition. However, I assumed it was marked required for a reason.  
- I am not 100% sure that `inherit` is the correct rule to set here, vs something like `normal`, but setting anything should fix the TypeScript error.