### PR TITLE
[style] Fix between media-query for xl

### DIFF
--- a/src/styles/createBreakpoints.js
+++ b/src/styles/createBreakpoints.js
@@ -34,19 +34,19 @@ export default function createBreakpoints(breakpoints: Object) {
   }
 
   function between(start, end) {
-    const startIndex = keys.indexOf(start);
-    const endIndex = keys.indexOf(end);
+    const endIndex = keys.indexOf(end) + 1;
+
+    if (endIndex === keys.length) {
+      return up(start);
+    }
+
     return (
-      `@media (min-width:${values[keys[startIndex]]}${unit}) and ` +
-      `(max-width:${values[keys[endIndex + 1]] - step / 100}${unit})`
+      `@media (min-width:${values[start]}${unit}) and ` +
+      `(max-width:${values[keys[endIndex]] - step / 100}${unit})`
     );
   }
 
   function only(key) {
-    const keyIndex = keys.indexOf(key);
-    if (keyIndex === keys.length - 1) {
-      return up(key);
-    }
     return between(key, key);
   }
 

--- a/src/styles/createBreakpoints.spec.js
+++ b/src/styles/createBreakpoints.spec.js
@@ -33,6 +33,10 @@ describe('createBreakpoints', () => {
         '@media (min-width:600px) and (max-width:1279.95px)',
       );
     });
+
+    it('on xl should call up', () => {
+      assert.strictEqual(breakpoints.between('lg', 'xl'), '@media (min-width:1280px)');
+    });
   });
 
   describe('only', () => {


### PR DESCRIPTION
Between breakpoints with an `xl` end produce some unexpected output

    > breakpoints.between('lg', 'xl')
    '@media (min-width:1280px) and (max-width:NaNpx)'
    
It should be equivalent to `up('lg')` given the half-open interval the other breakpoints have `(start, end]`