### PR TITLE
[Avatar] Fix alt align

### DIFF
--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -29,6 +29,7 @@ export const styles = (theme: Object) => ({
     maxWidth: '100%',
     width: '100%',
     height: 'auto',
+    textAlign: 'center',
   },
 });
 


### PR DESCRIPTION
Hi!

Sometimes `src` resource could be broken and image does not show. It's pretty good to have fallback to some initials in this case.

```ts
<Avatar src="/404.image.jpg" alt="KV" />
```

I can make it with `alt` attribute. But it has alignment problem:

![image](https://user-images.githubusercontent.com/1949681/32942254-8c6bad2a-cb99-11e7-8973-bcec0870fd4f.png)

This PR fixes it. So it looks like this:

![image](https://user-images.githubusercontent.com/1949681/32942453-25430930-cb9a-11e7-97d2-898ce1ec1bf7.png)

