### PR TITLE
[core] Document the overhead of importing a single component

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -1,0 +1,10 @@
+[
+  {
+    "path": "build/index.js",
+    "limit": "92 KB"
+  },
+  {
+    "path": "test/size/overhead.js",
+    "limit": "26 KB"
+  }
+]

--- a/docs/src/pages/guides/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size.md
@@ -1,5 +1,15 @@
 # Minimizing Bundle Size
 
+## Bundle size matter
+
+Material-UI takes the bundle size very seriously.
+We are relying on [size-limit](https://github.com/ai/size-limit) to prevent introducing any regression.
+We monitor the size of the bundle:
+- When importing **all the components**. This lets us spot any [unwanted bundle size increase](https://github.com/callemall/material-ui/tree/v1-beta/.size-limit#L4).
+- When importing **a single component**. This lets us estimate [the overhead of our core dependencies](https://github.com/callemall/material-ui/tree/v1-beta/.size-limit#L8). (styling, theming, etc.: ~20 kB gzipped)
+
+## How to reduce the bundle size?
+
 For convenience, Material-UI exposes its full API on the top-level `material-ui` import.
 This will work fine if you have tree shaking working.
 
@@ -7,7 +17,7 @@ However, in the case where tree shaking is not supported or configured in your b
 
 You have couple of options to overcome this situation:
 
-## Option 1
+### Option 1
 
 You can import directly from `material-ui/` to avoid pulling in unused modules. For instance, instead of:
 
@@ -24,7 +34,7 @@ import TextField from 'material-ui/TextField';
 
 The public API available in this manner is defined as the set of imports available from the top-level `material-ui` module. Anything not available through the top-level `material-ui` module is a **private API**, and is subject to change without notice.
 
-## Option 2
+### Option 2
 
 Another option is to keep using the shortened import like the following, but still have the size of the bundle optimized thanks to a **Babel plugin**:
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lint": "eslint . --cache && echo \"eslint: no lint errors\"",
     "size": "size-limit",
     "size:why": "size-limit --why build/index.js",
+    "size:overhead:why": "size-Limit --why ./test/size/overhead.js",
     "spellcheck": "eslint . --config .eslintrc.spellcheck.js && echo \"eslint: no lint errors\"",
     "start": "cd docs && yarn start",
     "test": "yarn lint && yarn flow && yarn typescript && yarn test:unit",
@@ -183,12 +184,6 @@
     "@types/react": "16.0.19"
   },
   "side-effects": false,
-  "size-limit": [
-    {
-      "path": "build/index.js",
-      "limit": "92 KB"
-    }
-  ],
   "nyc": {
     "include": [
       "src/**/*.js"

--- a/test/size/overhead.js
+++ b/test/size/overhead.js
@@ -1,0 +1,3 @@
+/* eslint-disable */
+
+import '../../build/Paper';


### PR DESCRIPTION
The number of dependencies the v1-beta branch can be discouraging (21).
Hopefully, being transparent about the bundle size implications should help.
One interesting point, importing a single simple component (Paper) results in a ~20 kB gzipped overhead. It's the cost of the styling, theming, etc. solution we use.
- 5 kB theming
- 13 kB styling

This has to be put into perspective with react + react-dom: 34.8 kB gzipped.