### PR TITLE
Strip keys from GridProps which won't get passed to override component

### DIFF
--- a/src/Grid/Grid.d.ts
+++ b/src/Grid/Grid.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StandardProps } from '..';
+import { StandardProps, Omit } from '..';
 import { HiddenProps } from '../Hidden/Hidden';
 import { Breakpoint } from '../styles/createBreakpoints';
 
@@ -27,7 +27,7 @@ export interface GridProps extends StandardProps<
   GridClassKey,
   'hidden'
 > {
-  component?: string | React.ComponentType<GridProps>;
+  component?: string | React.ComponentType<Omit<GridProps, StrippedProps>>;
   container?: boolean;
   item?: boolean;
   alignItems?: GridItemsAlignment;
@@ -82,3 +82,23 @@ export type GridClassKey =
 declare const Grid: React.ComponentType<GridProps>;
 
 export default Grid;
+
+type StrippedProps =
+  | 'classes'
+  | 'className'
+  | 'component'
+  | 'container'
+  | 'item'
+  | 'alignContent'
+  | 'alignItems'
+  | 'direction'
+  | 'spacing'
+  | 'hidden'
+  | 'justify'
+  | 'wrap'
+  | 'xs'
+  | 'sm'
+  | 'md'
+  | 'lg'
+  | 'xl'
+  ;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -38,9 +38,15 @@ export interface Color {
  * Utilies types based on:
  * https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-307871458
  */
-type Diff<T extends string, U extends string> = ({ [P in T]: P } &
-  { [P in U]: never } & { [x: string]: never })[T];
-type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+
+ /** @internal */
+type Diff<T extends string, U extends string> = (
+  { [P in T]: P } &
+  { [P in U]: never } & { [x: string]: never }
+)[T];
+
+/** @internal */
+export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
 
 export namespace PropTypes {
   type Alignment = 'inherit' | 'left' | 'center' | 'right' | 'justify';

--- a/test/typescript/components.spec.tsx
+++ b/test/typescript/components.spec.tsx
@@ -331,7 +331,7 @@ const DrawerTest = () => {
 };
 
 const GridTest = () =>
-  <Grid container>
+  <Grid component={Paper} container>
     <Grid item xs={12}>
       ...
     </Grid>


### PR DESCRIPTION
The current typings for override `component` props are overly conservative in that they assume all props from the parent component may be passed to the child, when in reality only a subset are. This can lead to spurious prop conflicts which are annoying to deal with. This fixes only `Grid`, but there are undoubtedly tons of other components which could benefit from similar treatment.

Fixes #9176.