### PR TITLE
[typescript] Specify props type for overriding components

### DIFF
--- a/src/Avatar/Avatar.d.ts
+++ b/src/Avatar/Avatar.d.ts
@@ -7,7 +7,7 @@ export interface AvatarProps extends StandardProps<
 > {
   alt?: string;
   childrenClassName?: string;
-  component?: React.ReactType;
+  component?: string | React.ComponentType<AvatarProps>;
   imgProps?: Object;
   sizes?: string;
   src?: string;

--- a/src/Button/Button.d.ts
+++ b/src/Button/Button.d.ts
@@ -7,7 +7,7 @@ export interface ButtonProps extends StandardProps<
   ButtonClassKey
 > {
   color?: PropTypes.Color | 'contrast';
-  component?: React.ReactType;
+  component?: string | React.ComponentType<ButtonProps>;
   dense?: boolean;
   disabled?: boolean;
   disableFocusRipple?: boolean;

--- a/src/ButtonBase/ButtonBase.d.ts
+++ b/src/ButtonBase/ButtonBase.d.ts
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { StandardProps, Replace } from '..';
+import { StandardProps } from '..';
 
 export interface ButtonBaseProps extends StandardProps<
-  Replace<React.AnchorHTMLAttributes<HTMLAnchorElement>, React.ButtonHTMLAttributes<HTMLButtonElement>>,
+  React.AnchorHTMLAttributes<HTMLAnchorElement> & React.ButtonHTMLAttributes<HTMLButtonElement>,
   ButtonBaseClassKey
 > {
   centerRipple?: boolean;
-  component?: React.ReactType;
+  component?: string | React.ComponentType<ButtonBaseProps>;
   disableRipple?: boolean;
   focusRipple?: boolean;
   keyboardFocusedClassName?: string;

--- a/src/Card/CardMedia.d.ts
+++ b/src/Card/CardMedia.d.ts
@@ -7,7 +7,7 @@ export interface CardMediaProps extends StandardProps<
 > {
   image?: string;
   src?: string;
-  component?: React.ReactType;
+  component?: string | React.ComponentType<CardMediaProps>;
 }
 
 export type CardMediaClassKey =

--- a/src/Form/FormControl.d.ts
+++ b/src/Form/FormControl.d.ts
@@ -12,7 +12,7 @@ export interface FormControlProps extends StandardProps<
   onBlur?: React.EventHandler<any>;
   onFocus?: React.EventHandler<any>;
   required?: boolean;
-  component?: React.ReactType;
+  component?: string | React.ComponentType<FormControlProps>;
 }
 
 export type FormControlClassKey =

--- a/src/Grid/Grid.d.ts
+++ b/src/Grid/Grid.d.ts
@@ -27,7 +27,7 @@ export interface GridProps extends StandardProps<
   GridClassKey,
   'hidden'
 > {
-  component?: React.ReactType;
+  component?: string | React.ComponentType<GridProps>;
   container?: boolean;
   item?: boolean;
   alignItems?: GridItemsAlignment;

--- a/src/GridList/GridList.d.ts
+++ b/src/GridList/GridList.d.ts
@@ -7,7 +7,7 @@ export interface GridListProps extends StandardProps<
 > {
   cellHeight?: number | 'auto';
   cols?: number;
-  component?: React.ReactType;
+  component?: string | React.ComponentType<GridListProps>;
   spacing?: number;
 }
 

--- a/src/GridList/GridListTile.d.ts
+++ b/src/GridList/GridListTile.d.ts
@@ -6,7 +6,7 @@ export interface GridListTileProps extends StandardProps<
   GridListTileClassKey
 > {
   cols?: number;
-  component?: React.ReactType;
+  component?: string | React.ComponentType<GridListTileProps>;
   rows?: number;
 }
 

--- a/src/Input/InputAdornment.d.ts
+++ b/src/Input/InputAdornment.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StandardProps } from '..';
 
 export interface InputAdornmentProps extends StandardProps<{}, InputAdornmentClassKey> {
-  component?: React.ReactType;
+  component?: string | React.ComponentType<InputAdornmentProps>;
   disableTypography?: boolean;
   position: 'start' | 'end';
 }

--- a/src/List/List.d.ts
+++ b/src/List/List.d.ts
@@ -5,7 +5,7 @@ export interface ListProps extends StandardProps<
   React.HTMLAttributes<HTMLUListElement>,
   ListClassKey
 > {
-  component?: React.ReactType;
+  component?: string | React.ComponentType<ListProps>;
   dense?: boolean;
   disablePadding?: boolean;
   rootRef?: React.Ref<any>;

--- a/src/List/ListItem.d.ts
+++ b/src/List/ListItem.d.ts
@@ -1,13 +1,13 @@
 import * as React from 'react';
-import { StandardProps, Replace } from '..';
+import { StandardProps } from '..';
 import { ButtonBaseProps, ButtonBaseClassKey } from '../ButtonBase';
 
 export interface ListItemProps extends StandardProps<
-  Replace<ButtonBaseProps, React.LiHTMLAttributes<HTMLLIElement>>,
+  ButtonBaseProps & React.LiHTMLAttributes<HTMLLIElement>,
   ListItemClassKey
 > {
   button?: boolean;
-  component?: React.ReactType;
+  component?: string | React.ComponentType<ListItemProps>;
   dense?: boolean;
   disabled?: boolean;
   disableGutters?: boolean;

--- a/src/List/ListSubheader.d.ts
+++ b/src/List/ListSubheader.d.ts
@@ -5,7 +5,7 @@ export interface ListSubheaderProps extends StandardProps<
   React.HTMLAttributes<HTMLDivElement>,
   ListSubheaderClassKey
 > {
-  component?: React.ReactType;
+  component?: string | React.ComponentType<ListSubheaderProps>;
   color?: 'default' | 'primary' | 'inherit';
   inset?: boolean;
   disableSticky?: boolean;

--- a/src/Menu/MenuItem.d.ts
+++ b/src/Menu/MenuItem.d.ts
@@ -6,7 +6,7 @@ export interface MenuItemProps extends StandardProps<
   ListItemProps,
   MenuItemClassKey
 > {
-  component?: React.ReactType;
+  component?: string | React.ComponentType<MenuItemProps>;
   role?: string;
   selected?: boolean;
 }

--- a/src/Paper/Paper.d.ts
+++ b/src/Paper/Paper.d.ts
@@ -5,7 +5,7 @@ export interface PaperProps extends StandardProps<
   React.HTMLAttributes<HTMLDivElement>,
   PaperClassKey
 > {
-  component?: React.ReactType;
+  component?: string | React.ComponentType<PaperProps>;
   elevation?: number;
   square?: boolean;
 }

--- a/src/Typography/Typography.d.ts
+++ b/src/Typography/Typography.d.ts
@@ -7,7 +7,7 @@ export interface TypographyProps extends StandardProps<
   TypographyClassKey
 > {
   align?: PropTypes.Alignment;
-  component?: React.ReactType;
+  component?: string | React.ComponentType<TypographyProps>;
   color?: PropTypes.Color | 'secondary' | 'error';
   gutterBottom?: boolean;
   headlineMapping?: { [type in TextStyle]: string };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -38,10 +38,9 @@ export interface Color {
  * Utilies types based on:
  * https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-307871458
  */
-export type Diff<T extends string, U extends string> = ({ [P in T]: P } &
+type Diff<T extends string, U extends string> = ({ [P in T]: P } &
   { [P in U]: never } & { [x: string]: never })[T];
-export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
-export type Replace<T, S> = Omit<T, keyof S & keyof T> & S
+type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
 
 export namespace PropTypes {
   type Alignment = 'inherit' | 'left' | 'center' | 'right' | 'justify';

--- a/src/transitions/Collapse.d.ts
+++ b/src/transitions/Collapse.d.ts
@@ -10,7 +10,7 @@ export interface CollapseProps extends StandardProps<
 > {
   children?: React.ReactNode;
   collapsedHeight?: string;
-  component?: React.ReactType;
+  component?: string | React.ComponentType<CollapseProps>;
   theme?: Theme;
   timeout?: TransitionDuration | 'auto';
 }


### PR DESCRIPTION
When overriding the root component of a `material-ui` component, the inner component should not expect to receive props that it will never actually receive from the outer component. This typing change enforces that.