### PR TITLE
[TableCell] Use solid version of theme divider

### DIFF
--- a/src/Table/TableCell.js
+++ b/src/Table/TableCell.js
@@ -6,6 +6,7 @@ import type { ElementType, Node } from 'react';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import { capitalizeFirstLetter } from '../utils/helpers';
+import { darken, fade, lighten } from '../styles/colorManipulator';
 
 export type Context = {
   table: Object,
@@ -58,7 +59,12 @@ export type Props = {
 export const styles = (theme: Object) => ({
   root: {
     // Same value as theme.palette.text.lightDivider without the transparency.
-    borderBottom: `1px solid ${theme.palette.type === 'light' ? '#ededed' : '#505050'}`,
+    borderBottom: `1px solid 
+    ${
+      theme.palette.type === 'light'
+        ? lighten(fade(theme.palette.text.lightDivider, 1), 0.93)
+        : darken(fade(theme.palette.text.lightDivider, 1), 0.685)
+    }`,
     textAlign: 'left',
   },
   numeric: {

--- a/src/Table/TableCell.js
+++ b/src/Table/TableCell.js
@@ -62,7 +62,7 @@ export const styles = (theme: Object) => ({
     borderBottom: `1px solid 
     ${
       theme.palette.type === 'light'
-        ? lighten(fade(theme.palette.text.lightDivider, 1), 0.93)
+        ? lighten(fade(theme.palette.text.lightDivider, 1), 0.925)
         : darken(fade(theme.palette.text.lightDivider, 1), 0.685)
     }`,
     textAlign: 'left',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Continues #9206

@oliviertassinari When using the default theme values for `lightDivider`, the chosen coefficients for `lighten()` and `darken()` result in the same RGB values as your hex colors. I have tested with a colored `lightDivider`, and it appears to result in satisfactory colors for the the table border, at least for the default background color.