### PR TITLE
[CircularProgress] Replaces string refs with callback refs

### DIFF
--- a/src/CircularProgress/CircularProgress.js
+++ b/src/CircularProgress/CircularProgress.js
@@ -112,8 +112,8 @@ class CircularProgress extends Component {
   };
 
   componentDidMount() {
-    this.scalePath(this.refs.path);
-    this.rotateWrapper(this.refs.wrapper);
+    this.scalePath(this.path);
+    this.rotateWrapper(this.wrapper);
   }
 
   componentWillUnmount() {
@@ -172,13 +172,16 @@ class CircularProgress extends Component {
 
     return (
       <div {...other} style={prepareStyles(Object.assign(styles.root, style))} >
-        <div ref="wrapper" style={prepareStyles(Object.assign(styles.wrapper, innerStyle))} >
+        <div
+          ref={(wrapper) => this.wrapper = wrapper}
+          style={prepareStyles(Object.assign(styles.wrapper, innerStyle))}
+        >
           <svg
             viewBox={`0 0 ${size} ${size}`}
             style={prepareStyles(styles.svg)}
           >
             <circle
-              ref="path"
+              ref={(path) => this.path = path}
               style={prepareStyles(styles.path)}
               cx={size / 2}
               cy={size / 2}


### PR DESCRIPTION
## Partially completes #9054 

We now have callback refs in the oh-so-important **`<CircularProgress/>`** component.

For reference, [here are the pertinent React docs](https://reactjs.org/docs/refs-and-the-dom.html#adding-a-ref-to-a-dom-element) about `refs`.

### In action

**Left**: these changes
**Right**: docs site in production

![mui-refs-circular-progress](https://user-images.githubusercontent.com/11624407/32582402-35aebad6-c4b4-11e7-8020-f499c53b2d49.gif)
