### PR TITLE
[breakpoint] Fix xs value

### DIFF
--- a/src/styles/createBreakpoints.js
+++ b/src/styles/createBreakpoints.js
@@ -9,8 +9,10 @@ export const keys = ['xs', 'sm', 'md', 'lg', 'xl'];
 // Keep in mind that @media is inclusive by the CSS specification.
 export default function createBreakpoints(breakpoints: Object) {
   const {
+    // The breakpoint **start** at this value.
+    // For instance with the first breakpoint xs: [xs, sm[.
     values = {
-      xs: 360,
+      xs: 1,
       sm: 600,
       md: 960,
       lg: 1280,
@@ -22,13 +24,7 @@ export default function createBreakpoints(breakpoints: Object) {
   } = breakpoints;
 
   function up(key) {
-    let value;
-    // min-width of xs starts at 0
-    if (key === 'xs') {
-      value = 0;
-    } else {
-      value = values[key] || key;
-    }
+    const value = values[key] || key;
     return `@media (min-width:${value}${unit})`;
   }
 

--- a/src/styles/createBreakpoints.spec.js
+++ b/src/styles/createBreakpoints.spec.js
@@ -12,7 +12,7 @@ describe('createBreakpoints', () => {
 
   describe('up', () => {
     it('should work for xs', () => {
-      assert.strictEqual(breakpoints.up('xs'), '@media (min-width:0px)');
+      assert.strictEqual(breakpoints.up('xs'), '@media (min-width:1px)');
     });
 
     it('should work for md', () => {


### PR DESCRIPTION
The breakpoint **start** at the values' value.
For instance, the first breakpoint xs will match the following range:
`[values.xs, values.sm[`