### PR TITLE
[transitions] Expose the transition components

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -112,7 +112,7 @@ export { default as Tabs, Tab } from './Tabs';
 export { default as Typography } from './Typography';
 export { default as TextField } from './TextField';
 export { default as Toolbar } from './Toolbar';
-
 export { default as Tooltip } from './Tooltip';
+export { Slide, Grow, Fade, Collapse } from './transitions';
 
 export { default as withWidth } from './utils/withWidth';

--- a/src/index.js
+++ b/src/index.js
@@ -68,5 +68,6 @@ export { default as Typography } from './Typography';
 export { default as TextField } from './TextField';
 export { default as Toolbar } from './Toolbar';
 export { default as Tooltip } from './Tooltip';
+export { Slide, Grow, Fade, Collapse } from './transitions';
 
 export { default as withWidth } from './utils/withWidth';

--- a/src/transitions/index.d.ts
+++ b/src/transitions/index.d.ts
@@ -1,0 +1,8 @@
+export { default as Slide } from './Slide';
+export * from './Slide';
+export { default as Grow } from './Grow';
+export * from './Grow';
+export { default as Fade } from './Fade';
+export * from './Fade';
+export { default as Collapse } from './Collapse';
+export * from './Collapse';

--- a/src/transitions/index.js
+++ b/src/transitions/index.js
@@ -1,0 +1,6 @@
+// @flow
+
+export { default as Slide } from './Slide';
+export { default as Grow } from './Grow';
+export { default as Fade } from './Fade';
+export { default as Collapse } from './Collapse';


### PR DESCRIPTION
This is a follow-on for #9012 for Material-ui/transitions

**Included files**
src/transitions/index.js
src/transitions/index.d.ts

**Edited Files**
src/index.js
src/index.d.ts

Closes #9012