### PR TITLE
[StepContent] Fix typings

### DIFF
--- a/src/Stepper/StepContent.d.ts
+++ b/src/Stepper/StepContent.d.ts
@@ -9,13 +9,13 @@ export interface StepContentProps extends StandardProps<
 > {
   active?: boolean;
   alternativeLabel?: boolean;
-  children: Node;
+  children: React.ReactNode;
   completed?: boolean;
   last?: boolean;
   optional?: boolean;
   orientation?: Orientation;
   transition?: Function;
-  transitionDuration: TransitionDuration;
+  transitionDuration?: TransitionDuration | 'auto';
 }
 
 export type StepContentClasskey =

--- a/src/Stepper/StepContent.js
+++ b/src/Stepper/StepContent.js
@@ -76,7 +76,7 @@ export type Props = {
   /**
    * Adjust the duration of the content expand transition.
    * Passed as a property to the transition component.
-   * 
+   *
    * Set to 'auto' to automatically calculate transition time based on height.
    */
   transitionDuration?: TransitionDuration,

--- a/src/Stepper/StepContent.js
+++ b/src/Stepper/StepContent.js
@@ -76,8 +76,10 @@ export type Props = {
   /**
    * Adjust the duration of the content expand transition.
    * Passed as a property to the transition component.
+   * 
+   * Set to 'auto' to automatically calculate transition time based on height.
    */
-  transitionDuration: TransitionDuration,
+  transitionDuration?: TransitionDuration,
 };
 
 function StepContent(props: ProvidedProps & Props) {


### PR DESCRIPTION
`Node` should be `React.ReactNode` for children.

`transitionDuration` is optional since the default `transition` is `Collapse`. I copied `'auto'` description from `Collapse`. 