### PR TITLE
[Switch] Fixes non-valid HTML when div used inside of label element

### DIFF
--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -133,7 +133,7 @@ export type Props = {
 
 function Switch(props: ProvidedProps & Props) {
   const { classes, className, ...other } = props;
-  const icon = <div className={classes.icon} />;
+  const icon = <span className={classes.icon} />;
 
   return (
     <div className={classNames(classes.root, className)}>
@@ -147,7 +147,7 @@ function Switch(props: ProvidedProps & Props) {
         checkedIcon={icon}
         {...other}
       />
-      <div className={classes.bar} />
+      <span className={classes.bar} />
     </div>
   );
 }

--- a/src/Switch/Switch.spec.js
+++ b/src/Switch/Switch.spec.js
@@ -35,16 +35,16 @@ describe('<Switch />', () => {
       assert.strictEqual(wrapper.hasClass('foo'), true);
     });
 
-    it('should render SwitchBase with a custom div icon with the icon class', () => {
+    it('should render SwitchBase with a custom span icon with the icon class', () => {
       const switchBase = wrapper.childAt(0);
       assert.strictEqual(switchBase.name(), 'withStyles(SwitchBase)');
-      assert.strictEqual(switchBase.props().icon.type, 'div');
+      assert.strictEqual(switchBase.props().icon.type, 'span');
       assert.strictEqual(switchBase.props().icon.props.className, classes.icon);
     });
 
     it('should render the bar as the 2nd child', () => {
       const bar = wrapper.childAt(1);
-      assert.strictEqual(bar.is('div'), true);
+      assert.strictEqual(bar.is('span'), true);
       assert.strictEqual(bar.hasClass(classes.bar), true);
     });
   });


### PR DESCRIPTION
**https://validator.w3.org** throws `Error: Element div not allowed as child of element label in this context.` This update replaces the `<div>` elements with `<span>`s. The CSS already in place maintains all styling.

Closes #9180