### PR TITLE
[ButtonBase] Restore the original keyboardFocusCheckTime value

### DIFF
--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -201,7 +201,7 @@ class ButtonBase extends React.Component<ProvidedProps & Props, State> {
   keyDown = false; // Used to help track keyboard activation keyDown
   button = null;
   keyboardFocusTimeout = null;
-  keyboardFocusCheckTime = 30;
+  keyboardFocusCheckTime = 50;
   keyboardFocusMaxCheckTimes = 5;
 
   handleKeyDown = event => {


### PR DESCRIPTION
I'm having a hard time reproducing the issue.
I'm assuming that setting the value back to the one Nathan used
in the first place will help.

Closes #8874

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
