### PR TITLE
[typescript] Fix typing of withWidth

### DIFF
--- a/src/utils/withWidth.d.ts
+++ b/src/utils/withWidth.d.ts
@@ -20,8 +20,8 @@ export function isWidthUp(
   inclusive?: boolean
 ): boolean;
 
-export default function withWidth<P = {}>(
+export default function withWidth(
   options?: WithWidthOptions
-): (
-  component: React.ComponentType<P>
-) => React.ComponentClass<P & WithWidthProps>;
+): <P>(
+  component: React.ComponentType<P & WithWidthProps>
+) => React.ComponentClass<P & Partial<WithWidthProps>>;

--- a/src/utils/withWidth.spec.tsx
+++ b/src/utils/withWidth.spec.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { Grid } from '..';
+import { Theme } from '../styles';
+import withStyles, { WithStyles } from '../styles/withStyles';
+import withWidth, { WithWidthProps } from '../utils/withWidth';
+
+const styles = (theme: Theme) => ({
+    root: {
+        backgroundColor: theme.palette.common.faintBlack,
+    },
+});
+
+interface IHelloProps {
+    name?: string;
+}
+
+export class Hello extends React.Component<IHelloProps & WithWidthProps & WithStyles<'root'>> {
+  public static defaultProps = {
+    name: 'Alex',
+  };
+
+  public render() {
+    return (
+      <Grid
+        className={this.props.classes.root}
+        direction={this.props.width === 'sm' ? 'column' : 'row'}
+      >
+        <h1>Hello {this.props.name}!</h1>
+      </Grid>
+    );
+  }
+}
+
+const Decorated = withWidth()(withStyles(styles)(Hello));
+
+<Decorated name="Bob" />;


### PR DESCRIPTION
Correct typing of `withWidth` so that
- `width` prop is definitely defined within the inner component
- `width` prop is possibly undefined for the outer component (so it is not required to be overridden)
- non-`width` props (`P`) are deferred to the second parameter group, similar to `withStyles`, to aid in type inference

Fixes issue mentioned [here](https://github.com/callemall/material-ui/issues/8824#issuecomment-344124872).
