### PR TITLE
[TextField] Fix undefined blur event

### DIFF
--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -178,7 +178,10 @@ class FormControl extends React.Component<ProvidedProps & Props, State> {
   };
 
   handleBlur = event => {
-    if (this.props.onBlur) {
+    // The event might be undefined.
+    // For instance, a child component might call this hook
+    // when an input is disabled but still having the focus.
+    if (this.props.onBlur && event) {
       this.props.onBlur(event);
     }
     if (this.state.focused) {

--- a/src/Form/FormControl.spec.js
+++ b/src/Form/FormControl.spec.js
@@ -227,7 +227,7 @@ describe('<FormControl />', () => {
           const handleBlur = spy();
           wrapper.setProps({ onBlur: handleBlur });
           muiFormControlContext.onFocus();
-          muiFormControlContext.onBlur();
+          muiFormControlContext.onBlur({});
           assert.strictEqual(handleBlur.callCount, 1);
         });
       });


### PR DESCRIPTION
Added check for existence of event on `FormControl.handleBlur(event)`. If event is `undefined` we don't call `onBlur()` of props.

Closes #9027