### PR TITLE
Support TypeScript 2.6 and --strictFunctionTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "rimraf": "^2.6.2",
     "sinon": "^4.1.2",
     "size-limit": "^0.13.1",
-    "typescript": "2.6.1",
+    "typescript": "^2.6.1",
     "url-loader": "^0.6.2",
     "vrtest": "^0.2.0",
     "webfontloader": "^1.6.28",

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "rimraf": "^2.6.2",
     "sinon": "^4.1.2",
     "size-limit": "^0.13.1",
-    "typescript": "2.5.3",
+    "typescript": "2.6.1",
     "url-loader": "^0.6.2",
     "vrtest": "^0.2.0",
     "webfontloader": "^1.6.28",

--- a/src/Button/Button.d.ts
+++ b/src/Button/Button.d.ts
@@ -4,7 +4,8 @@ import { ButtonBaseProps, ButtonBaseClassKey } from '../ButtonBase';
 
 export interface ButtonProps extends StandardProps<
   ButtonBaseProps,
-  ButtonClassKey
+  ButtonClassKey,
+  'component'
 > {
   color?: PropTypes.Color | 'contrast';
   component?: string | React.ComponentType<ButtonProps>;

--- a/src/List/ListItem.d.ts
+++ b/src/List/ListItem.d.ts
@@ -4,7 +4,8 @@ import { ButtonBaseProps, ButtonBaseClassKey } from '../ButtonBase';
 
 export interface ListItemProps extends StandardProps<
   ButtonBaseProps & React.LiHTMLAttributes<HTMLLIElement>,
-  ListItemClassKey
+  ListItemClassKey,
+  'component'
 > {
   button?: boolean;
   component?: string | React.ComponentType<ListItemProps>;

--- a/test/typescript/styles.spec.tsx
+++ b/test/typescript/styles.spec.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../src/styles';
 import Button from '../../src/Button/Button';
 import { StyleRulesCallback } from '../../src/styles/withStyles';
+import { Contrast } from '../../src/index';
 
 // Shared types for examples
 type ComponentClassNames = 'root';
@@ -89,7 +90,7 @@ const theme = createMuiTheme({
 
 const customTheme = createMuiTheme({
   palette: {
-    type: 'dark',
+    type: 'dark' as Contrast,
   },
 });
 
@@ -113,11 +114,9 @@ interface AllTheProps {
   classes: { root: string };
 }
 
-const AllTheStyles: React.SFC<AllTheProps> = ({ theme, classes }) => (
+const AllTheComposition = withTheme()(withStyles(styles)(({ theme, classes }) => (
   <div className={classes.root}>{theme.palette.text.primary}</div>
-);
-
-const AllTheComposition = withTheme()(withStyles(styles)(AllTheStyles));
+)));
 
 // Can't use withStyles effectively as a decorator in TypeScript
 // due to https://github.com/Microsoft/TypeScript/issues/4881

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "noImplicitAny": true,
     "strictNullChecks": true,
+    "strictFunctionTypes": true,
     "forceConsistentCasingInFileNames": true,
     "suppressImplicitAnyIndexErrors": true,
     "noEmit": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8662,9 +8662,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@2.5.3:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
+typescript@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
 
 ua-parser-js@^0.7.9:
   version "0.7.14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8662,7 +8662,7 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@2.6.1:
+typescript@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
 


### PR DESCRIPTION
[TypeScript 2.6 is out](https://blogs.msdn.microsoft.com/typescript/2017/10/31/announcing-typescript-2-6/) and includes a new strictness flag `--strictFunctionTypes` which is quite popular. `material-ui@v1.0.0-beta.21` is incompatible with this flag--this is a regression introduced by me in #9035 😨. This new PR fixes these problems, and also upgrades to TypeScript 2.6 and enables `--strictFunctionTypes` in the tests, to ensure we don't regress in the future.