### PR TITLE
[Select] Remove InputClasses

### DIFF
--- a/pages/api/select.md
+++ b/pages/api/select.md
@@ -12,7 +12,6 @@ filename: /src/Select/Select.js
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| InputClasses | Object |  | `classes` property applied to the `Input` element. |
 | MenuProps | Object |  | Properties applied to the `Menu` element. |
 | autoWidth | boolean | false | If true, the width of the popover will automatically be set according to the items inside the menu, otherwise it will be at least the width of the select input. |
 | <span style="color: #31a148">children *</span> | $ReadOnlyArray |  | The option elements to populate the select with. Can be some `MenuItem` when `native` is false and `option` when `native` is true. |

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -94,10 +94,6 @@ export type Props = {
    */
   input?: Element<any>,
   /**
-   * `classes` property applied to the `Input` element.
-   */
-  InputClasses?: Object,
-  /**
    * If `true`, the component will be using a native `select` element.
    */
   native?: boolean,
@@ -128,7 +124,6 @@ function Select(props: ProvidedProps & Props) {
     classes,
     displayEmpty,
     input,
-    InputClasses,
     native,
     multiple,
     MenuProps,
@@ -149,7 +144,6 @@ function Select(props: ProvidedProps & Props) {
     // Most of the logic is implemented in `SelectInput`.
     // The `Select` component is a simple API wrapper to expose something better to play with.
     inputComponent: SelectInput,
-    classes: InputClasses,
     ...other,
     inputProps: {
       ...(input ? input.props.inputProps : {}),

--- a/src/Table/TablePagination.js
+++ b/src/Table/TablePagination.js
@@ -183,10 +183,14 @@ class TablePagination extends React.Component<ProvidedProps & Props> {
           </Typography>
           <Select
             classes={{ root: classes.selectRoot, select: classes.select }}
-            InputClasses={{
-              root: classes.input,
-            }}
-            input={<Input disableUnderline />}
+            input={
+              <Input
+                classes={{
+                  root: classes.input,
+                }}
+                disableUnderline
+              />
+            }
             value={rowsPerPage}
             onChange={onChangeRowsPerPage}
           >


### PR DESCRIPTION
I have made an unwise call of adding the InputClasses property in an unrelated refactorization pull-request.
It's not taking the input classes property into account.
It was a breaking change and not needed.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
