### PR TITLE
[docs] Fix AppSearch horizontal rythm

### DIFF
--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -68,6 +68,7 @@ const styles = theme => ({
   wrapper: {
     fontFamily: theme.typography.fontFamily,
     position: 'relative',
+    marginRight: 16,
     borderRadius: 2,
     background: fade(theme.palette.common.white, 0.15),
     '&:hover': {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Fixes a minor layout niggle that's been bugging me since search was added. 😄 

Before:
<img width="398" alt="image" src="https://user-images.githubusercontent.com/357702/32698107-f416e4fa-c796-11e7-914e-501eee0e1538.png">

After:
<img width="401" alt="image" src="https://user-images.githubusercontent.com/357702/32698124-8a0182a4-c797-11e7-8275-4dd8389b7749.png">

I'll admit my chosen spacing is arbitrary, but it's visually more pleasing.