### PR TITLE
[docs] Updates Home h2 text to match v1

### DIFF
--- a/docs/src/app/components/pages/Home.js
+++ b/docs/src/app/components/pages/Home.js
@@ -86,8 +86,8 @@ class HomePage extends Component {
         <div style={styles.tagline}>
           <h1 style={styles.h1}>Material-UI</h1>
           <h2 style={styles.h2}>
-            A Set of React Components <span style={styles.nowrap}>
-            that Implement</span> <span style={styles.nowrap}>
+            React components <span style={styles.nowrap}>
+            that implement</span> <span style={styles.nowrap}>
             Google&apos;s Material Design</span>
           </h2>
           <RaisedButton


### PR DESCRIPTION
Fixes #9053 

![image](https://user-images.githubusercontent.com/11624407/32581604-2dd3c468-c4b0-11e7-9808-4cbf911c6a53.png)

**Updates:**

- Matches the more concise wording that already exists in the v1 branch.
- Adjusts capitalization to match normal sentence style as opposed to title style.

