### PR TITLE
[examples] Fix missing props for BaseComponent

### DIFF
--- a/examples/create-react-app/src/components/withRoot.js
+++ b/examples/create-react-app/src/components/withRoot.js
@@ -41,7 +41,7 @@ function withRoot(BaseComponent) {
         <JssProvider registry={context.sheetsRegistry} jss={context.jss}>
           <MuiThemeProvider theme={context.theme} sheetsManager={context.sheetsManager}>
             <AppWrapper>
-              <BaseComponent />
+              <BaseComponent {...this.props} />
             </AppWrapper>
           </MuiThemeProvider>
         </JssProvider>


### PR DESCRIPTION
In the `examples/create-react-app` project:

When using something like React Router to render BaseComponent (through WithRoot component) and its children (sub routes), the props isn't passed down by WithRoot component, making the
`this.props.children` "undefined" in BaseComponent.

This change make sure the props is getting spread in it.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
