### PR TITLE
[CircularProgress] Fix behavior when dir=rtl

### DIFF
--- a/src/Progress/CircularProgress.js
+++ b/src/Progress/CircularProgress.js
@@ -192,4 +192,4 @@ CircularProgress.defaultProps = {
   max: 100,
 };
 
-export default withStyles(styles, { name: 'MuiCircularProgress' })(CircularProgress);
+export default withStyles(styles, { name: 'MuiCircularProgress', flip: false })(CircularProgress);

--- a/src/internal/transition.d.ts
+++ b/src/internal/transition.d.ts
@@ -14,6 +14,7 @@ export type TransitionHandlers = {
 
 export interface TransitionProps extends Partial<TransitionHandlers> {
   children: React.ReactElement<any>;
+  style?: React.CSSProperties;
   className?: string;
   in: boolean;
   appear?: boolean;


### PR DESCRIPTION
Also, Transitions should be able to forward the `style` prop.