### PR TITLE
[DatePicker] Replaces string refs with callback refs

### DIFF
--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -205,11 +205,11 @@ class DatePicker extends Component {
     if (this.state.date !== undefined) {
       this.setState({
         dialogDate: this.getDate(),
-      }, this.refs.dialogWindow.show);
+      }, this.dialogWindow.show);
     } else {
       this.setState({
         dialogDate: new Date(),
-      }, this.refs.dialogWindow.show);
+      }, this.dialogWindow.show);
     }
   }
 
@@ -312,7 +312,7 @@ class DatePicker extends Component {
           {...other}
           onFocus={this.handleFocus}
           onClick={this.handleTouchTap}
-          ref="input"
+          ref={(input) => this.input = input}
           style={textFieldStyle}
           value={this.state.date ? formatDate(this.state.date) : ''}
         />
@@ -333,7 +333,7 @@ class DatePicker extends Component {
           onAccept={this.handleAccept}
           onShow={onShow}
           onDismiss={onDismiss}
-          ref="dialogWindow"
+          ref={(dialogWindow) => this.dialogWindow = dialogWindow}
           shouldDisableDate={shouldDisableDate}
           hideCalendarDate={hideCalendarDate}
           openToYearSelection={openToYearSelection}

--- a/src/DatePicker/DatePickerDialog.js
+++ b/src/DatePicker/DatePickerDialog.js
@@ -87,8 +87,8 @@ class DatePickerDialog extends Component {
   };
 
   handleTouchTapOk = () => {
-    if (this.props.onAccept && !this.refs.calendar.isSelectedDateDisabled()) {
-      this.props.onAccept(this.refs.calendar.getSelectedDate());
+    if (this.props.onAccept && !this.calendar.isSelectedDateDisabled()) {
+      this.props.onAccept(this.calendar.getSelectedDate());
     }
 
     this.setState({
@@ -147,13 +147,13 @@ class DatePickerDialog extends Component {
     const Container = (container === 'inline' ? Popover : Dialog);
 
     return (
-      <div {...other} ref="root">
+      <div {...other} ref={(root) => this.root = root}>
         <Container
-          anchorEl={this.refs.root} // For Popover
+          anchorEl={this.root} // For Popover
           animation={animation || PopoverAnimationVertical} // For Popover
           bodyStyle={styles.dialogBodyContent}
           contentStyle={styles.dialogContent}
-          ref="dialog"
+          ref={(dialog) => this.dialog = dialog}
           repositionOnUpdate={true}
           open={open}
           onRequestClose={this.handleRequestClose}
@@ -176,7 +176,7 @@ class DatePickerDialog extends Component {
             minDate={minDate}
             mode={mode}
             open={open}
-            ref="calendar"
+            ref={(calendar) => this.calendar = calendar}
             onTouchTapCancel={this.handleTouchTapCancel}
             onTouchTapOk={this.handleTouchTapOk}
             okLabel={okLabel}


### PR DESCRIPTION
## Partially completes #9054 

We now have callback refs in the **`<DatePicker/>`** component.

For reference, [here are the pertinent React docs](https://reactjs.org/docs/refs-and-the-dom.html#adding-a-ref-to-a-dom-element) about `refs`.

### In action

![mui-refs-datepicker](https://user-images.githubusercontent.com/11624407/32582789-1ab4b490-c4b6-11e7-84ea-c374c06d0357.gif)

