### PR TITLE
[core] Add material-ui-dependents to see the dependents on GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "material-ui",
+  "name": "material-ui-build-next",
   "private": true,
   "author": "Material-UI Team",
   "version": "1.0.0-beta.21",

--- a/packages/material-ui-dependents/package.json
+++ b/packages/material-ui-dependents/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "material-ui",
+  "author": "Material-UI Team",
+  "version": "0.0.1",
+  "description": "Empty package just to see the dependents on GitHub. The main package is build from material-ui-build-next.",
+  "license": "MIT"
+}


### PR DESCRIPTION
I have failed with f361f2032cc8b02ca8dbc10fd5bcb97f693b7e77. This time, it should give us the number of dependents statistic on GitHub:

![capture d ecran 2017-11-17 a 23 09 56](https://user-images.githubusercontent.com/3165635/32971222-7a75d07a-cbec-11e7-8c27-9470d37c2dd4.png)
