### PR TITLE
[FormControlLabel] Fixes non-valid HTML when p used in label element

### DIFF
--- a/src/Form/FormControlLabel.js
+++ b/src/Form/FormControlLabel.js
@@ -133,7 +133,9 @@ function FormControlLabel(props: ProvidedProps & Props, context: Context) {
         value: control.props.value || value,
         inputRef: control.props.inputRef || inputRef,
       })}
-      <Typography className={classes.label}>{label}</Typography>
+      <Typography type="caption" className={classes.label}>
+        {label}
+      </Typography>
     </label>
   );
 }

--- a/src/Form/FormControlLabel.js
+++ b/src/Form/FormControlLabel.js
@@ -133,7 +133,7 @@ function FormControlLabel(props: ProvidedProps & Props, context: Context) {
         value: control.props.value || value,
         inputRef: control.props.inputRef || inputRef,
       })}
-      <Typography type="caption" className={classes.label}>
+      <Typography component="span" className={classes.label}>
         {label}
       </Typography>
     </label>


### PR DESCRIPTION
https://validator.w3.org throws `Error: Element p not allowed as child of element label in this context.` This update adds the prop `type="caption"` to `Typography` so that a `<span>` is used instead of a `<p>`.
