### PR TITLE
[docs] Fill enhanced table to always have the same height on all pages

### DIFF
--- a/docs/src/pages/demos/tables/EnhancedTable.js
+++ b/docs/src/pages/demos/tables/EnhancedTable.js
@@ -267,6 +267,7 @@ class EnhancedTable extends React.Component {
   render() {
     const { classes } = this.props;
     const { data, order, orderBy, selected, rowsPerPage, page } = this.state;
+    const emptyRows = rowsPerPage - Math.min(rowsPerPage, data.length - page * rowsPerPage);
 
     return (
       <Paper className={classes.root}>
@@ -306,6 +307,11 @@ class EnhancedTable extends React.Component {
                   </TableRow>
                 );
               })}
+              {emptyRows > 0 && (
+                <TableRow style={{ height: 49 * emptyRows }}>
+                  <TableCell colSpan={6} />
+                </TableRow>
+              )}
             </TableBody>
             <TableFooter>
               <TableRow>


### PR DESCRIPTION
This adds a fill row to the demo that ensures that the table always has the same height even on the last page (where the number of rows may be smaller than `rowsPerPage`).
![image](https://user-images.githubusercontent.com/5544859/32979881-628bb8fa-cc5d-11e7-8eea-799528a193a2.png)

Somewhat related to the use case in #9135 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
