### PR TITLE
Conform Typography definition with React CSSProperties

### DIFF
--- a/src/styles/createTypography.d.ts
+++ b/src/styles/createTypography.d.ts
@@ -18,9 +18,9 @@ export type Style = TextStyle | 'button';
 export interface FontStyle {
   fontFamily: React.CSSProperties['fontFamily'];
   fontSize: React.CSSProperties['fontSize'];
-  fontWeightLight: number | string;
-  fontWeightRegular: number | string;
-  fontWeightMedium: number | string;
+  fontWeightLight: React.CSSProperties['fontWeight'];
+  fontWeightRegular: React.CSSProperties['fontWeight'];
+  fontWeightMedium: React.CSSProperties['fontWeight'];
   htmlFontSize?: number;
 }
 


### PR DESCRIPTION
I encounter an issue when consuming `Theme` in a `StyleRules` object, particularly `theme.typography.fontWeightLight` as in:

```typescript
const styles: StyleRulesCallback = (theme: any) => ({
  title: {
    fontSize: 24,
    fontWeight: theme.typography.fontWeightLight,
    marginBottom: 20,
  },
} as StyleRules);
```

## Expected Behavior
It conforms with `React.CSSProperties['fontWeight']`

## Actual Behaviour
TS complains: `Types of property 'fontWeight' are incompatible.
        Type 'string | number' is not comparable to type '"initial" | "inherit" | "unset" | "normal" | "bold" | "bolder" | "lighter" | 100 | 200 | 300 | 40...'.`

It collides with `StyleRules` which turns out is just a type alias of `Record<string, Partial<React.CSSProperties>>;`.

My only solution is to comply `theme.typography.fontWeight...` definition with `React.CSSProperties['fontWeight']`