### PR TITLE
[Select] Fix typescript typings

### DIFF
--- a/src/Select/Select.d.ts
+++ b/src/Select/Select.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { StandardProps } from '..';
 import { InputProps } from '../Input';
-import { InputClassKey } from '../Input/Input';
+import { MenuProps } from '../Menu';
 
 export interface SelectProps extends StandardProps<
   InputProps,
@@ -11,17 +11,19 @@ export interface SelectProps extends StandardProps<
   autoWidth?: boolean;
   displayEmpty?: boolean;
   input?: React.ReactNode;
+  InputClasses?: InputProps['classes'];
   native?: boolean;
   multiple?: boolean;
-  MenuProps?: Object;
+  MenuProps?: Partial<MenuProps>;
   renderValue?: Function;
   value?: Array<string | number> | string | number;
 }
 
 type SelectClassKey =
-  | InputClassKey
+  | 'root'
   | 'select'
   | 'selectMenu'
+  | 'disabled'
   | 'icon'
   ;
 

--- a/src/Select/Select.d.ts
+++ b/src/Select/Select.d.ts
@@ -11,7 +11,6 @@ export interface SelectProps extends StandardProps<
   autoWidth?: boolean;
   displayEmpty?: boolean;
   input?: React.ReactNode;
-  InputClasses?: InputProps['classes'];
   native?: boolean;
   multiple?: boolean;
   MenuProps?: Partial<MenuProps>;

--- a/src/Select/SelectInput.d.ts
+++ b/src/Select/SelectInput.d.ts
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { StandardProps } from '..';
+import { MenuProps } from '../Menu';
 
 export interface SelectInputProps extends StandardProps<{}, SelectInputClassKey> {
   autoWidth: boolean;
   disabled?: boolean;
   native: boolean;
   multiple: boolean;
-  MenuProps?: Object;
+  MenuProps?: Partial<MenuProps>;
   name?: string;
   onBlur?: React.FocusEventHandler<any>;
   onChange?: (event: React.ChangeEvent<{}>, child: React.ReactNode) => void,


### PR DESCRIPTION
`InputClasses` was missing on `Select` I fixed a few other problems too.